### PR TITLE
feat: add authenticated wallet top-up with optimistic locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This keeps domain rules independent from Spring and infrastructure while avoidin
 
 ## Current status
 
-The repository foundation and the initial identity flow are complete:
+The repository foundation, identity flow, and initial wallet-management capabilities are complete:
 
 - repository standards and CI verification
 - Docker-based PostgreSQL, Redis, and Kafka infrastructure
@@ -60,8 +60,13 @@ The repository foundation and the initial identity flow are complete:
 - one-wallet-per-user enforcement at application and database levels
 - stable `409 Conflict` response for duplicate wallet creation
 - unit, web, persistence, and PostgreSQL Testcontainers integration tests
+- authenticated simulated wallet top-up
+- aggregate-based wallet balance mutation
+- PostgreSQL optimistic locking for wallet updates
+- stable `409 Conflict` response for concurrent wallet updates
+- real PostgreSQL concurrency verification with Testcontainers
 
-The current delivery focus is simulated wallet top-up and PostgreSQL concurrency verification, followed by transfers, idempotency, and double-entry ledger records. See the [roadmap](docs/roadmap.md).
+The current delivery focus is wallet-to-wallet transfer processing, idempotency, and double-entry ledger records, building on the completed wallet top-up and PostgreSQL optimistic-locking foundation. See the [roadmap](docs/roadmap.md).
 
 ## Implemented API
 
@@ -72,7 +77,47 @@ The current delivery focus is simulated wallet top-up and PostgreSQL concurrency
 | `GET` | `/api/v1/users/me` | Bearer JWT | Returns the authenticated user's safe profile fields. |
 | `POST` | `/api/v1/wallets` | Bearer JWT | Opens a zero-balance wallet for the authenticated user. |
 | `GET` | `/api/v1/wallets/me` | Bearer JWT | Returns the authenticated user's wallet summary. |
+| `POST` | `/api/v1/wallets/me/top-ups` | Bearer JWT | Credits the authenticated user's wallet with a validated simulated amount. |
 | `GET` | `/api/v1/system/health` | Configuration-dependent | Exposes the application health status. |
+
+### Simulated wallet top-up
+
+```http
+POST /api/v1/wallets/me/top-ups
+Authorization: Bearer <access-token>
+Content-Type: application/json
+```
+
+Request body:
+
+```json
+{
+  "amount": 250.00
+}
+```
+
+Successful response:
+
+```json
+{
+  "id": "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db",
+  "balance": 250.00,
+  "currency": "TRY",
+  "status": "ACTIVE",
+  "createdAt": "2026-07-15T12:00:00Z"
+}
+```
+
+The currency is derived from the existing wallet rather than accepted from the client.
+
+Relevant error outcomes include:
+
+- `400 VALIDATION_FAILED`
+- `401 Unauthorized`
+- `404 WALLET_NOT_FOUND`
+- `409 WALLET_CONCURRENT_UPDATE`
+- `422 INVALID_MONEY_AMOUNT`
+- `422 WALLET_NOT_ACTIVE`
 
 ## Local development
 
@@ -145,9 +190,9 @@ Kafka decouples post-transfer work such as notifications, audit enrichment, and 
 
 Clients send an `Idempotency-Key`. The database stores the key with a uniqueness constraint scoped to the source wallet. Repeated requests return the original result instead of creating another transfer.
 
-### How are concurrent transfers protected?
+### How are concurrent wallet updates protected?
 
-Wallets use optimistic locking. Conflicting updates fail rather than silently overwriting each other. Concurrency behavior will be verified with PostgreSQL Testcontainers tests.
+Wallets use optimistic locking through a persisted version column. Conflicting updates fail rather than silently overwriting each other and are exposed as a stable `WALLET_CONCURRENT_UPDATE` conflict. The behavior is verified with two controlled concurrent transactions against PostgreSQL Testcontainers.
 
 ### What happens when a transfer fails?
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,9 +2,9 @@
 
 ## Current delivery focus
 
-The repository foundation, core identity flow, authenticated current-user profile, secure wallet creation, and authenticated wallet retrieval are complete.
+The repository foundation, core identity flow, authenticated current-user profile, secure wallet creation, authenticated wallet retrieval, simulated top-up, and PostgreSQL optimistic-locking verification are complete.
 
-The next delivery increment is simulated top-up and PostgreSQL optimistic-locking verification, followed by transfers, idempotency, and double-entry ledger records.
+The next delivery increment is wallet-to-wallet transfer processing with idempotency and double-entry ledger records.
 
 ## Milestone 0 — Repository foundation
 
