### PR TITLE
Docs/api contract

### DIFF
--- a/src/main/java/com/nursena/payflow/common/api/ApiError.java
+++ b/src/main/java/com/nursena/payflow/common/api/ApiError.java
@@ -3,14 +3,71 @@ package com.nursena.payflow.common.api;
 import java.time.Instant;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "ApiError",
+    description = "Stable error response returned by PayFlow."
+)
 public record ApiError(
-        Instant timestamp,
-        int status,
-        String code,
-        String message,
-        String path,
-        List<FieldViolation> violations
+
+    @Schema(
+        description = "Time at which the error was generated.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
+    Instant timestamp,
+
+    @Schema(
+        description = "HTTP status code.",
+        example = "400",
+        format = "int32"
+    )
+    int status,
+
+    @Schema(
+        description = "Stable machine-readable error code.",
+        example = "VALIDATION_FAILED"
+    )
+    String code,
+
+    @Schema(
+        description = "Human-readable error description.",
+        example = "Request validation failed."
+    )
+    String message,
+
+    @Schema(
+        description = "Request path that produced the error.",
+        example = "/api/v1/auth/register"
+    )
+    String path,
+
+    @Schema(
+        description =
+            "Field-level violations. Empty for "
+                + "non-validation errors."
+    )
+    List<FieldViolation> violations
 ) {
-    public record FieldViolation(String field, String message) {
+
+    @Schema(
+        name = "FieldViolation",
+        description = "A request-field validation failure."
+    )
+    public record FieldViolation(
+
+        @Schema(
+            description = "Invalid request field.",
+            example = "email"
+        )
+        String field,
+
+        @Schema(
+            description = "Field validation message.",
+            example = "Email must be valid."
+        )
+        String message
+    ) {
     }
 }

--- a/src/main/java/com/nursena/payflow/common/api/SystemController.java
+++ b/src/main/java/com/nursena/payflow/common/api/SystemController.java
@@ -1,23 +1,62 @@
 package com.nursena.payflow.common.api;
 
-import java.time.Instant;
-import java.util.Map;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import java.time.Instant;
+
+import com.nursena.payflow.configuration.OpenApiExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(
+    name = "System",
+    description = "Public service status operations."
+)
 @RestController
 @RequestMapping("/api/v1/system")
 public class SystemController {
 
+    @Operation(
+        operationId = "getSystemHealth",
+        summary = "Get service health",
+        description =
+            "Returns basic PayFlow service status information."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Service health returned.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        SystemHealthResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples.SYSTEM_HEALTH
+                )
+            )
+        )
+    })
     @GetMapping("/health")
