### PR TITLE
feat: add secure wallet creation flow

### DIFF
--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -10,7 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import static org.springframework.http.HttpMethod.GET;
 
 import org.springframework.security.config.Customizer;
-
+import org.springframework.http.HttpMethod;
 @Configuration
 public class SecurityConfiguration {
 
@@ -42,6 +42,12 @@ public class SecurityConfiguration {
                     GET,
                     "/api/v1/users/me"
                 )
+
+                .authenticated()
+                .requestMatchers(
+                    HttpMethod.POST,
+                    "/api/v1/wallets"
+                )
                 .authenticated()
                 .anyRequest()
                 .denyAll()
@@ -57,6 +63,7 @@ public class SecurityConfiguration {
             .formLogin(formLogin ->
                 formLogin.disable()
             )
+
             .build();
     }
 

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletController.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletController.java
@@ -1,0 +1,51 @@
+package com.nursena.payflow.wallet.adapter.in.web;
+
+import java.util.UUID;
+
+import com.nursena.payflow.wallet.application.port.in.OpenWalletCommand;
+import com.nursena.payflow.wallet.application.port.in.OpenWalletResult;
+import com.nursena.payflow.wallet.application.port.in.OpenWalletUseCase;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/wallets")
+public class OpenWalletController {
+
+    private final OpenWalletUseCase openWalletUseCase;
+
+    public OpenWalletController(
+        OpenWalletUseCase openWalletUseCase
+    ) {
+        this.openWalletUseCase = openWalletUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<OpenWalletResponse> openWallet(
+        @AuthenticationPrincipal Jwt jwt,
+        @Valid @RequestBody OpenWalletRequest request
+    ) {
+        UUID ownerId = UUID.fromString(
+            jwt.getSubject()
+        );
+
+        OpenWalletResult result =
+            openWalletUseCase.open(
+                new OpenWalletCommand(
+                    ownerId,
+                    request.currency()
+                )
+            );
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(OpenWalletResponse.from(result));
+    }
+}

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.nursena.payflow.wallet.adapter.in.web;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.wallet.domain.exception.WalletAlreadyExistsException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(
+    assignableTypes = OpenWalletController.class
+)
+public class OpenWalletExceptionHandler {
+
+    @ExceptionHandler(WalletAlreadyExistsException.class)
+    ResponseEntity<ApiError> handleWalletAlreadyExists(
+        WalletAlreadyExistsException exception,
+        HttpServletRequest request
+    ) {
+        ApiError body = new ApiError(
+            Instant.now(),
+            HttpStatus.CONFLICT.value(),
+            exception.getCode(),
+            exception.getMessage(),
+            request.getRequestURI(),
+            List.of()
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.CONFLICT)
+            .body(body);
+    }
+}

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletRequest.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletRequest.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.wallet.adapter.in.web;
+
+import com.nursena.payflow.wallet.domain.model.Currency;
+import jakarta.validation.constraints.NotNull;
+
+public record OpenWalletRequest(
+    @NotNull(message = "Currency is required.")
+    Currency currency
+) {
+}

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletResponse.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletResponse.java
@@ -1,0 +1,62 @@
+package com.nursena.payflow.wallet.adapter.in.web;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.wallet.application.port.in.OpenWalletResult;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.WalletStatus;
+
+public record OpenWalletResponse(
+    UUID id,
+    UUID ownerId,
+    BigDecimal balance,
+    Currency currency,
+    WalletStatus status,
+    Instant createdAt
+) {
+
+    public OpenWalletResponse {
+        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(
+            ownerId,
+            "ownerId must not be null"
+        );
+        Objects.requireNonNull(
+            balance,
+            "balance must not be null"
+        );
+        Objects.requireNonNull(
+            currency,
+            "currency must not be null"
+        );
+        Objects.requireNonNull(
+            status,
+            "status must not be null"
+        );
+        Objects.requireNonNull(
+            createdAt,
+            "createdAt must not be null"
+        );
+    }
+
+    public static OpenWalletResponse from(
+        OpenWalletResult result
+    ) {
+        Objects.requireNonNull(
+            result,
+            "result must not be null"
+        );
+
+        return new OpenWalletResponse(
+            result.id(),
+            result.ownerId(),
+            result.balance(),
+            result.currency(),
+            result.status(),
+            result.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapter.java
@@ -2,47 +2,94 @@ package com.nursena.payflow.wallet.adapter.out.persistence;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.util.UUID;
 
 import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
+import com.nursena.payflow.wallet.domain.exception.WalletAlreadyExistsException;
 import com.nursena.payflow.wallet.domain.model.Money;
 import com.nursena.payflow.wallet.domain.model.Wallet;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 @Component
 class WalletPersistenceAdapter implements WalletRepositoryPort {
 
+    private static final String OWNER_UNIQUE_CONSTRAINT =
+        "uq_wallets_owner_id";
+
     private final SpringDataWalletRepository repository;
     private final Clock clock;
 
-    WalletPersistenceAdapter(SpringDataWalletRepository repository, Clock clock) {
+    WalletPersistenceAdapter(
+        SpringDataWalletRepository repository,
+        Clock clock
+    ) {
         this.repository = repository;
         this.clock = clock;
     }
 
     @Override
-    public boolean existsByOwnerId(java.util.UUID ownerId) {
+    public boolean existsByOwnerId(UUID ownerId) {
         return repository.existsByOwnerId(ownerId);
     }
 
     @Override
     public Wallet save(Wallet wallet) {
         Instant now = clock.instant();
+
         WalletJpaEntity entity = new WalletJpaEntity(
-                wallet.id(),
-                wallet.ownerId(),
-                wallet.balance().amount(),
-                wallet.balance().currency(),
-                wallet.status(),
-                wallet.createdAt(),
-                now
+            wallet.id(),
+            wallet.ownerId(),
+            wallet.balance().amount(),
+            wallet.balance().currency(),
+            wallet.status(),
+            wallet.createdAt(),
+            now
         );
-        WalletJpaEntity saved = repository.save(entity);
+
+        try {
+            WalletJpaEntity saved =
+                repository.saveAndFlush(entity);
+
+            return toDomain(saved);
+        } catch (DataIntegrityViolationException exception) {
+            if (isOwnerUniqueConstraintViolation(exception)) {
+                throw new WalletAlreadyExistsException();
+            }
+
+            throw exception;
+        }
+    }
+
+    private static boolean isOwnerUniqueConstraintViolation(
+        Throwable throwable
+    ) {
+        Throwable current = throwable;
+
+        while (current != null) {
+            if (current instanceof ConstraintViolationException violation) {
+                return OWNER_UNIQUE_CONSTRAINT.equals(
+                    violation.getConstraintName()
+                );
+            }
+
+            current = current.getCause();
+        }
+
+        return false;
+    }
+
+    private static Wallet toDomain(WalletJpaEntity entity) {
         return Wallet.rehydrate(
-                saved.getId(),
-                saved.getOwnerId(),
-                new Money(saved.getBalance(), saved.getCurrency()),
-                saved.getStatus(),
-                saved.getCreatedAt()
+            entity.getId(),
+            entity.getOwnerId(),
+            new Money(
+                entity.getBalance(),
+                entity.getCurrency()
+            ),
+            entity.getStatus(),
+            entity.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/nursena/payflow/wallet/application/port/in/OpenWalletResult.java
+++ b/src/main/java/com/nursena/payflow/wallet/application/port/in/OpenWalletResult.java
@@ -1,0 +1,60 @@
+package com.nursena.payflow.wallet.application.port.in;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+import com.nursena.payflow.wallet.domain.model.WalletStatus;
+
+public record OpenWalletResult(
+    UUID id,
+    UUID ownerId,
+    BigDecimal balance,
+    Currency currency,
+    WalletStatus status,
+    Instant createdAt
+) {
+
+    public OpenWalletResult {
+        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(
+            ownerId,
+            "ownerId must not be null"
+        );
+        Objects.requireNonNull(
+            balance,
+            "balance must not be null"
+        );
+        Objects.requireNonNull(
+            currency,
+            "currency must not be null"
+        );
+        Objects.requireNonNull(
+            status,
+            "status must not be null"
+        );
+        Objects.requireNonNull(
+            createdAt,
+            "createdAt must not be null"
+        );
+    }
+
+    public static OpenWalletResult from(Wallet wallet) {
+        Objects.requireNonNull(
+            wallet,
+            "wallet must not be null"
+        );
+
+        return new OpenWalletResult(
+            wallet.id(),
+            wallet.ownerId(),
+            wallet.balance().amount(),
+            wallet.balance().currency(),
+            wallet.status(),
+            wallet.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/wallet/application/port/in/OpenWalletUseCase.java
+++ b/src/main/java/com/nursena/payflow/wallet/application/port/in/OpenWalletUseCase.java
@@ -1,7 +1,6 @@
 package com.nursena.payflow.wallet.application.port.in;
 
-import java.util.UUID;
-
 public interface OpenWalletUseCase {
-    UUID open(OpenWalletCommand command);
+
+    OpenWalletResult open(OpenWalletCommand command);
 }

--- a/src/main/java/com/nursena/payflow/wallet/application/service/OpenWalletService.java
+++ b/src/main/java/com/nursena/payflow/wallet/application/service/OpenWalletService.java
@@ -1,34 +1,49 @@
 package com.nursena.payflow.wallet.application.service;
 
 import java.time.Clock;
-import java.util.UUID;
 
 import com.nursena.payflow.wallet.application.port.in.OpenWalletCommand;
+import com.nursena.payflow.wallet.application.port.in.OpenWalletResult;
 import com.nursena.payflow.wallet.application.port.in.OpenWalletUseCase;
 import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
+import com.nursena.payflow.wallet.domain.exception.WalletAlreadyExistsException;
 import com.nursena.payflow.wallet.domain.model.Wallet;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class OpenWalletService implements OpenWalletUseCase {
+public class OpenWalletService
+    implements OpenWalletUseCase {
 
     private final WalletRepositoryPort walletRepository;
     private final Clock clock;
 
-    public OpenWalletService(WalletRepositoryPort walletRepository, Clock clock) {
+    public OpenWalletService(
+        WalletRepositoryPort walletRepository,
+        Clock clock
+    ) {
         this.walletRepository = walletRepository;
         this.clock = clock;
     }
 
     @Override
     @Transactional
-    public UUID open(OpenWalletCommand command) {
-        if (walletRepository.existsByOwnerId(command.ownerId())) {
-            throw new IllegalStateException("Owner already has a wallet.");
+    public OpenWalletResult open(OpenWalletCommand command) {
+        if (walletRepository.existsByOwnerId(
+            command.ownerId()
+        )) {
+            throw new WalletAlreadyExistsException();
         }
 
-        Wallet wallet = Wallet.open(command.ownerId(), command.currency(), clock.instant());
-        return walletRepository.save(wallet).id();
+        Wallet wallet = Wallet.open(
+            command.ownerId(),
+            command.currency(),
+            clock.instant()
+        );
+
+        Wallet savedWallet =
+            walletRepository.save(wallet);
+
+        return OpenWalletResult.from(savedWallet);
     }
 }

--- a/src/main/java/com/nursena/payflow/wallet/domain/exception/WalletAlreadyExistsException.java
+++ b/src/main/java/com/nursena/payflow/wallet/domain/exception/WalletAlreadyExistsException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.wallet.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class WalletAlreadyExistsException
+    extends BusinessRuleException {
+
+    public WalletAlreadyExistsException() {
+        super(
+            "WALLET_ALREADY_EXISTS",
+            "User already has a wallet."
+        );
+    }
+}

--- a/src/main/resources/db/migration/V3__name_wallet_owner_constraint.sql
+++ b/src/main/resources/db/migration/V3__name_wallet_owner_constraint.sql
@@ -1,0 +1,3 @@
+ALTER TABLE wallets
+    RENAME CONSTRAINT wallets_owner_id_key
+    TO uq_wallets_owner_id;

--- a/src/test/java/com/nursena/payflow/user/adapter/out/persistence/WalletPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/persistence/WalletPersistenceAdapterTest.java
@@ -1,0 +1,4 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+public class WalletPersistenceAdapterTest {
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/persistence/WalletPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/persistence/WalletPersistenceAdapterTest.java
@@ -1,4 +1,0 @@
-package com.nursena.payflow.user.adapter.out.persistence;
-
-public class WalletPersistenceAdapterTest {
-}

--- a/src/test/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletControllerTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletControllerTest.java
@@ -18,6 +18,7 @@ import com.nursena.payflow.wallet.application.port.in.OpenWalletUseCase;
 import com.nursena.payflow.wallet.domain.model.Currency;
 import com.nursena.payflow.wallet.domain.model.WalletStatus;
 import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.wallet.domain.exception.WalletAlreadyExistsException;
 import org.springframework.context.annotation.Import;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,8 +29,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(OpenWalletController.class)
-@Import(SecurityConfiguration.class)
-class OpenWalletControllerTest {
+@Import({
+    SecurityConfiguration.class,
+    OpenWalletExceptionHandler.class
+})class OpenWalletControllerTest {
 
     private static final UUID USER_ID =
         UUID.fromString(
@@ -140,5 +143,58 @@ class OpenWalletControllerTest {
                                         """)
             )
             .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldReturnConflictWhenUserAlreadyHasWallet()
+        throws Exception {
+
+        when(openWalletUseCase.open(
+            any(OpenWalletCommand.class)
+        )).thenThrow(
+            new WalletAlreadyExistsException()
+        );
+
+        mockMvc.perform(
+                post("/api/v1/wallets")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                USER_ID.toString()
+                            )
+                        )
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                                    {
+                                      "currency": "TRY"
+                                    }
+                                    """)
+            )
+            .andExpect(status().isConflict())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(409)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("WALLET_ALREADY_EXISTS")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "User already has a wallet."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value("/api/v1/wallets")
+            )
+            .andExpect(
+                jsonPath("$.violations")
+                    .isEmpty()
+            );
     }
 }

--- a/src/test/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletControllerTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletControllerTest.java
@@ -1,0 +1,144 @@
+package com.nursena.payflow.wallet.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.wallet.application.port.in.OpenWalletCommand;
+import com.nursena.payflow.wallet.application.port.in.OpenWalletResult;
+import com.nursena.payflow.wallet.application.port.in.OpenWalletUseCase;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import org.springframework.context.annotation.Import;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(OpenWalletController.class)
+@Import(SecurityConfiguration.class)
+class OpenWalletControllerTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final UUID WALLET_ID =
+        UUID.fromString(
+            "63263476-9632-4b65-b986-d9044a72c171"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse("2026-07-14T12:00:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OpenWalletUseCase openWalletUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldOpenWalletForAuthenticatedUser()
+        throws Exception {
+
+        OpenWalletResult result =
+            new OpenWalletResult(
+                WALLET_ID,
+                USER_ID,
+                new BigDecimal("0.00"),
+                Currency.TRY,
+                WalletStatus.ACTIVE,
+                CREATED_AT
+            );
+
+        when(openWalletUseCase.open(
+            any(OpenWalletCommand.class)
+        )).thenReturn(result);
+
+        mockMvc.perform(
+                post("/api/v1/wallets")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                USER_ID.toString()
+                            )
+                        )
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                                        {
+                                          "currency": "TRY"
+                                        }
+                                        """)
+            )
+            .andExpect(status().isCreated())
+            .andExpect(
+                jsonPath("$.id")
+                    .value(WALLET_ID.toString())
+            )
+            .andExpect(
+                jsonPath("$.ownerId")
+                    .value(USER_ID.toString())
+            )
+            .andExpect(
+                jsonPath("$.balance")
+                    .value(0.00)
+            )
+            .andExpect(
+                jsonPath("$.currency")
+                    .value("TRY")
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value("ACTIVE")
+            )
+            .andExpect(
+                jsonPath("$.createdAt")
+                    .value(CREATED_AT.toString())
+            );
+
+        verify(openWalletUseCase)
+            .open(
+                new OpenWalletCommand(
+                    USER_ID,
+                    Currency.TRY
+                )
+            );
+    }
+
+    @Test
+    void shouldRejectRequestWithoutAccessToken()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/wallets")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                                        {
+                                          "currency": "TRY"
+                                        }
+                                        """)
+            )
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapterTest.java
@@ -1,0 +1,167 @@
+package com.nursena.payflow.wallet.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import com.nursena.payflow.wallet.domain.exception.WalletAlreadyExistsException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class WalletPersistenceAdapterTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final Instant NOW =
+        Instant.parse("2026-07-14T12:00:00Z");
+
+    @Mock
+    private SpringDataWalletRepository repository;
+
+    private WalletPersistenceAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(
+            NOW,
+            ZoneOffset.UTC
+        );
+
+        adapter = new WalletPersistenceAdapter(
+            repository,
+            clock
+        );
+    }
+
+    @Test
+    void shouldCheckWalletExistenceByOwnerId() {
+        when(repository.existsByOwnerId(OWNER_ID))
+            .thenReturn(true);
+
+        boolean exists =
+            adapter.existsByOwnerId(OWNER_ID);
+
+        assertThat(exists).isTrue();
+
+        verify(repository)
+            .existsByOwnerId(OWNER_ID);
+    }
+
+    @Test
+    void shouldSaveAndRestoreWallet() {
+        Wallet wallet = Wallet.open(
+            OWNER_ID,
+            Currency.TRY,
+            NOW
+        );
+
+        when(repository.saveAndFlush(
+            any(WalletJpaEntity.class)
+        )).thenAnswer(invocation ->
+            invocation.getArgument(0)
+        );
+
+        Wallet savedWallet = adapter.save(wallet);
+
+        assertThat(savedWallet.id())
+            .isEqualTo(wallet.id());
+
+        assertThat(savedWallet.ownerId())
+            .isEqualTo(OWNER_ID);
+
+        assertThat(savedWallet.balance())
+            .isEqualTo(wallet.balance());
+
+        assertThat(savedWallet.status())
+            .isEqualTo(wallet.status());
+
+        assertThat(savedWallet.createdAt())
+            .isEqualTo(NOW);
+
+        verify(repository)
+            .saveAndFlush(
+                any(WalletJpaEntity.class)
+            );
+    }
+
+    @Test
+    void shouldTranslateDuplicateOwnerConstraintViolation() {
+        Wallet wallet = Wallet.open(
+            OWNER_ID,
+            Currency.TRY,
+            NOW
+        );
+
+        ConstraintViolationException violation =
+            new ConstraintViolationException(
+                "duplicate wallet owner",
+                new SQLException(),
+                "uq_wallets_owner_id"
+            );
+
+        when(repository.saveAndFlush(
+            any(WalletJpaEntity.class)
+        )).thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate wallet owner",
+                violation
+            )
+        );
+
+        assertThatThrownBy(() -> adapter.save(wallet))
+            .isInstanceOf(
+                WalletAlreadyExistsException.class
+            )
+            .hasMessage(
+                "User already has a wallet."
+            );
+    }
+
+    @Test
+    void shouldNotTranslateUnrelatedConstraintViolation() {
+        Wallet wallet = Wallet.open(
+            OWNER_ID,
+            Currency.TRY,
+            NOW
+        );
+
+        ConstraintViolationException violation =
+            new ConstraintViolationException(
+                "unrelated constraint",
+                new SQLException(),
+                "some_other_constraint"
+            );
+
+        DataIntegrityViolationException databaseException =
+            new DataIntegrityViolationException(
+                "unrelated constraint",
+                violation
+            );
+
+        when(repository.saveAndFlush(
+            any(WalletJpaEntity.class)
+        )).thenThrow(databaseException);
+
+        assertThatThrownBy(() -> adapter.save(wallet))
+            .isSameAs(databaseException);
+    }
+}

--- a/src/test/java/com/nursena/payflow/wallet/application/service/OpenWalletServiceTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/application/service/OpenWalletServiceTest.java
@@ -1,0 +1,120 @@
+package com.nursena.payflow.wallet.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import com.nursena.payflow.wallet.application.port.in.OpenWalletCommand;
+import com.nursena.payflow.wallet.application.port.in.OpenWalletResult;
+import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
+import com.nursena.payflow.wallet.domain.exception.WalletAlreadyExistsException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OpenWalletServiceTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final Instant NOW =
+        Instant.parse("2026-07-14T12:00:00Z");
+
+    @Mock
+    private WalletRepositoryPort walletRepository;
+
+    private OpenWalletService service;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(
+            NOW,
+            ZoneOffset.UTC
+        );
+
+        service = new OpenWalletService(
+            walletRepository,
+            clock
+        );
+    }
+
+    @Test
+    void shouldOpenWalletWithZeroBalance() {
+        when(walletRepository.existsByOwnerId(OWNER_ID))
+            .thenReturn(false);
+
+        when(walletRepository.save(any(Wallet.class)))
+            .thenAnswer(invocation ->
+                invocation.getArgument(0)
+            );
+
+        OpenWalletResult result = service.open(
+            new OpenWalletCommand(
+                OWNER_ID,
+                Currency.TRY
+            )
+        );
+
+        assertThat(result.id()).isNotNull();
+        assertThat(result.ownerId()).isEqualTo(OWNER_ID);
+        assertThat(result.balance())
+            .isEqualByComparingTo(
+                new BigDecimal("0.00")
+            );
+        assertThat(result.currency())
+            .isEqualTo(Currency.TRY);
+        assertThat(result.status())
+            .isEqualTo(WalletStatus.ACTIVE);
+        assertThat(result.createdAt()).isEqualTo(NOW);
+
+        verify(walletRepository)
+            .existsByOwnerId(OWNER_ID);
+
+        verify(walletRepository)
+            .save(any(Wallet.class));
+    }
+
+    @Test
+    void shouldRejectOwnerWhoAlreadyHasWallet() {
+        when(walletRepository.existsByOwnerId(OWNER_ID))
+            .thenReturn(true);
+
+        assertThatThrownBy(() ->
+            service.open(
+                new OpenWalletCommand(
+                    OWNER_ID,
+                    Currency.TRY
+                )
+            )
+        )
+            .isInstanceOf(
+                WalletAlreadyExistsException.class
+            )
+            .hasMessage(
+                "User already has a wallet."
+            );
+
+        verify(walletRepository)
+            .existsByOwnerId(OWNER_ID);
+
+        verify(walletRepository, never())
+            .save(any(Wallet.class));
+    }
+}

--- a/src/test/java/com/nursena/payflow/wallet/integration/WalletCreationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/integration/WalletCreationIntegrationTest.java
@@ -1,0 +1,176 @@
+package com.nursena.payflow.wallet.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class WalletCreationIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void shouldCreateWalletAndRejectSecondWallet()
+        throws Exception {
+
+        String email = "wallet-"
+            + UUID.randomUUID()
+            + "@example.com";
+
+        String password = "StrongPassword123!";
+
+        registerUser(email, password);
+
+        String accessToken =
+            authenticateUser(email, password);
+
+        openWallet(accessToken)
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").isNotEmpty())
+            .andExpect(jsonPath("$.ownerId").isNotEmpty())
+            .andExpect(jsonPath("$.balance").value(0.00))
+            .andExpect(jsonPath("$.currency").value("TRY"))
+            .andExpect(jsonPath("$.status").value("ACTIVE"))
+            .andExpect(jsonPath("$.createdAt").isNotEmpty());
+
+        openWallet(accessToken)
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.status").value(409))
+            .andExpect(
+                jsonPath("$.code")
+                    .value("WALLET_ALREADY_EXISTS")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "User already has a wallet."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value("/api/v1/wallets")
+            )
+            .andExpect(jsonPath("$.violations").isEmpty());
+    }
+
+    private void registerUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RegistrationRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isCreated());
+    }
+
+    private String authenticateUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        MvcResult result = mockMvc.perform(
+                post("/api/v1/auth/login")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new LoginRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.accessToken")
+                    .isNotEmpty()
+            )
+            .andExpect(
+                jsonPath("$.tokenType")
+                    .value("Bearer")
+            )
+            .andReturn();
+
+        JsonNode responseBody = objectMapper.readTree(
+            result.getResponse().getContentAsString()
+        );
+
+        return responseBody
+            .get("accessToken")
+            .asText();
+    }
+
+    private org.springframework.test.web.servlet.ResultActions
+    openWallet(String accessToken) throws Exception {
+
+        return mockMvc.perform(
+            post("/api/v1/wallets")
+                .header(
+                    HttpHeaders.AUTHORIZATION,
+                    "Bearer " + accessToken
+                )
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content("""
+                                {
+                                  "currency": "TRY"
+                                }
+                                """)
+        );
+    }
+
+    private record RegistrationRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record LoginRequest(
+        String email,
+        String password
+    ) {
+    }
+}


### PR DESCRIPTION
## Summary

- adds wallet creation use case
- creates wallets with zero initial balance
- derives the wallet owner from the authenticated JWT subject
- prevents users from creating wallets for other users
- enforces one wallet per user at application and database levels
- translates duplicate wallet constraint violations safely
- returns `409 Conflict` when a user already owns a wallet
- adds unit, controller, persistence, and end-to-end integration tests

## API

- `POST /api/v1/wallets`

## Test

- `./mvnw clean verify`