@@ -35,8 +35,8 @@ The next delivery increment is simulated top-up and PostgreSQL optimistic-lockin
 - [x] PostgreSQL persistence and integration tests with Testcontainers
 - [x] Retrieve the authenticated user's wallet summary
 - [x] Return a stable `WALLET_NOT_FOUND` response
-- [ ] Simulated top-up
-- [ ] Verify optimistic locking behavior with PostgreSQL concurrency tests
+- [x] Simulated top-up
+- [x] Verify optimistic locking behavior with PostgreSQL concurrency tests
 
 ## Milestone 3 — Transfers and ledger
 

--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -47,7 +47,8 @@ public class SecurityConfiguration {
                 .authenticated()
                 .requestMatchers(
                     POST,
-                    "/api/v1/wallets"
+                    "/api/v1/wallets",
+                    "/api/v1/wallets/me/top-ups"
                 )
                 .authenticated()
                 .anyRequest()

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletController.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletController.java
@@ -1,0 +1,50 @@
+package com.nursena.payflow.wallet.adapter.in.web;
+
+import java.util.UUID;
+
+import com.nursena.payflow.wallet.application.port.in.TopUpWalletCommand;
+import com.nursena.payflow.wallet.application.port.in.TopUpWalletResult;
+import com.nursena.payflow.wallet.application.port.in.TopUpWalletUseCase;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/wallets/me/top-ups")
+public class TopUpWalletController {
+
+    private final TopUpWalletUseCase topUpWalletUseCase;
+
+    public TopUpWalletController(
+        TopUpWalletUseCase topUpWalletUseCase
+    ) {
+        this.topUpWalletUseCase = topUpWalletUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<TopUpWalletResponse> topUpWallet(
+        @AuthenticationPrincipal Jwt jwt,
+        @Valid @RequestBody TopUpWalletRequest request
+    ) {
+        UUID ownerId = UUID.fromString(
+            jwt.getSubject()
+        );
+
+        TopUpWalletResult result =
+            topUpWalletUseCase.topUp(
+                new TopUpWalletCommand(
+                    ownerId,
+                    request.amount()
+                )
+            );
+
+        return ResponseEntity.ok(
+            TopUpWalletResponse.from(result)
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.nursena.payflow.wallet.adapter.in.web;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(
+    assignableTypes = TopUpWalletController.class
+)
+public class TopUpWalletExceptionHandler {
+
+    @ExceptionHandler(WalletNotFoundException.class)
+    ResponseEntity<ApiError> handleWalletNotFound(
+        WalletNotFoundException exception,
+        HttpServletRequest request
+    ) {
+        ApiError body = new ApiError(
+            Instant.now(),
+            HttpStatus.NOT_FOUND.value(),
+            exception.getCode(),
+            exception.getMessage(),
+            request.getRequestURI(),
+            List.of()
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(body);
+    }
+}

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.nursena.payflow.common.api.ApiError;
 import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.exception.WalletConcurrentUpdateException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -35,6 +36,25 @@ public class TopUpWalletExceptionHandler {
 
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
+            .body(body);
+    }
+
+    @ExceptionHandler(WalletConcurrentUpdateException.class)
+    ResponseEntity<ApiError> handleConcurrentUpdate(
+        WalletConcurrentUpdateException exception,
+        HttpServletRequest request
+    ) {
+        ApiError body = new ApiError(
+            Instant.now(),
+            HttpStatus.CONFLICT.value(),
+            exception.getCode(),
+            exception.getMessage(),
+            request.getRequestURI(),
+            List.of()
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.CONFLICT)
             .body(body);
     }
 }

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletRequest.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletRequest.java
@@ -1,0 +1,24 @@
+package com.nursena.payflow.wallet.adapter.in.web;
+
+import java.math.BigDecimal;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+
+public record TopUpWalletRequest(
+
+    @NotNull(message = "amount must not be null")
+    @DecimalMin(
+        value = "0.01",
+        message = "amount must be greater than zero"
+    )
+    @Digits(
+        integer = 17,
+        fraction = 2,
+        message = "amount must have at most 2 fractional digits"
+    )
+    BigDecimal amount
+
+) {
+}

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletResponse.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletResponse.java
@@ -1,0 +1,59 @@
+package com.nursena.payflow.wallet.adapter.in.web;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.wallet.application.port.in.TopUpWalletResult;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.WalletStatus;
+
+public record TopUpWalletResponse(
+    UUID id,
+    BigDecimal balance,
+    Currency currency,
+    WalletStatus status,
+    Instant createdAt
+) {
+
+    public TopUpWalletResponse {
+        Objects.requireNonNull(
+            id,
+            "id must not be null"
+        );
+        Objects.requireNonNull(
+            balance,
+            "balance must not be null"
+        );
+        Objects.requireNonNull(
+            currency,
+            "currency must not be null"
+        );
+        Objects.requireNonNull(
+            status,
+            "status must not be null"
+        );
+        Objects.requireNonNull(
+            createdAt,
+            "createdAt must not be null"
+        );
+    }
+
+    public static TopUpWalletResponse from(
+        TopUpWalletResult result
+    ) {
+        Objects.requireNonNull(
+            result,
+            "result must not be null"
+        );
+
+        return new TopUpWalletResponse(
+            result.id(),
+            result.balance(),
+            result.currency(),
+            result.status(),
+            result.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletJpaEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
+import java.util.Objects;
 
 @Entity
 @Table(name = "wallets")
@@ -63,6 +64,25 @@ class WalletJpaEntity {
         this.status = status;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+    }
+
+    void updateState(
+        BigDecimal balance,
+        WalletStatus status,
+        Instant updatedAt
+    ) {
+        this.balance = Objects.requireNonNull(
+            balance,
+            "balance must not be null"
+        );
+        this.status = Objects.requireNonNull(
+            status,
+            "status must not be null"
+        );
+        this.updatedAt = Objects.requireNonNull(
+            updatedAt,
+            "updatedAt must not be null"
+        );
     }
 
     UUID getId() {

--- a/src/main/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapter.java
@@ -13,6 +13,9 @@ import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.exception.WalletConcurrentUpdateException;
+import org.springframework.dao.OptimisticLockingFailureException;
+
 
 @Component
 class WalletPersistenceAdapter
@@ -84,7 +87,11 @@ class WalletPersistenceAdapter
             clock.instant()
         );
 
-        repository.flush();
+        try {
+            repository.flush();
+        } catch (OptimisticLockingFailureException exception) {
+            throw new WalletConcurrentUpdateException();
+        }
 
         return toDomain(entity);
     }

--- a/src/main/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapter.java
@@ -12,6 +12,7 @@ import com.nursena.payflow.wallet.domain.model.Wallet;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
 
 @Component
 class WalletPersistenceAdapter
@@ -69,6 +70,23 @@ class WalletPersistenceAdapter
 
             throw exception;
         }
+    }
+
+    @Override
+    public Wallet update(Wallet wallet) {
+        WalletJpaEntity entity = repository
+            .findById(wallet.id())
+            .orElseThrow(WalletNotFoundException::new);
+
+        entity.updateState(
+            wallet.balance().amount(),
+            wallet.status(),
+            clock.instant()
+        );
+
+        repository.flush();
+
+        return toDomain(entity);
     }
 
     private static boolean isOwnerUniqueConstraintViolation(

--- a/src/main/java/com/nursena/payflow/wallet/application/port/in/TopUpWalletCommand.java
+++ b/src/main/java/com/nursena/payflow/wallet/application/port/in/TopUpWalletCommand.java
@@ -1,0 +1,22 @@
+package com.nursena.payflow.wallet.application.port.in;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.UUID;
+
+public record TopUpWalletCommand(
+    UUID ownerId,
+    BigDecimal amount
+) {
+
+    public TopUpWalletCommand {
+        Objects.requireNonNull(
+            ownerId,
+            "ownerId must not be null"
+        );
+        Objects.requireNonNull(
+            amount,
+            "amount must not be null"
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/wallet/application/port/in/TopUpWalletResult.java
+++ b/src/main/java/com/nursena/payflow/wallet/application/port/in/TopUpWalletResult.java
@@ -1,0 +1,59 @@
+package com.nursena.payflow.wallet.application.port.in;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+import com.nursena.payflow.wallet.domain.model.WalletStatus;
+
+public record TopUpWalletResult(
+    UUID id,
+    BigDecimal balance,
+    Currency currency,
+    WalletStatus status,
+    Instant createdAt
+) {
+
+    public TopUpWalletResult {
+        Objects.requireNonNull(
+            id,
+            "id must not be null"
+        );
+        Objects.requireNonNull(
+            balance,
+            "balance must not be null"
+        );
+        Objects.requireNonNull(
+            currency,
+            "currency must not be null"
+        );
+        Objects.requireNonNull(
+            status,
+            "status must not be null"
+        );
+        Objects.requireNonNull(
+            createdAt,
+            "createdAt must not be null"
+        );
+    }
+
+    public static TopUpWalletResult from(
+        Wallet wallet
+    ) {
+        Objects.requireNonNull(
+            wallet,
+            "wallet must not be null"
+        );
+
+        return new TopUpWalletResult(
+            wallet.id(),
+            wallet.balance().amount(),
+            wallet.balance().currency(),
+            wallet.status(),
+            wallet.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/wallet/application/port/in/TopUpWalletUseCase.java
+++ b/src/main/java/com/nursena/payflow/wallet/application/port/in/TopUpWalletUseCase.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.wallet.application.port.in;
+
+public interface TopUpWalletUseCase {
+
+    TopUpWalletResult topUp(
+        TopUpWalletCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/wallet/application/port/out/WalletRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/wallet/application/port/out/WalletRepositoryPort.java
@@ -12,4 +12,6 @@ public interface WalletRepositoryPort {
     Optional<Wallet> findByOwnerId(UUID ownerId);
 
     Wallet save(Wallet wallet);
+
+    Wallet update(Wallet wallet);
 }

--- a/src/main/java/com/nursena/payflow/wallet/application/service/TopUpWalletService.java
+++ b/src/main/java/com/nursena/payflow/wallet/application/service/TopUpWalletService.java
@@ -1,0 +1,55 @@
+package com.nursena.payflow.wallet.application.service;
+
+import java.util.Objects;
+
+import com.nursena.payflow.wallet.application.port.in.TopUpWalletCommand;
+import com.nursena.payflow.wallet.application.port.in.TopUpWalletResult;
+import com.nursena.payflow.wallet.application.port.in.TopUpWalletUseCase;
+import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.model.Money;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TopUpWalletService
+    implements TopUpWalletUseCase {
+
+    private final WalletRepositoryPort walletRepository;
+
+    public TopUpWalletService(
+        WalletRepositoryPort walletRepository
+    ) {
+        this.walletRepository = walletRepository;
+    }
+
+    @Override
+    @Transactional
+    public TopUpWalletResult topUp(
+        TopUpWalletCommand command
+    ) {
+        Objects.requireNonNull(
+            command,
+            "command must not be null"
+        );
+
+        Wallet wallet = walletRepository
+            .findByOwnerId(command.ownerId())
+            .orElseThrow(WalletNotFoundException::new);
+
+        Money amount = new Money(
+            command.amount(),
+            wallet.balance().currency()
+        );
+
+        wallet.credit(amount);
+
+        Wallet updatedWallet =
+            walletRepository.update(wallet);
+
+        return TopUpWalletResult.from(
+            updatedWallet
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/wallet/domain/exception/WalletConcurrentUpdateException.java
+++ b/src/main/java/com/nursena/payflow/wallet/domain/exception/WalletConcurrentUpdateException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.wallet.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class WalletConcurrentUpdateException
+    extends BusinessRuleException {
+
+    public WalletConcurrentUpdateException() {
+        super(
+            "WALLET_CONCURRENT_UPDATE",
+            "Wallet was updated concurrently. Please retry the operation."
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletControllerTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletControllerTest.java
@@ -1,0 +1,262 @@
+package com.nursena.payflow.wallet.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.wallet.application.port.in.TopUpWalletCommand;
+import com.nursena.payflow.wallet.application.port.in.TopUpWalletResult;
+import com.nursena.payflow.wallet.application.port.in.TopUpWalletUseCase;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TopUpWalletController.class)
+@Import({
+    SecurityConfiguration.class,
+    TopUpWalletExceptionHandler.class
+})
+class TopUpWalletControllerTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final UUID WALLET_ID =
+        UUID.fromString(
+            "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse("2026-07-15T12:00:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TopUpWalletUseCase topUpWalletUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldTopUpAuthenticatedUsersWallet()
+        throws Exception {
+
+        when(topUpWalletUseCase.topUp(
+            any(TopUpWalletCommand.class)
+        )).thenReturn(
+            new TopUpWalletResult(
+                WALLET_ID,
+                new BigDecimal("350.00"),
+                Currency.TRY,
+                WalletStatus.ACTIVE,
+                CREATED_AT
+            )
+        );
+
+        mockMvc.perform(
+                post("/api/v1/wallets/me/top-ups")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "amount": 250.00
+                        }
+                        """)
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.id")
+                    .value(WALLET_ID.toString())
+            )
+            .andExpect(
+                jsonPath("$.balance")
+                    .value(350.00)
+            )
+            .andExpect(
+                jsonPath("$.currency")
+                    .value("TRY")
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value("ACTIVE")
+            )
+            .andExpect(
+                jsonPath("$.createdAt")
+                    .value(CREATED_AT.toString())
+            )
+            .andExpect(
+                jsonPath("$.ownerId")
+                    .doesNotExist()
+            );
+
+        verify(topUpWalletUseCase)
+            .topUp(
+                new TopUpWalletCommand(
+                    OWNER_ID,
+                    new BigDecimal("250.00")
+                )
+            );
+    }
+
+    @Test
+    void shouldRejectRequestWithoutAccessToken()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/wallets/me/top-ups")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "amount": 250.00
+                        }
+                        """)
+            )
+            .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(topUpWalletUseCase);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenUserHasNoWallet()
+        throws Exception {
+
+        when(topUpWalletUseCase.topUp(
+            any(TopUpWalletCommand.class)
+        )).thenThrow(
+            new WalletNotFoundException()
+        );
+
+        mockMvc.perform(
+                post("/api/v1/wallets/me/top-ups")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "amount": 25.00
+                        }
+                        """)
+            )
+            .andExpect(status().isNotFound())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(404)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("WALLET_NOT_FOUND")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Wallet could not be found."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/wallets/me/top-ups"
+                    )
+            );
+    }
+
+    @Test
+    void shouldRejectZeroAmount()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/wallets/me/top-ups")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "amount": 0.00
+                        }
+                        """)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            );
+
+        verifyNoInteractions(topUpWalletUseCase);
+    }
+
+    @Test
+    void shouldRejectAmountWithTooManyFractionDigits()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/wallets/me/top-ups")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "amount": 10.999
+                        }
+                        """)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            );
+
+        verifyNoInteractions(topUpWalletUseCase);
+    }
+}

--- a/src/test/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletControllerTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletControllerTest.java
@@ -20,6 +20,7 @@ import com.nursena.payflow.wallet.application.port.in.TopUpWalletUseCase;
 import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
 import com.nursena.payflow.wallet.domain.model.Currency;
 import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import com.nursena.payflow.wallet.domain.exception.WalletConcurrentUpdateException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -259,4 +260,63 @@ class TopUpWalletControllerTest {
 
         verifyNoInteractions(topUpWalletUseCase);
     }
+
+    @Test
+    void shouldReturnConflictWhenWalletIsUpdatedConcurrently()
+        throws Exception {
+
+        when(topUpWalletUseCase.topUp(
+            any(TopUpWalletCommand.class)
+        )).thenThrow(
+            new WalletConcurrentUpdateException()
+        );
+
+        mockMvc.perform(
+                post("/api/v1/wallets/me/top-ups")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                    {
+                      "amount": 25.00
+                    }
+                    """)
+            )
+            .andExpect(status().isConflict())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(409)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "WALLET_CONCURRENT_UPDATE"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Wallet was updated concurrently. "
+                            + "Please retry the operation."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/wallets/me/top-ups"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.violations")
+                    .isEmpty()
+            );
+    }
+
 }

--- a/src/test/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapterTest.java
@@ -27,6 +27,10 @@ import java.math.BigDecimal;
 import java.util.Optional;
 
 import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import static org.mockito.Mockito.doThrow;
+import com.nursena.payflow.wallet.domain.exception.WalletConcurrentUpdateException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
 @ExtendWith(MockitoExtension.class)
 class WalletPersistenceAdapterTest {
 
@@ -269,6 +273,58 @@ class WalletPersistenceAdapterTest {
 
         assertThat(updated.balance().currency())
             .isEqualTo(Currency.TRY);
+
+        verify(repository)
+            .findById(walletId);
+
+        verify(repository)
+            .flush();
+    }
+
+    @Test
+    void shouldTranslateOptimisticLockingFailure() {
+        UUID walletId = UUID.fromString(
+            "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db"
+        );
+
+        WalletJpaEntity entity = new WalletJpaEntity(
+            walletId,
+            OWNER_ID,
+            new BigDecimal("100.00"),
+            Currency.TRY,
+            WalletStatus.ACTIVE,
+            NOW,
+            NOW
+        );
+
+        Wallet wallet = Wallet.rehydrate(
+            walletId,
+            OWNER_ID,
+            Money.of("150.00", Currency.TRY),
+            WalletStatus.ACTIVE,
+            NOW
+        );
+
+        when(repository.findById(walletId))
+            .thenReturn(Optional.of(entity));
+
+        doThrow(
+            new ObjectOptimisticLockingFailureException(
+                WalletJpaEntity.class,
+                walletId
+            )
+        )
+            .when(repository)
+            .flush();
+
+        assertThatThrownBy(() -> adapter.update(wallet))
+            .isInstanceOf(
+                WalletConcurrentUpdateException.class
+            )
+            .hasMessage(
+                "Wallet was updated concurrently. "
+                    + "Please retry the operation."
+            );
 
         verify(repository)
             .findById(walletId);

--- a/src/test/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapterTest.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 
 import com.nursena.payflow.wallet.domain.exception.WalletAlreadyExistsException;
 import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Money;
 import com.nursena.payflow.wallet.domain.model.Wallet;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
@@ -231,4 +232,49 @@ class WalletPersistenceAdapterTest {
         verify(repository)
             .findByOwnerId(OWNER_ID);
     }
+
+    @Test
+    void shouldUpdateManagedWalletEntity() {
+        UUID walletId = UUID.fromString(
+            "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db"
+        );
+
+        WalletJpaEntity entity = new WalletJpaEntity(
+            walletId,
+            OWNER_ID,
+            new BigDecimal("100.00"),
+            Currency.TRY,
+            WalletStatus.ACTIVE,
+            NOW,
+            NOW
+        );
+
+        Wallet wallet = Wallet.rehydrate(
+            walletId,
+            OWNER_ID,
+            Money.of("250.00", Currency.TRY),
+            WalletStatus.ACTIVE,
+            NOW
+        );
+
+        when(repository.findById(walletId))
+            .thenReturn(Optional.of(entity));
+
+        Wallet updated = adapter.update(wallet);
+
+        assertThat(updated.balance().amount())
+            .isEqualByComparingTo(
+                new BigDecimal("250.00")
+            );
+
+        assertThat(updated.balance().currency())
+            .isEqualTo(Currency.TRY);
+
+        verify(repository)
+            .findById(walletId);
+
+        verify(repository)
+            .flush();
+    }
+
 }

--- a/src/test/java/com/nursena/payflow/wallet/application/service/TopUpWalletServiceTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/application/service/TopUpWalletServiceTest.java
@@ -1,0 +1,154 @@
+package com.nursena.payflow.wallet.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.wallet.application.port.in.TopUpWalletCommand;
+import com.nursena.payflow.wallet.application.port.in.TopUpWalletResult;
+import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
+import com.nursena.payflow.wallet.domain.exception.InvalidMoneyAmountException;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Money;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TopUpWalletServiceTest {
+
+    private static final UUID WALLET_ID =
+        UUID.fromString(
+            "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db"
+        );
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse("2026-07-15T12:00:00Z");
+
+    @Mock
+    private WalletRepositoryPort walletRepository;
+
+    private TopUpWalletService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TopUpWalletService(
+            walletRepository
+        );
+    }
+
+    @Test
+    void shouldCreditCurrentWallet() {
+        Wallet wallet = activeWallet();
+
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.of(wallet));
+
+        when(walletRepository.update(any(Wallet.class)))
+            .thenAnswer(invocation ->
+                invocation.getArgument(0)
+            );
+
+        TopUpWalletResult result = service.topUp(
+            new TopUpWalletCommand(
+                OWNER_ID,
+                new BigDecimal("250.00")
+            )
+        );
+
+        assertThat(result.id())
+            .isEqualTo(WALLET_ID);
+
+        assertThat(result.balance())
+            .isEqualByComparingTo(
+                new BigDecimal("350.00")
+            );
+
+        assertThat(result.currency())
+            .isEqualTo(Currency.TRY);
+
+        assertThat(result.status())
+            .isEqualTo(WalletStatus.ACTIVE);
+
+        verify(walletRepository)
+            .findByOwnerId(OWNER_ID);
+
+        verify(walletRepository)
+            .update(wallet);
+    }
+
+    @Test
+    void shouldRejectOwnerWithoutWallet() {
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            service.topUp(
+                new TopUpWalletCommand(
+                    OWNER_ID,
+                    new BigDecimal("25.00")
+                )
+            )
+        )
+            .isInstanceOf(
+                WalletNotFoundException.class
+            );
+
+        verify(walletRepository)
+            .findByOwnerId(OWNER_ID);
+
+        verify(walletRepository, never())
+            .update(any(Wallet.class));
+    }
+
+    @Test
+    void shouldRejectNonPositiveAmount() {
+        Wallet wallet = activeWallet();
+
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.of(wallet));
+
+        assertThatThrownBy(() ->
+            service.topUp(
+                new TopUpWalletCommand(
+                    OWNER_ID,
+                    new BigDecimal("0.00")
+                )
+            )
+        )
+            .isInstanceOf(
+                InvalidMoneyAmountException.class
+            );
+
+        verify(walletRepository, never())
+            .update(any(Wallet.class));
+    }
+
+    private static Wallet activeWallet() {
+        return Wallet.rehydrate(
+            WALLET_ID,
+            OWNER_ID,
+            Money.of("100.00", Currency.TRY),
+            WalletStatus.ACTIVE,
+            CREATED_AT
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/wallet/integration/WalletManagementIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/integration/WalletManagementIntegrationTest.java
@@ -25,9 +25,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.time.Duration;
-
+import java.math.BigDecimal;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -46,7 +45,7 @@ class WalletManagementIntegrationTest {
     private ObjectMapper objectMapper;
 
     @Test
-    void shouldCreateRetrieveAndRejectSecondWallet()
+    void shouldCreateTopUpRetrieveAndRejectSecondWallet()
         throws Exception {
 
         String email = uniqueEmail("wallet");
@@ -74,6 +73,36 @@ class WalletManagementIntegrationTest {
                 .getContentAsString()
         );
 
+        topUpWallet(
+            accessToken,
+            new BigDecimal("250.00")
+        )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.id")
+                    .value(createdWallet.get("id").asText())
+            )
+            .andExpect(
+                jsonPath("$.balance")
+                    .value(250.00)
+            )
+            .andExpect(
+                jsonPath("$.currency")
+                    .value("TRY")
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value("ACTIVE")
+            )
+            .andExpect(
+                jsonPath("$.createdAt")
+                    .isNotEmpty()
+            )
+            .andExpect(
+                jsonPath("$.ownerId")
+                    .doesNotExist()
+            );
+
         MvcResult currentWalletResult =
             getCurrentWallet(accessToken)
                 .andExpect(status().isOk())
@@ -83,7 +112,7 @@ class WalletManagementIntegrationTest {
                 )
                 .andExpect(
                     jsonPath("$.balance")
-                        .value(0.00)
+                        .value(250.00)
                 )
                 .andExpect(
                     jsonPath("$.currency")
@@ -197,6 +226,49 @@ class WalletManagementIntegrationTest {
             );
     }
 
+    @Test
+    void shouldReturnNotFoundWhenTopUpUserHasNoWallet()
+        throws Exception {
+
+        String email = uniqueEmail("top-up-not-found");
+        String password = "StrongPassword123!";
+
+        registerUser(email, password);
+
+        String accessToken =
+            authenticateUser(email, password);
+
+        topUpWallet(
+            accessToken,
+            new BigDecimal("50.00")
+        )
+            .andExpect(status().isNotFound())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(404)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("WALLET_NOT_FOUND")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Wallet could not be found."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/wallets/me/top-ups"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.violations")
+                    .isEmpty()
+            );
+    }
+
     private void registerUser(
         String email,
         String password
@@ -279,6 +351,28 @@ class WalletManagementIntegrationTest {
         );
     }
 
+    private ResultActions topUpWallet(
+        String accessToken,
+        BigDecimal amount
+    ) throws Exception {
+
+        return mockMvc.perform(
+            post("/api/v1/wallets/me/top-ups")
+                .header(
+                    HttpHeaders.AUTHORIZATION,
+                    bearer(accessToken)
+                )
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    objectMapper.writeValueAsString(
+                        new TopUpRequest(amount)
+                    )
+                )
+        );
+    }
+
     private ResultActions getCurrentWallet(
         String accessToken
     ) throws Exception {
@@ -316,6 +410,11 @@ class WalletManagementIntegrationTest {
     private record LoginRequest(
         String email,
         String password
+    ) {
+    }
+
+    private record TopUpRequest(
+        BigDecimal amount
     ) {
     }
 }

--- a/src/test/java/com/nursena/payflow/wallet/integration/WalletOptimisticLockingIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/integration/WalletOptimisticLockingIntegrationTest.java
@@ -1,0 +1,362 @@
+package com.nursena.payflow.wallet.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
+import com.nursena.payflow.wallet.domain.exception.WalletConcurrentUpdateException;
+import com.nursena.payflow.wallet.domain.model.Money;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class WalletOptimisticLockingIntegrationTest {
+
+    private static final BigDecimal TOP_UP_AMOUNT =
+        new BigDecimal("50.00");
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtDecoder jwtDecoder;
+
+    @Autowired
+    private WalletRepositoryPort walletRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void shouldRejectOneOfTwoConcurrentWalletUpdates()
+        throws Exception {
+
+        String email = uniqueEmail();
+        String password = "StrongPassword123!";
+
+        registerUser(email, password);
+
+        String accessToken =
+            authenticateUser(email, password);
+
+        openWallet(accessToken);
+
+        UUID ownerId = UUID.fromString(
+            jwtDecoder
+                .decode(accessToken)
+                .getSubject()
+        );
+
+        CountDownLatch walletsLoaded =
+            new CountDownLatch(2);
+
+        CountDownLatch releaseUpdates =
+            new CountDownLatch(1);
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(2);
+
+        try {
+            Future<Throwable> firstResult =
+                executor.submit(() ->
+                    executeConcurrentTopUp(
+                        ownerId,
+                        walletsLoaded,
+                        releaseUpdates
+                    )
+                );
+
+            Future<Throwable> secondResult =
+                executor.submit(() ->
+                    executeConcurrentTopUp(
+                        ownerId,
+                        walletsLoaded,
+                        releaseUpdates
+                    )
+                );
+
+            boolean bothTransactionsLoadedWallet =
+                walletsLoaded.await(
+                    10,
+                    TimeUnit.SECONDS
+                );
+
+            assertThat(bothTransactionsLoadedWallet)
+                .as(
+                    "Both transactions should load "
+                        + "the same wallet version"
+                )
+                .isTrue();
+
+            releaseUpdates.countDown();
+
+            Throwable firstFailure =
+                firstResult.get(
+                    20,
+                    TimeUnit.SECONDS
+                );
+
+            Throwable secondFailure =
+                secondResult.get(
+                    20,
+                    TimeUnit.SECONDS
+                );
+
+            List<Throwable> failures = Stream
+                .of(
+                    firstFailure,
+                    secondFailure
+                )
+                .filter(Objects::nonNull)
+                .toList();
+
+            assertThat(failures)
+                .hasSize(1);
+
+            assertThat(failures.getFirst())
+                .isInstanceOf(
+                    WalletConcurrentUpdateException.class
+                )
+                .hasMessage(
+                    "Wallet was updated concurrently. "
+                        + "Please retry the operation."
+                );
+
+            BigDecimal storedBalance =
+                jdbcTemplate.queryForObject(
+                    """
+                    SELECT balance
+                    FROM wallets
+                    WHERE owner_id = ?
+                    """,
+                    BigDecimal.class,
+                    ownerId
+                );
+
+            Long storedVersion =
+                jdbcTemplate.queryForObject(
+                    """
+                    SELECT version
+                    FROM wallets
+                    WHERE owner_id = ?
+                    """,
+                    Long.class,
+                    ownerId
+                );
+
+            assertThat(storedBalance)
+                .isEqualByComparingTo(
+                    TOP_UP_AMOUNT
+                );
+
+            assertThat(storedVersion)
+                .isEqualTo(1L);
+        } finally {
+            releaseUpdates.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    private Throwable executeConcurrentTopUp(
+        UUID ownerId,
+        CountDownLatch walletsLoaded,
+        CountDownLatch releaseUpdates
+    ) {
+        try {
+            TransactionTemplate transaction =
+                new TransactionTemplate(
+                    transactionManager
+                );
+
+            transaction.executeWithoutResult(status -> {
+                Wallet wallet = walletRepository
+                    .findByOwnerId(ownerId)
+                    .orElseThrow();
+
+                walletsLoaded.countDown();
+
+                await(releaseUpdates);
+
+                wallet.credit(
+                    new Money(
+                        TOP_UP_AMOUNT,
+                        wallet.balance().currency()
+                    )
+                );
+
+                walletRepository.update(wallet);
+            });
+
+            return null;
+        } catch (Throwable exception) {
+            return exception;
+        }
+    }
+
+    private static void await(
+        CountDownLatch latch
+    ) {
+        try {
+            boolean released = latch.await(
+                10,
+                TimeUnit.SECONDS
+            );
+
+            if (!released) {
+                throw new IllegalStateException(
+                    "Concurrent update barrier timed out."
+                );
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+
+            throw new IllegalStateException(
+                "Concurrent update was interrupted.",
+                exception
+            );
+        }
+    }
+
+    private void registerUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RegistrationRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isCreated());
+    }
+
+    private String authenticateUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        MvcResult result = mockMvc.perform(
+                post("/api/v1/auth/login")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new LoginRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode response = objectMapper.readTree(
+            result
+                .getResponse()
+                .getContentAsString()
+        );
+
+        return response
+            .get("accessToken")
+            .asText();
+    }
+
+    private void openWallet(
+        String accessToken
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/wallets")
+                    .header(
+                        HttpHeaders.AUTHORIZATION,
+                        bearer(accessToken)
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "currency": "TRY"
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated());
+    }
+
+    private static String bearer(
+        String accessToken
+    ) {
+        return "Bearer " + accessToken;
+    }
+
+    private static String uniqueEmail() {
+        return "optimistic-lock-"
+            + UUID.randomUUID()
+            + "@example.com";
+    }
+
+    private record RegistrationRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record LoginRequest(
+        String email,
+        String password
+    ) {
+    }
+}


### PR DESCRIPTION
## Summary

- add an authenticated simulated wallet top-up use case
- derive wallet ownership from the JWT subject
- validate positive monetary amounts and decimal precision
- mutate wallet balance through the domain aggregate
- persist updates through a managed JPA entity
- protect wallet updates with PostgreSQL optimistic locking
- return a stable `WALLET_CONCURRENT_UPDATE` conflict response
- document the top-up API and updated delivery roadmap

## API

`POST /api/v1/wallets/me/top-ups`

```json
{
  "amount": 250.00
}