### PR TITLE
feat: implement user registration flow

### DIFF
--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -15,7 +15,8 @@ public class SecurityConfiguration {
             "/actuator/health",
             "/v3/api-docs/**",
             "/swagger-ui.html",
-            "/swagger-ui/**"
+            "/swagger-ui/**",
+            "/api/v1/auth/register",
     };
 
     @Bean

--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -5,7 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 @Configuration
 public class SecurityConfiguration {
 
@@ -29,5 +30,10 @@ public class SecurityConfiguration {
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .formLogin(formLogin -> formLogin.disable())
                 .build();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(12);
     }
 }

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserController.java
@@ -1,0 +1,38 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import com.nursena.payflow.user.application.port.in.RegisterUserCommand;
+import com.nursena.payflow.user.application.port.in.RegisterUserUseCase;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class RegisterUserController {
+
+    private final RegisterUserUseCase registerUserUseCase;
+
+    public RegisterUserController(RegisterUserUseCase registerUserUseCase) {
+        this.registerUserUseCase = registerUserUseCase;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<RegisterUserResponse> register(
+        @Valid @RequestBody RegisterUserRequest request
+    ) {
+        RegisterUserCommand command = new RegisterUserCommand(
+            request.email(),
+            request.password()
+        );
+
+        var userId = registerUserUseCase.register(command);
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(new RegisterUserResponse(userId));
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserRequest.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserRequest.java
@@ -1,0 +1,22 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterUserRequest(
+
+    @NotBlank(message = "Email is required.")
+    @Email(message = "Email must be valid.")
+    @Size(max = 320, message = "Email must not exceed 320 characters.")
+    String email,
+
+    @NotBlank(message = "Password is required.")
+    @Size(
+        min = 12,
+        max = 72,
+        message = "Password must be between 12 and 72 characters."
+    )
+    String password
+) {
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserResponse.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import java.util.UUID;
+
+public record RegisterUserResponse(UUID userId) {
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/UserRegistrationExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/UserRegistrationExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.user.domain.exception.EmailAlreadyRegisteredException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(assignableTypes = RegisterUserController.class)
+public class UserRegistrationExceptionHandler {
+
+    @ExceptionHandler(EmailAlreadyRegisteredException.class)
+    ResponseEntity<ApiError> handleEmailAlreadyRegistered(
+        EmailAlreadyRegisteredException exception,
+        HttpServletRequest request
+    ) {
+        ApiError body = new ApiError(
+            Instant.now(),
+            HttpStatus.CONFLICT.value(),
+            exception.getCode(),
+            exception.getMessage(),
+            request.getRequestURI(),
+            List.of()
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.CONFLICT)
+            .body(body);
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataUserRepository.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataUserRepository.java
@@ -1,0 +1,11 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface SpringDataUserRepository
+    extends JpaRepository<UserJpaEntity, UUID> {
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/UserJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/UserJpaEntity.java
@@ -1,0 +1,90 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.user.domain.model.UserRole;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+class UserJpaEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(nullable = false, length = 320)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserStatus status;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected UserJpaEntity() {
+    }
+
+    UserJpaEntity(
+        UUID id,
+        String email,
+        String passwordHash,
+        UserRole role,
+        UserStatus status,
+        Instant createdAt,
+        Instant updatedAt
+    ) {
+        this.id = id;
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.role = role;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    UUID getId() {
+        return id;
+    }
+
+    String getEmail() {
+        return email;
+    }
+
+    String getPasswordHash() {
+        return passwordHash;
+    }
+
+    UserRole getRole() {
+        return role;
+    }
+
+    UserStatus getStatus() {
+        return status;
+    }
+
+    Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -1,0 +1,89 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.EmailAlreadyRegisteredException;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.User;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+@Component
+class UserPersistenceAdapter implements UserRepositoryPort {
+
+    private static final String EMAIL_CONSTRAINT = "users_email_key";
+    private static final String CASE_INSENSITIVE_EMAIL_CONSTRAINT =
+        "uq_users_email_lower";
+
+    private final SpringDataUserRepository repository;
+
+    UserPersistenceAdapter(SpringDataUserRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public boolean existsByEmail(EmailAddress email) {
+        return repository.existsByEmail(email.value());
+    }
+
+    @Override
+    public User save(User user) {
+        UserJpaEntity entity = toEntity(user);
+
+        try {
+            UserJpaEntity saved = repository.saveAndFlush(entity);
+            return toDomain(saved);
+        } catch (DataIntegrityViolationException exception) {
+            if (isEmailConstraintViolation(exception)) {
+                throw new EmailAlreadyRegisteredException();
+            }
+
+            throw exception;
+        }
+    }
+
+    private static UserJpaEntity toEntity(User user) {
+        return new UserJpaEntity(
+            user.id(),
+            user.email().value(),
+            user.passwordHash(),
+            user.role(),
+            user.status(),
+            user.createdAt(),
+            user.updatedAt()
+        );
+    }
+
+    private static User toDomain(UserJpaEntity entity) {
+        return User.rehydrate(
+            entity.getId(),
+            EmailAddress.of(entity.getEmail()),
+            entity.getPasswordHash(),
+            entity.getRole(),
+            entity.getStatus(),
+            entity.getCreatedAt(),
+            entity.getUpdatedAt()
+        );
+    }
+
+    private static boolean isEmailConstraintViolation(
+        DataIntegrityViolationException exception
+    ) {
+        Throwable cause = exception;
+
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException violation) {
+                String constraintName = violation.getConstraintName();
+
+                return EMAIL_CONSTRAINT.equals(constraintName)
+                    || CASE_INSENSITIVE_EMAIL_CONSTRAINT.equals(
+                    constraintName
+                );
+            }
+
+            cause = cause.getCause();
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/BCryptPasswordHashingAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/BCryptPasswordHashingAdapter.java
@@ -1,0 +1,20 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import com.nursena.payflow.user.application.port.out.PasswordHashingPort;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+class BCryptPasswordHashingAdapter implements PasswordHashingPort {
+
+    private final PasswordEncoder passwordEncoder;
+
+    BCryptPasswordHashingAdapter(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public String hash(String rawPassword) {
+        return passwordEncoder.encode(rawPassword);
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RegisterUserCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RegisterUserCommand.java
@@ -1,0 +1,18 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.util.Objects;
+
+public record RegisterUserCommand(
+    String email,
+    String rawPassword
+) {
+
+    public RegisterUserCommand {
+        Objects.requireNonNull(email, "email must not be null");
+        Objects.requireNonNull(rawPassword, "rawPassword must not be null");
+
+        if (rawPassword.isBlank()) {
+            throw new IllegalArgumentException("rawPassword must not be blank");
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RegisterUserUseCase.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RegisterUserUseCase.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.util.UUID;
+
+public interface RegisterUserUseCase {
+
+    UUID register(RegisterUserCommand command);
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/PasswordHashingPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/PasswordHashingPort.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.user.application.port.out;
+
+public interface PasswordHashingPort {
+
+    String hash(String rawPassword);
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/UserRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/UserRepositoryPort.java
@@ -1,0 +1,11 @@
+package com.nursena.payflow.user.application.port.out;
+
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.User;
+
+public interface UserRepositoryPort {
+
+    boolean existsByEmail(EmailAddress email);
+
+    User save(User user);
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/RegisterUserService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RegisterUserService.java
@@ -1,0 +1,52 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Clock;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.RegisterUserCommand;
+import com.nursena.payflow.user.application.port.in.RegisterUserUseCase;
+import com.nursena.payflow.user.application.port.out.PasswordHashingPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.EmailAlreadyRegisteredException;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RegisterUserService implements RegisterUserUseCase {
+
+    private final UserRepositoryPort userRepository;
+    private final PasswordHashingPort passwordHashing;
+    private final Clock clock;
+
+    public RegisterUserService(
+        UserRepositoryPort userRepository,
+        PasswordHashingPort passwordHashing,
+        Clock clock
+    ) {
+        this.userRepository = userRepository;
+        this.passwordHashing = passwordHashing;
+        this.clock = clock;
+    }
+
+    @Override
+    @Transactional
+    public UUID register(RegisterUserCommand command) {
+        EmailAddress email = EmailAddress.of(command.email());
+
+        if (userRepository.existsByEmail(email)) {
+            throw new EmailAlreadyRegisteredException();
+        }
+
+        String passwordHash = passwordHashing.hash(command.rawPassword());
+
+        User user = User.register(
+            email,
+            passwordHash,
+            clock.instant()
+        );
+
+        return userRepository.save(user).id();
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/exception/EmailAlreadyRegisteredException.java
+++ b/src/main/java/com/nursena/payflow/user/domain/exception/EmailAlreadyRegisteredException.java
@@ -1,0 +1,13 @@
+package com.nursena.payflow.user.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class EmailAlreadyRegisteredException extends BusinessRuleException {
+
+    public EmailAlreadyRegisteredException() {
+        super(
+            "EMAIL_ALREADY_REGISTERED",
+            "A user with this email address already exists."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/exception/InvalidEmailException.java
+++ b/src/main/java/com/nursena/payflow/user/domain/exception/InvalidEmailException.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.user.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class InvalidEmailException extends BusinessRuleException {
+
+    public InvalidEmailException() {
+        super("INVALID_EMAIL", "Email address is invalid.");
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/EmailAddress.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/EmailAddress.java
@@ -1,0 +1,33 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import com.nursena.payflow.user.domain.exception.InvalidEmailException;
+
+public record EmailAddress(String value) {
+
+    private static final int MAX_LENGTH = 320;
+
+    private static final Pattern EMAIL_PATTERN =
+        Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
+
+    public EmailAddress {
+        Objects.requireNonNull(value, "email must not be null");
+
+        String normalizedValue = value.trim().toLowerCase(Locale.ROOT);
+
+        if (normalizedValue.isBlank()
+            || normalizedValue.length() > MAX_LENGTH
+            || !EMAIL_PATTERN.matcher(normalizedValue).matches()) {
+            throw new InvalidEmailException();
+        }
+
+        value = normalizedValue;
+    }
+
+    public static EmailAddress of(String value) {
+        return new EmailAddress(value);
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/User.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/User.java
@@ -1,0 +1,111 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class User {
+
+    private final UUID id;
+    private final EmailAddress email;
+    private final String passwordHash;
+    private final UserRole role;
+    private UserStatus status;
+    private final Instant createdAt;
+    private Instant updatedAt;
+
+    private User(
+        UUID id,
+        EmailAddress email,
+        String passwordHash,
+        UserRole role,
+        UserStatus status,
+        Instant createdAt,
+        Instant updatedAt
+    ) {
+        this.id = Objects.requireNonNull(id, "id must not be null");
+        this.email = Objects.requireNonNull(email, "email must not be null");
+        this.passwordHash = requirePasswordHash(passwordHash);
+        this.role = Objects.requireNonNull(role, "role must not be null");
+        this.status = Objects.requireNonNull(status, "status must not be null");
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt must not be null");
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt must not be null");
+    }
+
+    public static User register(
+        EmailAddress email,
+        String passwordHash,
+        Instant now
+    ) {
+        return new User(
+            UUID.randomUUID(),
+            email,
+            passwordHash,
+            UserRole.USER,
+            UserStatus.ACTIVE,
+            now,
+            now
+        );
+    }
+
+    public static User rehydrate(
+        UUID id,
+        EmailAddress email,
+        String passwordHash,
+        UserRole role,
+        UserStatus status,
+        Instant createdAt,
+        Instant updatedAt
+    ) {
+        return new User(
+            id,
+            email,
+            passwordHash,
+            role,
+            status,
+            createdAt,
+            updatedAt
+        );
+    }
+
+    public void suspend(Instant now) {
+        status = UserStatus.SUSPENDED;
+        updatedAt = Objects.requireNonNull(now, "now must not be null");
+    }
+
+    private static String requirePasswordHash(String passwordHash) {
+        if (passwordHash == null || passwordHash.isBlank()) {
+            throw new IllegalArgumentException("passwordHash must not be blank");
+        }
+
+        return passwordHash;
+    }
+
+    public UUID id() {
+        return id;
+    }
+
+    public EmailAddress email() {
+        return email;
+    }
+
+    public String passwordHash() {
+        return passwordHash;
+    }
+
+    public UserRole role() {
+        return role;
+    }
+
+    public UserStatus status() {
+        return status;
+    }
+
+    public Instant createdAt() {
+        return createdAt;
+    }
+
+    public Instant updatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/UserRole.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/UserRole.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.user.domain.model;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/UserStatus.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/UserStatus.java
@@ -1,0 +1,7 @@
+package com.nursena.payflow.user.domain.model;
+
+public enum UserStatus {
+    ACTIVE,
+    SUSPENDED,
+    CLOSED
+}

--- a/src/main/resources/db/migration/V2__enforce_user_constraints.sql
+++ b/src/main/resources/db/migration/V2__enforce_user_constraints.sql
@@ -1,0 +1,10 @@
+CREATE UNIQUE INDEX uq_users_email_lower
+    ON users (LOWER(email));
+
+ALTER TABLE users
+    ADD CONSTRAINT chk_users_role
+        CHECK (role IN ('USER', 'ADMIN'));
+
+ALTER TABLE users
+    ADD CONSTRAINT chk_users_status
+        CHECK (status IN ('ACTIVE', 'SUSPENDED', 'CLOSED'));

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/RegisterUserControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/RegisterUserControllerTest.java
@@ -1,0 +1,122 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.user.application.port.in.RegisterUserCommand;
+import com.nursena.payflow.user.application.port.in.RegisterUserUseCase;
+import com.nursena.payflow.user.domain.exception.EmailAlreadyRegisteredException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(RegisterUserController.class)
+@Import({
+    SecurityConfiguration.class,
+    UserRegistrationExceptionHandler.class
+})
+class RegisterUserControllerTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString("0f65d80a-91fc-46f5-8782-4dbb32375b81");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RegisterUserUseCase registerUserUseCase;
+
+    @Test
+    void shouldRegisterUser() throws Exception {
+        when(registerUserUseCase.register(any(RegisterUserCommand.class)))
+            .thenReturn(USER_ID);
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                                {
+                                  "email": "nursena@example.com",
+                                  "password": "StrongPassword123!"
+                                }
+                                """))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.userId")
+                .value(USER_ID.toString()));
+
+        verify(registerUserUseCase).register(argThat(command ->
+            command.email().equals("nursena@example.com")
+                && command.rawPassword()
+                .equals("StrongPassword123!")
+        ));
+    }
+
+    @Test
+    void shouldRejectInvalidEmail() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                                {
+                                  "email": "not-an-email",
+                                  "password": "StrongPassword123!"
+                                }
+                                """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code")
+                .value("VALIDATION_FAILED"))
+            .andExpect(jsonPath("$.violations[0].field")
+                .value("email"));
+    }
+
+    @Test
+    void shouldRejectShortPassword() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                                {
+                                  "email": "nursena@example.com",
+                                  "password": "short"
+                                }
+                                """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code")
+                .value("VALIDATION_FAILED"))
+            .andExpect(jsonPath("$.violations[0].field")
+                .value("password"));
+    }
+
+    @Test
+    void shouldReturnConflictForRegisteredEmail() throws Exception {
+        when(registerUserUseCase.register(any(RegisterUserCommand.class)))
+            .thenThrow(new EmailAlreadyRegisteredException());
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                                {
+                                  "email": "nursena@example.com",
+                                  "password": "StrongPassword123!"
+                                }
+                                """))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code")
+                .value("EMAIL_ALREADY_REGISTERED"))
+            .andExpect(jsonPath("$.message")
+                .value(
+                    "A user with this email address already exists."
+                ))
+            .andExpect(jsonPath("$.path")
+                .value("/api/v1/auth/register"));
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/persistence/UserPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/persistence/UserPersistenceAdapterTest.java
@@ -1,0 +1,102 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.time.Instant;
+
+import com.nursena.payflow.user.domain.exception.EmailAlreadyRegisteredException;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.User;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class UserPersistenceAdapterTest {
+
+    private static final Instant NOW =
+        Instant.parse("2026-07-12T12:00:00Z");
+
+    @Mock
+    private SpringDataUserRepository repository;
+
+    private UserPersistenceAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new UserPersistenceAdapter(repository);
+    }
+
+    @Test
+    void shouldCheckExistenceUsingNormalizedEmail() {
+        EmailAddress email = EmailAddress.of("NURSENA@example.com");
+
+        when(repository.existsByEmail("nursena@example.com"))
+            .thenReturn(true);
+
+        boolean exists = adapter.existsByEmail(email);
+
+        assertThat(exists).isTrue();
+        verify(repository).existsByEmail("nursena@example.com");
+    }
+
+    @Test
+    void shouldSaveAndRestoreUser() {
+        User user = User.register(
+            EmailAddress.of("nursena@example.com"),
+            "$2a$12$hashed-password",
+            NOW
+        );
+
+        when(repository.saveAndFlush(any(UserJpaEntity.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        User savedUser = adapter.save(user);
+
+        assertThat(savedUser.id()).isEqualTo(user.id());
+        assertThat(savedUser.email()).isEqualTo(user.email());
+        assertThat(savedUser.passwordHash())
+            .isEqualTo(user.passwordHash());
+        assertThat(savedUser.role()).isEqualTo(user.role());
+        assertThat(savedUser.status()).isEqualTo(user.status());
+        assertThat(savedUser.createdAt()).isEqualTo(NOW);
+        assertThat(savedUser.updatedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    void shouldTranslateDuplicateEmailConstraintViolation() {
+        User user = User.register(
+            EmailAddress.of("nursena@example.com"),
+            "$2a$12$hashed-password",
+            NOW
+        );
+
+        ConstraintViolationException constraintViolation =
+            new ConstraintViolationException(
+                "duplicate email",
+                new SQLException(),
+                "uq_users_email_lower"
+            );
+
+        when(repository.saveAndFlush(any(UserJpaEntity.class)))
+            .thenThrow(new DataIntegrityViolationException(
+                "duplicate email",
+                constraintViolation
+            ));
+
+        assertThatThrownBy(() -> adapter.save(user))
+            .isInstanceOf(EmailAlreadyRegisteredException.class)
+            .hasMessage(
+                "A user with this email address already exists."
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/BCryptPasswordHashingAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/BCryptPasswordHashingAdapterTest.java
@@ -1,0 +1,24 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class BCryptPasswordHashingAdapterTest {
+
+    @Test
+    void shouldHashPasswordUsingBCrypt() {
+        PasswordEncoder encoder = new BCryptPasswordEncoder(4);
+        BCryptPasswordHashingAdapter adapter =
+            new BCryptPasswordHashingAdapter(encoder);
+
+        String rawPassword = "StrongPassword123!";
+
+        String passwordHash = adapter.hash(rawPassword);
+
+        assertThat(passwordHash).isNotEqualTo(rawPassword);
+        assertThat(encoder.matches(rawPassword, passwordHash)).isTrue();
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/RegisterUserServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RegisterUserServiceTest.java
@@ -1,0 +1,124 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.RegisterUserCommand;
+import com.nursena.payflow.user.application.port.out.PasswordHashingPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.EmailAlreadyRegisteredException;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.User;
+import com.nursena.payflow.user.domain.model.UserRole;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterUserServiceTest {
+
+    private static final Instant NOW =
+        Instant.parse("2026-07-12T12:00:00Z");
+
+    private static final String RAW_PASSWORD =
+        "StrongPassword123!";
+
+    private static final String PASSWORD_HASH =
+        "$2a$12$hashed-password";
+
+    @Mock
+    private UserRepositoryPort userRepository;
+
+    @Mock
+    private PasswordHashingPort passwordHashing;
+
+    private RegisterUserService registerUserService;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+
+        registerUserService = new RegisterUserService(
+            userRepository,
+            passwordHashing,
+            clock
+        );
+    }
+
+    @Test
+    void shouldRegisterUser() {
+        RegisterUserCommand command = new RegisterUserCommand(
+            "  Nursena@Example.COM  ",
+            RAW_PASSWORD
+        );
+
+        when(userRepository.existsByEmail(any(EmailAddress.class)))
+            .thenReturn(false);
+        when(passwordHashing.hash(RAW_PASSWORD))
+            .thenReturn(PASSWORD_HASH);
+        when(userRepository.save(any(User.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UUID userId = registerUserService.register(command);
+
+        ArgumentCaptor<User> userCaptor =
+            ArgumentCaptor.forClass(User.class);
+
+        verify(userRepository)
+            .existsByEmail(EmailAddress.of("nursena@example.com"));
+        verify(passwordHashing).hash(RAW_PASSWORD);
+        verify(userRepository).save(userCaptor.capture());
+
+        User savedUser = userCaptor.getValue();
+
+        assertThat(userId).isEqualTo(savedUser.id());
+        assertThat(savedUser.email().value())
+            .isEqualTo("nursena@example.com");
+        assertThat(savedUser.passwordHash())
+            .isEqualTo(PASSWORD_HASH);
+        assertThat(savedUser.role())
+            .isEqualTo(UserRole.USER);
+        assertThat(savedUser.status())
+            .isEqualTo(UserStatus.ACTIVE);
+        assertThat(savedUser.createdAt())
+            .isEqualTo(NOW);
+    }
+
+    @Test
+    void shouldRejectAlreadyRegisteredEmail() {
+        EmailAddress email =
+            EmailAddress.of("nursena@example.com");
+
+        when(userRepository.existsByEmail(email))
+            .thenReturn(true);
+
+        RegisterUserCommand command = new RegisterUserCommand(
+            "nursena@example.com",
+            RAW_PASSWORD
+        );
+
+        assertThatThrownBy(() -> registerUserService.register(command))
+            .isInstanceOf(EmailAlreadyRegisteredException.class)
+            .hasMessage(
+                "A user with this email address already exists."
+            );
+
+        verify(userRepository).existsByEmail(email);
+        verify(userRepository, never()).save(any(User.class));
+        verifyNoInteractions(passwordHashing);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/domain/model/EmailAddressTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/EmailAddressTest.java
@@ -1,0 +1,29 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nursena.payflow.user.domain.exception.InvalidEmailException;
+import org.junit.jupiter.api.Test;
+
+class EmailAddressTest {
+
+    @Test
+    void shouldNormalizeEmailAddress() {
+        EmailAddress email = EmailAddress.of("  Nursena@Example.COM  ");
+
+        assertThat(email.value()).isEqualTo("nursena@example.com");
+    }
+
+    @Test
+    void shouldRejectEmailWithoutAtSign() {
+        assertThatThrownBy(() -> EmailAddress.of("nursena.example.com"))
+            .isInstanceOf(InvalidEmailException.class);
+    }
+
+    @Test
+    void shouldRejectBlankEmail() {
+        assertThatThrownBy(() -> EmailAddress.of(" "))
+            .isInstanceOf(InvalidEmailException.class);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/domain/model/UserTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/UserTest.java
@@ -1,0 +1,58 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class UserTest {
+
+    private static final Instant NOW =
+        Instant.parse("2026-07-12T12:00:00Z");
+
+    @Test
+    void shouldRegisterActiveUserWithUserRole() {
+        User user = User.register(
+            EmailAddress.of("nursena@example.com"),
+            "$2a$12$hashed-password",
+            NOW
+        );
+
+        assertThat(user.id()).isNotNull();
+        assertThat(user.email().value()).isEqualTo("nursena@example.com");
+        assertThat(user.role()).isEqualTo(UserRole.USER);
+        assertThat(user.status()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(user.createdAt()).isEqualTo(NOW);
+        assertThat(user.updatedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    void shouldRejectBlankPasswordHash() {
+        assertThatThrownBy(() -> User.register(
+            EmailAddress.of("nursena@example.com"),
+            " ",
+            NOW
+        ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("passwordHash must not be blank");
+    }
+
+    @Test
+    void shouldSuspendUser() {
+        User user = User.register(
+            EmailAddress.of("nursena@example.com"),
+            "$2a$12$hashed-password",
+            NOW
+        );
+
+        Instant suspensionTime =
+            Instant.parse("2026-07-12T13:00:00Z");
+
+        user.suspend(suspensionTime);
+
+        assertThat(user.status()).isEqualTo(UserStatus.SUSPENDED);
+        assertThat(user.updatedAt()).isEqualTo(suspensionTime);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RegisterUserIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RegisterUserIntegrationTest.java
@@ -1,0 +1,141 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.nursena.payflow.user.domain.model.UserRole;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@SpringBootTest
+@AutoConfigureMockMvc
+class RegisterUserIntegrationTest {
+
+    private static final String RAW_PASSWORD =
+        "StrongPassword123!";
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRESQL =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update("DELETE FROM users");
+    }
+
+    @Test
+    void shouldRegisterUserThroughCompleteApplicationFlow() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                                {
+                                  "email": "Integration.User@Example.COM",
+                                  "password": "StrongPassword123!"
+                                }
+                                """))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.userId").isNotEmpty());
+
+        UserDatabaseRow user = jdbcTemplate.queryForObject(
+            """
+            SELECT email, password_hash, role, status
+            FROM users
+            WHERE email = ?
+            """,
+            (resultSet, rowNumber) -> new UserDatabaseRow(
+                resultSet.getString("email"),
+                resultSet.getString("password_hash"),
+                resultSet.getString("role"),
+                resultSet.getString("status")
+            ),
+            "integration.user@example.com"
+        );
+
+        assertThat(user).isNotNull();
+        assertThat(user.email())
+            .isEqualTo("integration.user@example.com");
+        assertThat(user.passwordHash())
+            .isNotEqualTo(RAW_PASSWORD);
+        assertThat(passwordEncoder.matches(
+            RAW_PASSWORD,
+            user.passwordHash()
+        )).isTrue();
+        assertThat(user.role())
+            .isEqualTo(UserRole.USER.name());
+        assertThat(user.status())
+            .isEqualTo(UserStatus.ACTIVE.name());
+    }
+
+    @Test
+    void shouldRejectDuplicateEmailAndKeepSingleDatabaseRecord()
+        throws Exception {
+
+        String requestBody = """
+                {
+                  "email": "duplicate@example.com",
+                  "password": "StrongPassword123!"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code")
+                .value("EMAIL_ALREADY_REGISTERED"))
+            .andExpect(jsonPath("$.message")
+                .value(
+                    "A user with this email address already exists."
+                ));
+
+        Integer userCount = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM users
+            WHERE email = ?
+            """,
+            Integer.class,
+            "duplicate@example.com"
+        );
+
+        assertThat(userCount).isEqualTo(1);
+    }
+
+    private record UserDatabaseRow(
+        String email,
+        String passwordHash,
+        String role,
+        String status
+    ) {
+    }
+}


### PR DESCRIPTION
## Summary

- add user domain model and email value object
- implement user registration use case
- add PostgreSQL persistence adapter
- add BCrypt password hashing adapter
- expose `POST /api/v1/auth/register`
- return structured validation and duplicate-email errors
- add Flyway constraints for user email, role, and status
- add unit, web-layer, persistence, and Testcontainers integration tests

## Architecture

- follows ports and adapters architecture
- keeps domain and application layers independent from persistence and HTTP concerns
- protects email uniqueness at both application and database levels
- stores passwords using BCrypt hashing

## Testing

- `.\mvnw.cmd clean verify`
- 24 tests passing
- registration returns `201 Created`
- duplicate email returns `409 Conflict`
- invalid request returns `400 Bad Request`
- PostgreSQL persistence verified with Testcontainers
- Flyway migrations verified against PostgreSQL 17

## API

### Register user

`POST /api/v1/auth/register`

```json
{
  "email": "user@example.com",
  "password": "StrongPassword123!"
}