### PR TITLE
Feat/transaction history

### DIFF
--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -42,13 +42,8 @@ public class SecurityConfiguration {
                 .requestMatchers(
                     GET,
                     "/api/v1/users/me",
-                    "/api/v1/wallets/me"
-                )
-                .authenticated()
-                .requestMatchers(
-                    POST,
-                    "/api/v1/wallets",
-                    "/api/v1/wallets/me/top-ups"
+                    "/api/v1/wallets/me",
+                    "/api/v1/transactions/me"
                 )
                 .authenticated()
                 .requestMatchers(

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryController.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryController.java
@@ -1,0 +1,74 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryQuery;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryUseCase;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/transactions")
+public class GetTransactionHistoryController {
+
+    private final GetTransactionHistoryUseCase
+        getTransactionHistoryUseCase;
+
+    public GetTransactionHistoryController(
+        GetTransactionHistoryUseCase
+            getTransactionHistoryUseCase
+    ) {
+        this.getTransactionHistoryUseCase =
+            getTransactionHistoryUseCase;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<TransactionHistoryResponse>
+    getTransactionHistory(
+        @AuthenticationPrincipal Jwt jwt,
+
+        @RequestParam(defaultValue = "0")
+        @Min(
+            value = 0,
+            message = "page must not be negative"
+        )
+        int page,
+
+        @RequestParam(defaultValue = "20")
+        @Min(
+            value = 1,
+            message = "size must be greater than zero"
+        )
+        @Max(
+            value = GetTransactionHistoryQuery.MAX_SIZE,
+            message = "size must not exceed 100"
+        )
+        int size
+    ) {
+        UUID ownerId = UUID.fromString(
+            jwt.getSubject()
+        );
+
+        TransactionHistoryPage result =
+            getTransactionHistoryUseCase
+                .getTransactionHistory(
+                    new GetTransactionHistoryQuery(
+                        ownerId,
+                        page,
+                        size
+                    )
+                );
+
+        return ResponseEntity.ok(
+            TransactionHistoryResponse.from(result)
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryController.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryController.java
@@ -1,12 +1,17 @@
 package com.nursena.payflow.transaction.adapter.in.web;
 
+import java.time.Instant;
 import java.util.UUID;
 
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
 import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
 import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryQuery;
 import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryUseCase;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -33,16 +38,23 @@ public class GetTransactionHistoryController {
     @GetMapping("/me")
     public ResponseEntity<TransactionHistoryResponse>
     getTransactionHistory(
-        @AuthenticationPrincipal Jwt jwt,
+        @AuthenticationPrincipal
+        Jwt jwt,
 
-        @RequestParam(defaultValue = "0")
+        @RequestParam(
+            name = "page",
+            defaultValue = "0"
+        )
         @Min(
             value = 0,
             message = "page must not be negative"
         )
         int page,
 
-        @RequestParam(defaultValue = "20")
+        @RequestParam(
+            name = "size",
+            defaultValue = "20"
+        )
         @Min(
             value = 1,
             message = "size must be greater than zero"
@@ -51,11 +63,49 @@ public class GetTransactionHistoryController {
             value = GetTransactionHistoryQuery.MAX_SIZE,
             message = "size must not exceed 100"
         )
-        int size
+        int size,
+
+        @RequestParam(
+            name = "direction",
+            required = false
+        )
+        TransactionDirection direction,
+
+        @RequestParam(
+            name = "status",
+            required = false
+        )
+        TransactionStatus status,
+
+        @RequestParam(
+            name = "from",
+            required = false
+        )
+        @DateTimeFormat(
+            iso = DateTimeFormat.ISO.DATE_TIME
+        )
+        Instant from,
+
+        @RequestParam(
+            name = "to",
+            required = false
+        )
+        @DateTimeFormat(
+            iso = DateTimeFormat.ISO.DATE_TIME
+        )
+        Instant to
     ) {
         UUID ownerId = UUID.fromString(
             jwt.getSubject()
         );
+
+        TransactionHistoryFilter filter =
+            new TransactionHistoryFilter(
+                direction,
+                status,
+                from,
+                to
+            );
 
         TransactionHistoryPage result =
             getTransactionHistoryUseCase
@@ -63,7 +113,8 @@ public class GetTransactionHistoryController {
                     new GetTransactionHistoryQuery(
                         ownerId,
                         page,
-                        size
+                        size,
+                        filter
                     )
                 );
 

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryExceptionHandler.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.List;
 
 import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.transaction.application.exception.InvalidTransactionHistoryFilterException;
 import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.Ordered;
@@ -37,9 +38,10 @@ public class TransactionHistoryExceptionHandler {
 
     @ExceptionHandler({
         HandlerMethodValidationException.class,
-        MethodArgumentTypeMismatchException.class
+        MethodArgumentTypeMismatchException.class,
+        InvalidTransactionHistoryFilterException.class
     })
-    ResponseEntity<ApiError> handleInvalidPagination(
+    ResponseEntity<ApiError> handleValidationFailure(
         Exception exception,
         HttpServletRequest request
     ) {

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryExceptionHandler.java
@@ -1,0 +1,73 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(
+    assignableTypes =
+        GetTransactionHistoryController.class
+)
+public class TransactionHistoryExceptionHandler {
+
+    @ExceptionHandler(WalletNotFoundException.class)
+    ResponseEntity<ApiError> handleWalletNotFound(
+        WalletNotFoundException exception,
+        HttpServletRequest request
+    ) {
+        return response(
+            HttpStatus.NOT_FOUND,
+            exception.getCode(),
+            exception.getMessage(),
+            request
+        );
+    }
+
+    @ExceptionHandler({
+        HandlerMethodValidationException.class,
+        MethodArgumentTypeMismatchException.class
+    })
+    ResponseEntity<ApiError> handleInvalidPagination(
+        Exception exception,
+        HttpServletRequest request
+    ) {
+        return response(
+            HttpStatus.BAD_REQUEST,
+            "VALIDATION_FAILED",
+            "Request validation failed.",
+            request
+        );
+    }
+
+    private static ResponseEntity<ApiError> response(
+        HttpStatus status,
+        String code,
+        String message,
+        HttpServletRequest request
+    ) {
+        ApiError body = new ApiError(
+            Instant.now(),
+            status.value(),
+            code,
+            message,
+            request.getRequestURI(),
+            List.of()
+        );
+
+        return ResponseEntity
+            .status(status)
+            .body(body);
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryItemResponse.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryItemResponse.java
@@ -1,0 +1,46 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryItem;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.domain.model.Currency;
+
+public record TransactionHistoryItemResponse(
+    UUID transactionId,
+    TransactionType type,
+    TransactionDirection direction,
+    UUID counterpartyWalletId,
+    BigDecimal amount,
+    Currency currency,
+    TransactionStatus status,
+    Instant createdAt,
+    Instant completedAt
+) {
+
+    static TransactionHistoryItemResponse from(
+        TransactionHistoryItem item
+    ) {
+        Objects.requireNonNull(
+            item,
+            "item must not be null"
+        );
+
+        return new TransactionHistoryItemResponse(
+            item.transactionId(),
+            item.type(),
+            item.direction(),
+            item.counterpartyWalletId(),
+            item.amount(),
+            item.currency(),
+            item.status(),
+            item.createdAt(),
+            item.completedAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryResponse.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryResponse.java
@@ -1,0 +1,48 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+
+public record TransactionHistoryResponse(
+    List<TransactionHistoryItemResponse> items,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean first,
+    boolean last,
+    boolean hasNext,
+    boolean hasPrevious
+) {
+
+    static TransactionHistoryResponse from(
+        TransactionHistoryPage result
+    ) {
+        Objects.requireNonNull(
+            result,
+            "result must not be null"
+        );
+
+        List<TransactionHistoryItemResponse> items =
+            result.items()
+                .stream()
+                .map(
+                    TransactionHistoryItemResponse::from
+                )
+                .toList();
+
+        return new TransactionHistoryResponse(
+            items,
+            result.page(),
+            result.size(),
+            result.totalElements(),
+            result.totalPages(),
+            result.first(),
+            result.last(),
+            result.hasNext(),
+            result.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/SpringDataPaymentTransactionRepository.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/SpringDataPaymentTransactionRepository.java
@@ -3,7 +3,11 @@ package com.nursena.payflow.transaction.adapter.out.persistence;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 interface SpringDataPaymentTransactionRepository
     extends JpaRepository<
@@ -15,5 +19,17 @@ interface SpringDataPaymentTransactionRepository
     findBySourceWalletIdAndIdempotencyKey(
         UUID sourceWalletId,
         String idempotencyKey
+    );
+
+    @Query("""
+        select paymentTransaction
+        from PaymentTransactionJpaEntity paymentTransaction
+        where paymentTransaction.sourceWalletId = :walletId
+           or paymentTransaction.targetWalletId = :walletId
+        """)
+    Page<PaymentTransactionJpaEntity>
+    findHistoryByWalletId(
+        @Param("walletId") UUID walletId,
+        Pageable pageable
     );
 }

--- a/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/SpringDataPaymentTransactionRepository.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/SpringDataPaymentTransactionRepository.java
@@ -1,8 +1,10 @@
 package com.nursena.payflow.transaction.adapter.out.persistence;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,14 +24,60 @@ interface SpringDataPaymentTransactionRepository
     );
 
     @Query("""
-        select paymentTransaction
-        from PaymentTransactionJpaEntity paymentTransaction
-        where paymentTransaction.sourceWalletId = :walletId
-           or paymentTransaction.targetWalletId = :walletId
-        """)
-    Page<PaymentTransactionJpaEntity>
-    findHistoryByWalletId(
-        @Param("walletId") UUID walletId,
+    select paymentTransaction
+    from PaymentTransactionJpaEntity paymentTransaction
+    where (
+        (
+            :includeOutgoing = true
+            and paymentTransaction.sourceWalletId = :walletId
+        )
+        or
+        (
+            :includeIncoming = true
+            and paymentTransaction.targetWalletId = :walletId
+        )
+    )
+    and (
+        :filterByStatus = false
+        or paymentTransaction.status = :status
+    )
+    and (
+        :filterByFrom = false
+        or paymentTransaction.createdAt >= :fromInclusive
+    )
+    and (
+        :filterByTo = false
+        or paymentTransaction.createdAt < :toExclusive
+    )
+    """)
+    Page<PaymentTransactionJpaEntity> findHistory(
+        @Param("walletId")
+        UUID walletId,
+
+        @Param("includeOutgoing")
+        boolean includeOutgoing,
+
+        @Param("includeIncoming")
+        boolean includeIncoming,
+
+        @Param("filterByStatus")
+        boolean filterByStatus,
+
+        @Param("status")
+        TransactionStatus status,
+
+        @Param("filterByFrom")
+        boolean filterByFrom,
+
+        @Param("fromInclusive")
+        Instant fromInclusive,
+
+        @Param("filterByTo")
+        boolean filterByTo,
+
+        @Param("toExclusive")
+        Instant toExclusive,
+
         Pageable pageable
     );
 }

--- a/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/TransactionHistoryPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/TransactionHistoryPersistenceAdapter.java
@@ -1,13 +1,16 @@
 package com.nursena.payflow.transaction.adapter.out.persistence;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
 import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
 import com.nursena.payflow.transaction.application.model.TransactionHistoryItem;
 import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
 import com.nursena.payflow.transaction.application.port.out.TransactionHistoryQueryPort;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -39,11 +42,17 @@ class TransactionHistoryPersistenceAdapter
     public TransactionHistoryPage findByWalletId(
         UUID walletId,
         int page,
-        int size
+        int size,
+        TransactionHistoryFilter filter
     ) {
         Objects.requireNonNull(
             walletId,
             "walletId must not be null"
+        );
+
+        Objects.requireNonNull(
+            filter,
+            "filter must not be null"
         );
 
         PageRequest pageRequest =
@@ -53,10 +62,62 @@ class TransactionHistoryPersistenceAdapter
                 HISTORY_SORT
             );
 
+        UUID sourceWalletId =
+            filter.direction()
+                == TransactionDirection.INCOMING
+                ? null
+                : walletId;
+
+        UUID targetWalletId =
+            filter.direction()
+                == TransactionDirection.OUTGOING
+                ? null
+                : walletId;
+
+        boolean includeOutgoing =
+            filter.direction()
+                != TransactionDirection.INCOMING;
+
+        boolean includeIncoming =
+            filter.direction()
+                != TransactionDirection.OUTGOING;
+
+        boolean filterByStatus =
+            filter.status() != null;
+
+        boolean filterByFrom =
+            filter.from() != null;
+
+        boolean filterByTo =
+            filter.to() != null;
+
+        TransactionStatus statusParameter =
+            filterByStatus
+                ? filter.status()
+                : TransactionStatus.PENDING;
+
+        Instant fromParameter =
+            filterByFrom
+                ? filter.from()
+                : Instant.EPOCH;
+
+        Instant toParameter =
+            filterByTo
+                ? filter.to()
+                : Instant.EPOCH;
+
         Page<PaymentTransactionJpaEntity>
             transactionPage =
-            repository.findHistoryByWalletId(
+            repository.findHistory(
                 walletId,
+                includeOutgoing,
+                includeIncoming,
+                filterByStatus,
+                statusParameter,
+                filterByFrom,
+                fromParameter,
+                filterByTo,
+                toParameter,
                 pageRequest
             );
 

--- a/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/TransactionHistoryPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/TransactionHistoryPersistenceAdapter.java
@@ -1,0 +1,133 @@
+package com.nursena.payflow.transaction.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryItem;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.application.port.out.TransactionHistoryQueryPort;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+@Component
+class TransactionHistoryPersistenceAdapter
+    implements TransactionHistoryQueryPort {
+
+    private static final Sort HISTORY_SORT =
+        Sort.by(
+            Sort.Order.desc("createdAt"),
+            Sort.Order.desc("id")
+        );
+
+    private final SpringDataPaymentTransactionRepository
+        repository;
+
+    TransactionHistoryPersistenceAdapter(
+        SpringDataPaymentTransactionRepository repository
+    ) {
+        this.repository = Objects.requireNonNull(
+            repository,
+            "repository must not be null"
+        );
+    }
+
+    @Override
+    public TransactionHistoryPage findByWalletId(
+        UUID walletId,
+        int page,
+        int size
+    ) {
+        Objects.requireNonNull(
+            walletId,
+            "walletId must not be null"
+        );
+
+        PageRequest pageRequest =
+            PageRequest.of(
+                page,
+                size,
+                HISTORY_SORT
+            );
+
+        Page<PaymentTransactionJpaEntity>
+            transactionPage =
+            repository.findHistoryByWalletId(
+                walletId,
+                pageRequest
+            );
+
+        List<TransactionHistoryItem> items =
+            transactionPage
+                .getContent()
+                .stream()
+                .map(entity ->
+                    toHistoryItem(
+                        walletId,
+                        entity
+                    )
+                )
+                .toList();
+
+        return new TransactionHistoryPage(
+            items,
+            transactionPage.getNumber(),
+            transactionPage.getSize(),
+            transactionPage.getTotalElements(),
+            transactionPage.getTotalPages()
+        );
+    }
+
+    private static TransactionHistoryItem
+    toHistoryItem(
+        UUID walletId,
+        PaymentTransactionJpaEntity entity
+    ) {
+        boolean outgoing = walletId.equals(
+            entity.getSourceWalletId()
+        );
+
+        boolean incoming = walletId.equals(
+            entity.getTargetWalletId()
+        );
+
+        if (outgoing == incoming) {
+            throw new IllegalStateException(
+                "Payment transaction must belong "
+                    + "to exactly one side of the wallet."
+            );
+        }
+
+        TransactionDirection direction =
+            outgoing
+                ? TransactionDirection.OUTGOING
+                : TransactionDirection.INCOMING;
+
+        UUID counterpartyWalletId =
+            outgoing
+                ? entity.getTargetWalletId()
+                : entity.getSourceWalletId();
+
+        if (counterpartyWalletId == null) {
+            throw new IllegalStateException(
+                "Transfer counterparty wallet "
+                    + "must not be null."
+            );
+        }
+
+        return new TransactionHistoryItem(
+            entity.getId(),
+            entity.getTransactionType(),
+            direction,
+            counterpartyWalletId,
+            entity.getAmount(),
+            entity.getCurrency(),
+            entity.getStatus(),
+            entity.getCreatedAt(),
+            entity.getCompletedAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/exception/InvalidTransactionHistoryFilterException.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/exception/InvalidTransactionHistoryFilterException.java
@@ -1,0 +1,12 @@
+package com.nursena.payflow.transaction.application.exception;
+
+public final class
+InvalidTransactionHistoryFilterException
+    extends IllegalArgumentException {
+
+    public InvalidTransactionHistoryFilterException(
+        String message
+    ) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/model/TransactionDirection.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/model/TransactionDirection.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.transaction.application.model;
+
+public enum TransactionDirection {
+    INCOMING,
+    OUTGOING
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryFilter.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryFilter.java
@@ -3,6 +3,7 @@ package com.nursena.payflow.transaction.application.model;
 import java.time.Instant;
 
 import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.application.exception.InvalidTransactionHistoryFilterException;
 
 public record TransactionHistoryFilter(
     TransactionDirection direction,
@@ -17,7 +18,7 @@ public record TransactionHistoryFilter(
                 && to != null
                 && from.isAfter(to)
         ) {
-            throw new IllegalArgumentException(
+            throw new InvalidTransactionHistoryFilterException(
                 "from must not be after to"
             );
         }

--- a/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryFilter.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryFilter.java
@@ -1,0 +1,34 @@
+package com.nursena.payflow.transaction.application.model;
+
+import java.time.Instant;
+
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+
+public record TransactionHistoryFilter(
+    TransactionDirection direction,
+    TransactionStatus status,
+    Instant from,
+    Instant to
+) {
+
+    public TransactionHistoryFilter {
+        if (
+            from != null
+                && to != null
+                && from.isAfter(to)
+        ) {
+            throw new IllegalArgumentException(
+                "from must not be after to"
+            );
+        }
+    }
+
+    public static TransactionHistoryFilter unfiltered() {
+        return new TransactionHistoryFilter(
+            null,
+            null,
+            null,
+            null
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryItem.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryItem.java
@@ -1,0 +1,64 @@
+package com.nursena.payflow.transaction.application.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.domain.model.Currency;
+
+public record TransactionHistoryItem(
+    UUID transactionId,
+    TransactionType type,
+    TransactionDirection direction,
+    UUID counterpartyWalletId,
+    BigDecimal amount,
+    Currency currency,
+    TransactionStatus status,
+    Instant createdAt,
+    Instant completedAt
+) {
+
+    public TransactionHistoryItem {
+        Objects.requireNonNull(
+            transactionId,
+            "transactionId must not be null"
+        );
+        Objects.requireNonNull(
+            type,
+            "type must not be null"
+        );
+        Objects.requireNonNull(
+            direction,
+            "direction must not be null"
+        );
+        Objects.requireNonNull(
+            counterpartyWalletId,
+            "counterpartyWalletId must not be null"
+        );
+        Objects.requireNonNull(
+            amount,
+            "amount must not be null"
+        );
+        Objects.requireNonNull(
+            currency,
+            "currency must not be null"
+        );
+        Objects.requireNonNull(
+            status,
+            "status must not be null"
+        );
+        Objects.requireNonNull(
+            createdAt,
+            "createdAt must not be null"
+        );
+
+        if (amount.signum() <= 0) {
+            throw new IllegalArgumentException(
+                "amount must be greater than zero"
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryPage.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryPage.java
@@ -1,0 +1,63 @@
+package com.nursena.payflow.transaction.application.model;
+
+import java.util.List;
+import java.util.Objects;
+
+public record TransactionHistoryPage(
+    List<TransactionHistoryItem> items,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages
+) {
+
+    public TransactionHistoryPage {
+        items = List.copyOf(
+            Objects.requireNonNull(
+                items,
+                "items must not be null"
+            )
+        );
+
+        if (page < 0) {
+            throw new IllegalArgumentException(
+                "page must not be negative"
+            );
+        }
+
+        if (size < 1) {
+            throw new IllegalArgumentException(
+                "size must be greater than zero"
+            );
+        }
+
+        if (totalElements < 0) {
+            throw new IllegalArgumentException(
+                "totalElements must not be negative"
+            );
+        }
+
+        if (totalPages < 0) {
+            throw new IllegalArgumentException(
+                "totalPages must not be negative"
+            );
+        }
+    }
+
+    public boolean first() {
+        return page == 0;
+    }
+
+    public boolean last() {
+        return totalPages == 0
+            || page >= totalPages - 1;
+    }
+
+    public boolean hasNext() {
+        return !last();
+    }
+
+    public boolean hasPrevious() {
+        return page > 0;
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryQuery.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryQuery.java
@@ -3,20 +3,41 @@ package com.nursena.payflow.transaction.application.port.in;
 import java.util.Objects;
 import java.util.UUID;
 
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
+
 public record GetTransactionHistoryQuery(
     UUID ownerId,
     int page,
-    int size
+    int size,
+    TransactionHistoryFilter filter
 ) {
 
     public static final int DEFAULT_PAGE = 0;
     public static final int DEFAULT_SIZE = 20;
     public static final int MAX_SIZE = 100;
 
+    public GetTransactionHistoryQuery(
+        UUID ownerId,
+        int page,
+        int size
+    ) {
+        this(
+            ownerId,
+            page,
+            size,
+            TransactionHistoryFilter.unfiltered()
+        );
+    }
+
     public GetTransactionHistoryQuery {
         Objects.requireNonNull(
             ownerId,
             "ownerId must not be null"
+        );
+
+        Objects.requireNonNull(
+            filter,
+            "filter must not be null"
         );
 
         if (page < 0) {

--- a/src/main/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryQuery.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryQuery.java
@@ -1,0 +1,35 @@
+package com.nursena.payflow.transaction.application.port.in;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record GetTransactionHistoryQuery(
+    UUID ownerId,
+    int page,
+    int size
+) {
+
+    public static final int DEFAULT_PAGE = 0;
+    public static final int DEFAULT_SIZE = 20;
+    public static final int MAX_SIZE = 100;
+
+    public GetTransactionHistoryQuery {
+        Objects.requireNonNull(
+            ownerId,
+            "ownerId must not be null"
+        );
+
+        if (page < 0) {
+            throw new IllegalArgumentException(
+                "page must not be negative"
+            );
+        }
+
+        if (size < 1 || size > MAX_SIZE) {
+            throw new IllegalArgumentException(
+                "size must be between 1 and "
+                    + MAX_SIZE
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryUseCase.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryUseCase.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.transaction.application.port.in;
+
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+
+public interface GetTransactionHistoryUseCase {
+
+    TransactionHistoryPage getTransactionHistory(
+        GetTransactionHistoryQuery query
+    );
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/port/out/TransactionHistoryQueryPort.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/out/TransactionHistoryQueryPort.java
@@ -2,6 +2,7 @@ package com.nursena.payflow.transaction.application.port.out;
 
 import java.util.UUID;
 
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
 import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
 
 public interface TransactionHistoryQueryPort {
@@ -9,6 +10,7 @@ public interface TransactionHistoryQueryPort {
     TransactionHistoryPage findByWalletId(
         UUID walletId,
         int page,
-        int size
+        int size,
+        TransactionHistoryFilter filter
     );
 }

--- a/src/main/java/com/nursena/payflow/transaction/application/port/out/TransactionHistoryQueryPort.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/out/TransactionHistoryQueryPort.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.transaction.application.port.out;
+
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+
+public interface TransactionHistoryQueryPort {
+
+    TransactionHistoryPage findByWalletId(
+        UUID walletId,
+        int page,
+        int size
+    );
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryService.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryService.java
@@ -1,0 +1,61 @@
+package com.nursena.payflow.transaction.application.service;
+
+import java.util.Objects;
+
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryQuery;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryUseCase;
+import com.nursena.payflow.transaction.application.port.out.TransactionHistoryQueryPort;
+import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+
+public final class GetTransactionHistoryService
+    implements GetTransactionHistoryUseCase {
+
+    private final WalletRepositoryPort walletRepository;
+    private final TransactionHistoryQueryPort
+        transactionHistoryQueryPort;
+
+    public GetTransactionHistoryService(
+        WalletRepositoryPort walletRepository,
+        TransactionHistoryQueryPort
+            transactionHistoryQueryPort
+    ) {
+        this.walletRepository = Objects.requireNonNull(
+            walletRepository,
+            "walletRepository must not be null"
+        );
+
+        this.transactionHistoryQueryPort =
+            Objects.requireNonNull(
+                transactionHistoryQueryPort,
+                "transactionHistoryQueryPort "
+                    + "must not be null"
+            );
+    }
+
+    @Override
+    public TransactionHistoryPage
+    getTransactionHistory(
+        GetTransactionHistoryQuery query
+    ) {
+        Objects.requireNonNull(
+            query,
+            "query must not be null"
+        );
+
+        Wallet wallet = walletRepository
+            .findByOwnerId(query.ownerId())
+            .orElseThrow(
+                WalletNotFoundException::new
+            );
+
+        return transactionHistoryQueryPort
+            .findByWalletId(
+                wallet.id(),
+                query.page(),
+                query.size()
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryService.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryService.java
@@ -9,8 +9,11 @@ import com.nursena.payflow.transaction.application.port.out.TransactionHistoryQu
 import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
 import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
 import com.nursena.payflow.wallet.domain.model.Wallet;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-public final class GetTransactionHistoryService
+@Service
+public class GetTransactionHistoryService
     implements GetTransactionHistoryUseCase {
 
     private final WalletRepositoryPort walletRepository;
@@ -36,6 +39,7 @@ public final class GetTransactionHistoryService
     }
 
     @Override
+    @Transactional(readOnly = true)
     public TransactionHistoryPage
     getTransactionHistory(
         GetTransactionHistoryQuery query

--- a/src/main/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryService.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryService.java
@@ -9,6 +9,7 @@ import com.nursena.payflow.transaction.application.port.out.TransactionHistoryQu
 import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
 import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
 import com.nursena.payflow.wallet.domain.model.Wallet;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,7 +60,8 @@ public class GetTransactionHistoryService
             .findByWalletId(
                 wallet.id(),
                 query.page(),
-                query.size()
+                query.size(),
+                query.filter()
             );
     }
 }

--- a/src/test/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryControllerTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryControllerTest.java
@@ -1,0 +1,440 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryItem;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryQuery;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryUseCase;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(GetTransactionHistoryController.class)
+@Import({
+    SecurityConfiguration.class,
+    TransactionHistoryExceptionHandler.class
+})
+class GetTransactionHistoryControllerTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "b4077781-34f4-466f-8e61-b79ca906bc98"
+        );
+
+    private static final UUID COUNTERPARTY_WALLET_ID =
+        UUID.fromString(
+            "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-16T10:00:00Z"
+        );
+
+    private static final Instant COMPLETED_AT =
+        Instant.parse(
+            "2026-07-16T10:00:01Z"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GetTransactionHistoryUseCase
+        getTransactionHistoryUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldReturnAuthenticatedUsersTransactionHistory()
+        throws Exception {
+
+        GetTransactionHistoryQuery expectedQuery =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                20
+            );
+
+        when(
+            getTransactionHistoryUseCase
+                .getTransactionHistory(expectedQuery)
+        ).thenReturn(historyPage());
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.items.length()")
+                    .value(1)
+            )
+            .andExpect(
+                jsonPath("$.items[0].transactionId")
+                    .value(TRANSACTION_ID.toString())
+            )
+            .andExpect(
+                jsonPath("$.items[0].type")
+                    .value("TRANSFER")
+            )
+            .andExpect(
+                jsonPath("$.items[0].direction")
+                    .value("OUTGOING")
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].counterpartyWalletId"
+                )
+                    .value(
+                        COUNTERPARTY_WALLET_ID.toString()
+                    )
+            )
+            .andExpect(
+                jsonPath("$.items[0].amount")
+                    .value(125.50)
+            )
+            .andExpect(
+                jsonPath("$.items[0].currency")
+                    .value("TRY")
+            )
+            .andExpect(
+                jsonPath("$.items[0].status")
+                    .value("COMPLETED")
+            )
+            .andExpect(
+                jsonPath("$.items[0].createdAt")
+                    .value(CREATED_AT.toString())
+            )
+            .andExpect(
+                jsonPath("$.items[0].completedAt")
+                    .value(COMPLETED_AT.toString())
+            )
+            .andExpect(
+                jsonPath("$.items[0].idempotencyKey")
+                    .doesNotExist()
+            )
+            .andExpect(
+                jsonPath("$.page")
+                    .value(0)
+            )
+            .andExpect(
+                jsonPath("$.size")
+                    .value(20)
+            )
+            .andExpect(
+                jsonPath("$.totalElements")
+                    .value(1)
+            )
+            .andExpect(
+                jsonPath("$.totalPages")
+                    .value(1)
+            )
+            .andExpect(
+                jsonPath("$.first")
+                    .value(true)
+            )
+            .andExpect(
+                jsonPath("$.last")
+                    .value(true)
+            )
+            .andExpect(
+                jsonPath("$.hasNext")
+                    .value(false)
+            )
+            .andExpect(
+                jsonPath("$.hasPrevious")
+                    .value(false)
+            );
+
+        verify(getTransactionHistoryUseCase)
+            .getTransactionHistory(expectedQuery);
+    }
+
+    @Test
+    void shouldApplyRequestedPagination()
+        throws Exception {
+
+        GetTransactionHistoryQuery expectedQuery =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                2,
+                10
+            );
+
+        when(
+            getTransactionHistoryUseCase
+                .getTransactionHistory(expectedQuery)
+        ).thenReturn(
+            new TransactionHistoryPage(
+                List.of(),
+                2,
+                10,
+                21,
+                3
+            )
+        );
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param("page", "2")
+                    .param("size", "10")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.items.length()")
+                    .value(0)
+            )
+            .andExpect(
+                jsonPath("$.page")
+                    .value(2)
+            )
+            .andExpect(
+                jsonPath("$.size")
+                    .value(10)
+            )
+            .andExpect(
+                jsonPath("$.totalElements")
+                    .value(21)
+            )
+            .andExpect(
+                jsonPath("$.totalPages")
+                    .value(3)
+            )
+            .andExpect(
+                jsonPath("$.first")
+                    .value(false)
+            )
+            .andExpect(
+                jsonPath("$.last")
+                    .value(true)
+            )
+            .andExpect(
+                jsonPath("$.hasNext")
+                    .value(false)
+            )
+            .andExpect(
+                jsonPath("$.hasPrevious")
+                    .value(true)
+            );
+
+        verify(getTransactionHistoryUseCase)
+            .getTransactionHistory(expectedQuery);
+    }
+
+    @Test
+    void shouldRejectRequestWithoutAccessToken()
+        throws Exception {
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+            )
+            .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(
+            getTransactionHistoryUseCase
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "-1, 20",
+        "0, 0",
+        "0, 101"
+    })
+    void shouldRejectInvalidPagination(
+        int page,
+        int size
+    ) throws Exception {
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param(
+                        "page",
+                        Integer.toString(page)
+                    )
+                    .param(
+                        "size",
+                        Integer.toString(size)
+                    )
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(400)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Request validation failed."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/transactions/me"
+                    )
+            );
+
+        verifyNoInteractions(
+            getTransactionHistoryUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectNonNumericPagination()
+        throws Exception {
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param("page", "invalid")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            );
+
+        verifyNoInteractions(
+            getTransactionHistoryUseCase
+        );
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenUserHasNoWallet()
+        throws Exception {
+
+        GetTransactionHistoryQuery query =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                20
+            );
+
+        when(
+            getTransactionHistoryUseCase
+                .getTransactionHistory(query)
+        ).thenThrow(
+            new WalletNotFoundException()
+        );
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isNotFound())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(404)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("WALLET_NOT_FOUND")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Wallet could not be found."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/transactions/me"
+                    )
+            );
+
+        verify(getTransactionHistoryUseCase)
+            .getTransactionHistory(query);
+    }
+
+    private static TransactionHistoryPage historyPage() {
+        TransactionHistoryItem item =
+            new TransactionHistoryItem(
+                TRANSACTION_ID,
+                TransactionType.TRANSFER,
+                TransactionDirection.OUTGOING,
+                COUNTERPARTY_WALLET_ID,
+                new BigDecimal("125.50"),
+                Currency.TRY,
+                TransactionStatus.COMPLETED,
+                CREATED_AT,
+                COMPLETED_AT
+            );
+
+        return new TransactionHistoryPage(
+            List.of(item),
+            0,
+            20,
+            1,
+            1
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryControllerTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryControllerTest.java
@@ -23,6 +23,7 @@ import com.nursena.payflow.transaction.domain.model.TransactionStatus;
 import com.nursena.payflow.transaction.domain.model.TransactionType;
 import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
 import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -266,6 +267,155 @@ class GetTransactionHistoryControllerTest {
     }
 
     @Test
+    void shouldApplyRequestedFilters()
+        throws Exception {
+
+        Instant from =
+            Instant.parse(
+                "2026-07-01T00:00:00Z"
+            );
+
+        Instant to =
+            Instant.parse(
+                "2026-08-01T00:00:00Z"
+            );
+
+        TransactionHistoryFilter filter =
+            new TransactionHistoryFilter(
+                TransactionDirection.OUTGOING,
+                TransactionStatus.COMPLETED,
+                from,
+                to
+            );
+
+        GetTransactionHistoryQuery expectedQuery =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                20,
+                filter
+            );
+
+        when(
+            getTransactionHistoryUseCase
+                .getTransactionHistory(expectedQuery)
+        ).thenReturn(
+            new TransactionHistoryPage(
+                List.of(),
+                0,
+                20,
+                0,
+                0
+            )
+        );
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param(
+                        "direction",
+                        "OUTGOING"
+                    )
+                    .param(
+                        "status",
+                        "COMPLETED"
+                    )
+                    .param(
+                        "from",
+                        from.toString()
+                    )
+                    .param(
+                        "to",
+                        to.toString()
+                    )
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.items.length()")
+                    .value(0)
+            )
+            .andExpect(
+                jsonPath("$.page")
+                    .value(0)
+            )
+            .andExpect(
+                jsonPath("$.size")
+                    .value(20)
+            );
+
+        verify(getTransactionHistoryUseCase)
+            .getTransactionHistory(expectedQuery);
+    }
+
+    @Test
+    void shouldAllowEqualDateBoundaries()
+        throws Exception {
+
+        Instant boundary =
+            Instant.parse(
+                "2026-07-01T00:00:00Z"
+            );
+
+        TransactionHistoryFilter filter =
+            new TransactionHistoryFilter(
+                null,
+                null,
+                boundary,
+                boundary
+            );
+
+        GetTransactionHistoryQuery expectedQuery =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                20,
+                filter
+            );
+
+        when(
+            getTransactionHistoryUseCase
+                .getTransactionHistory(expectedQuery)
+        ).thenReturn(
+            new TransactionHistoryPage(
+                List.of(),
+                0,
+                20,
+                0,
+                0
+            )
+        );
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param(
+                        "from",
+                        boundary.toString()
+                    )
+                    .param(
+                        "to",
+                        boundary.toString()
+                    )
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk());
+
+        verify(getTransactionHistoryUseCase)
+            .getTransactionHistory(expectedQuery);
+    }
+
+    @Test
     void shouldRejectRequestWithoutAccessToken()
         throws Exception {
 
@@ -273,6 +423,105 @@ class GetTransactionHistoryControllerTest {
                 get("/api/v1/transactions/me")
             )
             .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(
+            getTransactionHistoryUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectReversedDateRange()
+        throws Exception {
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param(
+                        "from",
+                        "2026-08-01T00:00:00Z"
+                    )
+                    .param(
+                        "to",
+                        "2026-07-01T00:00:00Z"
+                    )
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(400)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Request validation failed."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/transactions/me"
+                    )
+            );
+
+        verifyNoInteractions(
+            getTransactionHistoryUseCase
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "direction, SIDEWAYS",
+        "status, UNKNOWN",
+        "from, not-an-instant",
+        "to, not-an-instant"
+    })
+    void shouldRejectInvalidFilterValues(
+        String parameter,
+        String value
+    ) throws Exception {
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param(parameter, value)
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(400)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Request validation failed."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/transactions/me"
+                    )
+            );
 
         verifyNoInteractions(
             getTransactionHistoryUseCase

--- a/src/test/java/com/nursena/payflow/transaction/adapter/out/persistence/TransactionHistoryPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/adapter/out/persistence/TransactionHistoryPersistenceAdapterTest.java
@@ -17,12 +17,14 @@ import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
 import com.nursena.payflow.transaction.domain.model.TransactionStatus;
 import com.nursena.payflow.transaction.domain.model.TransactionType;
 import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.ArgumentMatchers.isNull;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -88,8 +90,16 @@ class TransactionHistoryPersistenceAdapterTest {
             PageRequest.of(1, 2);
 
         when(
-            repository.findHistoryByWalletId(
+            repository.findHistory(
                 eq(WALLET_ID),
+                eq(true),
+                eq(true),
+                eq(false),
+                eq(TransactionStatus.PENDING),
+                eq(false),
+                eq(Instant.EPOCH),
+                eq(false),
+                eq(Instant.EPOCH),
                 any(Pageable.class)
             )
         ).thenReturn(
@@ -104,7 +114,8 @@ class TransactionHistoryPersistenceAdapterTest {
             adapter.findByWalletId(
                 WALLET_ID,
                 1,
-                2
+                2,
+                TransactionHistoryFilter.unfiltered()
             );
 
         assertThat(result.page())
@@ -150,8 +161,16 @@ class TransactionHistoryPersistenceAdapterTest {
             ArgumentCaptor.forClass(Pageable.class);
 
         verify(repository)
-            .findHistoryByWalletId(
+            .findHistory(
                 eq(WALLET_ID),
+                eq(true),
+                eq(true),
+                eq(false),
+                eq(TransactionStatus.PENDING),
+                eq(false),
+                eq(Instant.EPOCH),
+                eq(false),
+                eq(Instant.EPOCH),
                 pageableCaptor.capture()
             );
 
@@ -195,8 +214,16 @@ class TransactionHistoryPersistenceAdapterTest {
             );
 
         when(
-            repository.findHistoryByWalletId(
+            repository.findHistory(
                 eq(WALLET_ID),
+                eq(true),
+                eq(true),
+                eq(false),
+                eq(TransactionStatus.PENDING),
+                eq(false),
+                eq(Instant.EPOCH),
+                eq(false),
+                eq(Instant.EPOCH),
                 any(Pageable.class)
             )
         ).thenReturn(
@@ -207,7 +234,8 @@ class TransactionHistoryPersistenceAdapterTest {
             adapter.findByWalletId(
                 WALLET_ID,
                 0,
-                20
+                20,
+                TransactionHistoryFilter.unfiltered()
             )
         )
             .isInstanceOf(

--- a/src/test/java/com/nursena/payflow/transaction/adapter/out/persistence/TransactionHistoryPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/adapter/out/persistence/TransactionHistoryPersistenceAdapterTest.java
@@ -1,0 +1,258 @@
+package com.nursena.payflow.transaction.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionHistoryPersistenceAdapterTest {
+
+    private static final UUID WALLET_ID =
+        UUID.fromString(
+            "11111111-1111-1111-1111-111111111111"
+        );
+
+    private static final UUID COUNTERPARTY_WALLET_ID =
+        UUID.fromString(
+            "22222222-2222-2222-2222-222222222222"
+        );
+
+    private static final UUID OUTGOING_TRANSACTION_ID =
+        UUID.fromString(
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        );
+
+    private static final UUID INCOMING_TRANSACTION_ID =
+        UUID.fromString(
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse("2026-07-16T10:00:00Z");
+
+    @Mock
+    private SpringDataPaymentTransactionRepository
+        repository;
+
+    private TransactionHistoryPersistenceAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter =
+            new TransactionHistoryPersistenceAdapter(
+                repository
+            );
+    }
+
+    @Test
+    void shouldMapOutgoingAndIncomingTransactions() {
+        PaymentTransactionJpaEntity outgoing =
+            transactionEntity(
+                OUTGOING_TRANSACTION_ID,
+                WALLET_ID,
+                COUNTERPARTY_WALLET_ID
+            );
+
+        PaymentTransactionJpaEntity incoming =
+            transactionEntity(
+                INCOMING_TRANSACTION_ID,
+                COUNTERPARTY_WALLET_ID,
+                WALLET_ID
+            );
+
+        PageRequest repositoryPageRequest =
+            PageRequest.of(1, 2);
+
+        when(
+            repository.findHistoryByWalletId(
+                eq(WALLET_ID),
+                any(Pageable.class)
+            )
+        ).thenReturn(
+            new PageImpl<>(
+                List.of(outgoing, incoming),
+                repositoryPageRequest,
+                4
+            )
+        );
+
+        TransactionHistoryPage result =
+            adapter.findByWalletId(
+                WALLET_ID,
+                1,
+                2
+            );
+
+        assertThat(result.page())
+            .isEqualTo(1);
+
+        assertThat(result.size())
+            .isEqualTo(2);
+
+        assertThat(result.totalElements())
+            .isEqualTo(4);
+
+        assertThat(result.totalPages())
+            .isEqualTo(2);
+
+        assertThat(result.items())
+            .hasSize(2);
+
+        assertThat(result.items().get(0).transactionId())
+            .isEqualTo(OUTGOING_TRANSACTION_ID);
+
+        assertThat(result.items().get(0).direction())
+            .isEqualTo(TransactionDirection.OUTGOING);
+
+        assertThat(
+            result.items()
+                .get(0)
+                .counterpartyWalletId()
+        ).isEqualTo(COUNTERPARTY_WALLET_ID);
+
+        assertThat(result.items().get(1).transactionId())
+            .isEqualTo(INCOMING_TRANSACTION_ID);
+
+        assertThat(result.items().get(1).direction())
+            .isEqualTo(TransactionDirection.INCOMING);
+
+        assertThat(
+            result.items()
+                .get(1)
+                .counterpartyWalletId()
+        ).isEqualTo(COUNTERPARTY_WALLET_ID);
+
+        ArgumentCaptor<Pageable> pageableCaptor =
+            ArgumentCaptor.forClass(Pageable.class);
+
+        verify(repository)
+            .findHistoryByWalletId(
+                eq(WALLET_ID),
+                pageableCaptor.capture()
+            );
+
+        Pageable capturedPageable =
+            pageableCaptor.getValue();
+
+        assertThat(capturedPageable.getPageNumber())
+            .isEqualTo(1);
+
+        assertThat(capturedPageable.getPageSize())
+            .isEqualTo(2);
+
+        assertDescendingSort(
+            capturedPageable,
+            "createdAt"
+        );
+
+        assertDescendingSort(
+            capturedPageable,
+            "id"
+        );
+    }
+
+    @Test
+    void shouldRejectTransactionOutsideRequestedWallet() {
+        UUID unrelatedSourceWalletId =
+            UUID.fromString(
+                "33333333-3333-3333-3333-333333333333"
+            );
+
+        UUID unrelatedTargetWalletId =
+            UUID.fromString(
+                "44444444-4444-4444-4444-444444444444"
+            );
+
+        PaymentTransactionJpaEntity unrelated =
+            transactionEntity(
+                OUTGOING_TRANSACTION_ID,
+                unrelatedSourceWalletId,
+                unrelatedTargetWalletId
+            );
+
+        when(
+            repository.findHistoryByWalletId(
+                eq(WALLET_ID),
+                any(Pageable.class)
+            )
+        ).thenReturn(
+            new PageImpl<>(List.of(unrelated))
+        );
+
+        assertThatThrownBy(() ->
+            adapter.findByWalletId(
+                WALLET_ID,
+                0,
+                20
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "Payment transaction must belong "
+                    + "to exactly one side of the wallet."
+            );
+    }
+
+    private static void assertDescendingSort(
+        Pageable pageable,
+        String property
+    ) {
+        Sort.Order order =
+            pageable
+                .getSort()
+                .getOrderFor(property);
+
+        assertThat(order)
+            .isNotNull();
+
+        assertThat(order.getDirection())
+            .isEqualTo(Sort.Direction.DESC);
+    }
+
+    private static PaymentTransactionJpaEntity
+    transactionEntity(
+        UUID transactionId,
+        UUID sourceWalletId,
+        UUID targetWalletId
+    ) {
+        return new PaymentTransactionJpaEntity(
+            transactionId,
+            sourceWalletId,
+            targetWalletId,
+            TransactionType.TRANSFER,
+            TransactionStatus.COMPLETED,
+            new BigDecimal("125.50"),
+            Currency.TRY,
+            transactionId.toString(),
+            null,
+            CREATED_AT,
+            CREATED_AT.plusSeconds(1)
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/application/model/TransactionHistoryFilterTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/application/model/TransactionHistoryFilterTest.java
@@ -1,0 +1,88 @@
+package com.nursena.payflow.transaction.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class TransactionHistoryFilterTest {
+
+    private static final Instant FROM =
+        Instant.parse(
+            "2026-07-01T00:00:00Z"
+        );
+
+    private static final Instant TO =
+        Instant.parse(
+            "2026-08-01T00:00:00Z"
+        );
+
+    @Test
+    void shouldCreateUnfilteredFilter() {
+        TransactionHistoryFilter filter =
+            TransactionHistoryFilter.unfiltered();
+
+        assertThat(filter.direction())
+            .isNull();
+
+        assertThat(filter.status())
+            .isNull();
+
+        assertThat(filter.from())
+            .isNull();
+
+        assertThat(filter.to())
+            .isNull();
+    }
+
+    @Test
+    void shouldAcceptValidDateRange() {
+        TransactionHistoryFilter filter =
+            new TransactionHistoryFilter(
+                TransactionDirection.INCOMING,
+                null,
+                FROM,
+                TO
+            );
+
+        assertThat(filter.from())
+            .isEqualTo(FROM);
+
+        assertThat(filter.to())
+            .isEqualTo(TO);
+    }
+
+    @Test
+    void shouldAllowEqualDateBoundaries() {
+        TransactionHistoryFilter filter =
+            new TransactionHistoryFilter(
+                null,
+                null,
+                FROM,
+                FROM
+            );
+
+        assertThat(filter.from())
+            .isEqualTo(filter.to());
+    }
+
+    @Test
+    void shouldRejectReversedDateRange() {
+        assertThatThrownBy(() ->
+            new TransactionHistoryFilter(
+                null,
+                null,
+                TO,
+                FROM
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "from must not be after to"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/application/model/TransactionHistoryFilterTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/application/model/TransactionHistoryFilterTest.java
@@ -3,6 +3,8 @@ package com.nursena.payflow.transaction.application.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.nursena.payflow.transaction.application.exception.InvalidTransactionHistoryFilterException;
+
 import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
@@ -79,7 +81,7 @@ class TransactionHistoryFilterTest {
             )
         )
             .isInstanceOf(
-                IllegalArgumentException.class
+                InvalidTransactionHistoryFilterException.class
             )
             .hasMessage(
                 "from must not be after to"

--- a/src/test/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryQueryTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryQueryTest.java
@@ -1,0 +1,86 @@
+package com.nursena.payflow.transaction.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class GetTransactionHistoryQueryTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    @Test
+    void shouldCreateValidQuery() {
+        GetTransactionHistoryQuery query =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                20
+            );
+
+        assertThat(query.ownerId())
+            .isEqualTo(OWNER_ID);
+
+        assertThat(query.page())
+            .isZero();
+
+        assertThat(query.size())
+            .isEqualTo(20);
+    }
+
+    @Test
+    void shouldRejectNegativePage() {
+        assertThatThrownBy(() ->
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                -1,
+                20
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "page must not be negative"
+            );
+    }
+
+    @Test
+    void shouldRejectZeroSize() {
+        assertThatThrownBy(() ->
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                0
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "size must be between 1 and 100"
+            );
+    }
+
+    @Test
+    void shouldRejectSizeAboveMaximum() {
+        assertThatThrownBy(() ->
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                101
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "size must be between 1 and 100"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryServiceTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryServiceTest.java
@@ -24,6 +24,7 @@ import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
 import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
 import com.nursena.payflow.wallet.domain.model.Currency;
 import com.nursena.payflow.wallet.domain.model.Wallet;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -88,12 +89,16 @@ class GetTransactionHistoryServiceTest {
         TransactionHistoryPage expectedPage =
             historyPage();
 
+        TransactionHistoryFilter filter =
+            TransactionHistoryFilter.unfiltered();
+
         when(
             transactionHistoryQueryPort
                 .findByWalletId(
                     WALLET_ID,
                     0,
-                    20
+                    20,
+                    filter
                 )
         ).thenReturn(expectedPage);
 
@@ -102,7 +107,8 @@ class GetTransactionHistoryServiceTest {
                 new GetTransactionHistoryQuery(
                     OWNER_ID,
                     0,
-                    20
+                    20,
+                    filter
                 )
             );
 
@@ -116,7 +122,8 @@ class GetTransactionHistoryServiceTest {
             .findByWalletId(
                 WALLET_ID,
                 0,
-                20
+                20,
+                filter
             );
     }
 

--- a/src/test/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryServiceTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryServiceTest.java
@@ -1,0 +1,175 @@
+package com.nursena.payflow.transaction.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryItem;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryQuery;
+import com.nursena.payflow.transaction.application.port.out.TransactionHistoryQueryPort;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GetTransactionHistoryServiceTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final UUID WALLET_ID =
+        UUID.fromString(
+            "11111111-1111-1111-1111-111111111111"
+        );
+
+    private static final UUID COUNTERPARTY_WALLET_ID =
+        UUID.fromString(
+            "22222222-2222-2222-2222-222222222222"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "b4077781-34f4-466f-8e61-b79ca906bc98"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-16T10:00:00Z"
+        );
+
+    private WalletRepositoryPort walletRepository;
+
+    private TransactionHistoryQueryPort
+        transactionHistoryQueryPort;
+
+    private GetTransactionHistoryService service;
+
+    @BeforeEach
+    void setUp() {
+        walletRepository =
+            mock(WalletRepositoryPort.class);
+
+        transactionHistoryQueryPort =
+            mock(TransactionHistoryQueryPort.class);
+
+        service = new GetTransactionHistoryService(
+            walletRepository,
+            transactionHistoryQueryPort
+        );
+    }
+
+    @Test
+    void shouldReturnAuthenticatedUsersTransactionHistory() {
+        Wallet wallet = mock(Wallet.class);
+
+        when(wallet.id())
+            .thenReturn(WALLET_ID);
+
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.of(wallet));
+
+        TransactionHistoryPage expectedPage =
+            historyPage();
+
+        when(
+            transactionHistoryQueryPort
+                .findByWalletId(
+                    WALLET_ID,
+                    0,
+                    20
+                )
+        ).thenReturn(expectedPage);
+
+        TransactionHistoryPage result =
+            service.getTransactionHistory(
+                new GetTransactionHistoryQuery(
+                    OWNER_ID,
+                    0,
+                    20
+                )
+            );
+
+        assertThat(result)
+            .isSameAs(expectedPage);
+
+        verify(walletRepository)
+            .findByOwnerId(OWNER_ID);
+
+        verify(transactionHistoryQueryPort)
+            .findByWalletId(
+                WALLET_ID,
+                0,
+                20
+            );
+    }
+
+    @Test
+    void shouldFailWhenAuthenticatedUserHasNoWallet() {
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.empty());
+
+        GetTransactionHistoryQuery query =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                20
+            );
+
+        assertThatThrownBy(() ->
+            service.getTransactionHistory(query)
+        )
+            .isInstanceOf(
+                WalletNotFoundException.class
+            )
+            .hasMessage(
+                "Wallet could not be found."
+            );
+
+        verify(walletRepository)
+            .findByOwnerId(OWNER_ID);
+
+        verifyNoInteractions(
+            transactionHistoryQueryPort
+        );
+    }
+
+    private static TransactionHistoryPage historyPage() {
+        TransactionHistoryItem item =
+            new TransactionHistoryItem(
+                TRANSACTION_ID,
+                TransactionType.TRANSFER,
+                TransactionDirection.OUTGOING,
+                COUNTERPARTY_WALLET_ID,
+                new BigDecimal("125.50"),
+                Currency.TRY,
+                TransactionStatus.COMPLETED,
+                CREATED_AT,
+                CREATED_AT
+            );
+
+        return new TransactionHistoryPage(
+            List.of(item),
+            0,
+            20,
+            1,
+            1
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/integration/TransactionHistoryPersistenceIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/integration/TransactionHistoryPersistenceIntegrationTest.java
@@ -280,6 +280,73 @@ class TransactionHistoryPersistenceIntegrationTest {
         ).isEqualTo(
             COUNTERPARTY_WALLET_B_ID
         );
+        TransactionHistoryPage outgoingPage =
+            transactionHistoryQueryPort
+                .findByWalletId(
+                    WALLET_ID,
+                    0,
+                    20,
+                    new TransactionHistoryFilter(
+                        TransactionDirection.OUTGOING,
+                        null,
+                        null,
+                        null
+                    )
+                );
+
+        assertThat(outgoingPage.items())
+            .extracting(item ->
+                item.transactionId()
+            )
+            .containsExactly(
+                SAME_TIME_HIGH_ID
+            );
+
+        TransactionHistoryPage incomingPage =
+            transactionHistoryQueryPort
+                .findByWalletId(
+                    WALLET_ID,
+                    0,
+                    20,
+                    new TransactionHistoryFilter(
+                        TransactionDirection.INCOMING,
+                        null,
+                        null,
+                        null
+                    )
+                );
+
+        assertThat(incomingPage.items())
+            .extracting(item ->
+                item.transactionId()
+            )
+            .containsExactly(
+                NEWEST_TRANSACTION_ID,
+                SAME_TIME_LOW_ID
+            );
+
+        TransactionHistoryPage dateFilteredPage =
+            transactionHistoryQueryPort
+                .findByWalletId(
+                    WALLET_ID,
+                    0,
+                    20,
+                    new TransactionHistoryFilter(
+                        null,
+                        null,
+                        BASE_TIME,
+                        BASE_TIME.plusSeconds(60)
+                    )
+                );
+
+        assertThat(dateFilteredPage.items())
+            .extracting(item ->
+                item.transactionId()
+            )
+            .containsExactly(
+                SAME_TIME_HIGH_ID,
+                SAME_TIME_LOW_ID
+            );
     }
 
     private void insertUser(

--- a/src/test/java/com/nursena/payflow/transaction/integration/TransactionHistoryPersistenceIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/integration/TransactionHistoryPersistenceIntegrationTest.java
@@ -1,0 +1,377 @@
+package com.nursena.payflow.transaction.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.application.port.out.TransactionHistoryQueryPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class TransactionHistoryPersistenceIntegrationTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "10000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID COUNTERPARTY_OWNER_A_ID =
+        UUID.fromString(
+            "10000000-0000-0000-0000-000000000002"
+        );
+
+    private static final UUID COUNTERPARTY_OWNER_B_ID =
+        UUID.fromString(
+            "10000000-0000-0000-0000-000000000003"
+        );
+
+    private static final UUID WALLET_ID =
+        UUID.fromString(
+            "20000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID COUNTERPARTY_WALLET_A_ID =
+        UUID.fromString(
+            "20000000-0000-0000-0000-000000000002"
+        );
+
+    private static final UUID COUNTERPARTY_WALLET_B_ID =
+        UUID.fromString(
+            "20000000-0000-0000-0000-000000000003"
+        );
+
+    private static final UUID NEWEST_TRANSACTION_ID =
+        UUID.fromString(
+            "30000000-0000-0000-0000-000000000003"
+        );
+
+    private static final UUID SAME_TIME_HIGH_ID =
+        UUID.fromString(
+            "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        );
+
+    private static final UUID SAME_TIME_LOW_ID =
+        UUID.fromString(
+            "00000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID UNRELATED_TRANSACTION_ID =
+        UUID.fromString(
+            "40000000-0000-0000-0000-000000000001"
+        );
+
+    private static final Instant BASE_TIME =
+        Instant.parse(
+            "2026-07-16T10:00:00Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private TransactionHistoryQueryPort
+        transactionHistoryQueryPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM ledger_entries"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM payment_transactions"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM wallets"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldReturnIsolatedDeterministicallyOrderedHistory() {
+        insertUser(
+            OWNER_ID,
+            "history-owner@example.com"
+        );
+
+        insertUser(
+            COUNTERPARTY_OWNER_A_ID,
+            "history-counterparty-a@example.com"
+        );
+
+        insertUser(
+            COUNTERPARTY_OWNER_B_ID,
+            "history-counterparty-b@example.com"
+        );
+
+        insertWallet(
+            WALLET_ID,
+            OWNER_ID
+        );
+
+        insertWallet(
+            COUNTERPARTY_WALLET_A_ID,
+            COUNTERPARTY_OWNER_A_ID
+        );
+
+        insertWallet(
+            COUNTERPARTY_WALLET_B_ID,
+            COUNTERPARTY_OWNER_B_ID
+        );
+
+        insertTransaction(
+            NEWEST_TRANSACTION_ID,
+            COUNTERPARTY_WALLET_A_ID,
+            WALLET_ID,
+            "history-newest",
+            BASE_TIME.plusSeconds(60)
+        );
+
+        insertTransaction(
+            SAME_TIME_HIGH_ID,
+            WALLET_ID,
+            COUNTERPARTY_WALLET_B_ID,
+            "history-same-high",
+            BASE_TIME
+        );
+
+        insertTransaction(
+            SAME_TIME_LOW_ID,
+            COUNTERPARTY_WALLET_B_ID,
+            WALLET_ID,
+            "history-same-low",
+            BASE_TIME
+        );
+
+        insertTransaction(
+            UNRELATED_TRANSACTION_ID,
+            COUNTERPARTY_WALLET_A_ID,
+            COUNTERPARTY_WALLET_B_ID,
+            "history-unrelated",
+            BASE_TIME.plusSeconds(120)
+        );
+
+        TransactionHistoryPage firstPage =
+            transactionHistoryQueryPort
+                .findByWalletId(
+                    WALLET_ID,
+                    0,
+                    2
+                );
+
+        assertThat(firstPage.totalElements())
+            .isEqualTo(3);
+
+        assertThat(firstPage.totalPages())
+            .isEqualTo(2);
+
+        assertThat(firstPage.page())
+            .isZero();
+
+        assertThat(firstPage.size())
+            .isEqualTo(2);
+
+        assertThat(firstPage.first())
+            .isTrue();
+
+        assertThat(firstPage.last())
+            .isFalse();
+
+        assertThat(firstPage.items())
+            .extracting(item ->
+                item.transactionId()
+            )
+            .containsExactly(
+                NEWEST_TRANSACTION_ID,
+                SAME_TIME_HIGH_ID
+            );
+
+        assertThat(
+            firstPage.items()
+                .get(0)
+                .direction()
+        ).isEqualTo(
+            TransactionDirection.INCOMING
+        );
+
+        assertThat(
+            firstPage.items()
+                .get(0)
+                .counterpartyWalletId()
+        ).isEqualTo(
+            COUNTERPARTY_WALLET_A_ID
+        );
+
+        assertThat(
+            firstPage.items()
+                .get(1)
+                .direction()
+        ).isEqualTo(
+            TransactionDirection.OUTGOING
+        );
+
+        assertThat(
+            firstPage.items()
+                .get(1)
+                .counterpartyWalletId()
+        ).isEqualTo(
+            COUNTERPARTY_WALLET_B_ID
+        );
+
+        TransactionHistoryPage secondPage =
+            transactionHistoryQueryPort
+                .findByWalletId(
+                    WALLET_ID,
+                    1,
+                    2
+                );
+
+        assertThat(secondPage.items())
+            .extracting(item ->
+                item.transactionId()
+            )
+            .containsExactly(
+                SAME_TIME_LOW_ID
+            );
+
+        assertThat(secondPage.last())
+            .isTrue();
+
+        assertThat(
+            secondPage.items()
+                .getFirst()
+                .direction()
+        ).isEqualTo(
+            TransactionDirection.INCOMING
+        );
+
+        assertThat(
+            secondPage.items()
+                .getFirst()
+                .counterpartyWalletId()
+        ).isEqualTo(
+            COUNTERPARTY_WALLET_B_ID
+        );
+    }
+
+    private void insertUser(
+        UUID userId,
+        String email
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            userId,
+            email,
+            "test-password-hash",
+            "USER",
+            "ACTIVE",
+            Timestamp.from(BASE_TIME),
+            Timestamp.from(BASE_TIME)
+        );
+    }
+
+    private void insertWallet(
+        UUID walletId,
+        UUID ownerId
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO wallets (
+                id,
+                owner_id,
+                balance,
+                currency,
+                status,
+                version,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            walletId,
+            ownerId,
+            new BigDecimal("500.00"),
+            "TRY",
+            "ACTIVE",
+            0L,
+            Timestamp.from(BASE_TIME),
+            Timestamp.from(BASE_TIME)
+        );
+    }
+
+    private void insertTransaction(
+        UUID transactionId,
+        UUID sourceWalletId,
+        UUID targetWalletId,
+        String idempotencyKey,
+        Instant createdAt
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO payment_transactions (
+                id,
+                source_wallet_id,
+                target_wallet_id,
+                transaction_type,
+                status,
+                amount,
+                currency,
+                idempotency_key,
+                failure_reason,
+                created_at,
+                completed_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            transactionId,
+            sourceWalletId,
+            targetWalletId,
+            "TRANSFER",
+            "COMPLETED",
+            new BigDecimal("125.50"),
+            "TRY",
+            idempotencyKey,
+            null,
+            Timestamp.from(createdAt),
+            Timestamp.from(
+                createdAt.plusSeconds(1)
+            )
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/integration/TransactionHistoryPersistenceIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/integration/TransactionHistoryPersistenceIntegrationTest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import com.nursena.payflow.transaction.application.model.TransactionDirection;
 import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
 import com.nursena.payflow.transaction.application.port.out.TransactionHistoryQueryPort;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -181,7 +182,8 @@ class TransactionHistoryPersistenceIntegrationTest {
                 .findByWalletId(
                     WALLET_ID,
                     0,
-                    2
+                    2,
+                    TransactionHistoryFilter.unfiltered()
                 );
 
         assertThat(firstPage.totalElements())
@@ -248,7 +250,8 @@ class TransactionHistoryPersistenceIntegrationTest {
                 .findByWalletId(
                     WALLET_ID,
                     1,
-                    2
+                    2,
+                    TransactionHistoryFilter.unfiltered()
                 );
 
         assertThat(secondPage.items())


### PR DESCRIPTION
## Summary

Adds authenticated transaction history retrieval for the current user's wallet.

## Changes

- adds transaction history application query model and use case
- adds paginated payment transaction persistence query
- maps incoming and outgoing transaction directions
- exposes `GET /api/v1/transactions/me`
- supports deterministic sorting by `createdAt DESC, id DESC`
- supports optional filters:
  - `direction`
  - `status`
  - `from` inclusive
  - `to` exclusive
- returns stable validation, authentication, and wallet-not-found errors
- keeps idempotency keys out of the public response

## API

```http
GET /api/v1/transactions/me
    ?page=0
    &size=20
    &direction=OUTGOING
    &status=COMPLETED
    &from=2026-07-01T00:00:00Z
    &to=2026-08-01T00:00:00Z