-    public ResponseEntity<Map<String, Object>> health() {
-        return ResponseEntity.ok(Map.of(
-                "status", "UP",
-                "service", "payflow",
-                "timestamp", Instant.now()
-        ));
+    public ResponseEntity<SystemHealthResponse> health() {
+        SystemHealthResponse response =
+            new SystemHealthResponse(
+                "UP",
+                "payflow",
+                Instant.now()
+            );
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/nursena/payflow/common/api/SystemHealthResponse.java
+++ b/src/main/java/com/nursena/payflow/common/api/SystemHealthResponse.java
@@ -1,0 +1,32 @@
+package com.nursena.payflow.common.api;
+
+import java.time.Instant;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "SystemHealthResponse",
+    description = "Basic PayFlow service health information."
+)
+public record SystemHealthResponse(
+
+    @Schema(
+        description = "Current service status.",
+        example = "UP"
+    )
+    String status,
+
+    @Schema(
+        description = "Service identifier.",
+        example = "payflow"
+    )
+    String service,
+
+    @Schema(
+        description = "Time at which the status was generated.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
+    Instant timestamp
+) {
+}

--- a/src/main/java/com/nursena/payflow/configuration/OpenApiConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/OpenApiConfiguration.java
@@ -1,0 +1,59 @@
+package com.nursena.payflow.configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class OpenApiConfiguration {
+
+    public static final String BEARER_AUTH_SCHEME =
+        "bearerAuth";
+
+    private static final String API_TITLE =
+        "PayFlow API";
+
+    private static final String API_VERSION =
+        "0.2.0";
+
+    private static final String API_DESCRIPTION =
+        """
+        REST API for the PayFlow simulated digital wallet \
+        and payment transaction backend.
+
+        PayFlow does not process real money.
+        """;
+
+    @Bean
+    OpenAPI payflowOpenApi() {
+        return new OpenAPI()
+            .info(
+                new Info()
+                    .title(API_TITLE)
+                    .version(API_VERSION)
+                    .description(API_DESCRIPTION)
+            )
+            .components(
+                new Components()
+                    .addSecuritySchemes(
+                        BEARER_AUTH_SCHEME,
+                        bearerJwtSecurityScheme()
+                    )
+            );
+    }
+
+    private static SecurityScheme
+    bearerJwtSecurityScheme() {
+        return new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+            .description(
+                "RSA-signed JWT access token returned "
+                    + "by the login endpoint."
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
@@ -1,0 +1,102 @@
+package com.nursena.payflow.configuration;
+
+public final class OpenApiExamples {
+
+    public static final String SYSTEM_HEALTH =
+        """
+        {
+          "status": "UP",
+          "service": "payflow",
+          "timestamp": "2026-07-17T12:00:00Z"
+        }
+        """;
+
+    public static final String REGISTER_SUCCESS =
+        """
+        {
+          "userId": "8805681d-d537-42f2-8906-5da1f0666ab7"
+        }
+        """;
+
+    public static final String LOGIN_SUCCESS =
+        """
+        {
+          "accessToken": "eyJhbGciOiJSUzI1NiJ9...",
+          "tokenType": "Bearer",
+          "expiresAt": "2026-07-17T12:15:00Z"
+        }
+        """;
+
+    public static final String REGISTER_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/auth/register",
+          "violations": [
+            {
+              "field": "password",
+              "message": "Password must be between 12 and 72 characters."
+            }
+          ]
+        }
+        """;
+
+    public static final String LOGIN_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/auth/login",
+          "violations": [
+            {
+              "field": "email",
+              "message": "Email must be valid."
+            }
+          ]
+        }
+        """;
+
+    public static final String EMAIL_ALREADY_REGISTERED =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 409,
+          "code": "EMAIL_ALREADY_REGISTERED",
+          "message": "A user with this email address already exists.",
+          "path": "/api/v1/auth/register",
+          "violations": []
+        }
+        """;
+
+    public static final String INVALID_CREDENTIALS =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 401,
+          "code": "INVALID_CREDENTIALS",
+          "message": "Email or password is incorrect.",
+          "path": "/api/v1/auth/login",
+          "violations": []
+        }
+        """;
+
+    public static final String USER_ACCOUNT_UNAVAILABLE =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 403,
+          "code": "USER_ACCOUNT_UNAVAILABLE",
+          "message": "User account is not available for authentication.",
+          "path": "/api/v1/auth/login",
+          "violations": []
+        }
+        """;
+
+    private OpenApiExamples() {
+    }
+}

--- a/src/main/java/com/nursena/payflow/configuration/TransactionApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/TransactionApiExamples.java
@@ -1,0 +1,199 @@
+package com.nursena.payflow.configuration;
+
+public final class TransactionApiExamples {
+
+    public static final String TRANSFER_SUCCESS =
+        """
+        {
+          "transactionId": "aa3ab0b3-3d85-42d7-a641-2ec43cd81dd9",
+          "sourceWalletId": "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+          "targetWalletId": "f4c8ab12-a4bb-43cb-b6a8-e797cc95e914",
+          "amount": 125.50,
+          "currency": "TRY",
+          "status": "COMPLETED",
+          "createdAt": "2026-07-17T12:00:00Z",
+          "completedAt": "2026-07-17T12:00:00.125Z"
+        }
+        """;
+
+    public static final String MISSING_IDEMPOTENCY_KEY =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "MISSING_IDEMPOTENCY_KEY",
+          "message": "Idempotency-Key header is required.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String TRANSFER_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/transfers",
+          "violations": [
+            {
+              "field": "amount",
+              "message": "amount must be greater than zero"
+            }
+          ]
+        }
+        """;
+
+    public static final String TRANSFER_WALLET_NOT_FOUND =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 404,
+          "code": "WALLET_NOT_FOUND",
+          "message": "Wallet could not be found.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String IDEMPOTENCY_KEY_CONFLICT =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 409,
+          "code": "IDEMPOTENCY_KEY_CONFLICT",
+          "message": "Idempotency key has already been used for another transfer request.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String IDEMPOTENCY_REQUEST_IN_PROGRESS =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 409,
+          "code": "IDEMPOTENCY_REQUEST_IN_PROGRESS",
+          "message": "A transfer with this idempotency key is still being processed.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String TRANSFER_CONCURRENT_UPDATE =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 409,
+          "code": "WALLET_CONCURRENT_UPDATE",
+          "message": "Wallet was updated concurrently. Please retry the operation.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String INVALID_IDEMPOTENCY_KEY =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 422,
+          "code": "INVALID_IDEMPOTENCY_KEY",
+          "message": "Idempotency key must contain between 1 and 100 characters.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String INSUFFICIENT_BALANCE =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 422,
+          "code": "INSUFFICIENT_BALANCE",
+          "message": "Wallet balance is insufficient for this operation.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String TRANSFER_WALLET_NOT_ACTIVE =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 422,
+          "code": "WALLET_NOT_ACTIVE",
+          "message": "Wallet must be active to perform this operation.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String TRANSFER_CURRENCY_MISMATCH =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 422,
+          "code": "TRANSFER_CURRENCY_MISMATCH",
+          "message": "Source and target wallet currencies must match.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String TRANSACTION_HISTORY_SUCCESS =
+        """
+        {
+          "items": [
+            {
+              "transactionId": "aa3ab0b3-3d85-42d7-a641-2ec43cd81dd9",
+              "type": "TRANSFER",
+              "direction": "OUTGOING",
+              "counterpartyWalletId": "f4c8ab12-a4bb-43cb-b6a8-e797cc95e914",
+              "amount": 125.50,
+              "currency": "TRY",
+              "status": "COMPLETED",
+              "createdAt": "2026-07-17T12:00:00Z",
+              "completedAt": "2026-07-17T12:00:00.125Z"
+            }
+          ],
+          "page": 0,
+          "size": 20,
+          "totalElements": 1,
+          "totalPages": 1,
+          "first": true,
+          "last": true,
+          "hasNext": false,
+          "hasPrevious": false
+        }
+        """;
+
+    public static final String
+        TRANSACTION_HISTORY_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/transactions/me",
+          "violations": []
+        }
+        """;
+
+    public static final String
+        TRANSACTION_HISTORY_WALLET_NOT_FOUND =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 404,
+          "code": "WALLET_NOT_FOUND",
+          "message": "Wallet could not be found.",
+          "path": "/api/v1/transactions/me",
+          "violations": []
+        }
+        """;
+
+    private TransactionApiExamples() {
+    }
+}

--- a/src/main/java/com/nursena/payflow/configuration/UserApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/UserApiExamples.java
@@ -1,0 +1,30 @@
+package com.nursena.payflow.configuration;
+
+public final class UserApiExamples {
+
+    public static final String CURRENT_USER_PROFILE =
+        """
+        {
+          "id": "8805681d-d537-42f2-8906-5da1f0666ab7",
+          "email": "nursena@example.com",
+          "role": "USER",
+          "status": "ACTIVE",
+          "createdAt": "2026-07-17T12:00:00Z"
+        }
+        """;
+
+    public static final String USER_NOT_FOUND =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 404,
+          "code": "USER_NOT_FOUND",
+          "message": "User could not be found.",
+          "path": "/api/v1/users/me",
+          "violations": []
+        }
+        """;
+
+    private UserApiExamples() {
+    }
+}

--- a/src/main/java/com/nursena/payflow/configuration/WalletApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/WalletApiExamples.java
@@ -1,0 +1,135 @@
+package com.nursena.payflow.configuration;
+
+public final class WalletApiExamples {
+
+    public static final String OPEN_WALLET =
+        """
+        {
+          "id": "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+          "ownerId": "8805681d-d537-42f2-8906-5da1f0666ab7",
+          "balance": 0.00,
+          "currency": "TRY",
+          "status": "ACTIVE",
+          "createdAt": "2026-07-17T12:00:00Z"
+        }
+        """;
+
+    public static final String OPEN_WALLET_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/wallets",
+          "violations": [
+            {
+              "field": "currency",
+              "message": "Currency is required."
+            }
+          ]
+        }
+        """;
+
+    public static final String WALLET_ALREADY_EXISTS =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 409,
+          "code": "WALLET_ALREADY_EXISTS",
+          "message": "User already has a wallet.",
+          "path": "/api/v1/wallets",
+          "violations": []
+        }
+        """;
+
+    public static final String CURRENT_WALLET =
+        """
+        {
+          "id": "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+          "balance": 250.00,
+          "currency": "TRY",
+          "status": "ACTIVE",
+          "createdAt": "2026-07-17T12:00:00Z"
+        }
+        """;
+
+    public static final String CURRENT_WALLET_NOT_FOUND =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 404,
+          "code": "WALLET_NOT_FOUND",
+          "message": "Wallet could not be found.",
+          "path": "/api/v1/wallets/me",
+          "violations": []
+        }
+        """;
+
+    public static final String TOP_UP_WALLET =
+        """
+        {
+          "id": "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+          "balance": 350.00,
+          "currency": "TRY",
+          "status": "ACTIVE",
+          "createdAt": "2026-07-17T12:00:00Z"
+        }
+        """;
+
+    public static final String TOP_UP_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/wallets/me/top-ups",
+          "violations": [
+            {
+              "field": "amount",
+              "message": "amount must be greater than zero"
+            }
+          ]
+        }
+        """;
+
+    public static final String TOP_UP_WALLET_NOT_FOUND =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 404,
+          "code": "WALLET_NOT_FOUND",
+          "message": "Wallet could not be found.",
+          "path": "/api/v1/wallets/me/top-ups",
+          "violations": []
+        }
+        """;
+
+    public static final String WALLET_CONCURRENT_UPDATE =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 409,
+          "code": "WALLET_CONCURRENT_UPDATE",
+          "message": "Wallet was updated concurrently. Please retry the operation.",
+          "path": "/api/v1/wallets/me/top-ups",
+          "violations": []
+        }
+        """;
+
+    public static final String WALLET_NOT_ACTIVE =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 422,
+          "code": "WALLET_NOT_ACTIVE",
+          "message": "Wallet must be active to perform this operation.",
+          "path": "/api/v1/wallets/me/top-ups",
+          "violations": []
+        }
+        """;
+
+    private WalletApiExamples() {
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryController.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryController.java
@@ -1,14 +1,28 @@
 package com.nursena.payflow.transaction.adapter.in.web;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.time.Instant;
 import java.util.UUID;
 
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.configuration.TransactionApiExamples;
 import com.nursena.payflow.transaction.application.model.TransactionDirection;
 import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
 import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
 import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryQuery;
 import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryUseCase;
 import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -20,6 +34,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(
+    name = "Transactions",
+    description =
+        "Authenticated transaction history operations."
+)
 @RestController
 @RequestMapping("/api/v1/transactions")
 public class GetTransactionHistoryController {
@@ -35,12 +54,91 @@ public class GetTransactionHistoryController {
             getTransactionHistoryUseCase;
     }
 
+    @Operation(
+        operationId = "getTransactionHistory",
+        summary = "Get transaction history",
+        description =
+            "Returns the authenticated user's wallet "
+                + "transactions ordered by creation time "
+                + "descending and transaction identifier "
+                + "descending."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description =
+                "Transaction history returned.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        TransactionHistoryResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        TransactionApiExamples
+                            .TRANSACTION_HISTORY_SUCCESS
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description =
+                "A pagination or filter value is invalid.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        TransactionApiExamples
+                            .TRANSACTION_HISTORY_VALIDATION_ERROR
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The authenticated user does not have a wallet.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        TransactionApiExamples
+                            .TRANSACTION_HISTORY_WALLET_NOT_FOUND
+                )
+            )
+        )
+    })
     @GetMapping("/me")
     public ResponseEntity<TransactionHistoryResponse>
     getTransactionHistory(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal
         Jwt jwt,
 
+        @Parameter(
+            name = "page",
+            description = "Zero-based result page index.",
+            example = "0",
+            schema = @Schema(
+                type = "integer",
+                minimum = "0",
+                defaultValue = "0"
+            )
+        )
         @RequestParam(
             name = "page",
             defaultValue = "0"
@@ -51,6 +149,18 @@ public class GetTransactionHistoryController {
         )
         int page,
 
+        @Parameter(
+            name = "size",
+            description =
+                "Number of transactions returned per page.",
+            example = "20",
+            schema = @Schema(
+                type = "integer",
+                minimum = "1",
+                maximum = "100",
+                defaultValue = "20"
+            )
+        )
         @RequestParam(
             name = "size",
             defaultValue = "20"
@@ -65,18 +175,54 @@ public class GetTransactionHistoryController {
         )
         int size,
 
+        @Parameter(
+            name = "direction",
+            description =
+                "Transaction direction relative to "
+                    + "the current wallet.",
+            example = "OUTGOING",
+            schema = @Schema(
+                allowableValues = {
+                    "INCOMING",
+                    "OUTGOING"
+                }
+            )
+        )
         @RequestParam(
             name = "direction",
             required = false
         )
         TransactionDirection direction,
 
+        @Parameter(
+            name = "status",
+            description = "Transaction status filter.",
+            example = "COMPLETED",
+            schema = @Schema(
+                allowableValues = {
+                    "PENDING",
+                    "COMPLETED",
+                    "FAILED"
+                }
+            )
+        )
         @RequestParam(
             name = "status",
             required = false
         )
         TransactionStatus status,
 
+        @Parameter(
+            name = "from",
+            description =
+                "Inclusive lower bound for the "
+                    + "transaction creation time.",
+            example = "2026-07-01T00:00:00Z",
+            schema = @Schema(
+                type = "string",
+                format = "date-time"
+            )
+        )
         @RequestParam(
             name = "from",
             required = false
@@ -86,6 +232,18 @@ public class GetTransactionHistoryController {
         )
         Instant from,
 
+        @Parameter(
+            name = "to",
+            description =
+                "Exclusive upper bound for the "
+                    + "transaction creation time. It may equal "
+                    + "the from value.",
+            example = "2026-08-01T00:00:00Z",
+            schema = @Schema(
+                type = "string",
+                format = "date-time"
+            )
+        )
         @RequestParam(
             name = "to",
             required = false

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryItemResponse.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryItemResponse.java
@@ -10,16 +10,78 @@ import com.nursena.payflow.transaction.application.model.TransactionHistoryItem;
 import com.nursena.payflow.transaction.domain.model.TransactionStatus;
 import com.nursena.payflow.transaction.domain.model.TransactionType;
 import com.nursena.payflow.wallet.domain.model.Currency;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "TransactionHistoryItemResponse",
+    description =
+        "A transaction from the authenticated user's perspective."
+)
 public record TransactionHistoryItemResponse(
+
+    @Schema(
+        description = "Payment transaction identifier.",
+        example =
+            "aa3ab0b3-3d85-42d7-a641-2ec43cd81dd9",
+        format = "uuid"
+    )
     UUID transactionId,
+
+    @Schema(
+        description = "Transaction type.",
+        example = "TRANSFER"
+    )
     TransactionType type,
+
+    @Schema(
+        description =
+            "Transaction direction relative to "
+                + "the authenticated user's wallet.",
+        example = "OUTGOING"
+    )
     TransactionDirection direction,
+
+    @Schema(
+        description =
+            "Wallet on the opposite side of the transaction.",
+        example =
+            "f4c8ab12-a4bb-43cb-b6a8-e797cc95e914",
+        format = "uuid"
+    )
     UUID counterpartyWalletId,
+
+    @Schema(
+        description = "Transaction amount.",
+        example = "125.50"
+    )
     BigDecimal amount,
+
+    @Schema(
+        description = "Transaction currency.",
+        example = "TRY"
+    )
     Currency currency,
+
+    @Schema(
+        description = "Current transaction status.",
+        example = "COMPLETED"
+    )
     TransactionStatus status,
+
+    @Schema(
+        description = "Transaction creation time.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
     Instant createdAt,
+
+    @Schema(
+        description =
+            "Transaction completion time. It may be absent "
+                + "until processing has completed.",
+        example = "2026-07-17T12:00:00.125Z",
+        format = "date-time"
+    )
     Instant completedAt
 ) {
 

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryResponse.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryResponse.java
@@ -4,16 +4,78 @@ import java.util.List;
 import java.util.Objects;
 
 import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "TransactionHistoryResponse",
+    description =
+        "Paginated transaction history of the "
+            + "authenticated user's wallet."
+)
 public record TransactionHistoryResponse(
+
+    @Schema(
+        description =
+            "Transactions contained in the current page."
+    )
     List<TransactionHistoryItemResponse> items,
+
+    @Schema(
+        description = "Zero-based current page index.",
+        example = "0",
+        minimum = "0"
+    )
     int page,
+
+    @Schema(
+        description = "Requested page size.",
+        example = "20",
+        minimum = "1",
+        maximum = "100"
+    )
     int size,
+
+    @Schema(
+        description =
+            "Total number of matching transactions.",
+        example = "1",
+        minimum = "0"
+    )
     long totalElements,
+
+    @Schema(
+        description = "Total number of result pages.",
+        example = "1",
+        minimum = "0"
+    )
     int totalPages,
+
+    @Schema(
+        description =
+            "Whether this is the first result page.",
+        example = "true"
+    )
     boolean first,
+
+    @Schema(
+        description =
+            "Whether this is the last result page.",
+        example = "true"
+    )
     boolean last,
+
+    @Schema(
+        description =
+            "Whether another result page is available.",
+        example = "false"
+    )
     boolean hasNext,
+
+    @Schema(
+        description =
+            "Whether a previous result page is available.",
+        example = "false"
+    )
     boolean hasPrevious
 ) {
 

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyController.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyController.java
@@ -1,10 +1,25 @@
 package com.nursena.payflow.transaction.adapter.in.web;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.util.UUID;
 
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.configuration.TransactionApiExamples;
 import com.nursena.payflow.transaction.application.port.in.TransferMoneyCommand;
 import com.nursena.payflow.transaction.application.port.in.TransferMoneyResult;
 import com.nursena.payflow.transaction.application.port.in.TransferMoneyUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +31,10 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(
+    name = "Transfers",
+    description = "Authenticated wallet transfer operations."
+)
 @RestController
 @RequestMapping("/api/v1/transfers")
 public class TransferMoneyController {
@@ -31,12 +50,197 @@ public class TransferMoneyController {
         this.transferMoneyUseCase = transferMoneyUseCase;
     }
 
+    @Operation(
+        operationId = "transferMoney",
+        summary = "Transfer money",
+        description =
+            "Transfers a simulated amount from the "
+                + "authenticated user's wallet to another wallet. "
+                + "Repeated requests with the same idempotency "
+                + "key and payload return the existing result."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "Transfer completed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        TransferMoneyResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        TransactionApiExamples
+                            .TRANSFER_SUCCESS
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description =
+                "The request is invalid or the "
+                    + "Idempotency-Key header is missing.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = {
+                    @ExampleObject(
+                        name = "missingIdempotencyKey",
+                        summary =
+                            "Idempotency-Key header is missing",
+                        value =
+                            TransactionApiExamples
+                                .MISSING_IDEMPOTENCY_KEY
+                    ),
+                    @ExampleObject(
+                        name = "validationFailed",
+                        summary =
+                            "Request body validation failed",
+                        value =
+                            TransactionApiExamples
+                                .TRANSFER_VALIDATION_ERROR
+                    )
+                }
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The source or target wallet "
+                    + "could not be found.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        TransactionApiExamples
+                            .TRANSFER_WALLET_NOT_FOUND
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "The request conflicts with an existing "
+                    + "idempotency record or concurrent update.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = {
+                    @ExampleObject(
+                        name = "idempotencyKeyConflict",
+                        summary =
+                            "Key reused with a different payload",
+                        value =
+                            TransactionApiExamples
+                                .IDEMPOTENCY_KEY_CONFLICT
+                    ),
+                    @ExampleObject(
+                        name = "requestInProgress",
+                        summary =
+                            "Original request is still running",
+                        value =
+                            TransactionApiExamples
+                                .IDEMPOTENCY_REQUEST_IN_PROGRESS
+                    ),
+                    @ExampleObject(
+                        name = "concurrentWalletUpdate",
+                        summary =
+                            "A wallet changed concurrently",
+                        value =
+                            TransactionApiExamples
+                                .TRANSFER_CONCURRENT_UPDATE
+                    )
+                }
+            )
+        ),
+        @ApiResponse(
+            responseCode = "422",
+            description =
+                "A transfer business rule was violated.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = {
+                    @ExampleObject(
+                        name = "invalidIdempotencyKey",
+                        summary =
+                            "Idempotency key length is invalid",
+                        value =
+                            TransactionApiExamples
+                                .INVALID_IDEMPOTENCY_KEY
+                    ),
+                    @ExampleObject(
+                        name = "insufficientBalance",
+                        summary =
+                            "Source wallet balance is insufficient",
+                        value =
+                            TransactionApiExamples
+                                .INSUFFICIENT_BALANCE
+                    ),
+                    @ExampleObject(
+                        name = "walletNotActive",
+                        summary =
+                            "Source or target wallet is inactive",
+                        value =
+                            TransactionApiExamples
+                                .TRANSFER_WALLET_NOT_ACTIVE
+                    ),
+                    @ExampleObject(
+                        name = "currencyMismatch",
+                        summary =
+                            "Wallet currencies do not match",
+                        value =
+                            TransactionApiExamples
+                                .TRANSFER_CURRENCY_MISMATCH
+                    )
+                }
+            )
+        )
+    })
     @PostMapping
     public ResponseEntity<TransferMoneyResponse> transfer(
-        @AuthenticationPrincipal Jwt jwt,
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt,
+
+        @Parameter(
+            name = IDEMPOTENCY_KEY_HEADER,
+            in = ParameterIn.HEADER,
+            description =
+                "Unique request key used to make "
+                    + "the transfer idempotent.",
+            required = true,
+            example = "transfer-20260717-001",
+            schema = @Schema(
+                type = "string",
+                minLength = 1,
+                maxLength = 100
+            )
+        )
         @RequestHeader(IDEMPOTENCY_KEY_HEADER)
         String idempotencyKey,
-        @Valid @RequestBody TransferMoneyRequest request
+
+        @Valid
+        @RequestBody
+        TransferMoneyRequest request
     ) {
         UUID ownerId = UUID.fromString(
             jwt.getSubject()

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyRequest.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyRequest.java
@@ -3,15 +3,34 @@ package com.nursena.payflow.transaction.adapter.in.web;
 import java.math.BigDecimal;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(
+    name = "TransferMoneyRequest",
+    description =
+        "Information required to transfer money "
+            + "to another wallet."
+)
 public record TransferMoneyRequest(
 
-    @NotNull(message = "targetWalletId must not be null")
+    @Schema(
+        description = "Identifier of the receiving wallet.",
+        example = "f4c8ab12-a4bb-43cb-b6a8-e797cc95e914",
+        format = "uuid"
+    )
+    @NotNull(
+        message = "targetWalletId must not be null"
+    )
     UUID targetWalletId,
 
+    @Schema(
+        description = "Positive amount to transfer.",
+        example = "125.50",
+        minimum = "0.01"
+    )
     @NotNull(message = "amount must not be null")
     @DecimalMin(
         value = "0.01",
@@ -20,9 +39,9 @@ public record TransferMoneyRequest(
     @Digits(
         integer = 17,
         fraction = 2,
-        message = "amount must have at most 2 fractional digits"
+        message =
+            "amount must have at most 2 fractional digits"
     )
     BigDecimal amount
-
 ) {
 }

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyResponse.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyResponse.java
@@ -8,15 +8,65 @@ import java.util.UUID;
 import com.nursena.payflow.transaction.application.port.in.TransferMoneyResult;
 import com.nursena.payflow.transaction.domain.model.TransactionStatus;
 import com.nursena.payflow.wallet.domain.model.Currency;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "TransferMoneyResponse",
+    description = "Completed wallet transfer information."
+)
 public record TransferMoneyResponse(
+
+    @Schema(
+        description = "Payment transaction identifier.",
+        example = "aa3ab0b3-3d85-42d7-a641-2ec43cd81dd9",
+        format = "uuid"
+    )
     UUID transactionId,
+
+    @Schema(
+        description = "Wallet debited by the transfer.",
+        example = "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+        format = "uuid"
+    )
     UUID sourceWalletId,
+
+    @Schema(
+        description = "Wallet credited by the transfer.",
+        example = "f4c8ab12-a4bb-43cb-b6a8-e797cc95e914",
+        format = "uuid"
+    )
     UUID targetWalletId,
+
+    @Schema(
+        description = "Transferred amount.",
+        example = "125.50"
+    )
     BigDecimal amount,
+
+    @Schema(
+        description = "Transfer currency.",
+        example = "TRY"
+    )
     Currency currency,
+
+    @Schema(
+        description = "Current transaction status.",
+        example = "COMPLETED"
+    )
     TransactionStatus status,
+
+    @Schema(
+        description = "Transaction creation time.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
     Instant createdAt,
+
+    @Schema(
+        description = "Transaction completion time.",
+        example = "2026-07-17T12:00:00.125Z",
+        format = "date-time"
+    )
     Instant completedAt
 ) {
 

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserController.java
@@ -3,12 +3,29 @@ package com.nursena.payflow.user.adapter.in.web;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiExamples;
+
+@Tag(
+    name = "Authentication",
+    description =
+        "Public user registration and authentication operations."
+)
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -23,6 +40,76 @@ public class AuthenticateUserController {
     ) {
         this.authenticateUserUseCase = authenticateUserUseCase;
     }
+
+    @Operation(
+        operationId = "authenticateUser",
+        summary = "Authenticate a user",
+        description =
+            "Validates user credentials and returns an "
+                + "RSA-signed JWT access token."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Authentication succeeded.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        AuthenticateUserResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples.LOGIN_SUCCESS
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .LOGIN_VALIDATION_ERROR
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "Credentials are invalid.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples.INVALID_CREDENTIALS
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description =
+                "The user account cannot be authenticated.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .USER_ACCOUNT_UNAVAILABLE
+                )
+            )
+        )
+    })
 
     @PostMapping("/login")
     public ResponseEntity<AuthenticateUserResponse> authenticate(

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserRequest.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserRequest.java
@@ -1,22 +1,41 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(
+    name = "AuthenticateUserRequest",
+    description = "Credentials used to authenticate a user."
+)
 public record AuthenticateUserRequest(
+
+    @Schema(
+        description = "Registered user email address.",
+        example = "nursena@example.com",
+        format = "email"
+    )
     @NotBlank(message = "Email is required.")
     @Email(message = "Email must be valid.")
     @Size(
         max = 320,
-        message = "Email must not exceed 320 characters."
+        message =
+            "Email must not exceed 320 characters."
     )
     String email,
 
+    @Schema(
+        description = "User password.",
+        example = "StrongPassword123!",
+        format = "password",
+        accessMode = Schema.AccessMode.WRITE_ONLY
+    )
     @NotBlank(message = "Password is required.")
     @Size(
         max = 72,
-        message = "Password must not exceed 72 characters."
+        message =
+            "Password must not exceed 72 characters."
     )
     String password
 ) {

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserResponse.java
@@ -2,9 +2,33 @@ package com.nursena.payflow.user.adapter.in.web;
 
 import java.time.Instant;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "AuthenticateUserResponse",
+    description =
+        "JWT access token returned after successful authentication."
+)
 public record AuthenticateUserResponse(
+
+    @Schema(
+        description = "RSA-signed JWT access token.",
+        example = "eyJhbGciOiJSUzI1NiJ9..."
+    )
     String accessToken,
+
+    @Schema(
+        description =
+            "Authentication scheme used with the token.",
+        example = "Bearer"
+    )
     String tokenType,
+
+    @Schema(
+        description = "Access-token expiration time.",
+        example = "2026-07-17T12:15:00Z",
+        format = "date-time"
+    )
     Instant expiresAt
 ) {
 }

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileController.java
@@ -10,6 +10,25 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.configuration.UserApiExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(
+    name = "Users",
+    description = "Authenticated user profile operations."
+)
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -23,10 +42,58 @@ public class CurrentUserProfileController {
         this.profileUseCase = profileUseCase;
     }
 
+    @Operation(
+        operationId = "getCurrentUserProfile",
+        summary = "Get current user profile",
+        description =
+            "Returns the profile represented by the JWT subject."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Current user profile returned.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        CurrentUserProfileResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        UserApiExamples.CURRENT_USER_PROFILE
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The JWT subject does not reference an existing user.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        UserApiExamples.USER_NOT_FOUND
+                )
+            )
+        )
+    })
     @GetMapping("/me")
     public ResponseEntity<CurrentUserProfileResponse>
     getCurrentUserProfile(
-        @AuthenticationPrincipal Jwt jwt
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt
     ) {
         UUID userId = UUID.fromString(
             jwt.getSubject()

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileResponse.java
@@ -6,12 +6,44 @@ import java.util.UUID;
 import com.nursena.payflow.user.application.port.in.GetCurrentUserProfileResult;
 import com.nursena.payflow.user.domain.model.UserRole;
 import com.nursena.payflow.user.domain.model.UserStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "CurrentUserProfileResponse",
+    description = "Profile information of the authenticated user."
+)
 public record CurrentUserProfileResponse(
+    @Schema(
+        description = "User identifier.",
+        example = "8805681d-d537-42f2-8906-5da1f0666ab7",
+        format = "uuid"
+    )
     UUID id,
+
+    @Schema(
+        description = "Normalized email address.",
+        example = "nursena@example.com",
+        format = "email"
+    )
     String email,
+
+    @Schema(
+        description = "Role assigned to the user.",
+        example = "USER"
+    )
     UserRole role,
+
+    @Schema(
+        description = "Current account status.",
+        example = "ACTIVE"
+    )
     UserStatus status,
+
+    @Schema(
+        description = "Account creation time.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
     Instant createdAt
 ) {
 

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserController.java
@@ -1,7 +1,16 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiExamples;
 import com.nursena.payflow.user.application.port.in.RegisterUserCommand;
 import com.nursena.payflow.user.application.port.in.RegisterUserUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +18,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Tag(
+    name = "Authentication",
+    description =
+        "Public user registration and authentication operations."
+)
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -19,6 +35,62 @@ public class RegisterUserController {
     public RegisterUserController(RegisterUserUseCase registerUserUseCase) {
         this.registerUserUseCase = registerUserUseCase;
     }
+
+    @Operation(
+        operationId = "registerUser",
+        summary = "Register a user",
+        description =
+            "Creates a user with a normalized email address "
+                + "and BCrypt password hash."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "User registered.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        RegisterUserResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples.REGISTER_SUCCESS
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .REGISTER_VALIDATION_ERROR
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "The email address is already registered.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .EMAIL_ALREADY_REGISTERED
+                )
+            )
+        )
+    })
 
     @PostMapping("/register")
     public ResponseEntity<RegisterUserResponse> register(

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserRequest.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserRequest.java
@@ -1,21 +1,45 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(
+    name = "RegisterUserRequest",
+    description = "Information required to register a user."
+)
 public record RegisterUserRequest(
 
+    @Schema(
+        description =
+            "User email address. The application "
+                + "normalizes the address before persistence.",
+        example = "nursena@example.com",
+        format = "email"
+    )
     @NotBlank(message = "Email is required.")
     @Email(message = "Email must be valid.")
-    @Size(max = 320, message = "Email must not exceed 320 characters.")
+    @Size(
+        max = 320,
+        message =
+            "Email must not exceed 320 characters."
+    )
     String email,
 
+    @Schema(
+        description =
+            "User password between 12 and 72 characters.",
+        example = "StrongPassword123!",
+        format = "password",
+        accessMode = Schema.AccessMode.WRITE_ONLY
+    )
     @NotBlank(message = "Password is required.")
     @Size(
         min = 12,
         max = 72,
-        message = "Password must be between 12 and 72 characters."
+        message =
+            "Password must be between 12 and 72 characters."
     )
     String password
 ) {

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserResponse.java
@@ -2,5 +2,20 @@ package com.nursena.payflow.user.adapter.in.web;
 
 import java.util.UUID;
 
-public record RegisterUserResponse(UUID userId) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "RegisterUserResponse",
+    description = "Result of a successful registration."
+)
+public record RegisterUserResponse(
+
+    @Schema(
+        description = "Identifier of the registered user.",
+        example =
+            "8805681d-d537-42f2-8906-5da1f0666ab7",
+        format = "uuid"
+    )
+    UUID userId
+) {
 }

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/GetCurrentWalletController.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/GetCurrentWalletController.java
@@ -2,14 +2,33 @@ package com.nursena.payflow.wallet.adapter.in.web;
 
 import java.util.UUID;
 
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.configuration.WalletApiExamples;
 import com.nursena.payflow.wallet.application.port.in.GetCurrentWalletResult;
 import com.nursena.payflow.wallet.application.port.in.GetCurrentWalletUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Tag(
+    name = "Wallets",
+    description = "Authenticated wallet management operations."
+)
 
 @RestController
 @RequestMapping("/api/v1/wallets")
@@ -24,10 +43,59 @@ public class GetCurrentWalletController {
             getCurrentWalletUseCase;
     }
 
+    @Operation(
+        operationId = "getCurrentWallet",
+        summary = "Get current wallet",
+        description =
+            "Returns the wallet owned by the authenticated user."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Current wallet returned.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        GetCurrentWalletResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples.CURRENT_WALLET
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The authenticated user does not have a wallet.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples
+                            .CURRENT_WALLET_NOT_FOUND
+                )
+            )
+        )
+    })
     @GetMapping("/me")
     public ResponseEntity<GetCurrentWalletResponse>
     getCurrentWallet(
-        @AuthenticationPrincipal Jwt jwt
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt
     ) {
         UUID ownerId = UUID.fromString(
             jwt.getSubject()

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/GetCurrentWalletResponse.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/GetCurrentWalletResponse.java
@@ -8,12 +8,44 @@ import java.util.UUID;
 import com.nursena.payflow.wallet.application.port.in.GetCurrentWalletResult;
 import com.nursena.payflow.wallet.domain.model.Currency;
 import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "GetCurrentWalletResponse",
+    description = "Current wallet of the authenticated user."
+)
 public record GetCurrentWalletResponse(
+
+    @Schema(
+        description = "Wallet identifier.",
+        example = "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+        format = "uuid"
+    )
     UUID id,
+
+    @Schema(
+        description = "Current wallet balance.",
+        example = "250.00"
+    )
     BigDecimal balance,
+
+    @Schema(
+        description = "Wallet currency.",
+        example = "TRY"
+    )
     Currency currency,
+
+    @Schema(
+        description = "Current wallet status.",
+        example = "ACTIVE"
+    )
     WalletStatus status,
+
+    @Schema(
+        description = "Wallet creation time.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
     Instant createdAt
 ) {
 

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletController.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletController.java
@@ -2,9 +2,21 @@ package com.nursena.payflow.wallet.adapter.in.web;
 
 import java.util.UUID;
 
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.configuration.WalletApiExamples;
 import com.nursena.payflow.wallet.application.port.in.OpenWalletCommand;
 import com.nursena.payflow.wallet.application.port.in.OpenWalletResult;
 import com.nursena.payflow.wallet.application.port.in.OpenWalletUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +26,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Tag(
+    name = "Wallets",
+    description = "Authenticated wallet management operations."
+)
 
 @RestController
 @RequestMapping("/api/v1/wallets")
@@ -27,10 +46,75 @@ public class OpenWalletController {
         this.openWalletUseCase = openWalletUseCase;
     }
 
+    @Operation(
+        operationId = "openWallet",
+        summary = "Open a wallet",
+        description =
+            "Creates one wallet for the authenticated user."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "Wallet created.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = OpenWalletResponse.class
+                ),
+                examples = @ExampleObject(
+                    value = WalletApiExamples.OPEN_WALLET
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples
+                            .OPEN_WALLET_VALIDATION_ERROR
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "The authenticated user already has a wallet.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples
+                            .WALLET_ALREADY_EXISTS
+                )
+            )
+        )
+    })
     @PostMapping
     public ResponseEntity<OpenWalletResponse> openWallet(
-        @AuthenticationPrincipal Jwt jwt,
-        @Valid @RequestBody OpenWalletRequest request
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt,
+
+        @Valid
+        @RequestBody
+        OpenWalletRequest request
     ) {
         UUID ownerId = UUID.fromString(
             jwt.getSubject()

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletRequest.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletRequest.java
@@ -2,8 +2,18 @@ package com.nursena.payflow.wallet.adapter.in.web;
 
 import com.nursena.payflow.wallet.domain.model.Currency;
 import jakarta.validation.constraints.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "OpenWalletRequest",
+    description = "Information required to open a wallet."
+)
 public record OpenWalletRequest(
+
+    @Schema(
+        description = "Wallet currency.",
+        example = "TRY"
+    )
     @NotNull(message = "Currency is required.")
     Currency currency
 ) {

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletResponse.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletResponse.java
@@ -8,18 +8,59 @@ import java.util.UUID;
 import com.nursena.payflow.wallet.application.port.in.OpenWalletResult;
 import com.nursena.payflow.wallet.domain.model.Currency;
 import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "OpenWalletResponse",
+    description = "Wallet created for the authenticated user."
+)
 public record OpenWalletResponse(
+
+    @Schema(
+        description = "Wallet identifier.",
+        example = "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+        format = "uuid"
+    )
     UUID id,
+
+    @Schema(
+        description = "Wallet owner identifier.",
+        example = "8805681d-d537-42f2-8906-5da1f0666ab7",
+        format = "uuid"
+    )
     UUID ownerId,
+
+    @Schema(
+        description = "Current wallet balance.",
+        example = "0.00"
+    )
     BigDecimal balance,
+
+    @Schema(
+        description = "Wallet currency.",
+        example = "TRY"
+    )
     Currency currency,
+
+    @Schema(
+        description = "Current wallet status.",
+        example = "ACTIVE"
+    )
     WalletStatus status,
+
+    @Schema(
+        description = "Wallet creation time.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
     Instant createdAt
 ) {
 
     public OpenWalletResponse {
-        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(
+            id,
+            "id must not be null"
+        );
         Objects.requireNonNull(
             ownerId,
             "ownerId must not be null"

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletController.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletController.java
@@ -2,9 +2,21 @@ package com.nursena.payflow.wallet.adapter.in.web;
 
 import java.util.UUID;
 
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.configuration.WalletApiExamples;
 import com.nursena.payflow.wallet.application.port.in.TopUpWalletCommand;
 import com.nursena.payflow.wallet.application.port.in.TopUpWalletResult;
 import com.nursena.payflow.wallet.application.port.in.TopUpWalletUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,6 +25,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Tag(
+    name = "Wallets",
+    description = "Authenticated wallet management operations."
+)
 
 @RestController
 @RequestMapping("/api/v1/wallets/me/top-ups")
@@ -26,10 +45,110 @@ public class TopUpWalletController {
         this.topUpWalletUseCase = topUpWalletUseCase;
     }
 
+    @Operation(
+        operationId = "topUpCurrentWallet",
+        summary = "Top up current wallet",
+        description =
+            "Credits a simulated amount to the authenticated "
+                + "user's wallet."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Wallet topped up.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        TopUpWalletResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples.TOP_UP_WALLET
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples
+                            .TOP_UP_VALIDATION_ERROR
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The authenticated user does not have a wallet.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples
+                            .TOP_UP_WALLET_NOT_FOUND
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "The wallet was updated concurrently.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples
+                            .WALLET_CONCURRENT_UPDATE
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "422",
+            description =
+                "The wallet is not active.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples.WALLET_NOT_ACTIVE
+                )
+            )
+        )
+    })
+
     @PostMapping
     public ResponseEntity<TopUpWalletResponse> topUpWallet(
-        @AuthenticationPrincipal Jwt jwt,
-        @Valid @RequestBody TopUpWalletRequest request
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt,
+
+        @Valid
+        @RequestBody
+        TopUpWalletRequest request
     ) {
         UUID ownerId = UUID.fromString(
             jwt.getSubject()

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletRequest.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletRequest.java
@@ -6,8 +6,19 @@ import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "TopUpWalletRequest",
+    description = "Amount credited to the current wallet."
+)
 public record TopUpWalletRequest(
 
+    @Schema(
+        description = "Positive top-up amount.",
+        example = "100.00",
+        minimum = "0.01"
+    )
     @NotNull(message = "amount must not be null")
     @DecimalMin(
         value = "0.01",
@@ -19,6 +30,5 @@ public record TopUpWalletRequest(
         message = "amount must have at most 2 fractional digits"
     )
     BigDecimal amount
-
 ) {
 }

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletResponse.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletResponse.java
@@ -8,12 +8,44 @@ import java.util.UUID;
 import com.nursena.payflow.wallet.application.port.in.TopUpWalletResult;
 import com.nursena.payflow.wallet.domain.model.Currency;
 import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "TopUpWalletResponse",
+    description = "Wallet state after a successful top-up."
+)
 public record TopUpWalletResponse(
+
+    @Schema(
+        description = "Wallet identifier.",
+        example = "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+        format = "uuid"
+    )
     UUID id,
+
+    @Schema(
+        description = "Current wallet balance after the top-up.",
+        example = "350.00"
+    )
     BigDecimal balance,
+
+    @Schema(
+        description = "Wallet currency.",
+        example = "TRY"
+    )
     Currency currency,
+
+    @Schema(
+        description = "Current wallet status.",
+        example = "ACTIVE"
+    )
     WalletStatus status,
+
+    @Schema(
+        description = "Wallet creation time.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
     Instant createdAt
 ) {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,8 +48,13 @@ management:
       show-details: when_authorized
 
 springdoc:
+  api-docs:
+    path: /v3/api-docs
   swagger-ui:
     path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+    display-request-duration: true
 
 logging:
   pattern:

--- a/src/test/java/com/nursena/payflow/configuration/AuthenticatedApiDocumentationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/AuthenticatedApiDocumentationTest.java
@@ -1,0 +1,200 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import com.nursena.payflow.user.adapter.in.web.CurrentUserProfileController;
+import com.nursena.payflow.wallet.adapter.in.web.GetCurrentWalletController;
+import com.nursena.payflow.wallet.adapter.in.web.OpenWalletController;
+import com.nursena.payflow.wallet.adapter.in.web.OpenWalletRequest;
+import com.nursena.payflow.wallet.adapter.in.web.TopUpWalletController;
+import com.nursena.payflow.wallet.adapter.in.web.TopUpWalletRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+class AuthenticatedApiDocumentationTest {
+
+    @Test
+    void shouldDocumentCurrentUserProfile()
+        throws NoSuchMethodException {
+
+        Method method =
+            CurrentUserProfileController.class
+                .getDeclaredMethod(
+                    "getCurrentUserProfile",
+                    Jwt.class
+                );
+
+        assertAuthenticatedDocumentation(
+            CurrentUserProfileController.class,
+            method,
+            "Users",
+            "getCurrentUserProfile",
+            "200",
+            "401",
+            "404"
+        );
+    }
+
+    @Test
+    void shouldDocumentWalletOpening()
+        throws NoSuchMethodException {
+
+        Method method =
+            OpenWalletController.class
+                .getDeclaredMethod(
+                    "openWallet",
+                    Jwt.class,
+                    OpenWalletRequest.class
+                );
+
+        assertAuthenticatedDocumentation(
+            OpenWalletController.class,
+            method,
+            "Wallets",
+            "openWallet",
+            "201",
+            "400",
+            "401",
+            "409"
+        );
+    }
+
+    @Test
+    void shouldDocumentCurrentWallet()
+        throws NoSuchMethodException {
+
+        Method method =
+            GetCurrentWalletController.class
+                .getDeclaredMethod(
+                    "getCurrentWallet",
+                    Jwt.class
+                );
+
+        assertAuthenticatedDocumentation(
+            GetCurrentWalletController.class,
+            method,
+            "Wallets",
+            "getCurrentWallet",
+            "200",
+            "401",
+            "404"
+        );
+    }
+
+    @Test
+    void shouldDocumentWalletTopUp()
+        throws NoSuchMethodException {
+
+        Method method =
+            TopUpWalletController.class
+                .getDeclaredMethod(
+                    "topUpWallet",
+                    Jwt.class,
+                    TopUpWalletRequest.class
+                );
+
+        assertAuthenticatedDocumentation(
+            TopUpWalletController.class,
+            method,
+            "Wallets",
+            "topUpCurrentWallet",
+            "200",
+            "400",
+            "401",
+            "404",
+            "409",
+            "422"
+        );
+    }
+
+    private static void assertAuthenticatedDocumentation(
+        Class<?> controllerType,
+        Method method,
+        String expectedTag,
+        String expectedOperationId,
+        String... expectedResponseCodes
+    ) {
+        Tag tag =
+            controllerType.getAnnotation(Tag.class);
+
+        assertThat(tag)
+            .isNotNull();
+
+        assertThat(tag.name())
+            .isEqualTo(expectedTag);
+
+        Operation operation =
+            method.getAnnotation(Operation.class);
+
+        assertThat(operation)
+            .isNotNull();
+
+        assertThat(operation.operationId())
+            .isEqualTo(expectedOperationId);
+
+        assertThat(operation.summary())
+            .isNotBlank();
+
+        SecurityRequirement security =
+            method.getAnnotation(
+                SecurityRequirement.class
+            );
+
+        assertThat(security)
+            .isNotNull();
+
+        assertThat(security.name())
+            .isEqualTo(
+                OpenApiConfiguration
+                    .BEARER_AUTH_SCHEME
+            );
+
+        Parameter jwtParameter =
+            method
+                .getParameters()[0]
+                .getAnnotation(Parameter.class);
+
+        assertThat(jwtParameter)
+            .isNotNull();
+
+        assertThat(jwtParameter.hidden())
+            .isTrue();
+
+        ApiResponses responses =
+            method.getAnnotation(ApiResponses.class);
+
+        assertThat(responses)
+            .isNotNull();
+
+        assertThat(
+            Arrays.stream(responses.value())
+                .map(ApiResponse::responseCode)
+                .toList()
+        )
+            .containsExactlyInAnyOrder(
+                expectedResponseCodes
+            );
+
+        ApiResponse unauthorizedResponse =
+            Arrays.stream(responses.value())
+                .filter(response ->
+                    response
+                        .responseCode()
+                        .equals("401")
+                )
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(unauthorizedResponse.content())
+            .isEmpty();
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/AuthenticatedApiDocumentationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/AuthenticatedApiDocumentationTest.java
@@ -19,6 +19,15 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.oauth2.jwt.Jwt;
+import com.nursena.payflow.transaction.adapter.in.web.TransferMoneyController;
+import com.nursena.payflow.transaction.adapter.in.web.TransferMoneyRequest;
+import org.springframework.web.bind.annotation.RequestHeader;
+import java.time.Instant;
+
+import com.nursena.payflow.transaction.adapter.in.web.GetTransactionHistoryController;
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+
 
 class AuthenticatedApiDocumentationTest {
 
@@ -197,4 +206,157 @@ class AuthenticatedApiDocumentationTest {
         assertThat(unauthorizedResponse.content())
             .isEmpty();
     }
+    @Test
+    void shouldDocumentMoneyTransfer()
+        throws NoSuchMethodException {
+
+        Method method =
+            TransferMoneyController.class
+                .getDeclaredMethod(
+                    "transfer",
+                    Jwt.class,
+                    String.class,
+                    TransferMoneyRequest.class
+                );
+
+        assertAuthenticatedDocumentation(
+            TransferMoneyController.class,
+            method,
+            "Transfers",
+            "transferMoney",
+            "201",
+            "400",
+            "401",
+            "404",
+            "409",
+            "422"
+        );
+
+        Parameter headerDocumentation =
+            method
+                .getParameters()[1]
+                .getAnnotation(Parameter.class);
+
+        assertThat(headerDocumentation)
+            .isNotNull();
+
+        assertThat(headerDocumentation.name())
+            .isEqualTo("Idempotency-Key");
+
+        assertThat(headerDocumentation.required())
+            .isTrue();
+
+        RequestHeader requestHeader =
+            method
+                .getParameters()[1]
+                .getAnnotation(RequestHeader.class);
+
+        assertThat(requestHeader)
+            .isNotNull();
+
+        assertThat(requestHeader.value())
+            .isEqualTo("Idempotency-Key");
+    }
+
+    @Test
+    void shouldDocumentTransactionHistory()
+        throws NoSuchMethodException {
+
+        Method method =
+            GetTransactionHistoryController.class
+                .getDeclaredMethod(
+                    "getTransactionHistory",
+                    Jwt.class,
+                    int.class,
+                    int.class,
+                    TransactionDirection.class,
+                    TransactionStatus.class,
+                    Instant.class,
+                    Instant.class
+                );
+
+        assertAuthenticatedDocumentation(
+            GetTransactionHistoryController.class,
+            method,
+            "Transactions",
+            "getTransactionHistory",
+            "200",
+            "400",
+            "401",
+            "404"
+        );
+
+        assertDocumentedParameter(
+            method,
+            1,
+            "page"
+        );
+
+        assertDocumentedParameter(
+            method,
+            2,
+            "size"
+        );
+
+        assertDocumentedParameter(
+            method,
+            3,
+            "direction"
+        );
+
+        assertDocumentedParameter(
+            method,
+            4,
+            "status"
+        );
+
+        assertDocumentedParameter(
+            method,
+            5,
+            "from"
+        );
+
+        assertDocumentedParameter(
+            method,
+            6,
+            "to"
+        );
+
+        Parameter fromParameter =
+            method
+                .getParameters()[5]
+                .getAnnotation(Parameter.class);
+
+        assertThat(fromParameter.description())
+            .containsIgnoringCase("inclusive");
+
+        Parameter toParameter =
+            method
+                .getParameters()[6]
+                .getAnnotation(Parameter.class);
+
+        assertThat(toParameter.description())
+            .containsIgnoringCase("exclusive");
+    }
+
+    private static void assertDocumentedParameter(
+        Method method,
+        int parameterIndex,
+        String expectedName
+    ) {
+        Parameter parameter =
+            method
+                .getParameters()[parameterIndex]
+                .getAnnotation(Parameter.class);
+
+        assertThat(parameter)
+            .isNotNull();
+
+        assertThat(parameter.name())
+            .isEqualTo(expectedName);
+
+        assertThat(parameter.description())
+            .isNotBlank();
+    }
+
 }

--- a/src/test/java/com/nursena/payflow/configuration/OpenApiConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/OpenApiConfigurationTest.java
@@ -1,0 +1,87 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OpenApiConfigurationTest {
+
+    private OpenAPI openApi;
+
+    @BeforeEach
+    void setUp() {
+        openApi =
+            new OpenApiConfiguration()
+                .payflowOpenApi();
+    }
+
+    @Test
+    void shouldExposePayflowApiMetadata() {
+        assertThat(openApi.getInfo())
+            .isNotNull();
+
+        assertThat(openApi.getInfo().getTitle())
+            .isEqualTo("PayFlow API");
+
+        assertThat(openApi.getInfo().getVersion())
+            .isEqualTo("0.2.0");
+
+        assertThat(openApi.getInfo().getDescription())
+            .contains(
+                "simulated digital wallet"
+            )
+            .contains(
+                "does not process real money"
+            );
+    }
+
+    @Test
+    void shouldExposeBearerJwtSecurityScheme() {
+        assertThat(openApi.getComponents())
+            .isNotNull();
+
+        assertThat(
+            openApi
+                .getComponents()
+                .getSecuritySchemes()
+        )
+            .containsKey(
+                OpenApiConfiguration
+                    .BEARER_AUTH_SCHEME
+            );
+
+        SecurityScheme securityScheme =
+            openApi
+                .getComponents()
+                .getSecuritySchemes()
+                .get(
+                    OpenApiConfiguration
+                        .BEARER_AUTH_SCHEME
+                );
+
+        assertThat(securityScheme.getType())
+            .isEqualTo(
+                SecurityScheme.Type.HTTP
+            );
+
+        assertThat(securityScheme.getScheme())
+            .isEqualTo("bearer");
+
+        assertThat(securityScheme.getBearerFormat())
+            .isEqualTo("JWT");
+
+        assertThat(securityScheme.getDescription())
+            .contains(
+                "login endpoint"
+            );
+    }
+
+    @Test
+    void shouldNotRequireAuthenticationGlobally() {
+        assertThat(openApi.getSecurity())
+            .isNullOrEmpty();
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/PublicApiDocumentationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/PublicApiDocumentationTest.java
@@ -1,0 +1,129 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import com.nursena.payflow.common.api.SystemController;
+import com.nursena.payflow.user.adapter.in.web.AuthenticateUserController;
+import com.nursena.payflow.user.adapter.in.web.AuthenticateUserRequest;
+import com.nursena.payflow.user.adapter.in.web.RegisterUserController;
+import com.nursena.payflow.user.adapter.in.web.RegisterUserRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.junit.jupiter.api.Test;
+
+class PublicApiDocumentationTest {
+
+    @Test
+    void shouldDocumentSystemHealthOperation()
+        throws NoSuchMethodException {
+
+        Method method =
+            SystemController.class
+                .getDeclaredMethod("health");
+
+        assertDocumentation(
+            SystemController.class,
+            method,
+            "System",
+            "getSystemHealth",
+            "200"
+        );
+    }
+
+    @Test
+    void shouldDocumentRegistrationOperation()
+        throws NoSuchMethodException {
+
+        Method method =
+            RegisterUserController.class
+                .getDeclaredMethod(
+                    "register",
+                    RegisterUserRequest.class
+                );
+
+        assertDocumentation(
+            RegisterUserController.class,
+            method,
+            "Authentication",
+            "registerUser",
+            "201",
+            "400",
+            "409"
+        );
+    }
+
+    @Test
+    void shouldDocumentAuthenticationOperation()
+        throws NoSuchMethodException {
+
+        Method method =
+            AuthenticateUserController.class
+                .getDeclaredMethod(
+                    "authenticate",
+                    AuthenticateUserRequest.class
+                );
+
+        assertDocumentation(
+            AuthenticateUserController.class,
+            method,
+            "Authentication",
+            "authenticateUser",
+            "200",
+            "400",
+            "401",
+            "403"
+        );
+    }
+
+    private static void assertDocumentation(
+        Class<?> controllerType,
+        Method method,
+        String expectedTag,
+        String expectedOperationId,
+        String... expectedResponseCodes
+    ) {
+        Tag tag =
+            controllerType.getAnnotation(Tag.class);
+
+        assertThat(tag)
+            .isNotNull();
+
+        assertThat(tag.name())
+            .isEqualTo(expectedTag);
+
+        Operation operation =
+            method.getAnnotation(Operation.class);
+
+        assertThat(operation)
+            .isNotNull();
+
+        assertThat(operation.operationId())
+            .isEqualTo(expectedOperationId);
+
+        assertThat(operation.summary())
+            .isNotBlank();
+
+        assertThat(operation.security())
+            .isEmpty();
+
+        ApiResponses responses =
+            method.getAnnotation(ApiResponses.class);
+
+        assertThat(responses)
+            .isNotNull();
+
+        assertThat(
+            Arrays.stream(responses.value())
+                .map(ApiResponse::responseCode)
+                .toList()
+        )
+            .containsExactlyInAnyOrder(
+                expectedResponseCodes
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -1,0 +1,739 @@
+package com.nursena.payflow.configuration.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet
+    .request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet
+    .result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet
+    .result.MockMvcResultMatchers.status;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.configuration
+    .OpenApiConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet
+    .AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers
+    .PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class OpenApiJsonContractIntegrationTest {
+
+    private static final String SYSTEM_HEALTH_PATH =
+        "/api/v1/system/health";
+
+    private static final String REGISTER_PATH =
+        "/api/v1/auth/register";
+
+    private static final String LOGIN_PATH =
+        "/api/v1/auth/login";
+
+    private static final String USER_PROFILE_PATH =
+        "/api/v1/users/me";
+
+    private static final String WALLETS_PATH =
+        "/api/v1/wallets";
+
+    private static final String CURRENT_WALLET_PATH =
+        "/api/v1/wallets/me";
+
+    private static final String TOP_UP_PATH =
+        "/api/v1/wallets/me/top-ups";
+
+    private static final String TRANSFERS_PATH =
+        "/api/v1/transfers";
+
+    private static final String TRANSACTIONS_PATH =
+        "/api/v1/transactions/me";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private JsonNode openApi;
+
+    @BeforeEach
+    void loadOpenApiDocument() throws Exception {
+        MvcResult result =
+            mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(
+                    content()
+                        .contentTypeCompatibleWith(
+                            MediaType.APPLICATION_JSON
+                        )
+                )
+                .andReturn();
+
+        openApi =
+            objectMapper.readTree(
+                result
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+    }
+
+    @Test
+    void shouldExposeApiMetadataAndBearerScheme() {
+        assertThat(openApi.path("openapi").asText())
+            .startsWith("3.");
+
+        JsonNode info = openApi.path("info");
+
+        assertThat(info.path("title").asText())
+            .isEqualTo("PayFlow API");
+
+        assertThat(info.path("version").asText())
+            .isEqualTo("0.2.0");
+
+        assertThat(info.path("description").asText())
+            .contains(
+                "PayFlow does not process real money."
+            );
+
+        assertThat(openApi.has("security"))
+            .isFalse();
+
+        JsonNode bearerScheme =
+            openApi
+                .path("components")
+                .path("securitySchemes")
+                .path(
+                    OpenApiConfiguration
+                        .BEARER_AUTH_SCHEME
+                );
+
+        assertThat(bearerScheme.isObject())
+            .isTrue();
+
+        assertThat(bearerScheme.path("type").asText())
+            .isEqualTo("http");
+
+        assertThat(bearerScheme.path("scheme").asText())
+            .isEqualTo("bearer");
+
+        assertThat(
+            bearerScheme
+                .path("bearerFormat")
+                .asText()
+        ).isEqualTo("JWT");
+    }
+
+    @Test
+    void shouldExposeExactlyThePublicApiPaths() {
+        assertThat(
+            fieldNames(openApi.path("paths"))
+        ).containsExactlyInAnyOrder(
+            SYSTEM_HEALTH_PATH,
+            REGISTER_PATH,
+            LOGIN_PATH,
+            USER_PROFILE_PATH,
+            WALLETS_PATH,
+            CURRENT_WALLET_PATH,
+            TOP_UP_PATH,
+            TRANSFERS_PATH,
+            TRANSACTIONS_PATH
+        );
+
+        JsonNode health =
+            operation(
+                SYSTEM_HEALTH_PATH,
+                "get"
+            );
+
+        assertPublicOperation(health);
+        assertResponseCodes(health, "200");
+
+        JsonNode register =
+            operation(
+                REGISTER_PATH,
+                "post"
+            );
+
+        assertPublicOperation(register);
+        assertResponseCodes(
+            register,
+            "201",
+            "400",
+            "409"
+        );
+
+        JsonNode login =
+            operation(
+                LOGIN_PATH,
+                "post"
+            );
+
+        assertPublicOperation(login);
+        assertResponseCodes(
+            login,
+            "200",
+            "400",
+            "401",
+            "403"
+        );
+    }
+
+    @Test
+    void shouldExposeAuthenticatedApiOperations() {
+        JsonNode profile =
+            operation(
+                USER_PROFILE_PATH,
+                "get"
+            );
+
+        assertAuthenticatedOperation(
+            profile,
+            "getCurrentUserProfile",
+            new String[] {
+                "200",
+                "401",
+                "404"
+            }
+        );
+
+        assertParameterNames(profile);
+
+        JsonNode openWallet =
+            operation(
+                WALLETS_PATH,
+                "post"
+            );
+
+        assertAuthenticatedOperation(
+            openWallet,
+            "openWallet",
+            new String[] {
+                "201",
+                "400",
+                "401",
+                "409"
+            }
+        );
+
+        assertParameterNames(openWallet);
+
+        JsonNode currentWallet =
+            operation(
+                CURRENT_WALLET_PATH,
+                "get"
+            );
+
+        assertAuthenticatedOperation(
+            currentWallet,
+            "getCurrentWallet",
+            new String[] {
+                "200",
+                "401",
+                "404"
+            }
+        );
+
+        assertParameterNames(currentWallet);
+
+        JsonNode topUp =
+            operation(
+                TOP_UP_PATH,
+                "post"
+            );
+
+        assertAuthenticatedOperation(
+            topUp,
+            "topUpCurrentWallet",
+            new String[] {
+                "200",
+                "400",
+                "401",
+                "404",
+                "409",
+                "422"
+            }
+        );
+
+        assertParameterNames(topUp);
+
+        JsonNode transfer =
+            operation(
+                TRANSFERS_PATH,
+                "post"
+            );
+
+        assertAuthenticatedOperation(
+            transfer,
+            "transferMoney",
+            new String[] {
+                "201",
+                "400",
+                "401",
+                "404",
+                "409",
+                "422"
+            }
+        );
+
+        assertParameterNames(
+            transfer,
+            "Idempotency-Key"
+        );
+
+        JsonNode history =
+            operation(
+                TRANSACTIONS_PATH,
+                "get"
+            );
+
+        assertAuthenticatedOperation(
+            history,
+            "getTransactionHistory",
+            new String[] {
+                "200",
+                "400",
+                "401",
+                "404"
+            }
+        );
+
+        assertParameterNames(
+            history,
+            "page",
+            "size",
+            "direction",
+            "status",
+            "from",
+            "to"
+        );
+    }
+
+    @Test
+    void shouldExposeTransferContract() {
+        JsonNode transfer =
+            operation(
+                TRANSFERS_PATH,
+                "post"
+            );
+
+        JsonNode idempotencyKey =
+            findParameter(
+                transfer,
+                "Idempotency-Key"
+            );
+
+        assertThat(idempotencyKey.path("in").asText())
+            .isEqualTo("header");
+
+        assertThat(
+            idempotencyKey
+                .path("required")
+                .asBoolean()
+        ).isTrue();
+
+        JsonNode schema =
+            idempotencyKey.path("schema");
+
+        assertThat(schema.path("type").asText())
+            .isEqualTo("string");
+
+        assertThat(schema.path("minLength").asInt())
+            .isEqualTo(1);
+
+        assertThat(schema.path("maxLength").asInt())
+            .isEqualTo(100);
+
+        assertExampleNames(
+            transfer,
+            "400",
+            "missingIdempotencyKey",
+            "validationFailed"
+        );
+
+        assertExampleNames(
+            transfer,
+            "409",
+            "idempotencyKeyConflict",
+            "requestInProgress",
+            "concurrentWalletUpdate"
+        );
+
+        assertExampleNames(
+            transfer,
+            "422",
+            "invalidIdempotencyKey",
+            "insufficientBalance",
+            "walletNotActive",
+            "currencyMismatch"
+        );
+
+        JsonNode schemas =
+            openApi
+                .path("components")
+                .path("schemas");
+
+        JsonNode responseProperties =
+            schemas
+                .path("TransferMoneyResponse")
+                .path("properties");
+
+        assertThat(
+            fieldNames(responseProperties)
+        ).doesNotContain("idempotencyKey");
+    }
+
+    @Test
+    void shouldExposeTransactionHistoryContract() {
+        JsonNode history =
+            operation(
+                TRANSACTIONS_PATH,
+                "get"
+            );
+
+        JsonNode page =
+            findParameter(history, "page");
+
+        assertQueryParameter(page);
+
+        assertThat(
+            page.path("schema")
+                .path("minimum")
+                .asInt()
+        ).isZero();
+
+        assertThat(
+            page.path("schema")
+                .path("default")
+                .asInt()
+        ).isZero();
+
+        JsonNode size =
+            findParameter(history, "size");
+
+        assertQueryParameter(size);
+
+        assertThat(
+            size.path("schema")
+                .path("minimum")
+                .asInt()
+        ).isEqualTo(1);
+
+        assertThat(
+            size.path("schema")
+                .path("maximum")
+                .asInt()
+        ).isEqualTo(100);
+
+        assertThat(
+            size.path("schema")
+                .path("default")
+                .asInt()
+        ).isEqualTo(20);
+
+        JsonNode direction =
+            findParameter(
+                history,
+                "direction"
+            );
+
+        assertQueryParameter(direction);
+
+        assertThat(
+            textValues(
+                direction
+                    .path("schema")
+                    .path("enum")
+            )
+        ).containsExactlyInAnyOrder(
+            "INCOMING",
+            "OUTGOING"
+        );
+
+        JsonNode transactionStatus =
+            findParameter(
+                history,
+                "status"
+            );
+
+        assertQueryParameter(transactionStatus);
+
+        assertThat(
+            textValues(
+                transactionStatus
+                    .path("schema")
+                    .path("enum")
+            )
+        ).containsExactlyInAnyOrder(
+            "PENDING",
+            "COMPLETED",
+            "FAILED"
+        );
+
+        JsonNode from =
+            findParameter(history, "from");
+
+        assertQueryParameter(from);
+
+        assertThat(
+            from.path("description").asText()
+        ).containsIgnoringCase("inclusive");
+
+        assertThat(
+            from.path("schema")
+                .path("format")
+                .asText()
+        ).isEqualTo("date-time");
+
+        JsonNode to =
+            findParameter(history, "to");
+
+        assertQueryParameter(to);
+
+        assertThat(
+            to.path("description").asText()
+        ).containsIgnoringCase("exclusive");
+
+        assertThat(
+            to.path("schema")
+                .path("format")
+                .asText()
+        ).isEqualTo("date-time");
+
+        JsonNode historyItemProperties =
+            openApi
+                .path("components")
+                .path("schemas")
+                .path(
+                    "TransactionHistoryItemResponse"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(historyItemProperties)
+        ).doesNotContain("idempotencyKey");
+    }
+
+    private JsonNode operation(
+        String path,
+        String method
+    ) {
+        JsonNode operation =
+            openApi
+                .path("paths")
+                .path(path)
+                .path(method);
+
+        assertThat(operation.isObject())
+            .as(
+                "%s %s operation must exist",
+                method.toUpperCase(),
+                path
+            )
+            .isTrue();
+
+        return operation;
+    }
+
+    private static void assertPublicOperation(
+        JsonNode operation
+    ) {
+        assertThat(operation.has("security"))
+            .isFalse();
+    }
+
+    private static void assertAuthenticatedOperation(
+        JsonNode operation,
+        String expectedOperationId,
+        String[] expectedResponseCodes
+    ) {
+        assertThat(
+            operation
+                .path("operationId")
+                .asText()
+        ).isEqualTo(expectedOperationId);
+
+        JsonNode security =
+            operation.path("security");
+
+        assertThat(security.isArray())
+            .isTrue();
+
+        boolean bearerSecurityPresent =
+            StreamSupport.stream(
+                    security.spliterator(),
+                    false
+                )
+                .anyMatch(requirement ->
+                    requirement.has(
+                        OpenApiConfiguration
+                            .BEARER_AUTH_SCHEME
+                    )
+                );
+
+        assertThat(bearerSecurityPresent)
+            .isTrue();
+
+        assertResponseCodes(
+            operation,
+            expectedResponseCodes
+        );
+    }
+
+    private static void assertResponseCodes(
+        JsonNode operation,
+        String... expectedCodes
+    ) {
+        JsonNode responses =
+            operation.path("responses");
+
+        assertThat(responses.isObject())
+            .isTrue();
+
+        assertThat(fieldNames(responses))
+            .containsExactlyInAnyOrder(
+                expectedCodes
+            );
+    }
+
+    private static void assertParameterNames(
+        JsonNode operation,
+        String... expectedNames
+    ) {
+        assertThat(
+            parameterNames(operation)
+        ).containsExactlyInAnyOrder(
+            expectedNames
+        );
+    }
+
+    private static Set<String> parameterNames(
+        JsonNode operation
+    ) {
+        Set<String> names =
+            new LinkedHashSet<>();
+
+        JsonNode parameters =
+            operation.path("parameters");
+
+        if (!parameters.isArray()) {
+            return names;
+        }
+
+        parameters.forEach(parameter ->
+            names.add(
+                parameter
+                    .path("name")
+                    .asText()
+            )
+        );
+
+        return names;
+    }
+
+    private static JsonNode findParameter(
+        JsonNode operation,
+        String expectedName
+    ) {
+        return StreamSupport.stream(
+                operation
+                    .path("parameters")
+                    .spliterator(),
+                false
+            )
+            .filter(parameter ->
+                expectedName.equals(
+                    parameter
+                        .path("name")
+                        .asText()
+                )
+            )
+            .findFirst()
+            .orElseThrow(() ->
+                new AssertionError(
+                    "OpenAPI parameter is missing: "
+                        + expectedName
+                )
+            );
+    }
+
+    private static void assertQueryParameter(
+        JsonNode parameter
+    ) {
+        assertThat(parameter.path("in").asText())
+            .isEqualTo("query");
+    }
+
+    private static void assertExampleNames(
+        JsonNode operation,
+        String responseCode,
+        String... expectedNames
+    ) {
+        JsonNode examples =
+            operation
+                .path("responses")
+                .path(responseCode)
+                .path("content")
+                .path(
+                    MediaType
+                        .APPLICATION_JSON_VALUE
+                )
+                .path("examples");
+
+        assertThat(examples.isObject())
+            .isTrue();
+
+        assertThat(fieldNames(examples))
+            .containsExactlyInAnyOrder(
+                expectedNames
+            );
+    }
+
+    private static Set<String> fieldNames(
+        JsonNode object
+    ) {
+        Set<String> names =
+            new LinkedHashSet<>();
+
+        object
+            .fieldNames()
+            .forEachRemaining(names::add);
+
+        return names;
+    }
+
+    private static Set<String> textValues(
+        JsonNode array
+    ) {
+        Set<String> values =
+            new LinkedHashSet<>();
+
+        array.forEach(value ->
+            values.add(value.asText())
+        );
+
+        return values;
+    }
+}


### PR DESCRIPTION
## Summary

- configure Springdoc OpenAPI and Swagger UI
- define PayFlow API metadata and JWT bearer authentication scheme
- document all public and authenticated API operations
- add request, response, validation and error schemas
- add representative success and error examples
- document transfer idempotency and transaction-history filters
- verify the generated `/v3/api-docs` JSON contract with an integration test

## Documented endpoints

### Public

- `GET /api/v1/system/health`
- `POST /api/v1/auth/register`
- `POST /api/v1/auth/login`

### Authenticated

- `GET /api/v1/users/me`
- `POST /api/v1/wallets`
- `GET /api/v1/wallets/me`
- `POST /api/v1/wallets/me/top-ups`
- `POST /api/v1/transfers`
- `GET /api/v1/transactions/me`

## Contract coverage

- API title, version and description
- RSA JWT bearer security scheme
- public and protected operation separation
- response status codes and stable error models
- `Idempotency-Key` header constraints
- transaction-history pagination and filters
- hidden JWT controller parameters
- prevention of idempotency-key exposure in response schemas

## Verification

- focused controller tests
- OpenAPI annotation contract tests
- generated `/v3/api-docs` integration test
- `mvn clean verify`