### PR TITLE
feat: add current user profile flow

### DIFF
--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -7,6 +7,10 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import static org.springframework.http.HttpMethod.GET;
+
+import org.springframework.security.config.Customizer;
+
 @Configuration
 public class SecurityConfiguration {
 
@@ -21,17 +25,39 @@ public class SecurityConfiguration {
     };
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain securityFilterChain(
+        HttpSecurity http
+    ) throws Exception {
         return http
-                .csrf(csrf -> csrf.disable())
-                .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
-                        .anyRequest().denyAll())
-                .httpBasic(httpBasic -> httpBasic.disable())
-                .formLogin(formLogin -> formLogin.disable())
-                .build();
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(
+                    SessionCreationPolicy.STATELESS
+                )
+            )
+            .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers(PUBLIC_ENDPOINTS)
+                .permitAll()
+                .requestMatchers(
+                    GET,
+                    "/api/v1/users/me"
+                )
+                .authenticated()
+                .anyRequest()
+                .denyAll()
+            )
+            .oauth2ResourceServer(resourceServer ->
+                resourceServer.jwt(
+                    Customizer.withDefaults()
+                )
+            )
+            .httpBasic(httpBasic ->
+                httpBasic.disable()
+            )
+            .formLogin(formLogin ->
+                formLogin.disable()
+            )
+            .build();
     }
 
     @Bean

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileController.java
@@ -1,0 +1,42 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.GetCurrentUserProfileResult;
+import com.nursena.payflow.user.application.port.in.GetCurrentUserProfileUseCase;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+public class CurrentUserProfileController {
+
+    private final GetCurrentUserProfileUseCase profileUseCase;
+
+    public CurrentUserProfileController(
+        GetCurrentUserProfileUseCase profileUseCase
+    ) {
+        this.profileUseCase = profileUseCase;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<CurrentUserProfileResponse>
+    getCurrentUserProfile(
+        @AuthenticationPrincipal Jwt jwt
+    ) {
+        UUID userId = UUID.fromString(
+            jwt.getSubject()
+        );
+
+        GetCurrentUserProfileResult result =
+            profileUseCase.getProfile(userId);
+
+        return ResponseEntity.ok(
+            CurrentUserProfileResponse.from(result)
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.user.domain.exception.UserNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(
+    assignableTypes =
+        CurrentUserProfileController.class
+)
+public class CurrentUserProfileExceptionHandler {
+
+    @ExceptionHandler(UserNotFoundException.class)
+    ResponseEntity<ApiError> handleUserNotFound(
+        UserNotFoundException exception,
+        HttpServletRequest request
+    ) {
+        ApiError body = new ApiError(
+            Instant.now(),
+            HttpStatus.NOT_FOUND.value(),
+            exception.getCode(),
+            exception.getMessage(),
+            request.getRequestURI(),
+            List.of()
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(body);
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileResponse.java
@@ -1,0 +1,29 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.GetCurrentUserProfileResult;
+import com.nursena.payflow.user.domain.model.UserRole;
+import com.nursena.payflow.user.domain.model.UserStatus;
+
+public record CurrentUserProfileResponse(
+    UUID id,
+    String email,
+    UserRole role,
+    UserStatus status,
+    Instant createdAt
+) {
+
+    static CurrentUserProfileResponse from(
+        GetCurrentUserProfileResult result
+    ) {
+        return new CurrentUserProfileResponse(
+            result.id(),
+            result.email(),
+            result.role(),
+            result.status(),
+            result.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -8,6 +8,7 @@ import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import java.util.Optional;
+import java.util.UUID;
 
 @Component
 class UserPersistenceAdapter implements UserRepositoryPort {
@@ -30,6 +31,12 @@ class UserPersistenceAdapter implements UserRepositoryPort {
     @Override
     public Optional<User> findByEmail(EmailAddress email) {
         return repository.findByEmail(email.value())
+            .map(UserPersistenceAdapter::toDomain);
+    }
+
+    @Override
+    public Optional<User> findById(UUID userId) {
+        return repository.findById(userId)
             .map(UserPersistenceAdapter::toDomain);
     }
 

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/JwtConfiguration.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/JwtConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
 
 @Configuration
 @Profile("!prod")
@@ -73,12 +74,23 @@ class JwtConfiguration {
     }
 
     @Bean
-    JwtDecoder jwtDecoder(KeyPair jwtKeyPair) {
+    JwtDecoder jwtDecoder(
+        KeyPair jwtKeyPair,
+        JwtProperties properties
+    ) {
         RSAPublicKey publicKey =
             (RSAPublicKey) jwtKeyPair.getPublic();
 
-        return NimbusJwtDecoder
+        NimbusJwtDecoder decoder = NimbusJwtDecoder
             .withPublicKey(publicKey)
             .build();
+
+        decoder.setJwtValidator(
+            JwtValidators.createDefaultWithIssuer(
+                properties.issuer()
+            )
+        );
+
+        return decoder;
     }
 }

--- a/src/main/java/com/nursena/payflow/user/application/port/in/GetCurrentUserProfileResult.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/GetCurrentUserProfileResult.java
@@ -1,0 +1,34 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.user.domain.model.UserRole;
+import com.nursena.payflow.user.domain.model.UserStatus;
+
+public record GetCurrentUserProfileResult(
+    UUID id,
+    String email,
+    UserRole role,
+    UserStatus status,
+    Instant createdAt
+) {
+
+    public GetCurrentUserProfileResult {
+        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(email, "email must not be null");
+        Objects.requireNonNull(role, "role must not be null");
+        Objects.requireNonNull(status, "status must not be null");
+        Objects.requireNonNull(
+            createdAt,
+            "createdAt must not be null"
+        );
+
+        if (email.isBlank()) {
+            throw new IllegalArgumentException(
+                "email must not be blank"
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/GetCurrentUserProfileUseCase.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/GetCurrentUserProfileUseCase.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.util.UUID;
+
+public interface GetCurrentUserProfileUseCase {
+
+    GetCurrentUserProfileResult getProfile(UUID userId);
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/UserRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/UserRepositoryPort.java
@@ -1,6 +1,7 @@
 package com.nursena.payflow.user.application.port.out;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import com.nursena.payflow.user.domain.model.EmailAddress;
 import com.nursena.payflow.user.domain.model.User;
@@ -10,6 +11,8 @@ public interface UserRepositoryPort {
     boolean existsByEmail(EmailAddress email);
 
     Optional<User> findByEmail(EmailAddress email);
+
+    Optional<User> findById(UUID userId);
 
     User save(User user);
 }

--- a/src/main/java/com/nursena/payflow/user/application/service/GetCurrentUserProfileService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/GetCurrentUserProfileService.java
@@ -1,0 +1,45 @@
+package com.nursena.payflow.user.application.service;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.GetCurrentUserProfileResult;
+import com.nursena.payflow.user.application.port.in.GetCurrentUserProfileUseCase;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.UserNotFoundException;
+import com.nursena.payflow.user.domain.model.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetCurrentUserProfileService
+    implements GetCurrentUserProfileUseCase {
+
+    private final UserRepositoryPort userRepository;
+
+    public GetCurrentUserProfileService(
+        UserRepositoryPort userRepository
+    ) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public GetCurrentUserProfileResult getProfile(UUID userId) {
+        Objects.requireNonNull(
+            userId,
+            "userId must not be null"
+        );
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(UserNotFoundException::new);
+
+        return new GetCurrentUserProfileResult(
+            user.id(),
+            user.email().value(),
+            user.role(),
+            user.status(),
+            user.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/exception/UserNotFoundException.java
+++ b/src/main/java/com/nursena/payflow/user/domain/exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.user.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class UserNotFoundException
+    extends BusinessRuleException {
+
+    public UserNotFoundException() {
+        super(
+            "USER_NOT_FOUND",
+            "User could not be found."
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserControllerTest.java
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 @WebMvcTest(AuthenticateUserController.class)
 @Import({
     SecurityConfiguration.class,
@@ -39,6 +39,9 @@ class AuthenticateUserControllerTest {
 
     @MockitoBean
     private AuthenticateUserUseCase authenticateUserUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
 
     @Test
     void shouldAuthenticateUser() throws Exception {

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileControllerTest.java
@@ -1,0 +1,131 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.user.application.port.in.GetCurrentUserProfileResult;
+import com.nursena.payflow.user.application.port.in.GetCurrentUserProfileUseCase;
+import com.nursena.payflow.user.domain.exception.UserNotFoundException;
+import com.nursena.payflow.user.domain.model.UserRole;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CurrentUserProfileController.class)
+@Import({
+    SecurityConfiguration.class,
+    CurrentUserProfileExceptionHandler.class
+})
+class CurrentUserProfileControllerTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse("2026-07-12T12:00:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GetCurrentUserProfileUseCase profileUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldReturnCurrentUserProfile()
+        throws Exception {
+
+        when(profileUseCase.getProfile(USER_ID))
+            .thenReturn(
+                new GetCurrentUserProfileResult(
+                    USER_ID,
+                    "nursena@example.com",
+                    UserRole.USER,
+                    UserStatus.ACTIVE,
+                    CREATED_AT
+                )
+            );
+
+        mockMvc.perform(
+                get("/api/v1/users/me")
+                    .with(jwt().jwt(token ->
+                        token.subject(
+                            USER_ID.toString()
+                        )
+                    ))
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id")
+                .value(USER_ID.toString()))
+            .andExpect(jsonPath("$.email")
+                .value("nursena@example.com"))
+            .andExpect(jsonPath("$.role")
+                .value("USER"))
+            .andExpect(jsonPath("$.status")
+                .value("ACTIVE"))
+            .andExpect(jsonPath("$.createdAt")
+                .value(CREATED_AT.toString()));
+
+        verify(profileUseCase)
+            .getProfile(USER_ID);
+    }
+
+    @Test
+    void shouldRejectRequestWithoutAccessToken()
+        throws Exception {
+
+        mockMvc.perform(
+                get("/api/v1/users/me")
+            )
+            .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(profileUseCase);
+    }
+
+    @Test
+    void shouldReturnNotFoundForUnknownUser()
+        throws Exception {
+
+        when(profileUseCase.getProfile(USER_ID))
+            .thenThrow(
+                new UserNotFoundException()
+            );
+
+        mockMvc.perform(
+                get("/api/v1/users/me")
+                    .with(jwt().jwt(token ->
+                        token.subject(
+                            USER_ID.toString()
+                        )
+                    ))
+            )
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code")
+                .value("USER_NOT_FOUND"))
+            .andExpect(jsonPath("$.message")
+                .value("User could not be found."))
+            .andExpect(jsonPath("$.path")
+                .value("/api/v1/users/me"));
+
+        verify(profileUseCase)
+            .getProfile(USER_ID);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/RegisterUserControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/RegisterUserControllerTest.java
@@ -21,7 +21,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 @WebMvcTest(RegisterUserController.class)
 @Import({
     SecurityConfiguration.class,
@@ -37,6 +37,9 @@ class RegisterUserControllerTest {
 
     @MockitoBean
     private RegisterUserUseCase registerUserUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
 
     @Test
     void shouldRegisterUser() throws Exception {

--- a/src/test/java/com/nursena/payflow/user/adapter/out/persistence/UserPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/persistence/UserPersistenceAdapterTest.java
@@ -143,4 +143,45 @@ class UserPersistenceAdapterTest {
                 "A user with this email address already exists."
             );
     }
+
+    @Test
+    void shouldFindUserById() {
+        User user = User.register(
+            EmailAddress.of("nursena@example.com"),
+            "$2a$12$hashed-password",
+            NOW
+        );
+
+        UserJpaEntity entity = new UserJpaEntity(
+            user.id(),
+            user.email().value(),
+            user.passwordHash(),
+            user.role(),
+            user.status(),
+            user.createdAt(),
+            user.updatedAt()
+        );
+
+        when(repository.findById(user.id()))
+            .thenReturn(Optional.of(entity));
+
+        Optional<User> result =
+            adapter.findById(user.id());
+
+        assertThat(result).isPresent();
+
+        User foundUser = result.orElseThrow();
+
+        assertThat(foundUser.id()).isEqualTo(user.id());
+        assertThat(foundUser.email())
+            .isEqualTo(user.email());
+        assertThat(foundUser.role())
+            .isEqualTo(user.role());
+        assertThat(foundUser.status())
+            .isEqualTo(user.status());
+        assertThat(foundUser.createdAt())
+            .isEqualTo(user.createdAt());
+
+        verify(repository).findById(user.id());
+    }
 }

--- a/src/test/java/com/nursena/payflow/user/application/service/GetCurrentUserProfileServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/GetCurrentUserProfileServiceTest.java
@@ -1,0 +1,95 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.GetCurrentUserProfileResult;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.UserNotFoundException;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.User;
+import com.nursena.payflow.user.domain.model.UserRole;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GetCurrentUserProfileServiceTest {
+
+    private static final UUID USER_ID = UUID.fromString(
+        "8805681d-d537-42f2-8906-5da1f0666ab7"
+    );
+
+    private static final Instant CREATED_AT =
+        Instant.parse("2026-07-12T12:00:00Z");
+
+    @Mock
+    private UserRepositoryPort userRepository;
+
+    private GetCurrentUserProfileService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new GetCurrentUserProfileService(
+            userRepository
+        );
+    }
+
+    @Test
+    void shouldReturnCurrentUserProfile() {
+        User user = activeUser();
+
+        when(userRepository.findById(USER_ID))
+            .thenReturn(Optional.of(user));
+
+        GetCurrentUserProfileResult result =
+            service.getProfile(USER_ID);
+
+        assertThat(result.id()).isEqualTo(USER_ID);
+        assertThat(result.email())
+            .isEqualTo("nursena@example.com");
+        assertThat(result.role())
+            .isEqualTo(UserRole.USER);
+        assertThat(result.status())
+            .isEqualTo(UserStatus.ACTIVE);
+        assertThat(result.createdAt())
+            .isEqualTo(CREATED_AT);
+
+        verify(userRepository).findById(USER_ID);
+    }
+
+    @Test
+    void shouldRejectUnknownUser() {
+        when(userRepository.findById(USER_ID))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+            () -> service.getProfile(USER_ID)
+        )
+            .isInstanceOf(UserNotFoundException.class)
+            .hasMessage("User could not be found.");
+
+        verify(userRepository).findById(USER_ID);
+    }
+
+    private static User activeUser() {
+        return User.rehydrate(
+            USER_ID,
+            EmailAddress.of("nursena@example.com"),
+            "$2a$12$hashed-password",
+            UserRole.USER,
+            UserStatus.ACTIVE,
+            CREATED_AT,
+            CREATED_AT
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/CurrentUserProfileIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/CurrentUserProfileIntegrationTest.java
@@ -1,0 +1,135 @@
+package com.nursena.payflow.user.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class CurrentUserProfileIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void shouldRegisterLoginAndReturnCurrentUserProfile()
+        throws Exception {
+
+        String email = "profile-"
+            + UUID.randomUUID()
+            + "@example.com";
+
+        String password = "StrongPassword123!";
+
+        registerUser(email, password);
+
+        String accessToken =
+            authenticateUser(email, password);
+
+        mockMvc.perform(
+                get("/api/v1/users/me")
+                    .header(
+                        HttpHeaders.AUTHORIZATION,
+                        "Bearer " + accessToken
+                    )
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").isNotEmpty())
+            .andExpect(jsonPath("$.email").value(email))
+            .andExpect(jsonPath("$.role").value("USER"))
+            .andExpect(jsonPath("$.status").value("ACTIVE"))
+            .andExpect(jsonPath("$.createdAt").isNotEmpty())
+            .andExpect(jsonPath("$.password").doesNotExist())
+            .andExpect(jsonPath("$.passwordHash").doesNotExist());
+    }
+
+    private void registerUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RegistrationRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isCreated());
+    }
+
+    private String authenticateUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        MvcResult result = mockMvc.perform(
+                post("/api/v1/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new LoginRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.accessToken").isNotEmpty())
+            .andExpect(jsonPath("$.tokenType").value("Bearer"))
+            .andReturn();
+
+        JsonNode responseBody = objectMapper.readTree(
+            result.getResponse().getContentAsString()
+        );
+
+        return responseBody
+            .get("accessToken")
+            .asText();
+    }
+
+    private record RegistrationRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record LoginRequest(
+        String email,
+        String password
+    ) {
+    }
+}


### PR DESCRIPTION
## Summary

- adds current user profile use case
- adds user lookup by ID
- secures GET /api/v1/users/me with JWT Bearer authentication
- validates JWT issuer, expiration, and RSA signature
- returns safe profile fields without password data
- adds unit, MockMvc, persistence, and end-to-end integration tests

## Test

- `./mvnw clean verify`