### PR TITLE
docs: document transaction history

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This keeps domain rules independent from Spring and infrastructure while avoidin
 
 ## Current status
 
-The repository foundation, identity flow, wallet management, and the first complete wallet-to-wallet transfer increment are implemented.
+The repository foundation, identity flow, wallet management, wallet-to-wallet transfer, double-entry ledger, and authenticated transaction history are implemented.
 
 Completed capabilities include:
 
@@ -74,8 +74,16 @@ Completed capabilities include:
 - controlled concurrent duplicate-transfer verification
 - real PostgreSQL integration tests with Testcontainers
 - real JWT endpoint-to-database transfer verification
+- authenticated current-wallet transaction history
+- incoming and outgoing transaction direction derivation
+- filtering by direction, transaction status, and date range
+- inclusive `from` and exclusive `to` date boundaries
+- deterministic pagination using `createdAt DESC, id DESC`
+- stable validation, authentication, and wallet-not-found responses
+- public transaction-history responses that exclude idempotency keys
+- real PostgreSQL verification of filtering, ordering, and pagination
 
-The next delivery focus is transaction history with filtering and pagination, followed by OpenAPI examples, a Postman collection, and the `v0.2.0` release. See the [roadmap](docs/roadmap.md).
+The next delivery focus is OpenAPI examples, a Postman collection, and the `v0.2.0` release, followed by transactional outbox and Kafka-based post-transfer processing. See the [roadmap](docs/roadmap.md).
 
 ## Implemented API
 
@@ -88,6 +96,7 @@ The next delivery focus is transaction history with filtering and pagination, fo
 | `GET` | `/api/v1/wallets/me` | Bearer JWT | Returns the authenticated user's wallet summary. |
 | `POST` | `/api/v1/wallets/me/top-ups` | Bearer JWT | Credits the authenticated user's wallet with a validated simulated amount. |
 | `POST` | `/api/v1/transfers` | Bearer JWT | Creates an atomic and idempotent wallet-to-wallet transfer. |
+| `GET` | `/api/v1/transactions/me` | Bearer JWT | Returns the authenticated user's paginated and filterable transaction history. |
 | `GET` | `/api/v1/system/health` | Configuration-dependent | Exposes the application health status. |
 
 ### Simulated wallet top-up
@@ -188,6 +197,66 @@ Relevant error outcomes include:
 - `422 SELF_TRANSFER_NOT_ALLOWED`
 - `422 TRANSFER_CURRENCY_MISMATCH`
 - `422 WALLET_NOT_ACTIVE`
+
+### Transaction history
+
+The endpoint resolves the wallet from the authenticated JWT subject. Clients cannot request another user's wallet history by supplying a wallet identifier.
+
+```http
+GET /api/v1/transactions/me?page=0&size=20&direction=OUTGOING&status=COMPLETED&from=2026-07-01T00:00:00Z&to=2026-08-01T00:00:00Z
+Authorization: Bearer <access-token>
+```
+
+Supported query parameters:
+
+| Parameter | Required | Description |
+|---|---|---|
+| `page` | No | Zero-based page number. Defaults to `0`. |
+| `size` | No | Page size between `1` and `100`. Defaults to `20`. |
+| `direction` | No | `INCOMING` or `OUTGOING`. |
+| `status` | No | `PENDING`, `COMPLETED`, or `FAILED`. |
+| `from` | No | Inclusive ISO-8601 instant. |
+| `to` | No | Exclusive ISO-8601 instant. |
+
+All filters are optional. When both date parameters are supplied, the endpoint uses the half-open interval `[from, to)`. Equal boundaries are valid and represent an empty date range.
+
+Successful response:
+
+```json
+{
+  "items": [
+    {
+      "transactionId": "b4077781-34f4-466f-8e61-b79ca906bc98",
+      "type": "TRANSFER",
+      "direction": "OUTGOING",
+      "counterpartyWalletId": "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db",
+      "amount": 125.50,
+      "currency": "TRY",
+      "status": "COMPLETED",
+      "createdAt": "2026-07-16T10:00:00Z",
+      "completedAt": "2026-07-16T10:00:01Z"
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 1,
+  "totalPages": 1,
+  "first": true,
+  "last": true,
+  "hasNext": false,
+  "hasPrevious": false
+}
+```
+
+Transactions are ordered by `createdAt DESC, id DESC` so pagination remains deterministic when multiple transactions share the same timestamp.
+
+The response intentionally excludes the transfer `Idempotency-Key`.
+
+Relevant error outcomes include:
+
+- `400 VALIDATION_FAILED`
+- `401 Unauthorized`
+- `404 WALLET_NOT_FOUND`
 
 ## Local development
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,6 +91,10 @@ The transaction module owns:
 - transfer request identity
 - `PENDING` and `COMPLETED` states
 - stable transfer results
+- authenticated transaction-history queries
+- incoming and outgoing direction mapping
+- transaction-status and date-range filtering
+- pagination and deterministic ordering
 
 ### Ledger module
 
@@ -102,6 +106,38 @@ The ledger module owns:
 - persistence of accounting records
 
 The transaction module coordinates the use case, but it does not absorb wallet or ledger domain responsibilities.
+
+## Transaction history read path
+
+Transaction history is implemented as an application-level read use case rather than exposing Spring Data or JPA models through the HTTP boundary.
+
+The read flow is:
+
+1. obtain the authenticated user identifier from the verified JWT subject
+2. resolve the wallet owned by that user
+3. construct an application-level transaction-history filter
+4. query payment transactions where the wallet is either the source or target
+5. derive `OUTGOING` or `INCOMING` from the wallet's position in the transaction
+6. map the opposite wallet as the counterparty
+7. return an application-owned paginated result
+8. map the result to HTTP response DTOs
+
+The persistence query supports optional filtering by:
+
+- transaction direction
+- transaction status
+- inclusive `from` instant
+- exclusive `to` instant
+
+Results use the deterministic ordering:
+
+```text
+createdAt DESC, id DESC
+```
+
+The UUID tie-breaker keeps pagination predictable when multiple transactions share the same creation timestamp.
+
+Spring Data `Page`, JPA entities, and transfer idempotency keys do not cross the application or HTTP boundaries.
 
 ## Transaction strategy
 
@@ -233,8 +269,9 @@ Clients cannot supply the source user or source wallet identifier for:
 - current-wallet retrieval
 - wallet top-up
 - wallet-to-wallet transfer
+- transaction-history retrieval
 
-This prevents a client from changing another user's state by submitting a different UUID in the request body.
+This prevents a client from accessing or changing another user's data by supplying a different user or wallet identifier in request input.
 
 Spring Security uses a deny-by-default policy. New routes remain inaccessible until they are explicitly classified as public or authenticated.
 
@@ -248,8 +285,10 @@ Spring Security uses a deny-by-default policy. New routes remain inaccessible un
 - JPA entities are never exposed through API responses
 - business errors use stable application error codes
 - validation errors include field violations
-- collection endpoints will use pagination and deterministic sorting
+- collection endpoints use pagination and deterministic sorting
 - financial mutation endpoints define explicit conflict behavior
+- transaction-history date ranges use inclusive `from` and exclusive `to` boundaries
+- invalid pagination, enum, and timestamp parameters return stable validation responses
 
 ## Testing strategy
 
@@ -260,6 +299,7 @@ The test suite uses several complementary levels:
 - MockMvc slice tests for HTTP, validation, security, and error mapping
 - persistence-adapter tests for JPA mapping and constraint translation
 - Testcontainers tests against real PostgreSQL
+- PostgreSQL transaction-history tests for filtering, isolation, pagination, and deterministic ordering
 - controlled concurrency tests
 - rollback and failure-path tests
 - authenticated endpoint-to-database integration tests

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,9 +2,9 @@
 
 ## Current delivery focus
 
-The repository foundation, core identity flow, authenticated current-user profile, secure wallet creation, authenticated wallet retrieval, simulated top-up, and PostgreSQL optimistic-locking verification are complete.
+The repository foundation, identity flow, wallet management, wallet-to-wallet transfer processing, double-entry ledger persistence, and authenticated transaction history are complete.
 
-The next delivery increment is wallet-to-wallet transfer processing with idempotency and double-entry ledger records.
+The next delivery increment focuses on API delivery and release readiness through OpenAPI examples, a Postman collection, and the `v0.2.0` release. Transactional outbox and Kafka-based post-transfer processing follow in the event-driven milestone.
 
 ## Milestone 0 — Repository foundation
 
@@ -57,9 +57,9 @@ The next delivery increment is wallet-to-wallet transfer processing with idempot
 - [x] Rollback verification when ledger persistence fails
 - [x] Concurrent duplicate-transfer verification
 - [x] Authenticated endpoint-to-database integration test
-- [ ] Transaction history
-- [ ] Filtering by direction, status, and date range
-- [ ] Pagination and stable sorting
+- [x] Transaction history
+- [x] Filtering by direction, status, and date range
+- [x] Pagination and deterministic sorting
 
 ## Milestone 4 — Event-driven processing
 


### PR DESCRIPTION
## Summary

Synchronizes the project documentation with the completed authenticated transaction-history feature.

## Changes

- documents `GET /api/v1/transactions/me`
- documents pagination and optional query filters
- explains `INCOMING` and `OUTGOING` direction mapping
- documents inclusive `from` and exclusive `to` boundaries
- adds a successful response example
- documents validation, authentication, and wallet-not-found outcomes
- explains the transaction-history application read path
- records deterministic `createdAt DESC, id DESC` ordering
- marks transaction history, filtering, and pagination as completed in the roadmap
- updates the next delivery focus

## Verification

- `./mvnw clean verify`
- `git diff --check`