### PR TITLE
release: v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This keeps domain rules independent from Spring and infrastructure while avoidin
 
 ## Current status
 
-The repository foundation, identity flow, wallet management, and the first complete wallet-to-wallet transfer increment are implemented.
+The repository foundation, identity flow, wallet management, wallet-to-wallet transfer, double-entry ledger, and authenticated transaction history are implemented.
 
 Completed capabilities include:
 
@@ -74,8 +74,16 @@ Completed capabilities include:
 - controlled concurrent duplicate-transfer verification
 - real PostgreSQL integration tests with Testcontainers
 - real JWT endpoint-to-database transfer verification
+- authenticated current-wallet transaction history
+- incoming and outgoing transaction direction derivation
+- filtering by direction, transaction status, and date range
+- inclusive `from` and exclusive `to` date boundaries
+- deterministic pagination using `createdAt DESC, id DESC`
+- stable validation, authentication, and wallet-not-found responses
+- public transaction-history responses that exclude idempotency keys
+- real PostgreSQL verification of filtering, ordering, and pagination
 
-The next delivery focus is transaction history with filtering and pagination, followed by OpenAPI examples, a Postman collection, and the `v0.2.0` release. See the [roadmap](docs/roadmap.md).
+The next delivery focus is OpenAPI examples, a Postman collection, and the `v0.2.0` release, followed by transactional outbox and Kafka-based post-transfer processing. See the [roadmap](docs/roadmap.md).
 
 ## Implemented API
 
@@ -88,6 +96,7 @@ The next delivery focus is transaction history with filtering and pagination, fo
 | `GET` | `/api/v1/wallets/me` | Bearer JWT | Returns the authenticated user's wallet summary. |
 | `POST` | `/api/v1/wallets/me/top-ups` | Bearer JWT | Credits the authenticated user's wallet with a validated simulated amount. |
 | `POST` | `/api/v1/transfers` | Bearer JWT | Creates an atomic and idempotent wallet-to-wallet transfer. |
+| `GET` | `/api/v1/transactions/me` | Bearer JWT | Returns the authenticated user's paginated and filterable transaction history. |
 | `GET` | `/api/v1/system/health` | Configuration-dependent | Exposes the application health status. |
 
 ### Simulated wallet top-up
@@ -188,6 +197,66 @@ Relevant error outcomes include:
 - `422 SELF_TRANSFER_NOT_ALLOWED`
 - `422 TRANSFER_CURRENCY_MISMATCH`
 - `422 WALLET_NOT_ACTIVE`
+
+### Transaction history
+
+The endpoint resolves the wallet from the authenticated JWT subject. Clients cannot request another user's wallet history by supplying a wallet identifier.
+
+```http
+GET /api/v1/transactions/me?page=0&size=20&direction=OUTGOING&status=COMPLETED&from=2026-07-01T00:00:00Z&to=2026-08-01T00:00:00Z
+Authorization: Bearer <access-token>
+```
+
+Supported query parameters:
+
+| Parameter | Required | Description |
+|---|---|---|
+| `page` | No | Zero-based page number. Defaults to `0`. |
+| `size` | No | Page size between `1` and `100`. Defaults to `20`. |
+| `direction` | No | `INCOMING` or `OUTGOING`. |
+| `status` | No | `PENDING`, `COMPLETED`, or `FAILED`. |
+| `from` | No | Inclusive ISO-8601 instant. |
+| `to` | No | Exclusive ISO-8601 instant. |
+
+All filters are optional. When both date parameters are supplied, the endpoint uses the half-open interval `[from, to)`. Equal boundaries are valid and represent an empty date range.
+
+Successful response:
+
+```json
+{
+  "items": [
+    {
+      "transactionId": "b4077781-34f4-466f-8e61-b79ca906bc98",
+      "type": "TRANSFER",
+      "direction": "OUTGOING",
+      "counterpartyWalletId": "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db",
+      "amount": 125.50,
+      "currency": "TRY",
+      "status": "COMPLETED",
+      "createdAt": "2026-07-16T10:00:00Z",
+      "completedAt": "2026-07-16T10:00:01Z"
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 1,
+  "totalPages": 1,
+  "first": true,
+  "last": true,
+  "hasNext": false,
+  "hasPrevious": false
+}
+```
+
+Transactions are ordered by `createdAt DESC, id DESC` so pagination remains deterministic when multiple transactions share the same timestamp.
+
+The response intentionally excludes the transfer `Idempotency-Key`.
+
+Relevant error outcomes include:
+
+- `400 VALIDATION_FAILED`
+- `401 Unauthorized`
+- `404 WALLET_NOT_FOUND`
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -45,28 +45,37 @@ This keeps domain rules independent from Spring and infrastructure while avoidin
 
 ## Current status
 
-The repository foundation, identity flow, and initial wallet-management capabilities are complete:
+The repository foundation, identity flow, wallet management, and the first complete wallet-to-wallet transfer increment are implemented.
 
-- repository standards and CI verification
+Completed capabilities include:
+
+- repository standards, contribution guidelines, and CI verification
 - Docker-based PostgreSQL, Redis, and Kafka infrastructure
-- Flyway core schema
+- versioned PostgreSQL schema management with Flyway
 - secure-by-default Spring Security configuration
 - user registration with normalized email addresses
 - BCrypt password hashing
 - user login with RSA-signed JWT access tokens
 - authenticated current-user profile
-- authenticated wallet creation
-- authenticated current-wallet retrieval with a stable `404 Not Found` response
+- authenticated wallet creation and current-wallet retrieval
 - one-wallet-per-user enforcement at application and database levels
-- stable `409 Conflict` response for duplicate wallet creation
-- unit, web, persistence, and PostgreSQL Testcontainers integration tests
 - authenticated simulated wallet top-up
 - aggregate-based wallet balance mutation
-- PostgreSQL optimistic locking for wallet updates
-- stable `409 Conflict` response for concurrent wallet updates
-- real PostgreSQL concurrency verification with Testcontainers
+- PostgreSQL optimistic locking for concurrent wallet updates
+- authenticated wallet-to-wallet transfer
+- source-wallet identity derived from the authenticated JWT subject
+- transfer lifecycle persistence with `PENDING` and `COMPLETED` states
+- atomic source-wallet debit and target-wallet credit
+- immutable double-entry ledger records
+- source-wallet-scoped `Idempotency-Key` uniqueness
+- completed-transfer replay for repeated requests with the same payload
+- stable conflict responses for key reuse with a different payload
+- complete rollback when ledger persistence fails
+- controlled concurrent duplicate-transfer verification
+- real PostgreSQL integration tests with Testcontainers
+- real JWT endpoint-to-database transfer verification
 
-The current delivery focus is wallet-to-wallet transfer processing, idempotency, and double-entry ledger records, building on the completed wallet top-up and PostgreSQL optimistic-locking foundation. See the [roadmap](docs/roadmap.md).
+The next delivery focus is transaction history with filtering and pagination, followed by OpenAPI examples, a Postman collection, and the `v0.2.0` release. See the [roadmap](docs/roadmap.md).
 
 ## Implemented API
 
@@ -78,6 +87,7 @@ The current delivery focus is wallet-to-wallet transfer processing, idempotency,
 | `POST` | `/api/v1/wallets` | Bearer JWT | Opens a zero-balance wallet for the authenticated user. |
 | `GET` | `/api/v1/wallets/me` | Bearer JWT | Returns the authenticated user's wallet summary. |
 | `POST` | `/api/v1/wallets/me/top-ups` | Bearer JWT | Credits the authenticated user's wallet with a validated simulated amount. |
+| `POST` | `/api/v1/transfers` | Bearer JWT | Creates an atomic and idempotent wallet-to-wallet transfer. |
 | `GET` | `/api/v1/system/health` | Configuration-dependent | Exposes the application health status. |
 
 ### Simulated wallet top-up
@@ -117,6 +127,66 @@ Relevant error outcomes include:
 - `404 WALLET_NOT_FOUND`
 - `409 WALLET_CONCURRENT_UPDATE`
 - `422 INVALID_MONEY_AMOUNT`
+- `422 WALLET_NOT_ACTIVE`
+
+### Wallet-to-wallet transfer
+
+The source wallet is resolved from the authenticated JWT subject. Clients cannot provide or override the source wallet identifier.
+
+```http
+POST /api/v1/transfers
+Authorization: Bearer <access-token>
+Idempotency-Key: transfer-request-123
+Content-Type: application/json
+```
+
+Request body:
+
+```json
+{
+  "targetWalletId": "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db",
+  "amount": 125.50
+}
+```
+
+Successful response:
+
+```json
+{
+  "transactionId": "b4077781-34f4-466f-8e61-b79ca906bc98",
+  "sourceWalletId": "11111111-1111-1111-1111-111111111111",
+  "targetWalletId": "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db",
+  "amount": 125.50,
+  "currency": "TRY",
+  "status": "COMPLETED",
+  "createdAt": "2026-07-15T18:30:00.123456Z",
+  "completedAt": "2026-07-15T18:30:00.123456Z"
+}
+```
+
+Transfer guarantees:
+
+- the source wallet belongs to the authenticated user
+- source debit and target credit execute in one PostgreSQL transaction
+- every successful transfer creates one `DEBIT` and one `CREDIT` ledger entry
+- debit and credit amounts must be equal
+- repeated completed requests with the same key and payload return the existing transfer
+- reusing the same key with a different payload returns a conflict
+- concurrent duplicate requests create at most one financial movement
+- persistence failure rolls back wallet, transaction, and ledger changes
+
+Relevant error outcomes include:
+
+- `400 VALIDATION_FAILED`
+- `400 MISSING_IDEMPOTENCY_KEY`
+- `401 Unauthorized`
+- `404 WALLET_NOT_FOUND`
+- `409 IDEMPOTENCY_KEY_CONFLICT`
+- `409 IDEMPOTENCY_REQUEST_IN_PROGRESS`
+- `409 WALLET_CONCURRENT_UPDATE`
+- `422 INSUFFICIENT_BALANCE`
+- `422 SELF_TRANSFER_NOT_ALLOWED`
+- `422 TRANSFER_CURRENCY_MISMATCH`
 - `422 WALLET_NOT_ACTIVE`
 
 ## Local development
@@ -165,7 +235,21 @@ docker compose --profile app up --build
 
 ## Database model
 
-The initial migration defines users, wallets, payment transactions, and immutable ledger entries. The wallet row includes an optimistic-lock version. Idempotency uniqueness is enforced for the source wallet and request key.
+Flyway migrations define users, wallets, payment transactions, and immutable ledger entries.
+
+Important database guarantees include:
+
+- unique normalized user email addresses
+- one wallet per user
+- non-negative wallet balances
+- optimistic-lock wallet versions
+- positive transaction and ledger amounts
+- source-wallet-scoped idempotency-key uniqueness
+- distinct source and target wallets for transfers
+- ledger entry types restricted to `DEBIT` and `CREDIT`
+- one ledger entry per transaction, wallet, and entry type
+
+JPA models store cross-module references as UUID values rather than direct entity associations. This keeps persistence coupling between the wallet, transaction, and ledger modules explicit.
 
 The source diagrams are stored in:
 
@@ -188,7 +272,11 @@ Kafka decouples post-transfer work such as notifications, audit enrichment, and 
 
 ### How are duplicate payments prevented?
 
-Clients send an `Idempotency-Key`. The database stores the key with a uniqueness constraint scoped to the source wallet. Repeated requests return the original result instead of creating another transfer.
+Clients send an `Idempotency-Key`. PostgreSQL enforces uniqueness for the combination of source wallet and key.
+
+When a completed transfer is requested again with the same key and payload, the application returns the existing transaction result without mutating balances or creating ledger entries again.
+
+Using the same key with a different target wallet or amount returns `IDEMPOTENCY_KEY_CONFLICT`. A duplicate request that encounters an unfinished transaction returns `IDEMPOTENCY_REQUEST_IN_PROGRESS`.
 
 ### How are concurrent wallet updates protected?
 
@@ -196,7 +284,9 @@ Wallets use optimistic locking through a persisted version column. Conflicting u
 
 ### What happens when a transfer fails?
 
-Wallet mutation, transaction state, ledger entries, and outbox record creation execute in one database transaction. An exception rolls back the complete unit of work. Expected business failures are represented with stable error codes.
+Wallet mutation, payment-transaction persistence, and ledger-entry persistence execute in one PostgreSQL transaction. An exception rolls back the complete unit of work, including wallet balances and optimistic-lock versions.
+
+Transactional outbox persistence will be added in a later milestone. Once implemented, the outbox record will join the same database transaction.
 
 ### How is the application tested?
 

--- a/docs/adr/0002-double-entry-ledger.md
+++ b/docs/adr/0002-double-entry-ledger.md
@@ -1,24 +1,115 @@
 # ADR 0002: Record transfers with a double-entry ledger
 
-- Status: Accepted
+- Status: Accepted and implemented
 - Date: 2026-07-12
+- Last updated: 2026-07-15
 
 ## Context
 
-Updating a mutable wallet balance alone does not provide a durable financial history or a strong audit trail.
+Updating only a mutable wallet balance does not provide a durable financial history or a strong audit trail.
+
+A wallet balance represents the current state, but it does not independently explain:
+
+- why the balance changed
+- which transaction caused the movement
+- which wallet received or supplied the value
+- whether the movement was recorded symmetrically
+
+Financial movements therefore require immutable accounting records in addition to current wallet balances.
 
 ## Decision
 
-Each completed transfer will create balanced ledger entries:
+Each completed wallet-to-wallet transfer creates two balanced ledger entries:
 
-- one debit entry for the source wallet
-- one credit entry for the target wallet
+- one `DEBIT` entry for the source wallet
+- one `CREDIT` entry for the target wallet
 
-Ledger entries are immutable. Wallet balances are treated as a performance-oriented projection that must remain consistent with the ledger.
+Both entries:
+
+- reference the same payment transaction
+- carry the same monetary amount
+- use the same currency
+- reference different wallets
+
+Wallet balances are treated as a current-state projection. Ledger entries provide the durable explanation for how those balances changed.
+
+Wallet mutation, payment-transaction persistence, and ledger persistence execute in the same PostgreSQL transaction.
+
+## Domain model
+
+The ledger module contains an immutable ledger-entry model and a `DoubleEntryLedger` domain model.
+
+`DoubleEntryLedger` validates that:
+
+- exactly two entries are supplied
+- one entry is a debit
+- one entry is a credit
+- both entries reference the same payment transaction
+- entries reference different wallets
+- amounts are equal
+- currencies are equal
+
+The domain model reconstructs debit and credit entries by their entry type rather than depending on collection order.
 
 ## Invariants
 
-- Entry amounts must be positive.
-- Debit and credit totals for a transaction must be equal.
-- Entries cannot be updated or deleted through application use cases.
-- A transaction reaches `COMPLETED` only after all required entries are persisted.
+- Ledger-entry amounts must be positive.
+- Each completed transfer must produce one debit and one credit entry.
+- Debit and credit amounts must be equal.
+- Debit and credit currencies must be equal.
+- Both entries must reference the same payment transaction.
+- Debit and credit entries must reference different wallets.
+- A transaction reaches `COMPLETED` only after required ledger entries are persisted.
+- A transaction, wallet, and entry-type combination must be unique.
+- Application use cases do not update or delete historical ledger entries.
+
+## Database enforcement
+
+PostgreSQL reinforces the domain rules through constraints.
+
+Current persistence guarantees include:
+
+- ledger entry type is restricted to `DEBIT` or `CREDIT`
+- entry amount must be positive
+- transaction, wallet, and entry-type combinations are unique
+- payment-transaction source and target wallets must be different
+
+Database constraints do not replace domain validation. They provide a final integrity boundary against programming errors and concurrent writes.
+
+## Transaction behavior
+
+Ledger persistence participates in the same Spring-managed PostgreSQL transaction as:
+
+- source-wallet debit
+- target-wallet credit
+- payment-transaction creation
+- payment-transaction completion
+
+When ledger persistence fails, the complete transaction rolls back.
+
+The rollback includes:
+
+- wallet balance mutations
+- wallet optimistic-lock version changes
+- payment-transaction rows
+- ledger-entry rows
+
+## Verification
+
+The decision is verified through:
+
+- ledger domain-model unit tests
+- ledger persistence-adapter tests
+- PostgreSQL constraint tests
+- transfer application-service tests
+- successful transfer integration tests
+- authenticated HTTP integration tests
+- forced ledger-failure rollback tests
+- concurrent duplicate-transfer tests
+
+The integration suite verifies that a successful transfer creates:
+
+```text
+1 COMPLETED payment transaction
+1 DEBIT ledger entry
+1 CREDIT ledger entry

--- a/docs/adr/0003-idempotent-transfer-processing.md
+++ b/docs/adr/0003-idempotent-transfer-processing.md
@@ -1,0 +1,135 @@
+# ADR 0003: Enforce transfer idempotency with PostgreSQL
+
+- Status: Accepted and implemented
+- Date: 2026-07-15
+
+## Context
+
+A client may repeat a transfer request because of network timeouts, connection interruption, application restarts, delayed responses, or uncertainty about whether the first request completed.
+
+Treating every retry as a new request could create duplicate financial movements.
+
+An application-level lookup alone is insufficient. Two concurrent requests may both observe that no transaction exists before either request inserts its transaction row.
+
+## Decision
+
+Every transfer request requires an `Idempotency-Key` HTTP header.
+
+The key is normalized and stored with the payment transaction. PostgreSQL enforces uniqueness for the combination:
+
+`source_wallet_id + idempotency_key`
+
+The source-wallet scope allows unrelated users to use the same client-generated key without conflicting.
+
+The database constraint remains the final authority for concurrent races.
+
+## Request evaluation
+
+The application searches for an existing payment transaction using the authenticated source wallet and normalized idempotency key.
+
+### No existing transaction
+
+A new transfer may begin.
+
+### Completed transaction with matching payload
+
+The existing transaction result is returned.
+
+The application does not:
+
+- debit the source wallet again
+- credit the target wallet again
+- create another payment transaction
+- create additional ledger entries
+
+### Existing transaction with a different payload
+
+The request is rejected with `IDEMPOTENCY_KEY_CONFLICT`.
+
+A key cannot represent two logically different transfers from the same source wallet.
+
+### Existing unfinished transaction
+
+The request is rejected with `IDEMPOTENCY_REQUEST_IN_PROGRESS`.
+
+An unfinished transaction cannot be returned as a completed replay.
+
+## Payload identity
+
+A replay matches the original request when the following values are equivalent:
+
+- source wallet
+- target wallet
+- amount
+- transfer currency
+- normalized idempotency key
+
+The source wallet is derived from the authenticated JWT subject rather than supplied by the client.
+
+## Concurrency behavior
+
+Concurrent requests may both pass the initial application lookup.
+
+PostgreSQL then controls ownership of the unique source-wallet and idempotency-key combination. Only one request can create the authoritative transaction row.
+
+Depending on timing, another caller may:
+
+- observe and replay the completed transaction
+- receive a stable idempotency conflict while the competing transaction owns the key
+
+Regardless of the caller outcome, persisted financial state must contain at most:
+
+- one payment transaction
+- one source-wallet debit
+- one target-wallet credit
+- one `DEBIT` ledger entry
+- one `CREDIT` ledger entry
+
+## Consequences
+
+### Positive consequences
+
+- Client retries do not duplicate completed transfers.
+- Completed replay returns a stable transaction identity.
+- Balance mutations are not repeated.
+- Ledger entries are not duplicated.
+- PostgreSQL remains the source of truth.
+- Concurrent races are protected by a database constraint.
+- Idempotency correctness does not depend on Redis availability.
+
+### Trade-offs
+
+- Clients must generate and retain stable request keys.
+- A key cannot be reused for a different transfer from the same source wallet.
+- Concurrent callers may receive a conflict instead of an immediate replay.
+- Idempotency records currently share the payment-transaction lifecycle.
+- A retention and archival policy will be required later.
+
+## Alternatives considered
+
+### Application lookup without a database constraint
+
+Rejected because concurrent requests could both pass the lookup and create duplicate transfers.
+
+### Redis-only idempotency
+
+Rejected as the source of truth because financial transaction ownership must remain durable in PostgreSQL.
+
+Redis may later support bounded acceleration or temporary metadata, but it will not replace the database guarantee.
+
+### Globally unique idempotency keys
+
+Not selected because independent users should be able to generate identical client-side keys without interfering with each other.
+
+## Verification
+
+The decision is verified through:
+
+- idempotency value-object tests
+- application-service replay tests
+- conflicting-payload tests
+- payment-transaction persistence tests
+- PostgreSQL unique-constraint tests
+- sequential integration tests
+- controlled concurrent integration tests
+- authenticated HTTP integration tests

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,6 +91,10 @@ The transaction module owns:
 - transfer request identity
 - `PENDING` and `COMPLETED` states
 - stable transfer results
+- authenticated transaction-history queries
+- incoming and outgoing direction mapping
+- transaction-status and date-range filtering
+- pagination and deterministic ordering
 
 ### Ledger module
 
@@ -102,6 +106,38 @@ The ledger module owns:
 - persistence of accounting records
 
 The transaction module coordinates the use case, but it does not absorb wallet or ledger domain responsibilities.
+
+## Transaction history read path
+
+Transaction history is implemented as an application-level read use case rather than exposing Spring Data or JPA models through the HTTP boundary.
+
+The read flow is:
+
+1. obtain the authenticated user identifier from the verified JWT subject
+2. resolve the wallet owned by that user
+3. construct an application-level transaction-history filter
+4. query payment transactions where the wallet is either the source or target
+5. derive `OUTGOING` or `INCOMING` from the wallet's position in the transaction
+6. map the opposite wallet as the counterparty
+7. return an application-owned paginated result
+8. map the result to HTTP response DTOs
+
+The persistence query supports optional filtering by:
+
+- transaction direction
+- transaction status
+- inclusive `from` instant
+- exclusive `to` instant
+
+Results use the deterministic ordering:
+
+```text
+createdAt DESC, id DESC
+```
+
+The UUID tie-breaker keeps pagination predictable when multiple transactions share the same creation timestamp.
+
+Spring Data `Page`, JPA entities, and transfer idempotency keys do not cross the application or HTTP boundaries.
 
 ## Transaction strategy
 
@@ -233,8 +269,9 @@ Clients cannot supply the source user or source wallet identifier for:
 - current-wallet retrieval
 - wallet top-up
 - wallet-to-wallet transfer
+- transaction-history retrieval
 
-This prevents a client from changing another user's state by submitting a different UUID in the request body.
+This prevents a client from accessing or changing another user's data by supplying a different user or wallet identifier in request input.
 
 Spring Security uses a deny-by-default policy. New routes remain inaccessible until they are explicitly classified as public or authenticated.
 
@@ -248,8 +285,10 @@ Spring Security uses a deny-by-default policy. New routes remain inaccessible un
 - JPA entities are never exposed through API responses
 - business errors use stable application error codes
 - validation errors include field violations
-- collection endpoints will use pagination and deterministic sorting
+- collection endpoints use pagination and deterministic sorting
 - financial mutation endpoints define explicit conflict behavior
+- transaction-history date ranges use inclusive `from` and exclusive `to` boundaries
+- invalid pagination, enum, and timestamp parameters return stable validation responses
 
 ## Testing strategy
 
@@ -260,6 +299,7 @@ The test suite uses several complementary levels:
 - MockMvc slice tests for HTTP, validation, security, and error mapping
 - persistence-adapter tests for JPA mapping and constraint translation
 - Testcontainers tests against real PostgreSQL
+- PostgreSQL transaction-history tests for filtering, isolation, pagination, and deterministic ordering
 - controlled concurrency tests
 - rollback and failure-path tests
 - authenticated endpoint-to-database integration tests

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,18 +2,30 @@
 
 PayFlow uses a modular monolith with hexagonal boundaries inside business modules.
 
+The system is deployed as a single Spring Boot application, while business capabilities remain separated by package, port, and dependency boundaries.
+
 ## Dependency rule
 
-`adapter -> application -> domain`
+```text
+adapter -> application -> domain
+```
 
-The domain model has no Spring, JPA, Kafka, Redis, or HTTP dependencies. Application services coordinate use cases and depend on output-port interfaces. Adapters implement infrastructure details.
+The domain model has no Spring, JPA, Kafka, Redis, or HTTP dependencies.
+
+Application services coordinate use cases and depend on input and output ports. Adapters translate between the application core and infrastructure concerns such as HTTP, PostgreSQL, security, and future messaging integrations.
 
 ## Package convention
 
 ```text
 com.nursena.payflow
-├── auth
 ├── user
+│   ├── domain
+│   ├── application
+│   │   ├── port.in
+│   │   └── port.out
+│   └── adapter
+│       ├── in.web
+│       └── out
 ├── wallet
 │   ├── domain
 │   ├── application
@@ -23,31 +35,240 @@ com.nursena.payflow
 │       ├── in.web
 │       └── out.persistence
 ├── transaction
+│   ├── domain
+│   ├── application
+│   │   ├── port.in
+│   │   └── port.out
+│   └── adapter
+│       ├── in.web
+│       └── out.persistence
 ├── ledger
+│   ├── domain
+│   ├── application
+│   │   └── port.out
+│   └── adapter
+│       └── out.persistence
 ├── notification
 ├── audit
-├── security
 ├── common
 └── configuration
 ```
 
+Packages that represent future capabilities may remain empty until a concrete use case requires them. Infrastructure is not added only to demonstrate a technology.
+
+## Module responsibilities
+
+### User module
+
+The user module owns:
+
+- registration
+- normalized email identity
+- password-hash persistence
+- authentication
+- RSA-signed JWT creation
+- authenticated current-user profile
+
+### Wallet module
+
+The wallet module owns:
+
+- wallet lifecycle
+- wallet currency and status
+- current balance
+- credit and debit rules
+- insufficient-balance validation
+- optimistic-lock versioning
+- one-wallet-per-user enforcement
+
+### Transaction module
+
+The transaction module owns:
+
+- transfer request orchestration
+- payment-transaction lifecycle
+- idempotency evaluation
+- transfer request identity
+- `PENDING` and `COMPLETED` states
+- stable transfer results
+
+### Ledger module
+
+The ledger module owns:
+
+- immutable ledger entries
+- debit and credit entry types
+- double-entry balance invariants
+- persistence of accounting records
+
+The transaction module coordinates the use case, but it does not absorb wallet or ledger domain responsibilities.
+
 ## Transaction strategy
 
-The first implementation keeps wallet mutation, transaction state, ledger entries, and outbox event creation in one PostgreSQL transaction. Kafka publication will use a transactional outbox rather than publishing directly inside the database transaction.
+Wallet mutation, payment-transaction persistence, transaction-state completion, and double-entry ledger persistence execute in one PostgreSQL transaction.
+
+The current transfer unit of work is:
+
+1. resolve the authenticated user's source wallet
+2. construct and validate the requested monetary amount
+3. normalize the `Idempotency-Key`
+4. evaluate whether an existing transaction already owns the key
+5. return the existing result when a completed matching request is replayed
+6. reject conflicting or unfinished duplicate requests
+7. resolve the target wallet
+8. validate wallet currency compatibility
+9. create a `PENDING` payment transaction
+10. debit the source wallet
+11. credit the target wallet
+12. persist the payment transaction
+13. persist both wallet mutations
+14. create one debit and one credit ledger entry
+15. persist the double-entry ledger
+16. mark the payment transaction as `COMPLETED`
+
+Any exception propagating from this unit of work rolls back:
+
+- source-wallet balance changes
+- target-wallet balance changes
+- wallet optimistic-lock version changes
+- payment-transaction persistence
+- ledger-entry persistence
+
+The rollback behavior is verified against PostgreSQL by forcing ledger persistence to fail after wallet and transaction persistence have begun.
+
+## Transactional outbox strategy
+
+Transactional outbox persistence is planned for a later milestone and is not part of the current transfer transaction.
+
+When implemented, the outbox record will be written in the same PostgreSQL transaction as the completed transfer. Kafka publication will happen after commit through a separate publisher.
+
+The transfer use case will not publish directly to Kafka inside the database transaction.
 
 ## Concurrency strategy
 
-- JPA optimistic locking on wallets through `@Version`
-- retry policy only for explicitly classified optimistic-lock conflicts
-- idempotency key uniqueness at database level
-- deterministic wallet locking/order if pessimistic locking is introduced later
-- ledger invariants enforced both in domain code and integration tests
+PayFlow uses multiple complementary controls rather than relying on a single application-level check.
+
+### Wallet updates
+
+- Wallet rows use JPA optimistic locking through `@Version`.
+- Persistence adapters translate classified optimistic-lock failures into a stable `WALLET_CONCURRENT_UPDATE` application exception.
+- Conflicting updates fail instead of silently overwriting committed balances.
+- Real PostgreSQL concurrency tests verify lost-update protection.
+- Automatic retry is not currently applied to financial mutations.
+- Wallet updates follow deterministic ordering to reduce inconsistent lock acquisition behavior.
+
+### Transfer idempotency
+
+- Clients provide an `Idempotency-Key`.
+- PostgreSQL enforces uniqueness for `source_wallet_id + idempotency_key`.
+- Application-level lookup provides replay and business-error behavior.
+- The database constraint remains the final authority when concurrent requests both pass the initial lookup.
+- Completed requests with the same payload replay the existing transaction.
+- Reusing the key with a different payload returns `IDEMPOTENCY_KEY_CONFLICT`.
+- Encountering an unfinished transaction returns `IDEMPOTENCY_REQUEST_IN_PROGRESS`.
+- Controlled concurrent integration tests verify that duplicate requests create at most one financial movement.
+
+### Ledger consistency
+
+- Double-entry invariants are validated by the domain model.
+- PostgreSQL check constraints restrict valid entry types.
+- PostgreSQL uniqueness prevents duplicate transaction-wallet-entry-type combinations.
+- Integration tests verify one debit and one credit entry for a completed transfer.
+- Rollback tests verify that partial ledger state cannot survive a failed transfer.
+
+## Persistence boundaries
+
+Cross-module persistence references are represented as UUID identifiers rather than direct JPA entity associations.
+
+For example:
+
+- a payment transaction stores source and target wallet identifiers
+- a ledger entry stores payment-transaction and wallet identifiers
+- transaction entities do not contain `@ManyToOne` references to wallet entities
+- ledger entities do not depend on transaction or wallet JPA entities
+
+This keeps module coupling explicit and prevents persistence mappings from becoming hidden domain dependencies.
+
+Repository ports expose domain-oriented operations. JPA repositories and entities remain adapter details.
+
+## Transfer consistency guarantees
+
+A completed transfer must satisfy all of the following:
+
+- source and target wallets exist
+- source wallet belongs to the authenticated user
+- source and target wallets are different
+- source and target wallets are active
+- source and target currencies match
+- amount is positive
+- amount uses supported monetary precision
+- source wallet has sufficient balance
+- source debit equals target credit
+- exactly one debit and one credit ledger entry represent the movement
+- both ledger entries reference the same payment transaction
+- debit and credit entries reference different wallets
+- transaction status is `COMPLETED`
+- replay does not create additional balance or ledger mutations
+
+These guarantees are enforced through a combination of:
+
+- domain invariants
+- application orchestration
+- PostgreSQL transactions
+- database constraints
+- optimistic locking
+- idempotency uniqueness
+- unit tests
+- persistence tests
+- real PostgreSQL integration tests
+
+## Security boundaries
+
+Protected endpoint identity is derived from the verified JWT subject.
+
+Clients cannot supply the source user or source wallet identifier for:
+
+- current-user profile access
+- wallet creation
+- current-wallet retrieval
+- wallet top-up
+- wallet-to-wallet transfer
+
+This prevents a client from changing another user's state by submitting a different UUID in the request body.
+
+Spring Security uses a deny-by-default policy. New routes remain inaccessible until they are explicitly classified as public or authenticated.
 
 ## API conventions
 
-- versioned routes under `/api/v1`
-- RFC-style structured errors with stable application error codes
-- DTOs at the HTTP boundary
-- validation before use-case execution
-- pagination for collection endpoints
-- no JPA entity exposure
+- routes are versioned under `/api/v1`
+- protected routes use Bearer JWT authentication
+- DTOs exist at the HTTP boundary
+- application commands and results remain independent from HTTP
+- request validation runs before use-case execution
+- JPA entities are never exposed through API responses
+- business errors use stable application error codes
+- validation errors include field violations
+- collection endpoints will use pagination and deterministic sorting
+- financial mutation endpoints define explicit conflict behavior
+
+## Testing strategy
+
+The test suite uses several complementary levels:
+
+- domain tests for pure financial rules
+- application-service unit tests for use-case coordination
+- MockMvc slice tests for HTTP, validation, security, and error mapping
+- persistence-adapter tests for JPA mapping and constraint translation
+- Testcontainers tests against real PostgreSQL
+- controlled concurrency tests
+- rollback and failure-path tests
+- authenticated endpoint-to-database integration tests
+
+PostgreSQL is used instead of an in-memory substitute for behavior involving:
+
+- named constraints
+- transaction rollback
+- optimistic locking
+- UUID persistence
+- timestamp precision
+- concurrent unique-key races

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,9 +2,9 @@
 
 ## Current delivery focus
 
-The repository foundation, core identity flow, authenticated current-user profile, secure wallet creation, authenticated wallet retrieval, simulated top-up, and PostgreSQL optimistic-locking verification are complete.
+The repository foundation, identity flow, wallet management, wallet-to-wallet transfer processing, double-entry ledger persistence, and authenticated transaction history are complete.
 
-The next delivery increment is wallet-to-wallet transfer processing with idempotency and double-entry ledger records.
+The next delivery increment focuses on API delivery and release readiness through OpenAPI examples, a Postman collection, and the `v0.2.0` release. Transactional outbox and Kafka-based post-transfer processing follow in the event-driven milestone.
 
 ## Milestone 0 — Repository foundation
 
@@ -57,9 +57,9 @@ The next delivery increment is wallet-to-wallet transfer processing with idempot
 - [x] Rollback verification when ledger persistence fails
 - [x] Concurrent duplicate-transfer verification
 - [x] Authenticated endpoint-to-database integration test
-- [ ] Transaction history
-- [ ] Filtering by direction, status, and date range
-- [ ] Pagination and stable sorting
+- [x] Transaction history
+- [x] Filtering by direction, status, and date range
+- [x] Pagination and deterministic sorting
 
 ## Milestone 4 — Event-driven processing
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,13 +40,26 @@ The next delivery increment is wallet-to-wallet transfer processing with idempot
 
 ## Milestone 3 — Transfers and ledger
 
-- [ ] Transfer use case
-- [ ] `Idempotency-Key` handling
-- [ ] Transaction state machine
-- [ ] Atomic source-wallet debit and target-wallet credit
-- [ ] Double-entry ledger
-- [ ] Rollback and concurrency tests
-- [ ] Filtering and pagination
+- [x] Transfer domain model and lifecycle
+- [x] Payment-transaction persistence
+- [x] `PENDING` to `COMPLETED` state transition
+- [x] Authenticated transfer use case
+- [x] Source wallet derived from JWT identity
+- [x] `Idempotency-Key` HTTP contract
+- [x] Source-wallet-scoped database uniqueness
+- [x] Completed-request replay
+- [x] Conflicting-payload detection
+- [x] In-progress request conflict behavior
+- [x] Atomic source-wallet debit and target-wallet credit
+- [x] Double-entry ledger domain model
+- [x] Immutable `DEBIT` and `CREDIT` persistence
+- [x] Database constraints for transfer and ledger invariants
+- [x] Rollback verification when ledger persistence fails
+- [x] Concurrent duplicate-transfer verification
+- [x] Authenticated endpoint-to-database integration test
+- [ ] Transaction history
+- [ ] Filtering by direction, status, and date range
+- [ ] Pagination and stable sorting
 
 ## Milestone 4 — Event-driven processing
 

--- a/src/main/java/com/nursena/payflow/common/api/ApiError.java
+++ b/src/main/java/com/nursena/payflow/common/api/ApiError.java
@@ -3,14 +3,71 @@ package com.nursena.payflow.common.api;
 import java.time.Instant;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "ApiError",
+    description = "Stable error response returned by PayFlow."
+)
 public record ApiError(
-        Instant timestamp,
-        int status,
-        String code,
-        String message,
-        String path,
-        List<FieldViolation> violations
+
+    @Schema(
+        description = "Time at which the error was generated.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
+    Instant timestamp,
+
+    @Schema(
+        description = "HTTP status code.",
+        example = "400",
+        format = "int32"
+    )
+    int status,
+
+    @Schema(
+        description = "Stable machine-readable error code.",
+        example = "VALIDATION_FAILED"
+    )
+    String code,
+
+    @Schema(
+        description = "Human-readable error description.",
+        example = "Request validation failed."
+    )
+    String message,
+
+    @Schema(
+        description = "Request path that produced the error.",
+        example = "/api/v1/auth/register"
+    )
+    String path,
+
+    @Schema(
+        description =
+            "Field-level violations. Empty for "
+                + "non-validation errors."
+    )
+    List<FieldViolation> violations
 ) {
-    public record FieldViolation(String field, String message) {
+
+    @Schema(
+        name = "FieldViolation",
+        description = "A request-field validation failure."
+    )
+    public record FieldViolation(
+
+        @Schema(
+            description = "Invalid request field.",
+            example = "email"
+        )
+        String field,
+
+        @Schema(
+            description = "Field validation message.",
+            example = "Email must be valid."
+        )
+        String message
+    ) {
     }
 }

--- a/src/main/java/com/nursena/payflow/common/api/SystemController.java
+++ b/src/main/java/com/nursena/payflow/common/api/SystemController.java
@@ -1,23 +1,62 @@
 package com.nursena.payflow.common.api;
 
-import java.time.Instant;
-import java.util.Map;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import java.time.Instant;
+
+import com.nursena.payflow.configuration.OpenApiExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(
+    name = "System",
+    description = "Public service status operations."
+)
 @RestController
 @RequestMapping("/api/v1/system")
 public class SystemController {
 
+    @Operation(
+        operationId = "getSystemHealth",
+        summary = "Get service health",
+        description =
+            "Returns basic PayFlow service status information."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Service health returned.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        SystemHealthResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples.SYSTEM_HEALTH
+                )
+            )
+        )
+    })
     @GetMapping("/health")
-    public ResponseEntity<Map<String, Object>> health() {
-        return ResponseEntity.ok(Map.of(
-                "status", "UP",
-                "service", "payflow",
-                "timestamp", Instant.now()
-        ));
+    public ResponseEntity<SystemHealthResponse> health() {
+        SystemHealthResponse response =
+            new SystemHealthResponse(
+                "UP",
+                "payflow",
+                Instant.now()
+            );
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/nursena/payflow/common/api/SystemHealthResponse.java
+++ b/src/main/java/com/nursena/payflow/common/api/SystemHealthResponse.java
@@ -1,0 +1,32 @@
+package com.nursena.payflow.common.api;
+
+import java.time.Instant;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "SystemHealthResponse",
+    description = "Basic PayFlow service health information."
+)
+public record SystemHealthResponse(
+
+    @Schema(
+        description = "Current service status.",
+        example = "UP"
+    )
+    String status,
+
+    @Schema(
+        description = "Service identifier.",
+        example = "payflow"
+    )
+    String service,
+
+    @Schema(
+        description = "Time at which the status was generated.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
+    Instant timestamp
+) {
+}

--- a/src/main/java/com/nursena/payflow/configuration/OpenApiConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/OpenApiConfiguration.java
@@ -1,0 +1,59 @@
+package com.nursena.payflow.configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class OpenApiConfiguration {
+
+    public static final String BEARER_AUTH_SCHEME =
+        "bearerAuth";
+
+    private static final String API_TITLE =
+        "PayFlow API";
+
+    private static final String API_VERSION =
+        "0.2.0";
+
+    private static final String API_DESCRIPTION =
+        """
+        REST API for the PayFlow simulated digital wallet \
+        and payment transaction backend.
+
+        PayFlow does not process real money.
+        """;
+
+    @Bean
+    OpenAPI payflowOpenApi() {
+        return new OpenAPI()
+            .info(
+                new Info()
+                    .title(API_TITLE)
+                    .version(API_VERSION)
+                    .description(API_DESCRIPTION)
+            )
+            .components(
+                new Components()
+                    .addSecuritySchemes(
+                        BEARER_AUTH_SCHEME,
+                        bearerJwtSecurityScheme()
+                    )
+            );
+    }
+
+    private static SecurityScheme
+    bearerJwtSecurityScheme() {
+        return new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+            .description(
+                "RSA-signed JWT access token returned "
+                    + "by the login endpoint."
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
@@ -1,0 +1,102 @@
+package com.nursena.payflow.configuration;
+
+public final class OpenApiExamples {
+
+    public static final String SYSTEM_HEALTH =
+        """
+        {
+          "status": "UP",
+          "service": "payflow",
+          "timestamp": "2026-07-17T12:00:00Z"
+        }
+        """;
+
+    public static final String REGISTER_SUCCESS =
+        """
+        {
+          "userId": "8805681d-d537-42f2-8906-5da1f0666ab7"
+        }
+        """;
+
+    public static final String LOGIN_SUCCESS =
+        """
+        {
+          "accessToken": "eyJhbGciOiJSUzI1NiJ9...",
+          "tokenType": "Bearer",
+          "expiresAt": "2026-07-17T12:15:00Z"
+        }
+        """;
+
+    public static final String REGISTER_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/auth/register",
+          "violations": [
+            {
+              "field": "password",
+              "message": "Password must be between 12 and 72 characters."
+            }
+          ]
+        }
+        """;
+
+    public static final String LOGIN_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/auth/login",
+          "violations": [
+            {
+              "field": "email",
+              "message": "Email must be valid."
+            }
+          ]
+        }
+        """;
+
+    public static final String EMAIL_ALREADY_REGISTERED =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 409,
+          "code": "EMAIL_ALREADY_REGISTERED",
+          "message": "A user with this email address already exists.",
+          "path": "/api/v1/auth/register",
+          "violations": []
+        }
+        """;
+
+    public static final String INVALID_CREDENTIALS =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 401,
+          "code": "INVALID_CREDENTIALS",
+          "message": "Email or password is incorrect.",
+          "path": "/api/v1/auth/login",
+          "violations": []
+        }
+        """;
+
+    public static final String USER_ACCOUNT_UNAVAILABLE =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 403,
+          "code": "USER_ACCOUNT_UNAVAILABLE",
+          "message": "User account is not available for authentication.",
+          "path": "/api/v1/auth/login",
+          "violations": []
+        }
+        """;
+
+    private OpenApiExamples() {
+    }
+}

--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -42,13 +42,8 @@ public class SecurityConfiguration {
                 .requestMatchers(
                     GET,
                     "/api/v1/users/me",
-                    "/api/v1/wallets/me"
-                )
-                .authenticated()
-                .requestMatchers(
-                    POST,
-                    "/api/v1/wallets",
-                    "/api/v1/wallets/me/top-ups"
+                    "/api/v1/wallets/me",
+                    "/api/v1/transactions/me"
                 )
                 .authenticated()
                 .requestMatchers(

--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -51,6 +51,13 @@ public class SecurityConfiguration {
                     "/api/v1/wallets/me/top-ups"
                 )
                 .authenticated()
+                .requestMatchers(
+                    POST,
+                    "/api/v1/wallets",
+                    "/api/v1/wallets/me/top-ups",
+                    "/api/v1/transfers"
+                )
+                .authenticated()
                 .anyRequest()
                 .denyAll()
             )

--- a/src/main/java/com/nursena/payflow/configuration/TransactionApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/TransactionApiExamples.java
@@ -1,0 +1,199 @@
+package com.nursena.payflow.configuration;
+
+public final class TransactionApiExamples {
+
+    public static final String TRANSFER_SUCCESS =
+        """
+        {
+          "transactionId": "aa3ab0b3-3d85-42d7-a641-2ec43cd81dd9",
+          "sourceWalletId": "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+          "targetWalletId": "f4c8ab12-a4bb-43cb-b6a8-e797cc95e914",
+          "amount": 125.50,
+          "currency": "TRY",
+          "status": "COMPLETED",
+          "createdAt": "2026-07-17T12:00:00Z",
+          "completedAt": "2026-07-17T12:00:00.125Z"
+        }
+        """;
+
+    public static final String MISSING_IDEMPOTENCY_KEY =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "MISSING_IDEMPOTENCY_KEY",
+          "message": "Idempotency-Key header is required.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String TRANSFER_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/transfers",
+          "violations": [
+            {
+              "field": "amount",
+              "message": "amount must be greater than zero"
+            }
+          ]
+        }
+        """;
+
+    public static final String TRANSFER_WALLET_NOT_FOUND =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 404,
+          "code": "WALLET_NOT_FOUND",
+          "message": "Wallet could not be found.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String IDEMPOTENCY_KEY_CONFLICT =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 409,
+          "code": "IDEMPOTENCY_KEY_CONFLICT",
+          "message": "Idempotency key has already been used for another transfer request.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String IDEMPOTENCY_REQUEST_IN_PROGRESS =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 409,
+          "code": "IDEMPOTENCY_REQUEST_IN_PROGRESS",
+          "message": "A transfer with this idempotency key is still being processed.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String TRANSFER_CONCURRENT_UPDATE =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 409,
+          "code": "WALLET_CONCURRENT_UPDATE",
+          "message": "Wallet was updated concurrently. Please retry the operation.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String INVALID_IDEMPOTENCY_KEY =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 422,
+          "code": "INVALID_IDEMPOTENCY_KEY",
+          "message": "Idempotency key must contain between 1 and 100 characters.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String INSUFFICIENT_BALANCE =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 422,
+          "code": "INSUFFICIENT_BALANCE",
+          "message": "Wallet balance is insufficient for this operation.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String TRANSFER_WALLET_NOT_ACTIVE =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 422,
+          "code": "WALLET_NOT_ACTIVE",
+          "message": "Wallet must be active to perform this operation.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String TRANSFER_CURRENCY_MISMATCH =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 422,
+          "code": "TRANSFER_CURRENCY_MISMATCH",
+          "message": "Source and target wallet currencies must match.",
+          "path": "/api/v1/transfers",
+          "violations": []
+        }
+        """;
+
+    public static final String TRANSACTION_HISTORY_SUCCESS =
+        """
+        {
+          "items": [
+            {
+              "transactionId": "aa3ab0b3-3d85-42d7-a641-2ec43cd81dd9",
+              "type": "TRANSFER",
+              "direction": "OUTGOING",
+              "counterpartyWalletId": "f4c8ab12-a4bb-43cb-b6a8-e797cc95e914",
+              "amount": 125.50,
+              "currency": "TRY",
+              "status": "COMPLETED",
+              "createdAt": "2026-07-17T12:00:00Z",
+              "completedAt": "2026-07-17T12:00:00.125Z"
+            }
+          ],
+          "page": 0,
+          "size": 20,
+          "totalElements": 1,
+          "totalPages": 1,
+          "first": true,
+          "last": true,
+          "hasNext": false,
+          "hasPrevious": false
+        }
+        """;
+
+    public static final String
+        TRANSACTION_HISTORY_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/transactions/me",
+          "violations": []
+        }
+        """;
+
+    public static final String
+        TRANSACTION_HISTORY_WALLET_NOT_FOUND =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 404,
+          "code": "WALLET_NOT_FOUND",
+          "message": "Wallet could not be found.",
+          "path": "/api/v1/transactions/me",
+          "violations": []
+        }
+        """;
+
+    private TransactionApiExamples() {
+    }
+}

--- a/src/main/java/com/nursena/payflow/configuration/UserApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/UserApiExamples.java
@@ -1,0 +1,30 @@
+package com.nursena.payflow.configuration;
+
+public final class UserApiExamples {
+
+    public static final String CURRENT_USER_PROFILE =
+        """
+        {
+          "id": "8805681d-d537-42f2-8906-5da1f0666ab7",
+          "email": "nursena@example.com",
+          "role": "USER",
+          "status": "ACTIVE",
+          "createdAt": "2026-07-17T12:00:00Z"
+        }
+        """;
+
+    public static final String USER_NOT_FOUND =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 404,
+          "code": "USER_NOT_FOUND",
+          "message": "User could not be found.",
+          "path": "/api/v1/users/me",
+          "violations": []
+        }
+        """;
+
+    private UserApiExamples() {
+    }
+}

--- a/src/main/java/com/nursena/payflow/configuration/WalletApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/WalletApiExamples.java
@@ -1,0 +1,135 @@
+package com.nursena.payflow.configuration;
+
+public final class WalletApiExamples {
+
+    public static final String OPEN_WALLET =
+        """
+        {
+          "id": "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+          "ownerId": "8805681d-d537-42f2-8906-5da1f0666ab7",
+          "balance": 0.00,
+          "currency": "TRY",
+          "status": "ACTIVE",
+          "createdAt": "2026-07-17T12:00:00Z"
+        }
+        """;
+
+    public static final String OPEN_WALLET_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/wallets",
+          "violations": [
+            {
+              "field": "currency",
+              "message": "Currency is required."
+            }
+          ]
+        }
+        """;
+
+    public static final String WALLET_ALREADY_EXISTS =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 409,
+          "code": "WALLET_ALREADY_EXISTS",
+          "message": "User already has a wallet.",
+          "path": "/api/v1/wallets",
+          "violations": []
+        }
+        """;
+
+    public static final String CURRENT_WALLET =
+        """
+        {
+          "id": "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+          "balance": 250.00,
+          "currency": "TRY",
+          "status": "ACTIVE",
+          "createdAt": "2026-07-17T12:00:00Z"
+        }
+        """;
+
+    public static final String CURRENT_WALLET_NOT_FOUND =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 404,
+          "code": "WALLET_NOT_FOUND",
+          "message": "Wallet could not be found.",
+          "path": "/api/v1/wallets/me",
+          "violations": []
+        }
+        """;
+
+    public static final String TOP_UP_WALLET =
+        """
+        {
+          "id": "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+          "balance": 350.00,
+          "currency": "TRY",
+          "status": "ACTIVE",
+          "createdAt": "2026-07-17T12:00:00Z"
+        }
+        """;
+
+    public static final String TOP_UP_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/wallets/me/top-ups",
+          "violations": [
+            {
+              "field": "amount",
+              "message": "amount must be greater than zero"
+            }
+          ]
+        }
+        """;
+
+    public static final String TOP_UP_WALLET_NOT_FOUND =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 404,
+          "code": "WALLET_NOT_FOUND",
+          "message": "Wallet could not be found.",
+          "path": "/api/v1/wallets/me/top-ups",
+          "violations": []
+        }
+        """;
+
+    public static final String WALLET_CONCURRENT_UPDATE =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 409,
+          "code": "WALLET_CONCURRENT_UPDATE",
+          "message": "Wallet was updated concurrently. Please retry the operation.",
+          "path": "/api/v1/wallets/me/top-ups",
+          "violations": []
+        }
+        """;
+
+    public static final String WALLET_NOT_ACTIVE =
+        """
+        {
+          "timestamp": "2026-07-17T12:00:00Z",
+          "status": 422,
+          "code": "WALLET_NOT_ACTIVE",
+          "message": "Wallet must be active to perform this operation.",
+          "path": "/api/v1/wallets/me/top-ups",
+          "violations": []
+        }
+        """;
+
+    private WalletApiExamples() {
+    }
+}

--- a/src/main/java/com/nursena/payflow/ledger/adapter/out/persistence/LedgerEntryJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/ledger/adapter/out/persistence/LedgerEntryJpaEntity.java
@@ -1,0 +1,112 @@
+package com.nursena.payflow.ledger.adapter.out.persistence;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.ledger.domain.model.LedgerEntryType;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "ledger_entries")
+class LedgerEntryJpaEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(
+        name = "transaction_id",
+        nullable = false
+    )
+    private UUID transactionId;
+
+    @Column(
+        name = "wallet_id",
+        nullable = false
+    )
+    private UUID walletId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+        name = "entry_type",
+        nullable = false,
+        length = 10
+    )
+    private LedgerEntryType entryType;
+
+    @Column(
+        nullable = false,
+        precision = 19,
+        scale = 2
+    )
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+        nullable = false,
+        length = 3
+    )
+    private Currency currency;
+
+    @Column(
+        name = "created_at",
+        nullable = false,
+        updatable = false
+    )
+    private Instant createdAt;
+
+    protected LedgerEntryJpaEntity() {
+    }
+
+    LedgerEntryJpaEntity(
+        UUID id,
+        UUID transactionId,
+        UUID walletId,
+        LedgerEntryType entryType,
+        BigDecimal amount,
+        Currency currency,
+        Instant createdAt
+    ) {
+        this.id = id;
+        this.transactionId = transactionId;
+        this.walletId = walletId;
+        this.entryType = entryType;
+        this.amount = amount;
+        this.currency = currency;
+        this.createdAt = createdAt;
+    }
+
+    UUID getId() {
+        return id;
+    }
+
+    UUID getTransactionId() {
+        return transactionId;
+    }
+
+    UUID getWalletId() {
+        return walletId;
+    }
+
+    LedgerEntryType getEntryType() {
+        return entryType;
+    }
+
+    BigDecimal getAmount() {
+        return amount;
+    }
+
+    Currency getCurrency() {
+        return currency;
+    }
+
+    Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/nursena/payflow/ledger/adapter/out/persistence/LedgerPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/ledger/adapter/out/persistence/LedgerPersistenceAdapter.java
@@ -1,0 +1,104 @@
+package com.nursena.payflow.ledger.adapter.out.persistence;
+
+import java.util.List;
+
+import com.nursena.payflow.ledger.application.port.out.LedgerRepositoryPort;
+import com.nursena.payflow.ledger.domain.exception.InvalidLedgerEntryPairException;
+import com.nursena.payflow.ledger.domain.model.DoubleEntryLedger;
+import com.nursena.payflow.ledger.domain.model.LedgerEntry;
+import com.nursena.payflow.ledger.domain.model.LedgerEntryType;
+import com.nursena.payflow.wallet.domain.model.Money;
+import org.springframework.stereotype.Component;
+
+@Component
+class LedgerPersistenceAdapter
+    implements LedgerRepositoryPort {
+
+    private final SpringDataLedgerEntryRepository repository;
+
+    LedgerPersistenceAdapter(
+        SpringDataLedgerEntryRepository repository
+    ) {
+        this.repository = repository;
+    }
+
+    @Override
+    public DoubleEntryLedger save(
+        DoubleEntryLedger ledger
+    ) {
+        List<LedgerEntryJpaEntity> entities = List.of(
+            toEntity(ledger.debitEntry()),
+            toEntity(ledger.creditEntry())
+        );
+
+        List<LedgerEntryJpaEntity> savedEntities =
+            repository.saveAllAndFlush(entities);
+
+        return toDomain(savedEntities);
+    }
+
+    private static LedgerEntryJpaEntity toEntity(
+        LedgerEntry entry
+    ) {
+        return new LedgerEntryJpaEntity(
+            entry.id(),
+            entry.transactionId(),
+            entry.walletId(),
+            entry.type(),
+            entry.amount().amount(),
+            entry.amount().currency(),
+            entry.createdAt()
+        );
+    }
+
+    private static DoubleEntryLedger toDomain(
+        List<LedgerEntryJpaEntity> entities
+    ) {
+        if (entities.size() != 2) {
+            throw new InvalidLedgerEntryPairException();
+        }
+
+        LedgerEntry debitEntry = entities.stream()
+            .filter(entity ->
+                entity.getEntryType()
+                    == LedgerEntryType.DEBIT
+            )
+            .findFirst()
+            .map(LedgerPersistenceAdapter::toDomain)
+            .orElseThrow(
+                InvalidLedgerEntryPairException::new
+            );
+
+        LedgerEntry creditEntry = entities.stream()
+            .filter(entity ->
+                entity.getEntryType()
+                    == LedgerEntryType.CREDIT
+            )
+            .findFirst()
+            .map(LedgerPersistenceAdapter::toDomain)
+            .orElseThrow(
+                InvalidLedgerEntryPairException::new
+            );
+
+        return new DoubleEntryLedger(
+            debitEntry,
+            creditEntry
+        );
+    }
+
+    private static LedgerEntry toDomain(
+        LedgerEntryJpaEntity entity
+    ) {
+        return LedgerEntry.rehydrate(
+            entity.getId(),
+            entity.getTransactionId(),
+            entity.getWalletId(),
+            entity.getEntryType(),
+            new Money(
+                entity.getAmount(),
+                entity.getCurrency()
+            ),
+            entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/ledger/adapter/out/persistence/SpringDataLedgerEntryRepository.java
+++ b/src/main/java/com/nursena/payflow/ledger/adapter/out/persistence/SpringDataLedgerEntryRepository.java
@@ -1,0 +1,9 @@
+package com.nursena.payflow.ledger.adapter.out.persistence;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface SpringDataLedgerEntryRepository
+    extends JpaRepository<LedgerEntryJpaEntity, UUID> {
+}

--- a/src/main/java/com/nursena/payflow/ledger/application/port/out/LedgerRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/ledger/application/port/out/LedgerRepositoryPort.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.ledger.application.port.out;
+
+import com.nursena.payflow.ledger.domain.model.DoubleEntryLedger;
+
+public interface LedgerRepositoryPort {
+
+    DoubleEntryLedger save(DoubleEntryLedger ledger);
+}

--- a/src/main/java/com/nursena/payflow/ledger/domain/exception/InvalidLedgerAmountException.java
+++ b/src/main/java/com/nursena/payflow/ledger/domain/exception/InvalidLedgerAmountException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.ledger.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class InvalidLedgerAmountException
+    extends BusinessRuleException {
+
+    public InvalidLedgerAmountException() {
+        super(
+            "INVALID_LEDGER_AMOUNT",
+            "Ledger entry amount must be greater than zero."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/ledger/domain/exception/InvalidLedgerEntryPairException.java
+++ b/src/main/java/com/nursena/payflow/ledger/domain/exception/InvalidLedgerEntryPairException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.ledger.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class InvalidLedgerEntryPairException
+    extends BusinessRuleException {
+
+    public InvalidLedgerEntryPairException() {
+        super(
+            "INVALID_LEDGER_ENTRY_PAIR",
+            "Ledger entries must form a balanced debit and credit pair."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/ledger/domain/model/DoubleEntryLedger.java
+++ b/src/main/java/com/nursena/payflow/ledger/domain/model/DoubleEntryLedger.java
@@ -1,0 +1,104 @@
+package com.nursena.payflow.ledger.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.ledger.domain.exception.InvalidLedgerEntryPairException;
+import com.nursena.payflow.wallet.domain.model.Money;
+
+public record DoubleEntryLedger(
+    LedgerEntry debitEntry,
+    LedgerEntry creditEntry
+) {
+
+    public DoubleEntryLedger {
+        Objects.requireNonNull(
+            debitEntry,
+            "debitEntry must not be null"
+        );
+        Objects.requireNonNull(
+            creditEntry,
+            "creditEntry must not be null"
+        );
+
+        boolean validTypes =
+            debitEntry.type() == LedgerEntryType.DEBIT
+                && creditEntry.type()
+                == LedgerEntryType.CREDIT;
+
+        boolean sameTransaction =
+            debitEntry.transactionId().equals(
+                creditEntry.transactionId()
+            );
+
+        boolean differentWallets =
+            !debitEntry.walletId().equals(
+                creditEntry.walletId()
+            );
+
+        boolean balancedAmount =
+            debitEntry.amount().equals(
+                creditEntry.amount()
+            );
+
+        if (!validTypes
+            || !sameTransaction
+            || !differentWallets
+            || !balancedAmount) {
+            throw new InvalidLedgerEntryPairException();
+        }
+    }
+
+    public static DoubleEntryLedger forTransfer(
+        UUID transactionId,
+        UUID sourceWalletId,
+        UUID targetWalletId,
+        Money amount,
+        Instant now
+    ) {
+        Objects.requireNonNull(
+            transactionId,
+            "transactionId must not be null"
+        );
+        Objects.requireNonNull(
+            sourceWalletId,
+            "sourceWalletId must not be null"
+        );
+        Objects.requireNonNull(
+            targetWalletId,
+            "targetWalletId must not be null"
+        );
+        Objects.requireNonNull(
+            amount,
+            "amount must not be null"
+        );
+        Objects.requireNonNull(
+            now,
+            "now must not be null"
+        );
+
+        LedgerEntry debitEntry =
+            LedgerEntry.create(
+                transactionId,
+                sourceWalletId,
+                LedgerEntryType.DEBIT,
+                amount,
+                now
+            );
+
+        LedgerEntry creditEntry =
+            LedgerEntry.create(
+                transactionId,
+                targetWalletId,
+                LedgerEntryType.CREDIT,
+                amount,
+                now
+            );
+
+        return new DoubleEntryLedger(
+            debitEntry,
+            creditEntry
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/ledger/domain/model/LedgerEntry.java
+++ b/src/main/java/com/nursena/payflow/ledger/domain/model/LedgerEntry.java
@@ -1,0 +1,115 @@
+package com.nursena.payflow.ledger.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.ledger.domain.exception.InvalidLedgerAmountException;
+import com.nursena.payflow.wallet.domain.model.Money;
+
+public final class LedgerEntry {
+
+    private final UUID id;
+    private final UUID transactionId;
+    private final UUID walletId;
+    private final LedgerEntryType type;
+    private final Money amount;
+    private final Instant createdAt;
+
+    private LedgerEntry(
+        UUID id,
+        UUID transactionId,
+        UUID walletId,
+        LedgerEntryType type,
+        Money amount,
+        Instant createdAt
+    ) {
+        this.id = Objects.requireNonNull(
+            id,
+            "id must not be null"
+        );
+        this.transactionId = Objects.requireNonNull(
+            transactionId,
+            "transactionId must not be null"
+        );
+        this.walletId = Objects.requireNonNull(
+            walletId,
+            "walletId must not be null"
+        );
+        this.type = Objects.requireNonNull(
+            type,
+            "type must not be null"
+        );
+        this.amount = Objects.requireNonNull(
+            amount,
+            "amount must not be null"
+        );
+        this.createdAt = Objects.requireNonNull(
+            createdAt,
+            "createdAt must not be null"
+        );
+
+        if (!amount.isPositive()) {
+            throw new InvalidLedgerAmountException();
+        }
+    }
+
+    public static LedgerEntry create(
+        UUID transactionId,
+        UUID walletId,
+        LedgerEntryType type,
+        Money amount,
+        Instant now
+    ) {
+        return new LedgerEntry(
+            UUID.randomUUID(),
+            transactionId,
+            walletId,
+            type,
+            amount,
+            now
+        );
+    }
+
+    public static LedgerEntry rehydrate(
+        UUID id,
+        UUID transactionId,
+        UUID walletId,
+        LedgerEntryType type,
+        Money amount,
+        Instant createdAt
+    ) {
+        return new LedgerEntry(
+            id,
+            transactionId,
+            walletId,
+            type,
+            amount,
+            createdAt
+        );
+    }
+
+    public UUID id() {
+        return id;
+    }
+
+    public UUID transactionId() {
+        return transactionId;
+    }
+
+    public UUID walletId() {
+        return walletId;
+    }
+
+    public LedgerEntryType type() {
+        return type;
+    }
+
+    public Money amount() {
+        return amount;
+    }
+
+    public Instant createdAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/nursena/payflow/ledger/domain/model/LedgerEntryType.java
+++ b/src/main/java/com/nursena/payflow/ledger/domain/model/LedgerEntryType.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.ledger.domain.model;
+
+public enum LedgerEntryType {
+    DEBIT,
+    CREDIT
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryController.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryController.java
@@ -1,0 +1,125 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryQuery;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryUseCase;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/transactions")
+public class GetTransactionHistoryController {
+
+    private final GetTransactionHistoryUseCase
+        getTransactionHistoryUseCase;
+
+    public GetTransactionHistoryController(
+        GetTransactionHistoryUseCase
+            getTransactionHistoryUseCase
+    ) {
+        this.getTransactionHistoryUseCase =
+            getTransactionHistoryUseCase;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<TransactionHistoryResponse>
+    getTransactionHistory(
+        @AuthenticationPrincipal
+        Jwt jwt,
+
+        @RequestParam(
+            name = "page",
+            defaultValue = "0"
+        )
+        @Min(
+            value = 0,
+            message = "page must not be negative"
+        )
+        int page,
+
+        @RequestParam(
+            name = "size",
+            defaultValue = "20"
+        )
+        @Min(
+            value = 1,
+            message = "size must be greater than zero"
+        )
+        @Max(
+            value = GetTransactionHistoryQuery.MAX_SIZE,
+            message = "size must not exceed 100"
+        )
+        int size,
+
+        @RequestParam(
+            name = "direction",
+            required = false
+        )
+        TransactionDirection direction,
+
+        @RequestParam(
+            name = "status",
+            required = false
+        )
+        TransactionStatus status,
+
+        @RequestParam(
+            name = "from",
+            required = false
+        )
+        @DateTimeFormat(
+            iso = DateTimeFormat.ISO.DATE_TIME
+        )
+        Instant from,
+
+        @RequestParam(
+            name = "to",
+            required = false
+        )
+        @DateTimeFormat(
+            iso = DateTimeFormat.ISO.DATE_TIME
+        )
+        Instant to
+    ) {
+        UUID ownerId = UUID.fromString(
+            jwt.getSubject()
+        );
+
+        TransactionHistoryFilter filter =
+            new TransactionHistoryFilter(
+                direction,
+                status,
+                from,
+                to
+            );
+
+        TransactionHistoryPage result =
+            getTransactionHistoryUseCase
+                .getTransactionHistory(
+                    new GetTransactionHistoryQuery(
+                        ownerId,
+                        page,
+                        size,
+                        filter
+                    )
+                );
+
+        return ResponseEntity.ok(
+            TransactionHistoryResponse.from(result)
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryController.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryController.java
@@ -1,14 +1,28 @@
 package com.nursena.payflow.transaction.adapter.in.web;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.time.Instant;
 import java.util.UUID;
 
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.configuration.TransactionApiExamples;
 import com.nursena.payflow.transaction.application.model.TransactionDirection;
 import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
 import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
 import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryQuery;
 import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryUseCase;
 import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -20,6 +34,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(
+    name = "Transactions",
+    description =
+        "Authenticated transaction history operations."
+)
 @RestController
 @RequestMapping("/api/v1/transactions")
 public class GetTransactionHistoryController {
@@ -35,12 +54,91 @@ public class GetTransactionHistoryController {
             getTransactionHistoryUseCase;
     }
 
+    @Operation(
+        operationId = "getTransactionHistory",
+        summary = "Get transaction history",
+        description =
+            "Returns the authenticated user's wallet "
+                + "transactions ordered by creation time "
+                + "descending and transaction identifier "
+                + "descending."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description =
+                "Transaction history returned.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        TransactionHistoryResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        TransactionApiExamples
+                            .TRANSACTION_HISTORY_SUCCESS
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description =
+                "A pagination or filter value is invalid.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        TransactionApiExamples
+                            .TRANSACTION_HISTORY_VALIDATION_ERROR
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The authenticated user does not have a wallet.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        TransactionApiExamples
+                            .TRANSACTION_HISTORY_WALLET_NOT_FOUND
+                )
+            )
+        )
+    })
     @GetMapping("/me")
     public ResponseEntity<TransactionHistoryResponse>
     getTransactionHistory(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal
         Jwt jwt,
 
+        @Parameter(
+            name = "page",
+            description = "Zero-based result page index.",
+            example = "0",
+            schema = @Schema(
+                type = "integer",
+                minimum = "0",
+                defaultValue = "0"
+            )
+        )
         @RequestParam(
             name = "page",
             defaultValue = "0"
@@ -51,6 +149,18 @@ public class GetTransactionHistoryController {
         )
         int page,
 
+        @Parameter(
+            name = "size",
+            description =
+                "Number of transactions returned per page.",
+            example = "20",
+            schema = @Schema(
+                type = "integer",
+                minimum = "1",
+                maximum = "100",
+                defaultValue = "20"
+            )
+        )
         @RequestParam(
             name = "size",
             defaultValue = "20"
@@ -65,18 +175,54 @@ public class GetTransactionHistoryController {
         )
         int size,
 
+        @Parameter(
+            name = "direction",
+            description =
+                "Transaction direction relative to "
+                    + "the current wallet.",
+            example = "OUTGOING",
+            schema = @Schema(
+                allowableValues = {
+                    "INCOMING",
+                    "OUTGOING"
+                }
+            )
+        )
         @RequestParam(
             name = "direction",
             required = false
         )
         TransactionDirection direction,
 
+        @Parameter(
+            name = "status",
+            description = "Transaction status filter.",
+            example = "COMPLETED",
+            schema = @Schema(
+                allowableValues = {
+                    "PENDING",
+                    "COMPLETED",
+                    "FAILED"
+                }
+            )
+        )
         @RequestParam(
             name = "status",
             required = false
         )
         TransactionStatus status,
 
+        @Parameter(
+            name = "from",
+            description =
+                "Inclusive lower bound for the "
+                    + "transaction creation time.",
+            example = "2026-07-01T00:00:00Z",
+            schema = @Schema(
+                type = "string",
+                format = "date-time"
+            )
+        )
         @RequestParam(
             name = "from",
             required = false
@@ -86,6 +232,18 @@ public class GetTransactionHistoryController {
         )
         Instant from,
 
+        @Parameter(
+            name = "to",
+            description =
+                "Exclusive upper bound for the "
+                    + "transaction creation time. It may equal "
+                    + "the from value.",
+            example = "2026-08-01T00:00:00Z",
+            schema = @Schema(
+                type = "string",
+                format = "date-time"
+            )
+        )
         @RequestParam(
             name = "to",
             required = false

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryExceptionHandler.java
@@ -1,0 +1,75 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.transaction.application.exception.InvalidTransactionHistoryFilterException;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(
+    assignableTypes =
+        GetTransactionHistoryController.class
+)
+public class TransactionHistoryExceptionHandler {
+
+    @ExceptionHandler(WalletNotFoundException.class)
+    ResponseEntity<ApiError> handleWalletNotFound(
+        WalletNotFoundException exception,
+        HttpServletRequest request
+    ) {
+        return response(
+            HttpStatus.NOT_FOUND,
+            exception.getCode(),
+            exception.getMessage(),
+            request
+        );
+    }
+
+    @ExceptionHandler({
+        HandlerMethodValidationException.class,
+        MethodArgumentTypeMismatchException.class,
+        InvalidTransactionHistoryFilterException.class
+    })
+    ResponseEntity<ApiError> handleValidationFailure(
+        Exception exception,
+        HttpServletRequest request
+    ) {
+        return response(
+            HttpStatus.BAD_REQUEST,
+            "VALIDATION_FAILED",
+            "Request validation failed.",
+            request
+        );
+    }
+
+    private static ResponseEntity<ApiError> response(
+        HttpStatus status,
+        String code,
+        String message,
+        HttpServletRequest request
+    ) {
+        ApiError body = new ApiError(
+            Instant.now(),
+            status.value(),
+            code,
+            message,
+            request.getRequestURI(),
+            List.of()
+        );
+
+        return ResponseEntity
+            .status(status)
+            .body(body);
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryItemResponse.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryItemResponse.java
@@ -1,0 +1,46 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryItem;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.domain.model.Currency;
+
+public record TransactionHistoryItemResponse(
+    UUID transactionId,
+    TransactionType type,
+    TransactionDirection direction,
+    UUID counterpartyWalletId,
+    BigDecimal amount,
+    Currency currency,
+    TransactionStatus status,
+    Instant createdAt,
+    Instant completedAt
+) {
+
+    static TransactionHistoryItemResponse from(
+        TransactionHistoryItem item
+    ) {
+        Objects.requireNonNull(
+            item,
+            "item must not be null"
+        );
+
+        return new TransactionHistoryItemResponse(
+            item.transactionId(),
+            item.type(),
+            item.direction(),
+            item.counterpartyWalletId(),
+            item.amount(),
+            item.currency(),
+            item.status(),
+            item.createdAt(),
+            item.completedAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryItemResponse.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryItemResponse.java
@@ -10,16 +10,78 @@ import com.nursena.payflow.transaction.application.model.TransactionHistoryItem;
 import com.nursena.payflow.transaction.domain.model.TransactionStatus;
 import com.nursena.payflow.transaction.domain.model.TransactionType;
 import com.nursena.payflow.wallet.domain.model.Currency;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "TransactionHistoryItemResponse",
+    description =
+        "A transaction from the authenticated user's perspective."
+)
 public record TransactionHistoryItemResponse(
+
+    @Schema(
+        description = "Payment transaction identifier.",
+        example =
+            "aa3ab0b3-3d85-42d7-a641-2ec43cd81dd9",
+        format = "uuid"
+    )
     UUID transactionId,
+
+    @Schema(
+        description = "Transaction type.",
+        example = "TRANSFER"
+    )
     TransactionType type,
+
+    @Schema(
+        description =
+            "Transaction direction relative to "
+                + "the authenticated user's wallet.",
+        example = "OUTGOING"
+    )
     TransactionDirection direction,
+
+    @Schema(
+        description =
+            "Wallet on the opposite side of the transaction.",
+        example =
+            "f4c8ab12-a4bb-43cb-b6a8-e797cc95e914",
+        format = "uuid"
+    )
     UUID counterpartyWalletId,
+
+    @Schema(
+        description = "Transaction amount.",
+        example = "125.50"
+    )
     BigDecimal amount,
+
+    @Schema(
+        description = "Transaction currency.",
+        example = "TRY"
+    )
     Currency currency,
+
+    @Schema(
+        description = "Current transaction status.",
+        example = "COMPLETED"
+    )
     TransactionStatus status,
+
+    @Schema(
+        description = "Transaction creation time.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
     Instant createdAt,
+
+    @Schema(
+        description =
+            "Transaction completion time. It may be absent "
+                + "until processing has completed.",
+        example = "2026-07-17T12:00:00.125Z",
+        format = "date-time"
+    )
     Instant completedAt
 ) {
 

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryResponse.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryResponse.java
@@ -4,16 +4,78 @@ import java.util.List;
 import java.util.Objects;
 
 import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "TransactionHistoryResponse",
+    description =
+        "Paginated transaction history of the "
+            + "authenticated user's wallet."
+)
 public record TransactionHistoryResponse(
+
+    @Schema(
+        description =
+            "Transactions contained in the current page."
+    )
     List<TransactionHistoryItemResponse> items,
+
+    @Schema(
+        description = "Zero-based current page index.",
+        example = "0",
+        minimum = "0"
+    )
     int page,
+
+    @Schema(
+        description = "Requested page size.",
+        example = "20",
+        minimum = "1",
+        maximum = "100"
+    )
     int size,
+
+    @Schema(
+        description =
+            "Total number of matching transactions.",
+        example = "1",
+        minimum = "0"
+    )
     long totalElements,
+
+    @Schema(
+        description = "Total number of result pages.",
+        example = "1",
+        minimum = "0"
+    )
     int totalPages,
+
+    @Schema(
+        description =
+            "Whether this is the first result page.",
+        example = "true"
+    )
     boolean first,
+
+    @Schema(
+        description =
+            "Whether this is the last result page.",
+        example = "true"
+    )
     boolean last,
+
+    @Schema(
+        description =
+            "Whether another result page is available.",
+        example = "false"
+    )
     boolean hasNext,
+
+    @Schema(
+        description =
+            "Whether a previous result page is available.",
+        example = "false"
+    )
     boolean hasPrevious
 ) {
 

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryResponse.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryResponse.java
@@ -1,0 +1,48 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+
+public record TransactionHistoryResponse(
+    List<TransactionHistoryItemResponse> items,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean first,
+    boolean last,
+    boolean hasNext,
+    boolean hasPrevious
+) {
+
+    static TransactionHistoryResponse from(
+        TransactionHistoryPage result
+    ) {
+        Objects.requireNonNull(
+            result,
+            "result must not be null"
+        );
+
+        List<TransactionHistoryItemResponse> items =
+            result.items()
+                .stream()
+                .map(
+                    TransactionHistoryItemResponse::from
+                )
+                .toList();
+
+        return new TransactionHistoryResponse(
+            items,
+            result.page(),
+            result.size(),
+            result.totalElements(),
+            result.totalPages(),
+            result.first(),
+            result.last(),
+            result.hasNext(),
+            result.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyController.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyController.java
@@ -1,0 +1,61 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyCommand;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyResult;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyUseCase;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/transfers")
+public class TransferMoneyController {
+
+    private static final String IDEMPOTENCY_KEY_HEADER =
+        "Idempotency-Key";
+
+    private final TransferMoneyUseCase transferMoneyUseCase;
+
+    public TransferMoneyController(
+        TransferMoneyUseCase transferMoneyUseCase
+    ) {
+        this.transferMoneyUseCase = transferMoneyUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<TransferMoneyResponse> transfer(
+        @AuthenticationPrincipal Jwt jwt,
+        @RequestHeader(IDEMPOTENCY_KEY_HEADER)
+        String idempotencyKey,
+        @Valid @RequestBody TransferMoneyRequest request
+    ) {
+        UUID ownerId = UUID.fromString(
+            jwt.getSubject()
+        );
+
+        TransferMoneyResult result =
+            transferMoneyUseCase.transfer(
+                new TransferMoneyCommand(
+                    ownerId,
+                    request.targetWalletId(),
+                    request.amount(),
+                    idempotencyKey
+                )
+            );
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(
+                TransferMoneyResponse.from(result)
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyController.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyController.java
@@ -1,10 +1,25 @@
 package com.nursena.payflow.transaction.adapter.in.web;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.util.UUID;
 
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.configuration.TransactionApiExamples;
 import com.nursena.payflow.transaction.application.port.in.TransferMoneyCommand;
 import com.nursena.payflow.transaction.application.port.in.TransferMoneyResult;
 import com.nursena.payflow.transaction.application.port.in.TransferMoneyUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +31,10 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(
+    name = "Transfers",
+    description = "Authenticated wallet transfer operations."
+)
 @RestController
 @RequestMapping("/api/v1/transfers")
 public class TransferMoneyController {
@@ -31,12 +50,197 @@ public class TransferMoneyController {
         this.transferMoneyUseCase = transferMoneyUseCase;
     }
 
+    @Operation(
+        operationId = "transferMoney",
+        summary = "Transfer money",
+        description =
+            "Transfers a simulated amount from the "
+                + "authenticated user's wallet to another wallet. "
+                + "Repeated requests with the same idempotency "
+                + "key and payload return the existing result."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "Transfer completed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        TransferMoneyResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        TransactionApiExamples
+                            .TRANSFER_SUCCESS
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description =
+                "The request is invalid or the "
+                    + "Idempotency-Key header is missing.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = {
+                    @ExampleObject(
+                        name = "missingIdempotencyKey",
+                        summary =
+                            "Idempotency-Key header is missing",
+                        value =
+                            TransactionApiExamples
+                                .MISSING_IDEMPOTENCY_KEY
+                    ),
+                    @ExampleObject(
+                        name = "validationFailed",
+                        summary =
+                            "Request body validation failed",
+                        value =
+                            TransactionApiExamples
+                                .TRANSFER_VALIDATION_ERROR
+                    )
+                }
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The source or target wallet "
+                    + "could not be found.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        TransactionApiExamples
+                            .TRANSFER_WALLET_NOT_FOUND
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "The request conflicts with an existing "
+                    + "idempotency record or concurrent update.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = {
+                    @ExampleObject(
+                        name = "idempotencyKeyConflict",
+                        summary =
+                            "Key reused with a different payload",
+                        value =
+                            TransactionApiExamples
+                                .IDEMPOTENCY_KEY_CONFLICT
+                    ),
+                    @ExampleObject(
+                        name = "requestInProgress",
+                        summary =
+                            "Original request is still running",
+                        value =
+                            TransactionApiExamples
+                                .IDEMPOTENCY_REQUEST_IN_PROGRESS
+                    ),
+                    @ExampleObject(
+                        name = "concurrentWalletUpdate",
+                        summary =
+                            "A wallet changed concurrently",
+                        value =
+                            TransactionApiExamples
+                                .TRANSFER_CONCURRENT_UPDATE
+                    )
+                }
+            )
+        ),
+        @ApiResponse(
+            responseCode = "422",
+            description =
+                "A transfer business rule was violated.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = {
+                    @ExampleObject(
+                        name = "invalidIdempotencyKey",
+                        summary =
+                            "Idempotency key length is invalid",
+                        value =
+                            TransactionApiExamples
+                                .INVALID_IDEMPOTENCY_KEY
+                    ),
+                    @ExampleObject(
+                        name = "insufficientBalance",
+                        summary =
+                            "Source wallet balance is insufficient",
+                        value =
+                            TransactionApiExamples
+                                .INSUFFICIENT_BALANCE
+                    ),
+                    @ExampleObject(
+                        name = "walletNotActive",
+                        summary =
+                            "Source or target wallet is inactive",
+                        value =
+                            TransactionApiExamples
+                                .TRANSFER_WALLET_NOT_ACTIVE
+                    ),
+                    @ExampleObject(
+                        name = "currencyMismatch",
+                        summary =
+                            "Wallet currencies do not match",
+                        value =
+                            TransactionApiExamples
+                                .TRANSFER_CURRENCY_MISMATCH
+                    )
+                }
+            )
+        )
+    })
     @PostMapping
     public ResponseEntity<TransferMoneyResponse> transfer(
-        @AuthenticationPrincipal Jwt jwt,
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt,
+
+        @Parameter(
+            name = IDEMPOTENCY_KEY_HEADER,
+            in = ParameterIn.HEADER,
+            description =
+                "Unique request key used to make "
+                    + "the transfer idempotent.",
+            required = true,
+            example = "transfer-20260717-001",
+            schema = @Schema(
+                type = "string",
+                minLength = 1,
+                maxLength = 100
+            )
+        )
         @RequestHeader(IDEMPOTENCY_KEY_HEADER)
         String idempotencyKey,
-        @Valid @RequestBody TransferMoneyRequest request
+
+        @Valid
+        @RequestBody
+        TransferMoneyRequest request
     ) {
         UUID ownerId = UUID.fromString(
             jwt.getSubject()

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyExceptionHandler.java
@@ -1,0 +1,110 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.transaction.domain.exception.IdempotencyConflictException;
+import com.nursena.payflow.transaction.domain.exception.IdempotencyRequestInProgressException;
+import com.nursena.payflow.wallet.domain.exception.WalletConcurrentUpdateException;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(
+    assignableTypes = TransferMoneyController.class
+)
+public class TransferMoneyExceptionHandler {
+
+    @ExceptionHandler(WalletNotFoundException.class)
+    ResponseEntity<ApiError> handleWalletNotFound(
+        WalletNotFoundException exception,
+        HttpServletRequest request
+    ) {
+        return buildResponse(
+            HttpStatus.NOT_FOUND,
+            exception.getCode(),
+            exception.getMessage(),
+            request
+        );
+    }
+
+    @ExceptionHandler({
+        IdempotencyConflictException.class,
+        IdempotencyRequestInProgressException.class,
+        WalletConcurrentUpdateException.class
+    })
+    ResponseEntity<ApiError> handleConflict(
+        RuntimeException exception,
+        HttpServletRequest request
+    ) {
+        String code;
+        String message;
+
+        if (exception
+            instanceof IdempotencyConflictException conflict) {
+            code = conflict.getCode();
+            message = conflict.getMessage();
+        } else if (
+            exception
+                instanceof IdempotencyRequestInProgressException
+                inProgress
+        ) {
+            code = inProgress.getCode();
+            message = inProgress.getMessage();
+        } else {
+            WalletConcurrentUpdateException concurrentUpdate =
+                (WalletConcurrentUpdateException) exception;
+
+            code = concurrentUpdate.getCode();
+            message = concurrentUpdate.getMessage();
+        }
+
+        return buildResponse(
+            HttpStatus.CONFLICT,
+            code,
+            message,
+            request
+        );
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    ResponseEntity<ApiError> handleMissingHeader(
+        MissingRequestHeaderException exception,
+        HttpServletRequest request
+    ) {
+        return buildResponse(
+            HttpStatus.BAD_REQUEST,
+            "MISSING_IDEMPOTENCY_KEY",
+            "Idempotency-Key header is required.",
+            request
+        );
+    }
+
+    private static ResponseEntity<ApiError> buildResponse(
+        HttpStatus status,
+        String code,
+        String message,
+        HttpServletRequest request
+    ) {
+        ApiError body = new ApiError(
+            Instant.now(),
+            status.value(),
+            code,
+            message,
+            request.getRequestURI(),
+            List.of()
+        );
+
+        return ResponseEntity
+            .status(status)
+            .body(body);
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyRequest.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyRequest.java
@@ -3,15 +3,34 @@ package com.nursena.payflow.transaction.adapter.in.web;
 import java.math.BigDecimal;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(
+    name = "TransferMoneyRequest",
+    description =
+        "Information required to transfer money "
+            + "to another wallet."
+)
 public record TransferMoneyRequest(
 
-    @NotNull(message = "targetWalletId must not be null")
+    @Schema(
+        description = "Identifier of the receiving wallet.",
+        example = "f4c8ab12-a4bb-43cb-b6a8-e797cc95e914",
+        format = "uuid"
+    )
+    @NotNull(
+        message = "targetWalletId must not be null"
+    )
     UUID targetWalletId,
 
+    @Schema(
+        description = "Positive amount to transfer.",
+        example = "125.50",
+        minimum = "0.01"
+    )
     @NotNull(message = "amount must not be null")
     @DecimalMin(
         value = "0.01",
@@ -20,9 +39,9 @@ public record TransferMoneyRequest(
     @Digits(
         integer = 17,
         fraction = 2,
-        message = "amount must have at most 2 fractional digits"
+        message =
+            "amount must have at most 2 fractional digits"
     )
     BigDecimal amount
-
 ) {
 }

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyRequest.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyRequest.java
@@ -1,0 +1,28 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+
+public record TransferMoneyRequest(
+
+    @NotNull(message = "targetWalletId must not be null")
+    UUID targetWalletId,
+
+    @NotNull(message = "amount must not be null")
+    @DecimalMin(
+        value = "0.01",
+        message = "amount must be greater than zero"
+    )
+    @Digits(
+        integer = 17,
+        fraction = 2,
+        message = "amount must have at most 2 fractional digits"
+    )
+    BigDecimal amount
+
+) {
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyResponse.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyResponse.java
@@ -8,15 +8,65 @@ import java.util.UUID;
 import com.nursena.payflow.transaction.application.port.in.TransferMoneyResult;
 import com.nursena.payflow.transaction.domain.model.TransactionStatus;
 import com.nursena.payflow.wallet.domain.model.Currency;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "TransferMoneyResponse",
+    description = "Completed wallet transfer information."
+)
 public record TransferMoneyResponse(
+
+    @Schema(
+        description = "Payment transaction identifier.",
+        example = "aa3ab0b3-3d85-42d7-a641-2ec43cd81dd9",
+        format = "uuid"
+    )
     UUID transactionId,
+
+    @Schema(
+        description = "Wallet debited by the transfer.",
+        example = "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+        format = "uuid"
+    )
     UUID sourceWalletId,
+
+    @Schema(
+        description = "Wallet credited by the transfer.",
+        example = "f4c8ab12-a4bb-43cb-b6a8-e797cc95e914",
+        format = "uuid"
+    )
     UUID targetWalletId,
+
+    @Schema(
+        description = "Transferred amount.",
+        example = "125.50"
+    )
     BigDecimal amount,
+
+    @Schema(
+        description = "Transfer currency.",
+        example = "TRY"
+    )
     Currency currency,
+
+    @Schema(
+        description = "Current transaction status.",
+        example = "COMPLETED"
+    )
     TransactionStatus status,
+
+    @Schema(
+        description = "Transaction creation time.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
     Instant createdAt,
+
+    @Schema(
+        description = "Transaction completion time.",
+        example = "2026-07-17T12:00:00.125Z",
+        format = "date-time"
+    )
     Instant completedAt
 ) {
 

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyResponse.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyResponse.java
@@ -1,0 +1,77 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyResult;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.wallet.domain.model.Currency;
+
+public record TransferMoneyResponse(
+    UUID transactionId,
+    UUID sourceWalletId,
+    UUID targetWalletId,
+    BigDecimal amount,
+    Currency currency,
+    TransactionStatus status,
+    Instant createdAt,
+    Instant completedAt
+) {
+
+    public TransferMoneyResponse {
+        Objects.requireNonNull(
+            transactionId,
+            "transactionId must not be null"
+        );
+        Objects.requireNonNull(
+            sourceWalletId,
+            "sourceWalletId must not be null"
+        );
+        Objects.requireNonNull(
+            targetWalletId,
+            "targetWalletId must not be null"
+        );
+        Objects.requireNonNull(
+            amount,
+            "amount must not be null"
+        );
+        Objects.requireNonNull(
+            currency,
+            "currency must not be null"
+        );
+        Objects.requireNonNull(
+            status,
+            "status must not be null"
+        );
+        Objects.requireNonNull(
+            createdAt,
+            "createdAt must not be null"
+        );
+        Objects.requireNonNull(
+            completedAt,
+            "completedAt must not be null"
+        );
+    }
+
+    public static TransferMoneyResponse from(
+        TransferMoneyResult result
+    ) {
+        Objects.requireNonNull(
+            result,
+            "result must not be null"
+        );
+
+        return new TransferMoneyResponse(
+            result.transactionId(),
+            result.sourceWalletId(),
+            result.targetWalletId(),
+            result.amount(),
+            result.currency(),
+            result.status(),
+            result.createdAt(),
+            result.completedAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/PaymentTransactionJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/PaymentTransactionJpaEntity.java
@@ -1,0 +1,159 @@
+package com.nursena.payflow.transaction.adapter.out.persistence;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "payment_transactions")
+class PaymentTransactionJpaEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "source_wallet_id")
+    private UUID sourceWalletId;
+
+    @Column(name = "target_wallet_id")
+    private UUID targetWalletId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+        name = "transaction_type",
+        nullable = false,
+        length = 30
+    )
+    private TransactionType transactionType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TransactionStatus status;
+
+    @Column(
+        nullable = false,
+        precision = 19,
+        scale = 2
+    )
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 3)
+    private Currency currency;
+
+    @Column(
+        name = "idempotency_key",
+        length = 100
+    )
+    private String idempotencyKey;
+
+    @Column(
+        name = "failure_reason",
+        length = 500
+    )
+    private String failureReason;
+
+    @Column(
+        name = "created_at",
+        nullable = false,
+        updatable = false
+    )
+    private Instant createdAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    protected PaymentTransactionJpaEntity() {
+    }
+
+    PaymentTransactionJpaEntity(
+        UUID id,
+        UUID sourceWalletId,
+        UUID targetWalletId,
+        TransactionType transactionType,
+        TransactionStatus status,
+        BigDecimal amount,
+        Currency currency,
+        String idempotencyKey,
+        String failureReason,
+        Instant createdAt,
+        Instant completedAt
+    ) {
+        this.id = id;
+        this.sourceWalletId = sourceWalletId;
+        this.targetWalletId = targetWalletId;
+        this.transactionType = transactionType;
+        this.status = status;
+        this.amount = amount;
+        this.currency = currency;
+        this.idempotencyKey = idempotencyKey;
+        this.failureReason = failureReason;
+        this.createdAt = createdAt;
+        this.completedAt = completedAt;
+    }
+
+    void updateState(
+        TransactionStatus status,
+        Instant completedAt
+    ) {
+        this.status = Objects.requireNonNull(
+            status,
+            "status must not be null"
+        );
+        this.completedAt = completedAt;
+    }
+
+    UUID getId() {
+        return id;
+    }
+
+    UUID getSourceWalletId() {
+        return sourceWalletId;
+    }
+
+    UUID getTargetWalletId() {
+        return targetWalletId;
+    }
+
+    TransactionType getTransactionType() {
+        return transactionType;
+    }
+
+    TransactionStatus getStatus() {
+        return status;
+    }
+
+    BigDecimal getAmount() {
+        return amount;
+    }
+
+    Currency getCurrency() {
+        return currency;
+    }
+
+    String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    String getFailureReason() {
+        return failureReason;
+    }
+
+    Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    Instant getCompletedAt() {
+        return completedAt;
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/PaymentTransactionPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/PaymentTransactionPersistenceAdapter.java
@@ -1,0 +1,152 @@
+package com.nursena.payflow.transaction.adapter.out.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.port.out.PaymentTransactionRepositoryPort;
+import com.nursena.payflow.transaction.domain.exception.PaymentTransactionNotFoundException;
+import com.nursena.payflow.transaction.domain.model.IdempotencyKey;
+import com.nursena.payflow.transaction.domain.model.PaymentTransaction;
+import com.nursena.payflow.wallet.domain.model.Money;
+import org.springframework.stereotype.Component;
+import com.nursena.payflow.transaction.domain.exception.IdempotencyConflictException;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@Component
+class PaymentTransactionPersistenceAdapter
+    implements PaymentTransactionRepositoryPort {
+
+    private final SpringDataPaymentTransactionRepository
+        repository;
+
+    private static final String IDEMPOTENCY_CONSTRAINT =
+        "uq_transaction_idempotency";
+
+    PaymentTransactionPersistenceAdapter(
+        SpringDataPaymentTransactionRepository repository
+    ) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Optional<PaymentTransaction>
+    findBySourceWalletIdAndIdempotencyKey(
+        UUID sourceWalletId,
+        IdempotencyKey idempotencyKey
+    ) {
+
+        return repository
+            .findBySourceWalletIdAndIdempotencyKey(
+                sourceWalletId,
+                idempotencyKey.value()
+            )
+            .map(
+                PaymentTransactionPersistenceAdapter
+                    ::toDomain
+            );
+    }
+
+    @Override
+    public PaymentTransaction save(
+        PaymentTransaction transaction
+    ) {
+        try {
+            PaymentTransactionJpaEntity saved =
+                repository.saveAndFlush(
+                    toEntity(transaction)
+                );
+
+            return toDomain(saved);
+        } catch (DataIntegrityViolationException exception) {
+            if (isIdempotencyConstraintViolation(
+                exception
+            )) {
+                throw new IdempotencyConflictException();
+            }
+
+            throw exception;
+        }
+    }
+
+    @Override
+    public PaymentTransaction update(
+        PaymentTransaction transaction
+    ) {
+        PaymentTransactionJpaEntity entity =
+            repository
+                .findById(transaction.id())
+                .orElseThrow(
+                    PaymentTransactionNotFoundException::new
+                );
+
+        entity.updateState(
+            transaction.status(),
+            transaction.completedAt()
+        );
+
+        repository.flush();
+
+        return toDomain(entity);
+    }
+
+    private static PaymentTransactionJpaEntity toEntity(
+        PaymentTransaction transaction
+    ) {
+        return new PaymentTransactionJpaEntity(
+            transaction.id(),
+            transaction.sourceWalletId(),
+            transaction.targetWalletId(),
+            transaction.type(),
+            transaction.status(),
+            transaction.amount().amount(),
+            transaction.amount().currency(),
+            transaction.idempotencyKey().value(),
+            null,
+            transaction.createdAt(),
+            transaction.completedAt()
+        );
+    }
+
+    private static PaymentTransaction toDomain(
+        PaymentTransactionJpaEntity entity
+    ) {
+        return PaymentTransaction.rehydrate(
+            entity.getId(),
+            entity.getSourceWalletId(),
+            entity.getTargetWalletId(),
+            new Money(
+                entity.getAmount(),
+                entity.getCurrency()
+            ),
+            new IdempotencyKey(
+                entity.getIdempotencyKey()
+            ),
+            entity.getTransactionType(),
+            entity.getStatus(),
+            entity.getCreatedAt(),
+            entity.getCompletedAt()
+        );
+    }
+    private static boolean
+    isIdempotencyConstraintViolation(
+        Throwable throwable
+    ) {
+
+        Throwable current = throwable;
+
+        while (current != null) {
+            if (current
+                instanceof ConstraintViolationException violation) {
+
+                return IDEMPOTENCY_CONSTRAINT.equals(
+                    violation.getConstraintName()
+                );
+            }
+
+            current = current.getCause();
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/SpringDataPaymentTransactionRepository.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/SpringDataPaymentTransactionRepository.java
@@ -1,0 +1,19 @@
+package com.nursena.payflow.transaction.adapter.out.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface SpringDataPaymentTransactionRepository
+    extends JpaRepository<
+    PaymentTransactionJpaEntity,
+    UUID
+    > {
+
+    Optional<PaymentTransactionJpaEntity>
+    findBySourceWalletIdAndIdempotencyKey(
+        UUID sourceWalletId,
+        String idempotencyKey
+    );
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/SpringDataPaymentTransactionRepository.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/SpringDataPaymentTransactionRepository.java
@@ -1,9 +1,15 @@
 package com.nursena.payflow.transaction.adapter.out.persistence;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 interface SpringDataPaymentTransactionRepository
     extends JpaRepository<
@@ -15,5 +21,63 @@ interface SpringDataPaymentTransactionRepository
     findBySourceWalletIdAndIdempotencyKey(
         UUID sourceWalletId,
         String idempotencyKey
+    );
+
+    @Query("""
+    select paymentTransaction
+    from PaymentTransactionJpaEntity paymentTransaction
+    where (
+        (
+            :includeOutgoing = true
+            and paymentTransaction.sourceWalletId = :walletId
+        )
+        or
+        (
+            :includeIncoming = true
+            and paymentTransaction.targetWalletId = :walletId
+        )
+    )
+    and (
+        :filterByStatus = false
+        or paymentTransaction.status = :status
+    )
+    and (
+        :filterByFrom = false
+        or paymentTransaction.createdAt >= :fromInclusive
+    )
+    and (
+        :filterByTo = false
+        or paymentTransaction.createdAt < :toExclusive
+    )
+    """)
+    Page<PaymentTransactionJpaEntity> findHistory(
+        @Param("walletId")
+        UUID walletId,
+
+        @Param("includeOutgoing")
+        boolean includeOutgoing,
+
+        @Param("includeIncoming")
+        boolean includeIncoming,
+
+        @Param("filterByStatus")
+        boolean filterByStatus,
+
+        @Param("status")
+        TransactionStatus status,
+
+        @Param("filterByFrom")
+        boolean filterByFrom,
+
+        @Param("fromInclusive")
+        Instant fromInclusive,
+
+        @Param("filterByTo")
+        boolean filterByTo,
+
+        @Param("toExclusive")
+        Instant toExclusive,
+
+        Pageable pageable
     );
 }

--- a/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/TransactionHistoryPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/out/persistence/TransactionHistoryPersistenceAdapter.java
@@ -1,0 +1,194 @@
+package com.nursena.payflow.transaction.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryItem;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.application.port.out.TransactionHistoryQueryPort;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+@Component
+class TransactionHistoryPersistenceAdapter
+    implements TransactionHistoryQueryPort {
+
+    private static final Sort HISTORY_SORT =
+        Sort.by(
+            Sort.Order.desc("createdAt"),
+            Sort.Order.desc("id")
+        );
+
+    private final SpringDataPaymentTransactionRepository
+        repository;
+
+    TransactionHistoryPersistenceAdapter(
+        SpringDataPaymentTransactionRepository repository
+    ) {
+        this.repository = Objects.requireNonNull(
+            repository,
+            "repository must not be null"
+        );
+    }
+
+    @Override
+    public TransactionHistoryPage findByWalletId(
+        UUID walletId,
+        int page,
+        int size,
+        TransactionHistoryFilter filter
+    ) {
+        Objects.requireNonNull(
+            walletId,
+            "walletId must not be null"
+        );
+
+        Objects.requireNonNull(
+            filter,
+            "filter must not be null"
+        );
+
+        PageRequest pageRequest =
+            PageRequest.of(
+                page,
+                size,
+                HISTORY_SORT
+            );
+
+        UUID sourceWalletId =
+            filter.direction()
+                == TransactionDirection.INCOMING
+                ? null
+                : walletId;
+
+        UUID targetWalletId =
+            filter.direction()
+                == TransactionDirection.OUTGOING
+                ? null
+                : walletId;
+
+        boolean includeOutgoing =
+            filter.direction()
+                != TransactionDirection.INCOMING;
+
+        boolean includeIncoming =
+            filter.direction()
+                != TransactionDirection.OUTGOING;
+
+        boolean filterByStatus =
+            filter.status() != null;
+
+        boolean filterByFrom =
+            filter.from() != null;
+
+        boolean filterByTo =
+            filter.to() != null;
+
+        TransactionStatus statusParameter =
+            filterByStatus
+                ? filter.status()
+                : TransactionStatus.PENDING;
+
+        Instant fromParameter =
+            filterByFrom
+                ? filter.from()
+                : Instant.EPOCH;
+
+        Instant toParameter =
+            filterByTo
+                ? filter.to()
+                : Instant.EPOCH;
+
+        Page<PaymentTransactionJpaEntity>
+            transactionPage =
+            repository.findHistory(
+                walletId,
+                includeOutgoing,
+                includeIncoming,
+                filterByStatus,
+                statusParameter,
+                filterByFrom,
+                fromParameter,
+                filterByTo,
+                toParameter,
+                pageRequest
+            );
+
+        List<TransactionHistoryItem> items =
+            transactionPage
+                .getContent()
+                .stream()
+                .map(entity ->
+                    toHistoryItem(
+                        walletId,
+                        entity
+                    )
+                )
+                .toList();
+
+        return new TransactionHistoryPage(
+            items,
+            transactionPage.getNumber(),
+            transactionPage.getSize(),
+            transactionPage.getTotalElements(),
+            transactionPage.getTotalPages()
+        );
+    }
+
+    private static TransactionHistoryItem
+    toHistoryItem(
+        UUID walletId,
+        PaymentTransactionJpaEntity entity
+    ) {
+        boolean outgoing = walletId.equals(
+            entity.getSourceWalletId()
+        );
+
+        boolean incoming = walletId.equals(
+            entity.getTargetWalletId()
+        );
+
+        if (outgoing == incoming) {
+            throw new IllegalStateException(
+                "Payment transaction must belong "
+                    + "to exactly one side of the wallet."
+            );
+        }
+
+        TransactionDirection direction =
+            outgoing
+                ? TransactionDirection.OUTGOING
+                : TransactionDirection.INCOMING;
+
+        UUID counterpartyWalletId =
+            outgoing
+                ? entity.getTargetWalletId()
+                : entity.getSourceWalletId();
+
+        if (counterpartyWalletId == null) {
+            throw new IllegalStateException(
+                "Transfer counterparty wallet "
+                    + "must not be null."
+            );
+        }
+
+        return new TransactionHistoryItem(
+            entity.getId(),
+            entity.getTransactionType(),
+            direction,
+            counterpartyWalletId,
+            entity.getAmount(),
+            entity.getCurrency(),
+            entity.getStatus(),
+            entity.getCreatedAt(),
+            entity.getCompletedAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/exception/InvalidTransactionHistoryFilterException.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/exception/InvalidTransactionHistoryFilterException.java
@@ -1,0 +1,12 @@
+package com.nursena.payflow.transaction.application.exception;
+
+public final class
+InvalidTransactionHistoryFilterException
+    extends IllegalArgumentException {
+
+    public InvalidTransactionHistoryFilterException(
+        String message
+    ) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/model/TransactionDirection.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/model/TransactionDirection.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.transaction.application.model;
+
+public enum TransactionDirection {
+    INCOMING,
+    OUTGOING
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryFilter.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryFilter.java
@@ -1,0 +1,35 @@
+package com.nursena.payflow.transaction.application.model;
+
+import java.time.Instant;
+
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.application.exception.InvalidTransactionHistoryFilterException;
+
+public record TransactionHistoryFilter(
+    TransactionDirection direction,
+    TransactionStatus status,
+    Instant from,
+    Instant to
+) {
+
+    public TransactionHistoryFilter {
+        if (
+            from != null
+                && to != null
+                && from.isAfter(to)
+        ) {
+            throw new InvalidTransactionHistoryFilterException(
+                "from must not be after to"
+            );
+        }
+    }
+
+    public static TransactionHistoryFilter unfiltered() {
+        return new TransactionHistoryFilter(
+            null,
+            null,
+            null,
+            null
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryItem.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryItem.java
@@ -1,0 +1,64 @@
+package com.nursena.payflow.transaction.application.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.domain.model.Currency;
+
+public record TransactionHistoryItem(
+    UUID transactionId,
+    TransactionType type,
+    TransactionDirection direction,
+    UUID counterpartyWalletId,
+    BigDecimal amount,
+    Currency currency,
+    TransactionStatus status,
+    Instant createdAt,
+    Instant completedAt
+) {
+
+    public TransactionHistoryItem {
+        Objects.requireNonNull(
+            transactionId,
+            "transactionId must not be null"
+        );
+        Objects.requireNonNull(
+            type,
+            "type must not be null"
+        );
+        Objects.requireNonNull(
+            direction,
+            "direction must not be null"
+        );
+        Objects.requireNonNull(
+            counterpartyWalletId,
+            "counterpartyWalletId must not be null"
+        );
+        Objects.requireNonNull(
+            amount,
+            "amount must not be null"
+        );
+        Objects.requireNonNull(
+            currency,
+            "currency must not be null"
+        );
+        Objects.requireNonNull(
+            status,
+            "status must not be null"
+        );
+        Objects.requireNonNull(
+            createdAt,
+            "createdAt must not be null"
+        );
+
+        if (amount.signum() <= 0) {
+            throw new IllegalArgumentException(
+                "amount must be greater than zero"
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryPage.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/model/TransactionHistoryPage.java
@@ -1,0 +1,63 @@
+package com.nursena.payflow.transaction.application.model;
+
+import java.util.List;
+import java.util.Objects;
+
+public record TransactionHistoryPage(
+    List<TransactionHistoryItem> items,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages
+) {
+
+    public TransactionHistoryPage {
+        items = List.copyOf(
+            Objects.requireNonNull(
+                items,
+                "items must not be null"
+            )
+        );
+
+        if (page < 0) {
+            throw new IllegalArgumentException(
+                "page must not be negative"
+            );
+        }
+
+        if (size < 1) {
+            throw new IllegalArgumentException(
+                "size must be greater than zero"
+            );
+        }
+
+        if (totalElements < 0) {
+            throw new IllegalArgumentException(
+                "totalElements must not be negative"
+            );
+        }
+
+        if (totalPages < 0) {
+            throw new IllegalArgumentException(
+                "totalPages must not be negative"
+            );
+        }
+    }
+
+    public boolean first() {
+        return page == 0;
+    }
+
+    public boolean last() {
+        return totalPages == 0
+            || page >= totalPages - 1;
+    }
+
+    public boolean hasNext() {
+        return !last();
+    }
+
+    public boolean hasPrevious() {
+        return page > 0;
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryQuery.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryQuery.java
@@ -1,0 +1,56 @@
+package com.nursena.payflow.transaction.application.port.in;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
+
+public record GetTransactionHistoryQuery(
+    UUID ownerId,
+    int page,
+    int size,
+    TransactionHistoryFilter filter
+) {
+
+    public static final int DEFAULT_PAGE = 0;
+    public static final int DEFAULT_SIZE = 20;
+    public static final int MAX_SIZE = 100;
+
+    public GetTransactionHistoryQuery(
+        UUID ownerId,
+        int page,
+        int size
+    ) {
+        this(
+            ownerId,
+            page,
+            size,
+            TransactionHistoryFilter.unfiltered()
+        );
+    }
+
+    public GetTransactionHistoryQuery {
+        Objects.requireNonNull(
+            ownerId,
+            "ownerId must not be null"
+        );
+
+        Objects.requireNonNull(
+            filter,
+            "filter must not be null"
+        );
+
+        if (page < 0) {
+            throw new IllegalArgumentException(
+                "page must not be negative"
+            );
+        }
+
+        if (size < 1 || size > MAX_SIZE) {
+            throw new IllegalArgumentException(
+                "size must be between 1 and "
+                    + MAX_SIZE
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryUseCase.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryUseCase.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.transaction.application.port.in;
+
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+
+public interface GetTransactionHistoryUseCase {
+
+    TransactionHistoryPage getTransactionHistory(
+        GetTransactionHistoryQuery query
+    );
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/port/in/TransferMoneyCommand.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/in/TransferMoneyCommand.java
@@ -1,0 +1,32 @@
+package com.nursena.payflow.transaction.application.port.in;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.UUID;
+
+public record TransferMoneyCommand(
+    UUID ownerId,
+    UUID targetWalletId,
+    BigDecimal amount,
+    String idempotencyKey
+) {
+
+    public TransferMoneyCommand {
+        Objects.requireNonNull(
+            ownerId,
+            "ownerId must not be null"
+        );
+        Objects.requireNonNull(
+            targetWalletId,
+            "targetWalletId must not be null"
+        );
+        Objects.requireNonNull(
+            amount,
+            "amount must not be null"
+        );
+        Objects.requireNonNull(
+            idempotencyKey,
+            "idempotencyKey must not be null"
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/port/in/TransferMoneyResult.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/in/TransferMoneyResult.java
@@ -1,0 +1,36 @@
+package com.nursena.payflow.transaction.application.port.in;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.domain.model.PaymentTransaction;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.wallet.domain.model.Currency;
+
+public record TransferMoneyResult(
+    UUID transactionId,
+    UUID sourceWalletId,
+    UUID targetWalletId,
+    BigDecimal amount,
+    Currency currency,
+    TransactionStatus status,
+    Instant createdAt,
+    Instant completedAt
+) {
+
+    public static TransferMoneyResult from(
+        PaymentTransaction transaction
+    ) {
+        return new TransferMoneyResult(
+            transaction.id(),
+            transaction.sourceWalletId(),
+            transaction.targetWalletId(),
+            transaction.amount().amount(),
+            transaction.amount().currency(),
+            transaction.status(),
+            transaction.createdAt(),
+            transaction.completedAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/port/in/TransferMoneyUseCase.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/in/TransferMoneyUseCase.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.transaction.application.port.in;
+
+public interface TransferMoneyUseCase {
+
+    TransferMoneyResult transfer(
+        TransferMoneyCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/port/out/PaymentTransactionRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/out/PaymentTransactionRepositoryPort.java
@@ -1,0 +1,24 @@
+package com.nursena.payflow.transaction.application.port.out;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.domain.model.IdempotencyKey;
+import com.nursena.payflow.transaction.domain.model.PaymentTransaction;
+
+public interface PaymentTransactionRepositoryPort {
+
+    Optional<PaymentTransaction>
+    findBySourceWalletIdAndIdempotencyKey(
+        UUID sourceWalletId,
+        IdempotencyKey idempotencyKey
+    );
+
+    PaymentTransaction save(
+        PaymentTransaction transaction
+    );
+
+    PaymentTransaction update(
+        PaymentTransaction transaction
+    );
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/port/out/TransactionHistoryQueryPort.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/out/TransactionHistoryQueryPort.java
@@ -1,0 +1,16 @@
+package com.nursena.payflow.transaction.application.port.out;
+
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+
+public interface TransactionHistoryQueryPort {
+
+    TransactionHistoryPage findByWalletId(
+        UUID walletId,
+        int page,
+        int size,
+        TransactionHistoryFilter filter
+    );
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryService.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryService.java
@@ -1,0 +1,67 @@
+package com.nursena.payflow.transaction.application.service;
+
+import java.util.Objects;
+
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryQuery;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryUseCase;
+import com.nursena.payflow.transaction.application.port.out.TransactionHistoryQueryPort;
+import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GetTransactionHistoryService
+    implements GetTransactionHistoryUseCase {
+
+    private final WalletRepositoryPort walletRepository;
+    private final TransactionHistoryQueryPort
+        transactionHistoryQueryPort;
+
+    public GetTransactionHistoryService(
+        WalletRepositoryPort walletRepository,
+        TransactionHistoryQueryPort
+            transactionHistoryQueryPort
+    ) {
+        this.walletRepository = Objects.requireNonNull(
+            walletRepository,
+            "walletRepository must not be null"
+        );
+
+        this.transactionHistoryQueryPort =
+            Objects.requireNonNull(
+                transactionHistoryQueryPort,
+                "transactionHistoryQueryPort "
+                    + "must not be null"
+            );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public TransactionHistoryPage
+    getTransactionHistory(
+        GetTransactionHistoryQuery query
+    ) {
+        Objects.requireNonNull(
+            query,
+            "query must not be null"
+        );
+
+        Wallet wallet = walletRepository
+            .findByOwnerId(query.ownerId())
+            .orElseThrow(
+                WalletNotFoundException::new
+            );
+
+        return transactionHistoryQueryPort
+            .findByWalletId(
+                wallet.id(),
+                query.page(),
+                query.size(),
+                query.filter()
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/service/TransferMoneyService.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/service/TransferMoneyService.java
@@ -1,0 +1,191 @@
+package com.nursena.payflow.transaction.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.*;
+import java.time.temporal.ChronoUnit;
+
+import com.nursena.payflow.transaction.domain.exception.IdempotencyConflictException;
+import com.nursena.payflow.transaction.domain.exception.IdempotencyRequestInProgressException;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.ledger.application.port.out.LedgerRepositoryPort;
+import com.nursena.payflow.ledger.domain.model.DoubleEntryLedger;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyCommand;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyResult;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyUseCase;
+import com.nursena.payflow.transaction.application.port.out.PaymentTransactionRepositoryPort;
+import com.nursena.payflow.transaction.domain.exception.TransferCurrencyMismatchException;
+import com.nursena.payflow.transaction.domain.model.IdempotencyKey;
+import com.nursena.payflow.transaction.domain.model.PaymentTransaction;
+import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.model.Money;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TransferMoneyService
+    implements TransferMoneyUseCase {
+
+    private final WalletRepositoryPort walletRepository;
+    private final PaymentTransactionRepositoryPort
+        transactionRepository;
+    private final LedgerRepositoryPort ledgerRepository;
+    private final Clock clock;
+
+    public TransferMoneyService(
+        WalletRepositoryPort walletRepository,
+        PaymentTransactionRepositoryPort transactionRepository,
+        LedgerRepositoryPort ledgerRepository,
+        Clock clock
+    ) {
+        this.walletRepository = walletRepository;
+        this.transactionRepository = transactionRepository;
+        this.ledgerRepository = ledgerRepository;
+        this.clock = clock;
+    }
+
+    @Override
+    @Transactional
+    public TransferMoneyResult transfer(
+        TransferMoneyCommand command
+    ) {
+        Objects.requireNonNull(
+            command,
+            "command must not be null"
+        );
+
+        Wallet sourceWallet = walletRepository
+            .findByOwnerId(command.ownerId())
+            .orElseThrow(WalletNotFoundException::new);
+
+        Money amount = new Money(
+            command.amount(),
+            sourceWallet.balance().currency()
+        );
+
+        IdempotencyKey idempotencyKey =
+            new IdempotencyKey(
+                command.idempotencyKey()
+            );
+
+        Optional<PaymentTransaction> existingTransaction =
+            transactionRepository
+                .findBySourceWalletIdAndIdempotencyKey(
+                    sourceWallet.id(),
+                    idempotencyKey
+                );
+
+        if (existingTransaction.isPresent()) {
+            return replayExistingTransaction(
+                existingTransaction.orElseThrow(),
+                command.targetWalletId(),
+                amount
+            );
+        }
+
+        Wallet targetWallet = walletRepository
+            .findById(command.targetWalletId())
+            .orElseThrow(WalletNotFoundException::new);
+
+        ensureMatchingCurrencies(
+            sourceWallet,
+            targetWallet
+        );
+
+        Instant createdAt = currentTime();
+
+        PaymentTransaction transaction =
+            PaymentTransaction.startTransfer(
+                sourceWallet.id(),
+                targetWallet.id(),
+                amount,
+                idempotencyKey,
+                createdAt
+            );
+
+        sourceWallet.debit(amount);
+        targetWallet.credit(amount);
+
+        PaymentTransaction savedTransaction =
+            transactionRepository.save(transaction);
+
+        updateWalletsInDeterministicOrder(
+            sourceWallet,
+            targetWallet
+        );
+
+        DoubleEntryLedger ledger =
+            DoubleEntryLedger.forTransfer(
+                savedTransaction.id(),
+                sourceWallet.id(),
+                targetWallet.id(),
+                amount,
+                createdAt
+            );
+
+        ledgerRepository.save(ledger);
+
+        savedTransaction.complete(currentTime());
+
+        PaymentTransaction completedTransaction =
+            transactionRepository.update(
+                savedTransaction
+            );
+
+        return TransferMoneyResult.from(
+            completedTransaction
+        );
+    }
+
+    private static TransferMoneyResult
+    replayExistingTransaction(
+        PaymentTransaction transaction,
+        UUID targetWalletId,
+        Money amount
+    ) {
+
+        if (!transaction.matchesTransferRequest(
+            targetWalletId,
+            amount
+        )) {
+            throw new IdempotencyConflictException();
+        }
+
+        if (transaction.status()
+            != TransactionStatus.COMPLETED) {
+            throw new IdempotencyRequestInProgressException();
+        }
+
+        return TransferMoneyResult.from(transaction);
+    }
+
+    private void updateWalletsInDeterministicOrder(
+        Wallet firstWallet,
+        Wallet secondWallet
+    ) {
+        List.of(firstWallet, secondWallet)
+            .stream()
+            .sorted(
+                Comparator.comparing(
+                    wallet -> wallet.id().toString()
+                )
+            )
+            .forEach(walletRepository::update);
+    }
+
+    private static void ensureMatchingCurrencies(
+        Wallet sourceWallet,
+        Wallet targetWallet
+    ) {
+        if (sourceWallet.balance().currency()
+            != targetWallet.balance().currency()) {
+            throw new TransferCurrencyMismatchException();
+        }
+    }
+    private Instant currentTime() {
+        return clock.instant()
+            .truncatedTo(ChronoUnit.MICROS);
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/domain/exception/IdempotencyConflictException.java
+++ b/src/main/java/com/nursena/payflow/transaction/domain/exception/IdempotencyConflictException.java
@@ -1,0 +1,15 @@
+package com.nursena.payflow.transaction.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class IdempotencyConflictException
+    extends BusinessRuleException {
+
+    public IdempotencyConflictException() {
+        super(
+            "IDEMPOTENCY_KEY_CONFLICT",
+            "Idempotency key has already been used "
+                + "for another transfer request."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/domain/exception/IdempotencyRequestInProgressException.java
+++ b/src/main/java/com/nursena/payflow/transaction/domain/exception/IdempotencyRequestInProgressException.java
@@ -1,0 +1,15 @@
+package com.nursena.payflow.transaction.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class IdempotencyRequestInProgressException
+    extends BusinessRuleException {
+
+    public IdempotencyRequestInProgressException() {
+        super(
+            "IDEMPOTENCY_REQUEST_IN_PROGRESS",
+            "A transfer with this idempotency key "
+                + "is still being processed."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/domain/exception/InvalidIdempotencyKeyException.java
+++ b/src/main/java/com/nursena/payflow/transaction/domain/exception/InvalidIdempotencyKeyException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.transaction.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class InvalidIdempotencyKeyException
+    extends BusinessRuleException {
+
+    public InvalidIdempotencyKeyException() {
+        super(
+            "INVALID_IDEMPOTENCY_KEY",
+            "Idempotency key must contain between 1 and 100 characters."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/domain/exception/InvalidTransactionStateException.java
+++ b/src/main/java/com/nursena/payflow/transaction/domain/exception/InvalidTransactionStateException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.transaction.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class InvalidTransactionStateException
+    extends BusinessRuleException {
+
+    public InvalidTransactionStateException() {
+        super(
+            "INVALID_TRANSACTION_STATE",
+            "Transaction state does not allow this operation."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/domain/exception/InvalidTransferAmountException.java
+++ b/src/main/java/com/nursena/payflow/transaction/domain/exception/InvalidTransferAmountException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.transaction.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class InvalidTransferAmountException
+    extends BusinessRuleException {
+
+    public InvalidTransferAmountException() {
+        super(
+            "INVALID_TRANSFER_AMOUNT",
+            "Transfer amount must be greater than zero."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/domain/exception/PaymentTransactionNotFoundException.java
+++ b/src/main/java/com/nursena/payflow/transaction/domain/exception/PaymentTransactionNotFoundException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.transaction.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class PaymentTransactionNotFoundException
+    extends BusinessRuleException {
+
+    public PaymentTransactionNotFoundException() {
+        super(
+            "PAYMENT_TRANSACTION_NOT_FOUND",
+            "Payment transaction could not be found."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/domain/exception/SelfTransferNotAllowedException.java
+++ b/src/main/java/com/nursena/payflow/transaction/domain/exception/SelfTransferNotAllowedException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.transaction.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class SelfTransferNotAllowedException
+    extends BusinessRuleException {
+
+    public SelfTransferNotAllowedException() {
+        super(
+            "SELF_TRANSFER_NOT_ALLOWED",
+            "Source and target wallets must be different."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/domain/exception/TransferCurrencyMismatchException.java
+++ b/src/main/java/com/nursena/payflow/transaction/domain/exception/TransferCurrencyMismatchException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.transaction.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class TransferCurrencyMismatchException
+    extends BusinessRuleException {
+
+    public TransferCurrencyMismatchException() {
+        super(
+            "TRANSFER_CURRENCY_MISMATCH",
+            "Source and target wallet currencies must match."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/domain/model/IdempotencyKey.java
+++ b/src/main/java/com/nursena/payflow/transaction/domain/model/IdempotencyKey.java
@@ -1,0 +1,24 @@
+package com.nursena.payflow.transaction.domain.model;
+
+import java.util.Objects;
+
+import com.nursena.payflow.transaction.domain.exception.InvalidIdempotencyKeyException;
+
+public record IdempotencyKey(String value) {
+
+    public static final int MAX_LENGTH = 100;
+
+    public IdempotencyKey {
+        Objects.requireNonNull(
+            value,
+            "value must not be null"
+        );
+
+        value = value.trim();
+
+        if (value.isEmpty()
+            || value.length() > MAX_LENGTH) {
+            throw new InvalidIdempotencyKeyException();
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/domain/model/PaymentTransaction.java
+++ b/src/main/java/com/nursena/payflow/transaction/domain/model/PaymentTransaction.java
@@ -1,0 +1,211 @@
+package com.nursena.payflow.transaction.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.domain.exception.InvalidTransactionStateException;
+import com.nursena.payflow.transaction.domain.exception.InvalidTransferAmountException;
+import com.nursena.payflow.transaction.domain.exception.SelfTransferNotAllowedException;
+import com.nursena.payflow.wallet.domain.model.Money;
+
+public final class PaymentTransaction {
+
+    private final UUID id;
+    private final UUID sourceWalletId;
+    private final UUID targetWalletId;
+    private final Money amount;
+    private final IdempotencyKey idempotencyKey;
+    private final TransactionType type;
+    private final Instant createdAt;
+
+    private TransactionStatus status;
+    private Instant completedAt;
+
+    private PaymentTransaction(
+        UUID id,
+        UUID sourceWalletId,
+        UUID targetWalletId,
+        Money amount,
+        IdempotencyKey idempotencyKey,
+        TransactionType type,
+        TransactionStatus status,
+        Instant createdAt,
+        Instant completedAt
+    ) {
+        this.id = Objects.requireNonNull(
+            id,
+            "id must not be null"
+        );
+        this.sourceWalletId = Objects.requireNonNull(
+            sourceWalletId,
+            "sourceWalletId must not be null"
+        );
+        this.targetWalletId = Objects.requireNonNull(
+            targetWalletId,
+            "targetWalletId must not be null"
+        );
+        this.amount = Objects.requireNonNull(
+            amount,
+            "amount must not be null"
+        );
+        this.idempotencyKey = Objects.requireNonNull(
+            idempotencyKey,
+            "idempotencyKey must not be null"
+        );
+        this.type = Objects.requireNonNull(
+            type,
+            "type must not be null"
+        );
+        this.status = Objects.requireNonNull(
+            status,
+            "status must not be null"
+        );
+        this.createdAt = Objects.requireNonNull(
+            createdAt,
+            "createdAt must not be null"
+        );
+        this.completedAt = completedAt;
+    }
+
+    public static PaymentTransaction startTransfer(
+        UUID sourceWalletId,
+        UUID targetWalletId,
+        Money amount,
+        IdempotencyKey idempotencyKey,
+        Instant now
+    ) {
+        Objects.requireNonNull(
+            sourceWalletId,
+            "sourceWalletId must not be null"
+        );
+        Objects.requireNonNull(
+            targetWalletId,
+            "targetWalletId must not be null"
+        );
+        Objects.requireNonNull(
+            amount,
+            "amount must not be null"
+        );
+        Objects.requireNonNull(
+            idempotencyKey,
+            "idempotencyKey must not be null"
+        );
+        Objects.requireNonNull(
+            now,
+            "now must not be null"
+        );
+
+        if (sourceWalletId.equals(targetWalletId)) {
+            throw new SelfTransferNotAllowedException();
+        }
+
+        if (!amount.isPositive()) {
+            throw new InvalidTransferAmountException();
+        }
+
+        return new PaymentTransaction(
+            UUID.randomUUID(),
+            sourceWalletId,
+            targetWalletId,
+            amount,
+            idempotencyKey,
+            TransactionType.TRANSFER,
+            TransactionStatus.PENDING,
+            now,
+            null
+        );
+    }
+
+    public static PaymentTransaction rehydrate(
+            UUID id,
+            UUID sourceWalletId,
+            UUID targetWalletId,
+            Money amount,
+            IdempotencyKey idempotencyKey,
+            TransactionType type,
+            TransactionStatus status,
+            Instant createdAt,
+            Instant completedAt
+    ) {
+        return new PaymentTransaction(
+                id,
+                sourceWalletId,
+                targetWalletId,
+                amount,
+                idempotencyKey,
+                type,
+                status,
+                createdAt,
+                completedAt
+        );
+    }
+
+    public void complete(Instant now) {
+        Objects.requireNonNull(
+            now,
+            "now must not be null"
+        );
+
+        if (status != TransactionStatus.PENDING) {
+            throw new InvalidTransactionStateException();
+        }
+
+        status = TransactionStatus.COMPLETED;
+        completedAt = now;
+    }
+
+    public boolean matchesTransferRequest(
+            UUID targetWalletId,
+            Money amount
+    ) {
+        Objects.requireNonNull(
+                targetWalletId,
+                "targetWalletId must not be null"
+        );
+        Objects.requireNonNull(
+                amount,
+                "amount must not be null"
+        );
+
+        return type == TransactionType.TRANSFER
+                && this.targetWalletId.equals(targetWalletId)
+                && this.amount.equals(amount);
+    }
+
+    public UUID id() {
+        return id;
+    }
+
+    public UUID sourceWalletId() {
+        return sourceWalletId;
+    }
+
+    public UUID targetWalletId() {
+        return targetWalletId;
+    }
+
+    public Money amount() {
+        return amount;
+    }
+
+    public IdempotencyKey idempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public TransactionType type() {
+        return type;
+    }
+
+    public TransactionStatus status() {
+        return status;
+    }
+
+    public Instant createdAt() {
+        return createdAt;
+    }
+
+    public Instant completedAt() {
+        return completedAt;
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/domain/model/TransactionStatus.java
+++ b/src/main/java/com/nursena/payflow/transaction/domain/model/TransactionStatus.java
@@ -1,0 +1,7 @@
+package com.nursena.payflow.transaction.domain.model;
+
+public enum TransactionStatus {
+    PENDING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/nursena/payflow/transaction/domain/model/TransactionType.java
+++ b/src/main/java/com/nursena/payflow/transaction/domain/model/TransactionType.java
@@ -1,0 +1,5 @@
+package com.nursena.payflow.transaction.domain.model;
+
+public enum TransactionType {
+    TRANSFER
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserController.java
@@ -3,12 +3,29 @@ package com.nursena.payflow.user.adapter.in.web;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiExamples;
+
+@Tag(
+    name = "Authentication",
+    description =
+        "Public user registration and authentication operations."
+)
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -23,6 +40,76 @@ public class AuthenticateUserController {
     ) {
         this.authenticateUserUseCase = authenticateUserUseCase;
     }
+
+    @Operation(
+        operationId = "authenticateUser",
+        summary = "Authenticate a user",
+        description =
+            "Validates user credentials and returns an "
+                + "RSA-signed JWT access token."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Authentication succeeded.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        AuthenticateUserResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples.LOGIN_SUCCESS
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .LOGIN_VALIDATION_ERROR
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "Credentials are invalid.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples.INVALID_CREDENTIALS
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description =
+                "The user account cannot be authenticated.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .USER_ACCOUNT_UNAVAILABLE
+                )
+            )
+        )
+    })
 
     @PostMapping("/login")
     public ResponseEntity<AuthenticateUserResponse> authenticate(

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserRequest.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserRequest.java
@@ -1,22 +1,41 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(
+    name = "AuthenticateUserRequest",
+    description = "Credentials used to authenticate a user."
+)
 public record AuthenticateUserRequest(
+
+    @Schema(
+        description = "Registered user email address.",
+        example = "nursena@example.com",
+        format = "email"
+    )
     @NotBlank(message = "Email is required.")
     @Email(message = "Email must be valid.")
     @Size(
         max = 320,
-        message = "Email must not exceed 320 characters."
+        message =
+            "Email must not exceed 320 characters."
     )
     String email,
 
+    @Schema(
+        description = "User password.",
+        example = "StrongPassword123!",
+        format = "password",
+        accessMode = Schema.AccessMode.WRITE_ONLY
+    )
     @NotBlank(message = "Password is required.")
     @Size(
         max = 72,
-        message = "Password must not exceed 72 characters."
+        message =
+            "Password must not exceed 72 characters."
     )
     String password
 ) {

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserResponse.java
@@ -2,9 +2,33 @@ package com.nursena.payflow.user.adapter.in.web;
 
 import java.time.Instant;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "AuthenticateUserResponse",
+    description =
+        "JWT access token returned after successful authentication."
+)
 public record AuthenticateUserResponse(
+
+    @Schema(
+        description = "RSA-signed JWT access token.",
+        example = "eyJhbGciOiJSUzI1NiJ9..."
+    )
     String accessToken,
+
+    @Schema(
+        description =
+            "Authentication scheme used with the token.",
+        example = "Bearer"
+    )
     String tokenType,
+
+    @Schema(
+        description = "Access-token expiration time.",
+        example = "2026-07-17T12:15:00Z",
+        format = "date-time"
+    )
     Instant expiresAt
 ) {
 }

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileController.java
@@ -10,6 +10,25 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.configuration.UserApiExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(
+    name = "Users",
+    description = "Authenticated user profile operations."
+)
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -23,10 +42,58 @@ public class CurrentUserProfileController {
         this.profileUseCase = profileUseCase;
     }
 
+    @Operation(
+        operationId = "getCurrentUserProfile",
+        summary = "Get current user profile",
+        description =
+            "Returns the profile represented by the JWT subject."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Current user profile returned.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        CurrentUserProfileResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        UserApiExamples.CURRENT_USER_PROFILE
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The JWT subject does not reference an existing user.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        UserApiExamples.USER_NOT_FOUND
+                )
+            )
+        )
+    })
     @GetMapping("/me")
     public ResponseEntity<CurrentUserProfileResponse>
     getCurrentUserProfile(
-        @AuthenticationPrincipal Jwt jwt
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt
     ) {
         UUID userId = UUID.fromString(
             jwt.getSubject()

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileResponse.java
@@ -6,12 +6,44 @@ import java.util.UUID;
 import com.nursena.payflow.user.application.port.in.GetCurrentUserProfileResult;
 import com.nursena.payflow.user.domain.model.UserRole;
 import com.nursena.payflow.user.domain.model.UserStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "CurrentUserProfileResponse",
+    description = "Profile information of the authenticated user."
+)
 public record CurrentUserProfileResponse(
+    @Schema(
+        description = "User identifier.",
+        example = "8805681d-d537-42f2-8906-5da1f0666ab7",
+        format = "uuid"
+    )
     UUID id,
+
+    @Schema(
+        description = "Normalized email address.",
+        example = "nursena@example.com",
+        format = "email"
+    )
     String email,
+
+    @Schema(
+        description = "Role assigned to the user.",
+        example = "USER"
+    )
     UserRole role,
+
+    @Schema(
+        description = "Current account status.",
+        example = "ACTIVE"
+    )
     UserStatus status,
+
+    @Schema(
+        description = "Account creation time.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
     Instant createdAt
 ) {
 

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserController.java
@@ -1,7 +1,16 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiExamples;
 import com.nursena.payflow.user.application.port.in.RegisterUserCommand;
 import com.nursena.payflow.user.application.port.in.RegisterUserUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +18,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Tag(
+    name = "Authentication",
+    description =
+        "Public user registration and authentication operations."
+)
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -19,6 +35,62 @@ public class RegisterUserController {
     public RegisterUserController(RegisterUserUseCase registerUserUseCase) {
         this.registerUserUseCase = registerUserUseCase;
     }
+
+    @Operation(
+        operationId = "registerUser",
+        summary = "Register a user",
+        description =
+            "Creates a user with a normalized email address "
+                + "and BCrypt password hash."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "User registered.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        RegisterUserResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples.REGISTER_SUCCESS
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .REGISTER_VALIDATION_ERROR
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "The email address is already registered.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .EMAIL_ALREADY_REGISTERED
+                )
+            )
+        )
+    })
 
     @PostMapping("/register")
     public ResponseEntity<RegisterUserResponse> register(

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserRequest.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserRequest.java
@@ -1,21 +1,45 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(
+    name = "RegisterUserRequest",
+    description = "Information required to register a user."
+)
 public record RegisterUserRequest(
 
+    @Schema(
+        description =
+            "User email address. The application "
+                + "normalizes the address before persistence.",
+        example = "nursena@example.com",
+        format = "email"
+    )
     @NotBlank(message = "Email is required.")
     @Email(message = "Email must be valid.")
-    @Size(max = 320, message = "Email must not exceed 320 characters.")
+    @Size(
+        max = 320,
+        message =
+            "Email must not exceed 320 characters."
+    )
     String email,
 
+    @Schema(
+        description =
+            "User password between 12 and 72 characters.",
+        example = "StrongPassword123!",
+        format = "password",
+        accessMode = Schema.AccessMode.WRITE_ONLY
+    )
     @NotBlank(message = "Password is required.")
     @Size(
         min = 12,
         max = 72,
-        message = "Password must be between 12 and 72 characters."
+        message =
+            "Password must be between 12 and 72 characters."
     )
     String password
 ) {

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RegisterUserResponse.java
@@ -2,5 +2,20 @@ package com.nursena.payflow.user.adapter.in.web;
 
 import java.util.UUID;
 
-public record RegisterUserResponse(UUID userId) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "RegisterUserResponse",
+    description = "Result of a successful registration."
+)
+public record RegisterUserResponse(
+
+    @Schema(
+        description = "Identifier of the registered user.",
+        example =
+            "8805681d-d537-42f2-8906-5da1f0666ab7",
+        format = "uuid"
+    )
+    UUID userId
+) {
 }

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/GetCurrentWalletController.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/GetCurrentWalletController.java
@@ -2,14 +2,33 @@ package com.nursena.payflow.wallet.adapter.in.web;
 
 import java.util.UUID;
 
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.configuration.WalletApiExamples;
 import com.nursena.payflow.wallet.application.port.in.GetCurrentWalletResult;
 import com.nursena.payflow.wallet.application.port.in.GetCurrentWalletUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Tag(
+    name = "Wallets",
+    description = "Authenticated wallet management operations."
+)
 
 @RestController
 @RequestMapping("/api/v1/wallets")
@@ -24,10 +43,59 @@ public class GetCurrentWalletController {
             getCurrentWalletUseCase;
     }
 
+    @Operation(
+        operationId = "getCurrentWallet",
+        summary = "Get current wallet",
+        description =
+            "Returns the wallet owned by the authenticated user."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Current wallet returned.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        GetCurrentWalletResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples.CURRENT_WALLET
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The authenticated user does not have a wallet.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples
+                            .CURRENT_WALLET_NOT_FOUND
+                )
+            )
+        )
+    })
     @GetMapping("/me")
     public ResponseEntity<GetCurrentWalletResponse>
     getCurrentWallet(
-        @AuthenticationPrincipal Jwt jwt
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt
     ) {
         UUID ownerId = UUID.fromString(
             jwt.getSubject()

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/GetCurrentWalletResponse.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/GetCurrentWalletResponse.java
@@ -8,12 +8,44 @@ import java.util.UUID;
 import com.nursena.payflow.wallet.application.port.in.GetCurrentWalletResult;
 import com.nursena.payflow.wallet.domain.model.Currency;
 import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "GetCurrentWalletResponse",
+    description = "Current wallet of the authenticated user."
+)
 public record GetCurrentWalletResponse(
+
+    @Schema(
+        description = "Wallet identifier.",
+        example = "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+        format = "uuid"
+    )
     UUID id,
+
+    @Schema(
+        description = "Current wallet balance.",
+        example = "250.00"
+    )
     BigDecimal balance,
+
+    @Schema(
+        description = "Wallet currency.",
+        example = "TRY"
+    )
     Currency currency,
+
+    @Schema(
+        description = "Current wallet status.",
+        example = "ACTIVE"
+    )
     WalletStatus status,
+
+    @Schema(
+        description = "Wallet creation time.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
     Instant createdAt
 ) {
 

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletController.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletController.java
@@ -2,9 +2,21 @@ package com.nursena.payflow.wallet.adapter.in.web;
 
 import java.util.UUID;
 
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.configuration.WalletApiExamples;
 import com.nursena.payflow.wallet.application.port.in.OpenWalletCommand;
 import com.nursena.payflow.wallet.application.port.in.OpenWalletResult;
 import com.nursena.payflow.wallet.application.port.in.OpenWalletUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +26,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Tag(
+    name = "Wallets",
+    description = "Authenticated wallet management operations."
+)
 
 @RestController
 @RequestMapping("/api/v1/wallets")
@@ -27,10 +46,75 @@ public class OpenWalletController {
         this.openWalletUseCase = openWalletUseCase;
     }
 
+    @Operation(
+        operationId = "openWallet",
+        summary = "Open a wallet",
+        description =
+            "Creates one wallet for the authenticated user."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "Wallet created.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = OpenWalletResponse.class
+                ),
+                examples = @ExampleObject(
+                    value = WalletApiExamples.OPEN_WALLET
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples
+                            .OPEN_WALLET_VALIDATION_ERROR
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "The authenticated user already has a wallet.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples
+                            .WALLET_ALREADY_EXISTS
+                )
+            )
+        )
+    })
     @PostMapping
     public ResponseEntity<OpenWalletResponse> openWallet(
-        @AuthenticationPrincipal Jwt jwt,
-        @Valid @RequestBody OpenWalletRequest request
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt,
+
+        @Valid
+        @RequestBody
+        OpenWalletRequest request
     ) {
         UUID ownerId = UUID.fromString(
             jwt.getSubject()

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletRequest.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletRequest.java
@@ -2,8 +2,18 @@ package com.nursena.payflow.wallet.adapter.in.web;
 
 import com.nursena.payflow.wallet.domain.model.Currency;
 import jakarta.validation.constraints.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "OpenWalletRequest",
+    description = "Information required to open a wallet."
+)
 public record OpenWalletRequest(
+
+    @Schema(
+        description = "Wallet currency.",
+        example = "TRY"
+    )
     @NotNull(message = "Currency is required.")
     Currency currency
 ) {

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletResponse.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletResponse.java
@@ -8,18 +8,59 @@ import java.util.UUID;
 import com.nursena.payflow.wallet.application.port.in.OpenWalletResult;
 import com.nursena.payflow.wallet.domain.model.Currency;
 import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "OpenWalletResponse",
+    description = "Wallet created for the authenticated user."
+)
 public record OpenWalletResponse(
+
+    @Schema(
+        description = "Wallet identifier.",
+        example = "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+        format = "uuid"
+    )
     UUID id,
+
+    @Schema(
+        description = "Wallet owner identifier.",
+        example = "8805681d-d537-42f2-8906-5da1f0666ab7",
+        format = "uuid"
+    )
     UUID ownerId,
+
+    @Schema(
+        description = "Current wallet balance.",
+        example = "0.00"
+    )
     BigDecimal balance,
+
+    @Schema(
+        description = "Wallet currency.",
+        example = "TRY"
+    )
     Currency currency,
+
+    @Schema(
+        description = "Current wallet status.",
+        example = "ACTIVE"
+    )
     WalletStatus status,
+
+    @Schema(
+        description = "Wallet creation time.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
     Instant createdAt
 ) {
 
     public OpenWalletResponse {
-        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(
+            id,
+            "id must not be null"
+        );
         Objects.requireNonNull(
             ownerId,
             "ownerId must not be null"

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletController.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletController.java
@@ -2,9 +2,21 @@ package com.nursena.payflow.wallet.adapter.in.web;
 
 import java.util.UUID;
 
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.configuration.WalletApiExamples;
 import com.nursena.payflow.wallet.application.port.in.TopUpWalletCommand;
 import com.nursena.payflow.wallet.application.port.in.TopUpWalletResult;
 import com.nursena.payflow.wallet.application.port.in.TopUpWalletUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,6 +25,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Tag(
+    name = "Wallets",
+    description = "Authenticated wallet management operations."
+)
 
 @RestController
 @RequestMapping("/api/v1/wallets/me/top-ups")
@@ -26,10 +45,110 @@ public class TopUpWalletController {
         this.topUpWalletUseCase = topUpWalletUseCase;
     }
 
+    @Operation(
+        operationId = "topUpCurrentWallet",
+        summary = "Top up current wallet",
+        description =
+            "Credits a simulated amount to the authenticated "
+                + "user's wallet."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Wallet topped up.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        TopUpWalletResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples.TOP_UP_WALLET
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples
+                            .TOP_UP_VALIDATION_ERROR
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The authenticated user does not have a wallet.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples
+                            .TOP_UP_WALLET_NOT_FOUND
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "The wallet was updated concurrently.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples
+                            .WALLET_CONCURRENT_UPDATE
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "422",
+            description =
+                "The wallet is not active.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        WalletApiExamples.WALLET_NOT_ACTIVE
+                )
+            )
+        )
+    })
+
     @PostMapping
     public ResponseEntity<TopUpWalletResponse> topUpWallet(
-        @AuthenticationPrincipal Jwt jwt,
-        @Valid @RequestBody TopUpWalletRequest request
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt,
+
+        @Valid
+        @RequestBody
+        TopUpWalletRequest request
     ) {
         UUID ownerId = UUID.fromString(
             jwt.getSubject()

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletRequest.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletRequest.java
@@ -6,8 +6,19 @@ import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "TopUpWalletRequest",
+    description = "Amount credited to the current wallet."
+)
 public record TopUpWalletRequest(
 
+    @Schema(
+        description = "Positive top-up amount.",
+        example = "100.00",
+        minimum = "0.01"
+    )
     @NotNull(message = "amount must not be null")
     @DecimalMin(
         value = "0.01",
@@ -19,6 +30,5 @@ public record TopUpWalletRequest(
         message = "amount must have at most 2 fractional digits"
     )
     BigDecimal amount
-
 ) {
 }

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletResponse.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletResponse.java
@@ -8,12 +8,44 @@ import java.util.UUID;
 import com.nursena.payflow.wallet.application.port.in.TopUpWalletResult;
 import com.nursena.payflow.wallet.domain.model.Currency;
 import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(
+    name = "TopUpWalletResponse",
+    description = "Wallet state after a successful top-up."
+)
 public record TopUpWalletResponse(
+
+    @Schema(
+        description = "Wallet identifier.",
+        example = "4a2d98c0-2673-4d21-b5c1-9b69833db721",
+        format = "uuid"
+    )
     UUID id,
+
+    @Schema(
+        description = "Current wallet balance after the top-up.",
+        example = "350.00"
+    )
     BigDecimal balance,
+
+    @Schema(
+        description = "Wallet currency.",
+        example = "TRY"
+    )
     Currency currency,
+
+    @Schema(
+        description = "Current wallet status.",
+        example = "ACTIVE"
+    )
     WalletStatus status,
+
+    @Schema(
+        description = "Wallet creation time.",
+        example = "2026-07-17T12:00:00Z",
+        format = "date-time"
+    )
     Instant createdAt
 ) {
 

--- a/src/main/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapter.java
@@ -48,6 +48,13 @@ class WalletPersistenceAdapter
     }
 
     @Override
+    public Optional<Wallet> findById(UUID walletId) {
+        return repository
+            .findById(walletId)
+            .map(WalletPersistenceAdapter::toDomain);
+    }
+
+    @Override
     public Wallet save(Wallet wallet) {
         Instant now = clock.instant();
 

--- a/src/main/java/com/nursena/payflow/wallet/application/port/out/WalletRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/wallet/application/port/out/WalletRepositoryPort.java
@@ -11,6 +11,8 @@ public interface WalletRepositoryPort {
 
     Optional<Wallet> findByOwnerId(UUID ownerId);
 
+    Optional<Wallet> findById(UUID walletId);
+
     Wallet save(Wallet wallet);
 
     Wallet update(Wallet wallet);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,8 +48,13 @@ management:
       show-details: when_authorized
 
 springdoc:
+  api-docs:
+    path: /v3/api-docs
   swagger-ui:
     path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+    display-request-duration: true
 
 logging:
   pattern:

--- a/src/main/resources/db/migration/V4__enforce_transfer_ledger_constraints.sql
+++ b/src/main/resources/db/migration/V4__enforce_transfer_ledger_constraints.sql
@@ -1,0 +1,19 @@
+ALTER TABLE payment_transactions
+    ADD CONSTRAINT chk_payment_transactions_distinct_wallets
+        CHECK (
+            source_wallet_id IS NULL
+            OR target_wallet_id IS NULL
+            OR source_wallet_id <> target_wallet_id
+        );
+
+ALTER TABLE ledger_entries
+    ADD CONSTRAINT chk_ledger_entries_entry_type
+        CHECK (entry_type IN ('DEBIT', 'CREDIT'));
+
+ALTER TABLE ledger_entries
+    ADD CONSTRAINT uq_ledger_entries_transaction_wallet_type
+        UNIQUE (
+            transaction_id,
+            wallet_id,
+            entry_type
+        );

--- a/src/test/java/com/nursena/payflow/configuration/AuthenticatedApiDocumentationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/AuthenticatedApiDocumentationTest.java
@@ -1,0 +1,362 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import com.nursena.payflow.user.adapter.in.web.CurrentUserProfileController;
+import com.nursena.payflow.wallet.adapter.in.web.GetCurrentWalletController;
+import com.nursena.payflow.wallet.adapter.in.web.OpenWalletController;
+import com.nursena.payflow.wallet.adapter.in.web.OpenWalletRequest;
+import com.nursena.payflow.wallet.adapter.in.web.TopUpWalletController;
+import com.nursena.payflow.wallet.adapter.in.web.TopUpWalletRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+import com.nursena.payflow.transaction.adapter.in.web.TransferMoneyController;
+import com.nursena.payflow.transaction.adapter.in.web.TransferMoneyRequest;
+import org.springframework.web.bind.annotation.RequestHeader;
+import java.time.Instant;
+
+import com.nursena.payflow.transaction.adapter.in.web.GetTransactionHistoryController;
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+
+
+class AuthenticatedApiDocumentationTest {
+
+    @Test
+    void shouldDocumentCurrentUserProfile()
+        throws NoSuchMethodException {
+
+        Method method =
+            CurrentUserProfileController.class
+                .getDeclaredMethod(
+                    "getCurrentUserProfile",
+                    Jwt.class
+                );
+
+        assertAuthenticatedDocumentation(
+            CurrentUserProfileController.class,
+            method,
+            "Users",
+            "getCurrentUserProfile",
+            "200",
+            "401",
+            "404"
+        );
+    }
+
+    @Test
+    void shouldDocumentWalletOpening()
+        throws NoSuchMethodException {
+
+        Method method =
+            OpenWalletController.class
+                .getDeclaredMethod(
+                    "openWallet",
+                    Jwt.class,
+                    OpenWalletRequest.class
+                );
+
+        assertAuthenticatedDocumentation(
+            OpenWalletController.class,
+            method,
+            "Wallets",
+            "openWallet",
+            "201",
+            "400",
+            "401",
+            "409"
+        );
+    }
+
+    @Test
+    void shouldDocumentCurrentWallet()
+        throws NoSuchMethodException {
+
+        Method method =
+            GetCurrentWalletController.class
+                .getDeclaredMethod(
+                    "getCurrentWallet",
+                    Jwt.class
+                );
+
+        assertAuthenticatedDocumentation(
+            GetCurrentWalletController.class,
+            method,
+            "Wallets",
+            "getCurrentWallet",
+            "200",
+            "401",
+            "404"
+        );
+    }
+
+    @Test
+    void shouldDocumentWalletTopUp()
+        throws NoSuchMethodException {
+
+        Method method =
+            TopUpWalletController.class
+                .getDeclaredMethod(
+                    "topUpWallet",
+                    Jwt.class,
+                    TopUpWalletRequest.class
+                );
+
+        assertAuthenticatedDocumentation(
+            TopUpWalletController.class,
+            method,
+            "Wallets",
+            "topUpCurrentWallet",
+            "200",
+            "400",
+            "401",
+            "404",
+            "409",
+            "422"
+        );
+    }
+
+    private static void assertAuthenticatedDocumentation(
+        Class<?> controllerType,
+        Method method,
+        String expectedTag,
+        String expectedOperationId,
+        String... expectedResponseCodes
+    ) {
+        Tag tag =
+            controllerType.getAnnotation(Tag.class);
+
+        assertThat(tag)
+            .isNotNull();
+
+        assertThat(tag.name())
+            .isEqualTo(expectedTag);
+
+        Operation operation =
+            method.getAnnotation(Operation.class);
+
+        assertThat(operation)
+            .isNotNull();
+
+        assertThat(operation.operationId())
+            .isEqualTo(expectedOperationId);
+
+        assertThat(operation.summary())
+            .isNotBlank();
+
+        SecurityRequirement security =
+            method.getAnnotation(
+                SecurityRequirement.class
+            );
+
+        assertThat(security)
+            .isNotNull();
+
+        assertThat(security.name())
+            .isEqualTo(
+                OpenApiConfiguration
+                    .BEARER_AUTH_SCHEME
+            );
+
+        Parameter jwtParameter =
+            method
+                .getParameters()[0]
+                .getAnnotation(Parameter.class);
+
+        assertThat(jwtParameter)
+            .isNotNull();
+
+        assertThat(jwtParameter.hidden())
+            .isTrue();
+
+        ApiResponses responses =
+            method.getAnnotation(ApiResponses.class);
+
+        assertThat(responses)
+            .isNotNull();
+
+        assertThat(
+            Arrays.stream(responses.value())
+                .map(ApiResponse::responseCode)
+                .toList()
+        )
+            .containsExactlyInAnyOrder(
+                expectedResponseCodes
+            );
+
+        ApiResponse unauthorizedResponse =
+            Arrays.stream(responses.value())
+                .filter(response ->
+                    response
+                        .responseCode()
+                        .equals("401")
+                )
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(unauthorizedResponse.content())
+            .isEmpty();
+    }
+    @Test
+    void shouldDocumentMoneyTransfer()
+        throws NoSuchMethodException {
+
+        Method method =
+            TransferMoneyController.class
+                .getDeclaredMethod(
+                    "transfer",
+                    Jwt.class,
+                    String.class,
+                    TransferMoneyRequest.class
+                );
+
+        assertAuthenticatedDocumentation(
+            TransferMoneyController.class,
+            method,
+            "Transfers",
+            "transferMoney",
+            "201",
+            "400",
+            "401",
+            "404",
+            "409",
+            "422"
+        );
+
+        Parameter headerDocumentation =
+            method
+                .getParameters()[1]
+                .getAnnotation(Parameter.class);
+
+        assertThat(headerDocumentation)
+            .isNotNull();
+
+        assertThat(headerDocumentation.name())
+            .isEqualTo("Idempotency-Key");
+
+        assertThat(headerDocumentation.required())
+            .isTrue();
+
+        RequestHeader requestHeader =
+            method
+                .getParameters()[1]
+                .getAnnotation(RequestHeader.class);
+
+        assertThat(requestHeader)
+            .isNotNull();
+
+        assertThat(requestHeader.value())
+            .isEqualTo("Idempotency-Key");
+    }
+
+    @Test
+    void shouldDocumentTransactionHistory()
+        throws NoSuchMethodException {
+
+        Method method =
+            GetTransactionHistoryController.class
+                .getDeclaredMethod(
+                    "getTransactionHistory",
+                    Jwt.class,
+                    int.class,
+                    int.class,
+                    TransactionDirection.class,
+                    TransactionStatus.class,
+                    Instant.class,
+                    Instant.class
+                );
+
+        assertAuthenticatedDocumentation(
+            GetTransactionHistoryController.class,
+            method,
+            "Transactions",
+            "getTransactionHistory",
+            "200",
+            "400",
+            "401",
+            "404"
+        );
+
+        assertDocumentedParameter(
+            method,
+            1,
+            "page"
+        );
+
+        assertDocumentedParameter(
+            method,
+            2,
+            "size"
+        );
+
+        assertDocumentedParameter(
+            method,
+            3,
+            "direction"
+        );
+
+        assertDocumentedParameter(
+            method,
+            4,
+            "status"
+        );
+
+        assertDocumentedParameter(
+            method,
+            5,
+            "from"
+        );
+
+        assertDocumentedParameter(
+            method,
+            6,
+            "to"
+        );
+
+        Parameter fromParameter =
+            method
+                .getParameters()[5]
+                .getAnnotation(Parameter.class);
+
+        assertThat(fromParameter.description())
+            .containsIgnoringCase("inclusive");
+
+        Parameter toParameter =
+            method
+                .getParameters()[6]
+                .getAnnotation(Parameter.class);
+
+        assertThat(toParameter.description())
+            .containsIgnoringCase("exclusive");
+    }
+
+    private static void assertDocumentedParameter(
+        Method method,
+        int parameterIndex,
+        String expectedName
+    ) {
+        Parameter parameter =
+            method
+                .getParameters()[parameterIndex]
+                .getAnnotation(Parameter.class);
+
+        assertThat(parameter)
+            .isNotNull();
+
+        assertThat(parameter.name())
+            .isEqualTo(expectedName);
+
+        assertThat(parameter.description())
+            .isNotBlank();
+    }
+
+}

--- a/src/test/java/com/nursena/payflow/configuration/OpenApiConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/OpenApiConfigurationTest.java
@@ -1,0 +1,87 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OpenApiConfigurationTest {
+
+    private OpenAPI openApi;
+
+    @BeforeEach
+    void setUp() {
+        openApi =
+            new OpenApiConfiguration()
+                .payflowOpenApi();
+    }
+
+    @Test
+    void shouldExposePayflowApiMetadata() {
+        assertThat(openApi.getInfo())
+            .isNotNull();
+
+        assertThat(openApi.getInfo().getTitle())
+            .isEqualTo("PayFlow API");
+
+        assertThat(openApi.getInfo().getVersion())
+            .isEqualTo("0.2.0");
+
+        assertThat(openApi.getInfo().getDescription())
+            .contains(
+                "simulated digital wallet"
+            )
+            .contains(
+                "does not process real money"
+            );
+    }
+
+    @Test
+    void shouldExposeBearerJwtSecurityScheme() {
+        assertThat(openApi.getComponents())
+            .isNotNull();
+
+        assertThat(
+            openApi
+                .getComponents()
+                .getSecuritySchemes()
+        )
+            .containsKey(
+                OpenApiConfiguration
+                    .BEARER_AUTH_SCHEME
+            );
+
+        SecurityScheme securityScheme =
+            openApi
+                .getComponents()
+                .getSecuritySchemes()
+                .get(
+                    OpenApiConfiguration
+                        .BEARER_AUTH_SCHEME
+                );
+
+        assertThat(securityScheme.getType())
+            .isEqualTo(
+                SecurityScheme.Type.HTTP
+            );
+
+        assertThat(securityScheme.getScheme())
+            .isEqualTo("bearer");
+
+        assertThat(securityScheme.getBearerFormat())
+            .isEqualTo("JWT");
+
+        assertThat(securityScheme.getDescription())
+            .contains(
+                "login endpoint"
+            );
+    }
+
+    @Test
+    void shouldNotRequireAuthenticationGlobally() {
+        assertThat(openApi.getSecurity())
+            .isNullOrEmpty();
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/PublicApiDocumentationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/PublicApiDocumentationTest.java
@@ -1,0 +1,129 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import com.nursena.payflow.common.api.SystemController;
+import com.nursena.payflow.user.adapter.in.web.AuthenticateUserController;
+import com.nursena.payflow.user.adapter.in.web.AuthenticateUserRequest;
+import com.nursena.payflow.user.adapter.in.web.RegisterUserController;
+import com.nursena.payflow.user.adapter.in.web.RegisterUserRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.junit.jupiter.api.Test;
+
+class PublicApiDocumentationTest {
+
+    @Test
+    void shouldDocumentSystemHealthOperation()
+        throws NoSuchMethodException {
+
+        Method method =
+            SystemController.class
+                .getDeclaredMethod("health");
+
+        assertDocumentation(
+            SystemController.class,
+            method,
+            "System",
+            "getSystemHealth",
+            "200"
+        );
+    }
+
+    @Test
+    void shouldDocumentRegistrationOperation()
+        throws NoSuchMethodException {
+
+        Method method =
+            RegisterUserController.class
+                .getDeclaredMethod(
+                    "register",
+                    RegisterUserRequest.class
+                );
+
+        assertDocumentation(
+            RegisterUserController.class,
+            method,
+            "Authentication",
+            "registerUser",
+            "201",
+            "400",
+            "409"
+        );
+    }
+
+    @Test
+    void shouldDocumentAuthenticationOperation()
+        throws NoSuchMethodException {
+
+        Method method =
+            AuthenticateUserController.class
+                .getDeclaredMethod(
+                    "authenticate",
+                    AuthenticateUserRequest.class
+                );
+
+        assertDocumentation(
+            AuthenticateUserController.class,
+            method,
+            "Authentication",
+            "authenticateUser",
+            "200",
+            "400",
+            "401",
+            "403"
+        );
+    }
+
+    private static void assertDocumentation(
+        Class<?> controllerType,
+        Method method,
+        String expectedTag,
+        String expectedOperationId,
+        String... expectedResponseCodes
+    ) {
+        Tag tag =
+            controllerType.getAnnotation(Tag.class);
+
+        assertThat(tag)
+            .isNotNull();
+
+        assertThat(tag.name())
+            .isEqualTo(expectedTag);
+
+        Operation operation =
+            method.getAnnotation(Operation.class);
+
+        assertThat(operation)
+            .isNotNull();
+
+        assertThat(operation.operationId())
+            .isEqualTo(expectedOperationId);
+
+        assertThat(operation.summary())
+            .isNotBlank();
+
+        assertThat(operation.security())
+            .isEmpty();
+
+        ApiResponses responses =
+            method.getAnnotation(ApiResponses.class);
+
+        assertThat(responses)
+            .isNotNull();
+
+        assertThat(
+            Arrays.stream(responses.value())
+                .map(ApiResponse::responseCode)
+                .toList()
+        )
+            .containsExactlyInAnyOrder(
+                expectedResponseCodes
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -1,0 +1,739 @@
+package com.nursena.payflow.configuration.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet
+    .request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet
+    .result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet
+    .result.MockMvcResultMatchers.status;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.configuration
+    .OpenApiConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet
+    .AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers
+    .PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class OpenApiJsonContractIntegrationTest {
+
+    private static final String SYSTEM_HEALTH_PATH =
+        "/api/v1/system/health";
+
+    private static final String REGISTER_PATH =
+        "/api/v1/auth/register";
+
+    private static final String LOGIN_PATH =
+        "/api/v1/auth/login";
+
+    private static final String USER_PROFILE_PATH =
+        "/api/v1/users/me";
+
+    private static final String WALLETS_PATH =
+        "/api/v1/wallets";
+
+    private static final String CURRENT_WALLET_PATH =
+        "/api/v1/wallets/me";
+
+    private static final String TOP_UP_PATH =
+        "/api/v1/wallets/me/top-ups";
+
+    private static final String TRANSFERS_PATH =
+        "/api/v1/transfers";
+
+    private static final String TRANSACTIONS_PATH =
+        "/api/v1/transactions/me";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private JsonNode openApi;
+
+    @BeforeEach
+    void loadOpenApiDocument() throws Exception {
+        MvcResult result =
+            mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(
+                    content()
+                        .contentTypeCompatibleWith(
+                            MediaType.APPLICATION_JSON
+                        )
+                )
+                .andReturn();
+
+        openApi =
+            objectMapper.readTree(
+                result
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+    }
+
+    @Test
+    void shouldExposeApiMetadataAndBearerScheme() {
+        assertThat(openApi.path("openapi").asText())
+            .startsWith("3.");
+
+        JsonNode info = openApi.path("info");
+
+        assertThat(info.path("title").asText())
+            .isEqualTo("PayFlow API");
+
+        assertThat(info.path("version").asText())
+            .isEqualTo("0.2.0");
+
+        assertThat(info.path("description").asText())
+            .contains(
+                "PayFlow does not process real money."
+            );
+
+        assertThat(openApi.has("security"))
+            .isFalse();
+
+        JsonNode bearerScheme =
+            openApi
+                .path("components")
+                .path("securitySchemes")
+                .path(
+                    OpenApiConfiguration
+                        .BEARER_AUTH_SCHEME
+                );
+
+        assertThat(bearerScheme.isObject())
+            .isTrue();
+
+        assertThat(bearerScheme.path("type").asText())
+            .isEqualTo("http");
+
+        assertThat(bearerScheme.path("scheme").asText())
+            .isEqualTo("bearer");
+
+        assertThat(
+            bearerScheme
+                .path("bearerFormat")
+                .asText()
+        ).isEqualTo("JWT");
+    }
+
+    @Test
+    void shouldExposeExactlyThePublicApiPaths() {
+        assertThat(
+            fieldNames(openApi.path("paths"))
+        ).containsExactlyInAnyOrder(
+            SYSTEM_HEALTH_PATH,
+            REGISTER_PATH,
+            LOGIN_PATH,
+            USER_PROFILE_PATH,
+            WALLETS_PATH,
+            CURRENT_WALLET_PATH,
+            TOP_UP_PATH,
+            TRANSFERS_PATH,
+            TRANSACTIONS_PATH
+        );
+
+        JsonNode health =
+            operation(
+                SYSTEM_HEALTH_PATH,
+                "get"
+            );
+
+        assertPublicOperation(health);
+        assertResponseCodes(health, "200");
+
+        JsonNode register =
+            operation(
+                REGISTER_PATH,
+                "post"
+            );
+
+        assertPublicOperation(register);
+        assertResponseCodes(
+            register,
+            "201",
+            "400",
+            "409"
+        );
+
+        JsonNode login =
+            operation(
+                LOGIN_PATH,
+                "post"
+            );
+
+        assertPublicOperation(login);
+        assertResponseCodes(
+            login,
+            "200",
+            "400",
+            "401",
+            "403"
+        );
+    }
+
+    @Test
+    void shouldExposeAuthenticatedApiOperations() {
+        JsonNode profile =
+            operation(
+                USER_PROFILE_PATH,
+                "get"
+            );
+
+        assertAuthenticatedOperation(
+            profile,
+            "getCurrentUserProfile",
+            new String[] {
+                "200",
+                "401",
+                "404"
+            }
+        );
+
+        assertParameterNames(profile);
+
+        JsonNode openWallet =
+            operation(
+                WALLETS_PATH,
+                "post"
+            );
+
+        assertAuthenticatedOperation(
+            openWallet,
+            "openWallet",
+            new String[] {
+                "201",
+                "400",
+                "401",
+                "409"
+            }
+        );
+
+        assertParameterNames(openWallet);
+
+        JsonNode currentWallet =
+            operation(
+                CURRENT_WALLET_PATH,
+                "get"
+            );
+
+        assertAuthenticatedOperation(
+            currentWallet,
+            "getCurrentWallet",
+            new String[] {
+                "200",
+                "401",
+                "404"
+            }
+        );
+
+        assertParameterNames(currentWallet);
+
+        JsonNode topUp =
+            operation(
+                TOP_UP_PATH,
+                "post"
+            );
+
+        assertAuthenticatedOperation(
+            topUp,
+            "topUpCurrentWallet",
+            new String[] {
+                "200",
+                "400",
+                "401",
+                "404",
+                "409",
+                "422"
+            }
+        );
+
+        assertParameterNames(topUp);
+
+        JsonNode transfer =
+            operation(
+                TRANSFERS_PATH,
+                "post"
+            );
+
+        assertAuthenticatedOperation(
+            transfer,
+            "transferMoney",
+            new String[] {
+                "201",
+                "400",
+                "401",
+                "404",
+                "409",
+                "422"
+            }
+        );
+
+        assertParameterNames(
+            transfer,
+            "Idempotency-Key"
+        );
+
+        JsonNode history =
+            operation(
+                TRANSACTIONS_PATH,
+                "get"
+            );
+
+        assertAuthenticatedOperation(
+            history,
+            "getTransactionHistory",
+            new String[] {
+                "200",
+                "400",
+                "401",
+                "404"
+            }
+        );
+
+        assertParameterNames(
+            history,
+            "page",
+            "size",
+            "direction",
+            "status",
+            "from",
+            "to"
+        );
+    }
+
+    @Test
+    void shouldExposeTransferContract() {
+        JsonNode transfer =
+            operation(
+                TRANSFERS_PATH,
+                "post"
+            );
+
+        JsonNode idempotencyKey =
+            findParameter(
+                transfer,
+                "Idempotency-Key"
+            );
+
+        assertThat(idempotencyKey.path("in").asText())
+            .isEqualTo("header");
+
+        assertThat(
+            idempotencyKey
+                .path("required")
+                .asBoolean()
+        ).isTrue();
+
+        JsonNode schema =
+            idempotencyKey.path("schema");
+
+        assertThat(schema.path("type").asText())
+            .isEqualTo("string");
+
+        assertThat(schema.path("minLength").asInt())
+            .isEqualTo(1);
+
+        assertThat(schema.path("maxLength").asInt())
+            .isEqualTo(100);
+
+        assertExampleNames(
+            transfer,
+            "400",
+            "missingIdempotencyKey",
+            "validationFailed"
+        );
+
+        assertExampleNames(
+            transfer,
+            "409",
+            "idempotencyKeyConflict",
+            "requestInProgress",
+            "concurrentWalletUpdate"
+        );
+
+        assertExampleNames(
+            transfer,
+            "422",
+            "invalidIdempotencyKey",
+            "insufficientBalance",
+            "walletNotActive",
+            "currencyMismatch"
+        );
+
+        JsonNode schemas =
+            openApi
+                .path("components")
+                .path("schemas");
+
+        JsonNode responseProperties =
+            schemas
+                .path("TransferMoneyResponse")
+                .path("properties");
+
+        assertThat(
+            fieldNames(responseProperties)
+        ).doesNotContain("idempotencyKey");
+    }
+
+    @Test
+    void shouldExposeTransactionHistoryContract() {
+        JsonNode history =
+            operation(
+                TRANSACTIONS_PATH,
+                "get"
+            );
+
+        JsonNode page =
+            findParameter(history, "page");
+
+        assertQueryParameter(page);
+
+        assertThat(
+            page.path("schema")
+                .path("minimum")
+                .asInt()
+        ).isZero();
+
+        assertThat(
+            page.path("schema")
+                .path("default")
+                .asInt()
+        ).isZero();
+
+        JsonNode size =
+            findParameter(history, "size");
+
+        assertQueryParameter(size);
+
+        assertThat(
+            size.path("schema")
+                .path("minimum")
+                .asInt()
+        ).isEqualTo(1);
+
+        assertThat(
+            size.path("schema")
+                .path("maximum")
+                .asInt()
+        ).isEqualTo(100);
+
+        assertThat(
+            size.path("schema")
+                .path("default")
+                .asInt()
+        ).isEqualTo(20);
+
+        JsonNode direction =
+            findParameter(
+                history,
+                "direction"
+            );
+
+        assertQueryParameter(direction);
+
+        assertThat(
+            textValues(
+                direction
+                    .path("schema")
+                    .path("enum")
+            )
+        ).containsExactlyInAnyOrder(
+            "INCOMING",
+            "OUTGOING"
+        );
+
+        JsonNode transactionStatus =
+            findParameter(
+                history,
+                "status"
+            );
+
+        assertQueryParameter(transactionStatus);
+
+        assertThat(
+            textValues(
+                transactionStatus
+                    .path("schema")
+                    .path("enum")
+            )
+        ).containsExactlyInAnyOrder(
+            "PENDING",
+            "COMPLETED",
+            "FAILED"
+        );
+
+        JsonNode from =
+            findParameter(history, "from");
+
+        assertQueryParameter(from);
+
+        assertThat(
+            from.path("description").asText()
+        ).containsIgnoringCase("inclusive");
+
+        assertThat(
+            from.path("schema")
+                .path("format")
+                .asText()
+        ).isEqualTo("date-time");
+
+        JsonNode to =
+            findParameter(history, "to");
+
+        assertQueryParameter(to);
+
+        assertThat(
+            to.path("description").asText()
+        ).containsIgnoringCase("exclusive");
+
+        assertThat(
+            to.path("schema")
+                .path("format")
+                .asText()
+        ).isEqualTo("date-time");
+
+        JsonNode historyItemProperties =
+            openApi
+                .path("components")
+                .path("schemas")
+                .path(
+                    "TransactionHistoryItemResponse"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(historyItemProperties)
+        ).doesNotContain("idempotencyKey");
+    }
+
+    private JsonNode operation(
+        String path,
+        String method
+    ) {
+        JsonNode operation =
+            openApi
+                .path("paths")
+                .path(path)
+                .path(method);
+
+        assertThat(operation.isObject())
+            .as(
+                "%s %s operation must exist",
+                method.toUpperCase(),
+                path
+            )
+            .isTrue();
+
+        return operation;
+    }
+
+    private static void assertPublicOperation(
+        JsonNode operation
+    ) {
+        assertThat(operation.has("security"))
+            .isFalse();
+    }
+
+    private static void assertAuthenticatedOperation(
+        JsonNode operation,
+        String expectedOperationId,
+        String[] expectedResponseCodes
+    ) {
+        assertThat(
+            operation
+                .path("operationId")
+                .asText()
+        ).isEqualTo(expectedOperationId);
+
+        JsonNode security =
+            operation.path("security");
+
+        assertThat(security.isArray())
+            .isTrue();
+
+        boolean bearerSecurityPresent =
+            StreamSupport.stream(
+                    security.spliterator(),
+                    false
+                )
+                .anyMatch(requirement ->
+                    requirement.has(
+                        OpenApiConfiguration
+                            .BEARER_AUTH_SCHEME
+                    )
+                );
+
+        assertThat(bearerSecurityPresent)
+            .isTrue();
+
+        assertResponseCodes(
+            operation,
+            expectedResponseCodes
+        );
+    }
+
+    private static void assertResponseCodes(
+        JsonNode operation,
+        String... expectedCodes
+    ) {
+        JsonNode responses =
+            operation.path("responses");
+
+        assertThat(responses.isObject())
+            .isTrue();
+
+        assertThat(fieldNames(responses))
+            .containsExactlyInAnyOrder(
+                expectedCodes
+            );
+    }
+
+    private static void assertParameterNames(
+        JsonNode operation,
+        String... expectedNames
+    ) {
+        assertThat(
+            parameterNames(operation)
+        ).containsExactlyInAnyOrder(
+            expectedNames
+        );
+    }
+
+    private static Set<String> parameterNames(
+        JsonNode operation
+    ) {
+        Set<String> names =
+            new LinkedHashSet<>();
+
+        JsonNode parameters =
+            operation.path("parameters");
+
+        if (!parameters.isArray()) {
+            return names;
+        }
+
+        parameters.forEach(parameter ->
+            names.add(
+                parameter
+                    .path("name")
+                    .asText()
+            )
+        );
+
+        return names;
+    }
+
+    private static JsonNode findParameter(
+        JsonNode operation,
+        String expectedName
+    ) {
+        return StreamSupport.stream(
+                operation
+                    .path("parameters")
+                    .spliterator(),
+                false
+            )
+            .filter(parameter ->
+                expectedName.equals(
+                    parameter
+                        .path("name")
+                        .asText()
+                )
+            )
+            .findFirst()
+            .orElseThrow(() ->
+                new AssertionError(
+                    "OpenAPI parameter is missing: "
+                        + expectedName
+                )
+            );
+    }
+
+    private static void assertQueryParameter(
+        JsonNode parameter
+    ) {
+        assertThat(parameter.path("in").asText())
+            .isEqualTo("query");
+    }
+
+    private static void assertExampleNames(
+        JsonNode operation,
+        String responseCode,
+        String... expectedNames
+    ) {
+        JsonNode examples =
+            operation
+                .path("responses")
+                .path(responseCode)
+                .path("content")
+                .path(
+                    MediaType
+                        .APPLICATION_JSON_VALUE
+                )
+                .path("examples");
+
+        assertThat(examples.isObject())
+            .isTrue();
+
+        assertThat(fieldNames(examples))
+            .containsExactlyInAnyOrder(
+                expectedNames
+            );
+    }
+
+    private static Set<String> fieldNames(
+        JsonNode object
+    ) {
+        Set<String> names =
+            new LinkedHashSet<>();
+
+        object
+            .fieldNames()
+            .forEachRemaining(names::add);
+
+        return names;
+    }
+
+    private static Set<String> textValues(
+        JsonNode array
+    ) {
+        Set<String> values =
+            new LinkedHashSet<>();
+
+        array.forEach(value ->
+            values.add(value.asText())
+        );
+
+        return values;
+    }
+}

--- a/src/test/java/com/nursena/payflow/ledger/adapter/out/persistence/LedgerPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/ledger/adapter/out/persistence/LedgerPersistenceAdapterTest.java
@@ -1,0 +1,213 @@
+package com.nursena.payflow.ledger.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.nursena.payflow.ledger.domain.exception.InvalidLedgerEntryPairException;
+import com.nursena.payflow.ledger.domain.model.DoubleEntryLedger;
+import com.nursena.payflow.ledger.domain.model.LedgerEntryType;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Money;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.stream.StreamSupport;
+
+@ExtendWith(MockitoExtension.class)
+class LedgerPersistenceAdapterTest {
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "b4077781-34f4-466f-8e61-b79ca906bc98"
+        );
+
+    private static final UUID SOURCE_WALLET_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final UUID TARGET_WALLET_ID =
+        UUID.fromString(
+            "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db"
+        );
+
+    private static final UUID DEBIT_ENTRY_ID =
+        UUID.fromString(
+            "0d7d81e9-2480-4f4b-920d-f51b3635fc92"
+        );
+
+    private static final UUID CREDIT_ENTRY_ID =
+        UUID.fromString(
+            "b2b059b6-8ffb-4ef4-8dc3-808965642059"
+        );
+
+    private static final Instant NOW =
+        Instant.parse("2026-07-15T17:00:00Z");
+
+    @Mock
+    private SpringDataLedgerEntryRepository repository;
+
+    private LedgerPersistenceAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new LedgerPersistenceAdapter(repository);
+    }
+
+    @Test
+    void shouldSaveAndRestoreEntriesRegardlessOfReturnOrder() {
+        DoubleEntryLedger ledger =
+            DoubleEntryLedger.forTransfer(
+                TRANSACTION_ID,
+                SOURCE_WALLET_ID,
+                TARGET_WALLET_ID,
+                Money.of("125.50", Currency.TRY),
+                NOW
+            );
+
+        LedgerEntryJpaEntity savedDebit =
+            debitEntity();
+
+        LedgerEntryJpaEntity savedCredit =
+            creditEntity();
+
+        when(repository.saveAllAndFlush(
+            argThat(
+                (Iterable<LedgerEntryJpaEntity> entities) ->
+                    toList(entities).size() == 2
+            )
+        )).thenReturn(
+            List.of(
+                savedCredit,
+                savedDebit
+            )
+        );
+
+        DoubleEntryLedger saved =
+            adapter.save(ledger);
+
+        assertThat(saved.debitEntry().id())
+            .isEqualTo(DEBIT_ENTRY_ID);
+
+        assertThat(saved.debitEntry().walletId())
+            .isEqualTo(SOURCE_WALLET_ID);
+
+        assertThat(saved.debitEntry().type())
+            .isEqualTo(LedgerEntryType.DEBIT);
+
+        assertThat(saved.creditEntry().id())
+            .isEqualTo(CREDIT_ENTRY_ID);
+
+        assertThat(saved.creditEntry().walletId())
+            .isEqualTo(TARGET_WALLET_ID);
+
+        assertThat(saved.creditEntry().type())
+            .isEqualTo(LedgerEntryType.CREDIT);
+
+        assertThat(saved.debitEntry().amount())
+            .isEqualTo(saved.creditEntry().amount());
+
+        verify(repository).saveAllAndFlush(
+            argThat(
+                (Iterable<LedgerEntryJpaEntity> entities) -> {
+                    List<LedgerEntryJpaEntity> entityList =
+                        toList(entities);
+
+                    return entityList.size() == 2
+                        && entityList.stream().anyMatch(
+                        entity ->
+                            entity.getEntryType()
+                                == LedgerEntryType.DEBIT
+                                && entity.getWalletId()
+                                .equals(SOURCE_WALLET_ID)
+                    )
+                        && entityList.stream().anyMatch(
+                        entity ->
+                            entity.getEntryType()
+                                == LedgerEntryType.CREDIT
+                                && entity.getWalletId()
+                                .equals(TARGET_WALLET_ID)
+                    );
+                }
+            )
+        );
+    }
+
+    @Test
+    void shouldRejectIncompletePersistenceResult() {
+        DoubleEntryLedger ledger =
+            DoubleEntryLedger.forTransfer(
+                TRANSACTION_ID,
+                SOURCE_WALLET_ID,
+                TARGET_WALLET_ID,
+                Money.of("125.50", Currency.TRY),
+                NOW
+            );
+
+        when(repository.saveAllAndFlush(
+            argThat(
+                (Iterable<LedgerEntryJpaEntity> entities) ->
+                    toList(entities).size() == 2
+            )
+        )).thenReturn(
+            List.of(debitEntity())
+        );
+
+        assertThatThrownBy(() ->
+            adapter.save(ledger)
+        )
+            .isInstanceOf(
+                InvalidLedgerEntryPairException.class
+            )
+            .hasMessage(
+                "Ledger entries must form a balanced "
+                    + "debit and credit pair."
+            );
+    }
+
+    private static LedgerEntryJpaEntity debitEntity() {
+        return new LedgerEntryJpaEntity(
+            DEBIT_ENTRY_ID,
+            TRANSACTION_ID,
+            SOURCE_WALLET_ID,
+            LedgerEntryType.DEBIT,
+            Money.of(
+                "125.50",
+                Currency.TRY
+            ).amount(),
+            Currency.TRY,
+            NOW
+        );
+    }
+
+    private static LedgerEntryJpaEntity creditEntity() {
+        return new LedgerEntryJpaEntity(
+            CREDIT_ENTRY_ID,
+            TRANSACTION_ID,
+            TARGET_WALLET_ID,
+            LedgerEntryType.CREDIT,
+            Money.of(
+                "125.50",
+                Currency.TRY
+            ).amount(),
+            Currency.TRY,
+            NOW
+        );
+    }
+    private static List<LedgerEntryJpaEntity> toList(
+        Iterable<LedgerEntryJpaEntity> entities
+    ) {
+        return StreamSupport
+            .stream(entities.spliterator(), false)
+            .toList();
+    }
+}

--- a/src/test/java/com/nursena/payflow/ledger/domain/model/DoubleEntryLedgerTest.java
+++ b/src/test/java/com/nursena/payflow/ledger/domain/model/DoubleEntryLedgerTest.java
@@ -1,0 +1,153 @@
+package com.nursena.payflow.ledger.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.ledger.domain.exception.InvalidLedgerEntryPairException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Money;
+import org.junit.jupiter.api.Test;
+
+class DoubleEntryLedgerTest {
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "b4077781-34f4-466f-8e61-b79ca906bc98"
+        );
+
+    private static final UUID SOURCE_WALLET_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final UUID TARGET_WALLET_ID =
+        UUID.fromString(
+            "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db"
+        );
+
+    private static final Instant NOW =
+        Instant.parse("2026-07-15T15:00:00Z");
+
+    @Test
+    void shouldCreateBalancedEntriesForTransfer() {
+        DoubleEntryLedger ledger =
+            DoubleEntryLedger.forTransfer(
+                TRANSACTION_ID,
+                SOURCE_WALLET_ID,
+                TARGET_WALLET_ID,
+                Money.of("125.50", Currency.TRY),
+                NOW
+            );
+
+        LedgerEntry debit = ledger.debitEntry();
+        LedgerEntry credit = ledger.creditEntry();
+
+        assertThat(debit.type())
+            .isEqualTo(LedgerEntryType.DEBIT);
+
+        assertThat(debit.walletId())
+            .isEqualTo(SOURCE_WALLET_ID);
+
+        assertThat(credit.type())
+            .isEqualTo(LedgerEntryType.CREDIT);
+
+        assertThat(credit.walletId())
+            .isEqualTo(TARGET_WALLET_ID);
+
+        assertThat(debit.transactionId())
+            .isEqualTo(TRANSACTION_ID);
+
+        assertThat(credit.transactionId())
+            .isEqualTo(TRANSACTION_ID);
+
+        assertThat(debit.amount())
+            .isEqualTo(credit.amount());
+
+        assertThat(debit.createdAt())
+            .isEqualTo(NOW);
+
+        assertThat(credit.createdAt())
+            .isEqualTo(NOW);
+    }
+
+    @Test
+    void shouldRejectEntriesForSameWallet() {
+        assertThatThrownBy(() ->
+            DoubleEntryLedger.forTransfer(
+                TRANSACTION_ID,
+                SOURCE_WALLET_ID,
+                SOURCE_WALLET_ID,
+                Money.of("25.00", Currency.TRY),
+                NOW
+            )
+        )
+            .isInstanceOf(
+                InvalidLedgerEntryPairException.class
+            );
+    }
+
+    @Test
+    void shouldRejectUnbalancedEntryPair() {
+        LedgerEntry debit = LedgerEntry.create(
+            TRANSACTION_ID,
+            SOURCE_WALLET_ID,
+            LedgerEntryType.DEBIT,
+            Money.of("100.00", Currency.TRY),
+            NOW
+        );
+
+        LedgerEntry credit = LedgerEntry.create(
+            TRANSACTION_ID,
+            TARGET_WALLET_ID,
+            LedgerEntryType.CREDIT,
+            Money.of("99.00", Currency.TRY),
+            NOW
+        );
+
+        assertThatThrownBy(() ->
+            new DoubleEntryLedger(
+                debit,
+                credit
+            )
+        )
+            .isInstanceOf(
+                InvalidLedgerEntryPairException.class
+            )
+            .hasMessage(
+                "Ledger entries must form a balanced "
+                    + "debit and credit pair."
+            );
+    }
+
+    @Test
+    void shouldRejectEntriesFromDifferentTransactions() {
+        LedgerEntry debit = LedgerEntry.create(
+            TRANSACTION_ID,
+            SOURCE_WALLET_ID,
+            LedgerEntryType.DEBIT,
+            Money.of("100.00", Currency.TRY),
+            NOW
+        );
+
+        LedgerEntry credit = LedgerEntry.create(
+            UUID.randomUUID(),
+            TARGET_WALLET_ID,
+            LedgerEntryType.CREDIT,
+            Money.of("100.00", Currency.TRY),
+            NOW
+        );
+
+        assertThatThrownBy(() ->
+            new DoubleEntryLedger(
+                debit,
+                credit
+            )
+        )
+            .isInstanceOf(
+                InvalidLedgerEntryPairException.class
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/ledger/domain/model/LedgerEntryTest.java
+++ b/src/test/java/com/nursena/payflow/ledger/domain/model/LedgerEntryTest.java
@@ -1,0 +1,72 @@
+package com.nursena.payflow.ledger.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.ledger.domain.exception.InvalidLedgerAmountException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Money;
+import org.junit.jupiter.api.Test;
+
+class LedgerEntryTest {
+
+    private static final Instant NOW =
+        Instant.parse("2026-07-15T15:00:00Z");
+
+    @Test
+    void shouldCreateImmutableDebitEntry() {
+        UUID transactionId = UUID.randomUUID();
+        UUID walletId = UUID.randomUUID();
+
+        LedgerEntry entry = LedgerEntry.create(
+            transactionId,
+            walletId,
+            LedgerEntryType.DEBIT,
+            Money.of("125.50", Currency.TRY),
+            NOW
+        );
+
+        assertThat(entry.id())
+            .isNotNull();
+
+        assertThat(entry.transactionId())
+            .isEqualTo(transactionId);
+
+        assertThat(entry.walletId())
+            .isEqualTo(walletId);
+
+        assertThat(entry.type())
+            .isEqualTo(LedgerEntryType.DEBIT);
+
+        assertThat(entry.amount())
+            .isEqualTo(
+                Money.of("125.50", Currency.TRY)
+            );
+
+        assertThat(entry.createdAt())
+            .isEqualTo(NOW);
+    }
+
+    @Test
+    void shouldRejectNonPositiveEntryAmount() {
+        assertThatThrownBy(() ->
+            LedgerEntry.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                LedgerEntryType.CREDIT,
+                Money.of("0.00", Currency.TRY),
+                NOW
+            )
+        )
+            .isInstanceOf(
+                InvalidLedgerAmountException.class
+            )
+            .hasMessage(
+                "Ledger entry amount must "
+                    + "be greater than zero."
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryControllerTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryControllerTest.java
@@ -1,0 +1,689 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryItem;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryQuery;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryUseCase;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(GetTransactionHistoryController.class)
+@Import({
+    SecurityConfiguration.class,
+    TransactionHistoryExceptionHandler.class
+})
+class GetTransactionHistoryControllerTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "b4077781-34f4-466f-8e61-b79ca906bc98"
+        );
+
+    private static final UUID COUNTERPARTY_WALLET_ID =
+        UUID.fromString(
+            "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-16T10:00:00Z"
+        );
+
+    private static final Instant COMPLETED_AT =
+        Instant.parse(
+            "2026-07-16T10:00:01Z"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GetTransactionHistoryUseCase
+        getTransactionHistoryUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldReturnAuthenticatedUsersTransactionHistory()
+        throws Exception {
+
+        GetTransactionHistoryQuery expectedQuery =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                20
+            );
+
+        when(
+            getTransactionHistoryUseCase
+                .getTransactionHistory(expectedQuery)
+        ).thenReturn(historyPage());
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.items.length()")
+                    .value(1)
+            )
+            .andExpect(
+                jsonPath("$.items[0].transactionId")
+                    .value(TRANSACTION_ID.toString())
+            )
+            .andExpect(
+                jsonPath("$.items[0].type")
+                    .value("TRANSFER")
+            )
+            .andExpect(
+                jsonPath("$.items[0].direction")
+                    .value("OUTGOING")
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].counterpartyWalletId"
+                )
+                    .value(
+                        COUNTERPARTY_WALLET_ID.toString()
+                    )
+            )
+            .andExpect(
+                jsonPath("$.items[0].amount")
+                    .value(125.50)
+            )
+            .andExpect(
+                jsonPath("$.items[0].currency")
+                    .value("TRY")
+            )
+            .andExpect(
+                jsonPath("$.items[0].status")
+                    .value("COMPLETED")
+            )
+            .andExpect(
+                jsonPath("$.items[0].createdAt")
+                    .value(CREATED_AT.toString())
+            )
+            .andExpect(
+                jsonPath("$.items[0].completedAt")
+                    .value(COMPLETED_AT.toString())
+            )
+            .andExpect(
+                jsonPath("$.items[0].idempotencyKey")
+                    .doesNotExist()
+            )
+            .andExpect(
+                jsonPath("$.page")
+                    .value(0)
+            )
+            .andExpect(
+                jsonPath("$.size")
+                    .value(20)
+            )
+            .andExpect(
+                jsonPath("$.totalElements")
+                    .value(1)
+            )
+            .andExpect(
+                jsonPath("$.totalPages")
+                    .value(1)
+            )
+            .andExpect(
+                jsonPath("$.first")
+                    .value(true)
+            )
+            .andExpect(
+                jsonPath("$.last")
+                    .value(true)
+            )
+            .andExpect(
+                jsonPath("$.hasNext")
+                    .value(false)
+            )
+            .andExpect(
+                jsonPath("$.hasPrevious")
+                    .value(false)
+            );
+
+        verify(getTransactionHistoryUseCase)
+            .getTransactionHistory(expectedQuery);
+    }
+
+    @Test
+    void shouldApplyRequestedPagination()
+        throws Exception {
+
+        GetTransactionHistoryQuery expectedQuery =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                2,
+                10
+            );
+
+        when(
+            getTransactionHistoryUseCase
+                .getTransactionHistory(expectedQuery)
+        ).thenReturn(
+            new TransactionHistoryPage(
+                List.of(),
+                2,
+                10,
+                21,
+                3
+            )
+        );
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param("page", "2")
+                    .param("size", "10")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.items.length()")
+                    .value(0)
+            )
+            .andExpect(
+                jsonPath("$.page")
+                    .value(2)
+            )
+            .andExpect(
+                jsonPath("$.size")
+                    .value(10)
+            )
+            .andExpect(
+                jsonPath("$.totalElements")
+                    .value(21)
+            )
+            .andExpect(
+                jsonPath("$.totalPages")
+                    .value(3)
+            )
+            .andExpect(
+                jsonPath("$.first")
+                    .value(false)
+            )
+            .andExpect(
+                jsonPath("$.last")
+                    .value(true)
+            )
+            .andExpect(
+                jsonPath("$.hasNext")
+                    .value(false)
+            )
+            .andExpect(
+                jsonPath("$.hasPrevious")
+                    .value(true)
+            );
+
+        verify(getTransactionHistoryUseCase)
+            .getTransactionHistory(expectedQuery);
+    }
+
+    @Test
+    void shouldApplyRequestedFilters()
+        throws Exception {
+
+        Instant from =
+            Instant.parse(
+                "2026-07-01T00:00:00Z"
+            );
+
+        Instant to =
+            Instant.parse(
+                "2026-08-01T00:00:00Z"
+            );
+
+        TransactionHistoryFilter filter =
+            new TransactionHistoryFilter(
+                TransactionDirection.OUTGOING,
+                TransactionStatus.COMPLETED,
+                from,
+                to
+            );
+
+        GetTransactionHistoryQuery expectedQuery =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                20,
+                filter
+            );
+
+        when(
+            getTransactionHistoryUseCase
+                .getTransactionHistory(expectedQuery)
+        ).thenReturn(
+            new TransactionHistoryPage(
+                List.of(),
+                0,
+                20,
+                0,
+                0
+            )
+        );
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param(
+                        "direction",
+                        "OUTGOING"
+                    )
+                    .param(
+                        "status",
+                        "COMPLETED"
+                    )
+                    .param(
+                        "from",
+                        from.toString()
+                    )
+                    .param(
+                        "to",
+                        to.toString()
+                    )
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.items.length()")
+                    .value(0)
+            )
+            .andExpect(
+                jsonPath("$.page")
+                    .value(0)
+            )
+            .andExpect(
+                jsonPath("$.size")
+                    .value(20)
+            );
+
+        verify(getTransactionHistoryUseCase)
+            .getTransactionHistory(expectedQuery);
+    }
+
+    @Test
+    void shouldAllowEqualDateBoundaries()
+        throws Exception {
+
+        Instant boundary =
+            Instant.parse(
+                "2026-07-01T00:00:00Z"
+            );
+
+        TransactionHistoryFilter filter =
+            new TransactionHistoryFilter(
+                null,
+                null,
+                boundary,
+                boundary
+            );
+
+        GetTransactionHistoryQuery expectedQuery =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                20,
+                filter
+            );
+
+        when(
+            getTransactionHistoryUseCase
+                .getTransactionHistory(expectedQuery)
+        ).thenReturn(
+            new TransactionHistoryPage(
+                List.of(),
+                0,
+                20,
+                0,
+                0
+            )
+        );
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param(
+                        "from",
+                        boundary.toString()
+                    )
+                    .param(
+                        "to",
+                        boundary.toString()
+                    )
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk());
+
+        verify(getTransactionHistoryUseCase)
+            .getTransactionHistory(expectedQuery);
+    }
+
+    @Test
+    void shouldRejectRequestWithoutAccessToken()
+        throws Exception {
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+            )
+            .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(
+            getTransactionHistoryUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectReversedDateRange()
+        throws Exception {
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param(
+                        "from",
+                        "2026-08-01T00:00:00Z"
+                    )
+                    .param(
+                        "to",
+                        "2026-07-01T00:00:00Z"
+                    )
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(400)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Request validation failed."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/transactions/me"
+                    )
+            );
+
+        verifyNoInteractions(
+            getTransactionHistoryUseCase
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "direction, SIDEWAYS",
+        "status, UNKNOWN",
+        "from, not-an-instant",
+        "to, not-an-instant"
+    })
+    void shouldRejectInvalidFilterValues(
+        String parameter,
+        String value
+    ) throws Exception {
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param(parameter, value)
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(400)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Request validation failed."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/transactions/me"
+                    )
+            );
+
+        verifyNoInteractions(
+            getTransactionHistoryUseCase
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "-1, 20",
+        "0, 0",
+        "0, 101"
+    })
+    void shouldRejectInvalidPagination(
+        int page,
+        int size
+    ) throws Exception {
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param(
+                        "page",
+                        Integer.toString(page)
+                    )
+                    .param(
+                        "size",
+                        Integer.toString(size)
+                    )
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(400)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Request validation failed."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/transactions/me"
+                    )
+            );
+
+        verifyNoInteractions(
+            getTransactionHistoryUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectNonNumericPagination()
+        throws Exception {
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .param("page", "invalid")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            );
+
+        verifyNoInteractions(
+            getTransactionHistoryUseCase
+        );
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenUserHasNoWallet()
+        throws Exception {
+
+        GetTransactionHistoryQuery query =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                20
+            );
+
+        when(
+            getTransactionHistoryUseCase
+                .getTransactionHistory(query)
+        ).thenThrow(
+            new WalletNotFoundException()
+        );
+
+        mockMvc.perform(
+                get("/api/v1/transactions/me")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isNotFound())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(404)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("WALLET_NOT_FOUND")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Wallet could not be found."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/transactions/me"
+                    )
+            );
+
+        verify(getTransactionHistoryUseCase)
+            .getTransactionHistory(query);
+    }
+
+    private static TransactionHistoryPage historyPage() {
+        TransactionHistoryItem item =
+            new TransactionHistoryItem(
+                TRANSACTION_ID,
+                TransactionType.TRANSFER,
+                TransactionDirection.OUTGOING,
+                COUNTERPARTY_WALLET_ID,
+                new BigDecimal("125.50"),
+                Currency.TRY,
+                TransactionStatus.COMPLETED,
+                CREATED_AT,
+                COMPLETED_AT
+            );
+
+        return new TransactionHistoryPage(
+            List.of(item),
+            0,
+            20,
+            1,
+            1
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyControllerTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyControllerTest.java
@@ -1,0 +1,382 @@
+package com.nursena.payflow.transaction.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyCommand;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyResult;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyUseCase;
+import com.nursena.payflow.transaction.domain.exception.IdempotencyConflictException;
+import com.nursena.payflow.transaction.domain.exception.IdempotencyRequestInProgressException;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.wallet.domain.exception.InsufficientBalanceException;
+import com.nursena.payflow.wallet.domain.exception.WalletConcurrentUpdateException;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TransferMoneyController.class)
+@Import({
+    SecurityConfiguration.class,
+    TransferMoneyExceptionHandler.class
+})
+class TransferMoneyControllerTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "b4077781-34f4-466f-8e61-b79ca906bc98"
+        );
+
+    private static final UUID SOURCE_WALLET_ID =
+        UUID.fromString(
+            "11111111-1111-1111-1111-111111111111"
+        );
+
+    private static final UUID TARGET_WALLET_ID =
+        UUID.fromString(
+            "22222222-2222-2222-2222-222222222222"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-15T18:30:00.123456Z"
+        );
+
+    private static final String IDEMPOTENCY_KEY =
+        "transfer-request-1";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TransferMoneyUseCase transferMoneyUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldCreateAuthenticatedTransfer()
+        throws Exception {
+
+        when(transferMoneyUseCase.transfer(
+            any(TransferMoneyCommand.class)
+        )).thenReturn(successfulResult());
+
+        mockMvc.perform(
+                validTransferRequest()
+            )
+            .andExpect(status().isCreated())
+            .andExpect(
+                jsonPath("$.transactionId")
+                    .value(TRANSACTION_ID.toString())
+            )
+            .andExpect(
+                jsonPath("$.sourceWalletId")
+                    .value(SOURCE_WALLET_ID.toString())
+            )
+            .andExpect(
+                jsonPath("$.targetWalletId")
+                    .value(TARGET_WALLET_ID.toString())
+            )
+            .andExpect(
+                jsonPath("$.amount")
+                    .value(125.50)
+            )
+            .andExpect(
+                jsonPath("$.currency")
+                    .value("TRY")
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value("COMPLETED")
+            )
+            .andExpect(
+                jsonPath("$.createdAt")
+                    .value(CREATED_AT.toString())
+            )
+            .andExpect(
+                jsonPath("$.completedAt")
+                    .value(CREATED_AT.toString())
+            );
+
+        verify(transferMoneyUseCase)
+            .transfer(
+                new TransferMoneyCommand(
+                    OWNER_ID,
+                    TARGET_WALLET_ID,
+                    new BigDecimal("125.50"),
+                    IDEMPOTENCY_KEY
+                )
+            );
+    }
+
+    @Test
+    void shouldRejectRequestWithoutAccessToken()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/transfers")
+                    .header(
+                        "Idempotency-Key",
+                        IDEMPOTENCY_KEY
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(validRequestBody())
+            )
+            .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(transferMoneyUseCase);
+    }
+
+    @Test
+    void shouldRejectMissingIdempotencyKey()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/transfers")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(validRequestBody())
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("MISSING_IDEMPOTENCY_KEY")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Idempotency-Key header is required."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value("/api/v1/transfers")
+            );
+
+        verifyNoInteractions(transferMoneyUseCase);
+    }
+
+    @Test
+    void shouldRejectZeroAmount()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/transfers")
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                OWNER_ID.toString()
+                            )
+                        )
+                    )
+                    .header(
+                        "Idempotency-Key",
+                        IDEMPOTENCY_KEY
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "targetWalletId":
+                            "%s",
+                          "amount": 0.00
+                        }
+                        """.formatted(
+                            TARGET_WALLET_ID
+                        )
+                    )
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            );
+
+        verifyNoInteractions(transferMoneyUseCase);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenWalletIsMissing()
+        throws Exception {
+
+        when(transferMoneyUseCase.transfer(
+            any(TransferMoneyCommand.class)
+        )).thenThrow(
+            new WalletNotFoundException()
+        );
+
+        mockMvc.perform(validTransferRequest())
+            .andExpect(status().isNotFound())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(404)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("WALLET_NOT_FOUND")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Wallet could not be found."
+                    )
+            );
+    }
+
+    @Test
+    void shouldReturnConflictForReusedKeyWithDifferentPayload()
+        throws Exception {
+
+        when(transferMoneyUseCase.transfer(
+            any(TransferMoneyCommand.class)
+        )).thenThrow(
+            new IdempotencyConflictException()
+        );
+
+        mockMvc.perform(validTransferRequest())
+            .andExpect(status().isConflict())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("IDEMPOTENCY_KEY_CONFLICT")
+            );
+    }
+
+    @Test
+    void shouldReturnConflictWhileRequestIsInProgress()
+        throws Exception {
+
+        when(transferMoneyUseCase.transfer(
+            any(TransferMoneyCommand.class)
+        )).thenThrow(
+            new IdempotencyRequestInProgressException()
+        );
+
+        mockMvc.perform(validTransferRequest())
+            .andExpect(status().isConflict())
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "IDEMPOTENCY_REQUEST_IN_PROGRESS"
+                    )
+            );
+    }
+
+    @Test
+    void shouldReturnConflictForConcurrentWalletUpdate()
+        throws Exception {
+
+        when(transferMoneyUseCase.transfer(
+            any(TransferMoneyCommand.class)
+        )).thenThrow(
+            new WalletConcurrentUpdateException()
+        );
+
+        mockMvc.perform(validTransferRequest())
+            .andExpect(status().isConflict())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("WALLET_CONCURRENT_UPDATE")
+            );
+    }
+
+    @Test
+    void shouldReturnUnprocessableEntityForInsufficientBalance()
+        throws Exception {
+
+        when(transferMoneyUseCase.transfer(
+            any(TransferMoneyCommand.class)
+        )).thenThrow(
+            new InsufficientBalanceException()
+        );
+
+        mockMvc.perform(validTransferRequest())
+            .andExpect(
+                status().isUnprocessableEntity()
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("INSUFFICIENT_BALANCE")
+            );
+    }
+
+    private org.springframework.test.web.servlet
+        .request.MockHttpServletRequestBuilder
+    validTransferRequest() {
+
+        return post("/api/v1/transfers")
+            .with(
+                jwt().jwt(token ->
+                    token.subject(
+                        OWNER_ID.toString()
+                    )
+                )
+            )
+            .header(
+                "Idempotency-Key",
+                IDEMPOTENCY_KEY
+            )
+            .contentType(
+                MediaType.APPLICATION_JSON
+            )
+            .content(validRequestBody());
+    }
+
+    private static String validRequestBody() {
+        return """
+            {
+              "targetWalletId": "%s",
+              "amount": 125.50
+            }
+            """.formatted(
+            TARGET_WALLET_ID
+        );
+    }
+
+    private static TransferMoneyResult successfulResult() {
+        return new TransferMoneyResult(
+            TRANSACTION_ID,
+            SOURCE_WALLET_ID,
+            TARGET_WALLET_ID,
+            new BigDecimal("125.50"),
+            Currency.TRY,
+            TransactionStatus.COMPLETED,
+            CREATED_AT,
+            CREATED_AT
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/adapter/out/persistence/PaymentTransactionPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/adapter/out/persistence/PaymentTransactionPersistenceAdapterTest.java
@@ -1,0 +1,282 @@
+package com.nursena.payflow.transaction.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.domain.exception.IdempotencyConflictException;
+import com.nursena.payflow.transaction.domain.exception.PaymentTransactionNotFoundException;
+import com.nursena.payflow.transaction.domain.model.IdempotencyKey;
+import com.nursena.payflow.transaction.domain.model.PaymentTransaction;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Money;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentTransactionPersistenceAdapterTest {
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "b4077781-34f4-466f-8e61-b79ca906bc98"
+        );
+
+    private static final UUID SOURCE_WALLET_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final UUID TARGET_WALLET_ID =
+        UUID.fromString(
+            "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse("2026-07-15T16:00:00Z");
+
+    private static final Instant COMPLETED_AT =
+        Instant.parse("2026-07-15T16:00:01Z");
+
+    @Mock
+    private SpringDataPaymentTransactionRepository
+        repository;
+
+    private PaymentTransactionPersistenceAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter =
+            new PaymentTransactionPersistenceAdapter(
+                repository
+            );
+    }
+
+    @Test
+    void shouldSaveAndRestoreTransaction() {
+        PaymentTransaction transaction =
+            pendingTransaction();
+
+        when(repository.saveAndFlush(
+            any(PaymentTransactionJpaEntity.class)
+        )).thenAnswer(invocation ->
+            invocation.getArgument(0)
+        );
+
+        PaymentTransaction saved =
+            adapter.save(transaction);
+
+        assertThat(saved.id())
+            .isEqualTo(TRANSACTION_ID);
+
+        assertThat(saved.sourceWalletId())
+            .isEqualTo(SOURCE_WALLET_ID);
+
+        assertThat(saved.targetWalletId())
+            .isEqualTo(TARGET_WALLET_ID);
+
+        assertThat(saved.amount())
+            .isEqualTo(
+                Money.of("125.50", Currency.TRY)
+            );
+
+        assertThat(saved.idempotencyKey())
+            .isEqualTo(
+                new IdempotencyKey("request-1")
+            );
+
+        assertThat(saved.type())
+            .isEqualTo(TransactionType.TRANSFER);
+
+        assertThat(saved.status())
+            .isEqualTo(TransactionStatus.PENDING);
+
+        verify(repository)
+            .saveAndFlush(
+                any(PaymentTransactionJpaEntity.class)
+            );
+    }
+
+    @Test
+    void shouldFindTransactionBySourceAndIdempotencyKey() {
+        PaymentTransactionJpaEntity entity =
+            pendingEntity();
+
+        when(
+            repository
+                .findBySourceWalletIdAndIdempotencyKey(
+                    SOURCE_WALLET_ID,
+                    "request-1"
+                )
+        ).thenReturn(Optional.of(entity));
+
+        Optional<PaymentTransaction> result =
+            adapter
+                .findBySourceWalletIdAndIdempotencyKey(
+                    SOURCE_WALLET_ID,
+                    new IdempotencyKey("request-1")
+                );
+
+        assertThat(result).isPresent();
+
+        assertThat(result.orElseThrow().id())
+            .isEqualTo(TRANSACTION_ID);
+
+        verify(repository)
+            .findBySourceWalletIdAndIdempotencyKey(
+                SOURCE_WALLET_ID,
+                "request-1"
+            );
+    }
+
+    @Test
+    void shouldUpdateManagedTransactionState() {
+        PaymentTransaction transaction =
+            pendingTransaction();
+
+        transaction.complete(COMPLETED_AT);
+
+        PaymentTransactionJpaEntity entity =
+            pendingEntity();
+
+        when(repository.findById(TRANSACTION_ID))
+            .thenReturn(Optional.of(entity));
+
+        PaymentTransaction updated =
+            adapter.update(transaction);
+
+        assertThat(updated.status())
+            .isEqualTo(TransactionStatus.COMPLETED);
+
+        assertThat(updated.completedAt())
+            .isEqualTo(COMPLETED_AT);
+
+        verify(repository)
+            .findById(TRANSACTION_ID);
+
+        verify(repository)
+            .flush();
+    }
+
+    @Test
+    void shouldRejectUpdatingMissingTransaction() {
+        PaymentTransaction transaction =
+            pendingTransaction();
+
+        transaction.complete(COMPLETED_AT);
+
+        when(repository.findById(TRANSACTION_ID))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            adapter.update(transaction)
+        )
+            .isInstanceOf(
+                PaymentTransactionNotFoundException.class
+            )
+            .hasMessage(
+                "Payment transaction could not be found."
+            );
+    }
+
+    private static PaymentTransaction pendingTransaction() {
+        return PaymentTransaction.rehydrate(
+            TRANSACTION_ID,
+            SOURCE_WALLET_ID,
+            TARGET_WALLET_ID,
+            Money.of("125.50", Currency.TRY),
+            new IdempotencyKey("request-1"),
+            TransactionType.TRANSFER,
+            TransactionStatus.PENDING,
+            CREATED_AT,
+            null
+        );
+    }
+
+    private static PaymentTransactionJpaEntity pendingEntity() {
+        return new PaymentTransactionJpaEntity(
+            TRANSACTION_ID,
+            SOURCE_WALLET_ID,
+            TARGET_WALLET_ID,
+            TransactionType.TRANSFER,
+            TransactionStatus.PENDING,
+            Money.of(
+                "125.50",
+                Currency.TRY
+            ).amount(),
+            Currency.TRY,
+            "request-1",
+            null,
+            CREATED_AT,
+            null
+        );
+    }
+
+    @Test
+    void shouldTranslateDuplicateIdempotencyConstraint() {
+        ConstraintViolationException violation =
+            new ConstraintViolationException(
+                "duplicate idempotency key",
+                new SQLException(),
+                "uq_transaction_idempotency"
+            );
+
+        when(repository.saveAndFlush(
+            any(PaymentTransactionJpaEntity.class)
+        )).thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate idempotency key",
+                violation
+            )
+        );
+
+        assertThatThrownBy(() ->
+            adapter.save(pendingTransaction())
+        )
+            .isInstanceOf(
+                IdempotencyConflictException.class
+            )
+            .hasMessage(
+                "Idempotency key has already been used "
+                    + "for another transfer request."
+            );
+    }
+
+    @Test
+    void shouldNotTranslateUnrelatedConstraintViolation() {
+        ConstraintViolationException violation =
+            new ConstraintViolationException(
+                "unrelated constraint",
+                new SQLException(),
+                "some_other_constraint"
+            );
+
+        DataIntegrityViolationException databaseException =
+            new DataIntegrityViolationException(
+                "unrelated constraint",
+                violation
+            );
+
+        when(repository.saveAndFlush(
+            any(PaymentTransactionJpaEntity.class)
+        )).thenThrow(databaseException);
+
+        assertThatThrownBy(() ->
+            adapter.save(pendingTransaction())
+        ).isSameAs(databaseException);
+    }
+
+}

--- a/src/test/java/com/nursena/payflow/transaction/adapter/out/persistence/TransactionHistoryPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/adapter/out/persistence/TransactionHistoryPersistenceAdapterTest.java
@@ -1,0 +1,286 @@
+package com.nursena.payflow.transaction.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.ArgumentMatchers.isNull;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionHistoryPersistenceAdapterTest {
+
+    private static final UUID WALLET_ID =
+        UUID.fromString(
+            "11111111-1111-1111-1111-111111111111"
+        );
+
+    private static final UUID COUNTERPARTY_WALLET_ID =
+        UUID.fromString(
+            "22222222-2222-2222-2222-222222222222"
+        );
+
+    private static final UUID OUTGOING_TRANSACTION_ID =
+        UUID.fromString(
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        );
+
+    private static final UUID INCOMING_TRANSACTION_ID =
+        UUID.fromString(
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse("2026-07-16T10:00:00Z");
+
+    @Mock
+    private SpringDataPaymentTransactionRepository
+        repository;
+
+    private TransactionHistoryPersistenceAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter =
+            new TransactionHistoryPersistenceAdapter(
+                repository
+            );
+    }
+
+    @Test
+    void shouldMapOutgoingAndIncomingTransactions() {
+        PaymentTransactionJpaEntity outgoing =
+            transactionEntity(
+                OUTGOING_TRANSACTION_ID,
+                WALLET_ID,
+                COUNTERPARTY_WALLET_ID
+            );
+
+        PaymentTransactionJpaEntity incoming =
+            transactionEntity(
+                INCOMING_TRANSACTION_ID,
+                COUNTERPARTY_WALLET_ID,
+                WALLET_ID
+            );
+
+        PageRequest repositoryPageRequest =
+            PageRequest.of(1, 2);
+
+        when(
+            repository.findHistory(
+                eq(WALLET_ID),
+                eq(true),
+                eq(true),
+                eq(false),
+                eq(TransactionStatus.PENDING),
+                eq(false),
+                eq(Instant.EPOCH),
+                eq(false),
+                eq(Instant.EPOCH),
+                any(Pageable.class)
+            )
+        ).thenReturn(
+            new PageImpl<>(
+                List.of(outgoing, incoming),
+                repositoryPageRequest,
+                4
+            )
+        );
+
+        TransactionHistoryPage result =
+            adapter.findByWalletId(
+                WALLET_ID,
+                1,
+                2,
+                TransactionHistoryFilter.unfiltered()
+            );
+
+        assertThat(result.page())
+            .isEqualTo(1);
+
+        assertThat(result.size())
+            .isEqualTo(2);
+
+        assertThat(result.totalElements())
+            .isEqualTo(4);
+
+        assertThat(result.totalPages())
+            .isEqualTo(2);
+
+        assertThat(result.items())
+            .hasSize(2);
+
+        assertThat(result.items().get(0).transactionId())
+            .isEqualTo(OUTGOING_TRANSACTION_ID);
+
+        assertThat(result.items().get(0).direction())
+            .isEqualTo(TransactionDirection.OUTGOING);
+
+        assertThat(
+            result.items()
+                .get(0)
+                .counterpartyWalletId()
+        ).isEqualTo(COUNTERPARTY_WALLET_ID);
+
+        assertThat(result.items().get(1).transactionId())
+            .isEqualTo(INCOMING_TRANSACTION_ID);
+
+        assertThat(result.items().get(1).direction())
+            .isEqualTo(TransactionDirection.INCOMING);
+
+        assertThat(
+            result.items()
+                .get(1)
+                .counterpartyWalletId()
+        ).isEqualTo(COUNTERPARTY_WALLET_ID);
+
+        ArgumentCaptor<Pageable> pageableCaptor =
+            ArgumentCaptor.forClass(Pageable.class);
+
+        verify(repository)
+            .findHistory(
+                eq(WALLET_ID),
+                eq(true),
+                eq(true),
+                eq(false),
+                eq(TransactionStatus.PENDING),
+                eq(false),
+                eq(Instant.EPOCH),
+                eq(false),
+                eq(Instant.EPOCH),
+                pageableCaptor.capture()
+            );
+
+        Pageable capturedPageable =
+            pageableCaptor.getValue();
+
+        assertThat(capturedPageable.getPageNumber())
+            .isEqualTo(1);
+
+        assertThat(capturedPageable.getPageSize())
+            .isEqualTo(2);
+
+        assertDescendingSort(
+            capturedPageable,
+            "createdAt"
+        );
+
+        assertDescendingSort(
+            capturedPageable,
+            "id"
+        );
+    }
+
+    @Test
+    void shouldRejectTransactionOutsideRequestedWallet() {
+        UUID unrelatedSourceWalletId =
+            UUID.fromString(
+                "33333333-3333-3333-3333-333333333333"
+            );
+
+        UUID unrelatedTargetWalletId =
+            UUID.fromString(
+                "44444444-4444-4444-4444-444444444444"
+            );
+
+        PaymentTransactionJpaEntity unrelated =
+            transactionEntity(
+                OUTGOING_TRANSACTION_ID,
+                unrelatedSourceWalletId,
+                unrelatedTargetWalletId
+            );
+
+        when(
+            repository.findHistory(
+                eq(WALLET_ID),
+                eq(true),
+                eq(true),
+                eq(false),
+                eq(TransactionStatus.PENDING),
+                eq(false),
+                eq(Instant.EPOCH),
+                eq(false),
+                eq(Instant.EPOCH),
+                any(Pageable.class)
+            )
+        ).thenReturn(
+            new PageImpl<>(List.of(unrelated))
+        );
+
+        assertThatThrownBy(() ->
+            adapter.findByWalletId(
+                WALLET_ID,
+                0,
+                20,
+                TransactionHistoryFilter.unfiltered()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "Payment transaction must belong "
+                    + "to exactly one side of the wallet."
+            );
+    }
+
+    private static void assertDescendingSort(
+        Pageable pageable,
+        String property
+    ) {
+        Sort.Order order =
+            pageable
+                .getSort()
+                .getOrderFor(property);
+
+        assertThat(order)
+            .isNotNull();
+
+        assertThat(order.getDirection())
+            .isEqualTo(Sort.Direction.DESC);
+    }
+
+    private static PaymentTransactionJpaEntity
+    transactionEntity(
+        UUID transactionId,
+        UUID sourceWalletId,
+        UUID targetWalletId
+    ) {
+        return new PaymentTransactionJpaEntity(
+            transactionId,
+            sourceWalletId,
+            targetWalletId,
+            TransactionType.TRANSFER,
+            TransactionStatus.COMPLETED,
+            new BigDecimal("125.50"),
+            Currency.TRY,
+            transactionId.toString(),
+            null,
+            CREATED_AT,
+            CREATED_AT.plusSeconds(1)
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/application/model/TransactionHistoryFilterTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/application/model/TransactionHistoryFilterTest.java
@@ -1,0 +1,90 @@
+package com.nursena.payflow.transaction.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nursena.payflow.transaction.application.exception.InvalidTransactionHistoryFilterException;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class TransactionHistoryFilterTest {
+
+    private static final Instant FROM =
+        Instant.parse(
+            "2026-07-01T00:00:00Z"
+        );
+
+    private static final Instant TO =
+        Instant.parse(
+            "2026-08-01T00:00:00Z"
+        );
+
+    @Test
+    void shouldCreateUnfilteredFilter() {
+        TransactionHistoryFilter filter =
+            TransactionHistoryFilter.unfiltered();
+
+        assertThat(filter.direction())
+            .isNull();
+
+        assertThat(filter.status())
+            .isNull();
+
+        assertThat(filter.from())
+            .isNull();
+
+        assertThat(filter.to())
+            .isNull();
+    }
+
+    @Test
+    void shouldAcceptValidDateRange() {
+        TransactionHistoryFilter filter =
+            new TransactionHistoryFilter(
+                TransactionDirection.INCOMING,
+                null,
+                FROM,
+                TO
+            );
+
+        assertThat(filter.from())
+            .isEqualTo(FROM);
+
+        assertThat(filter.to())
+            .isEqualTo(TO);
+    }
+
+    @Test
+    void shouldAllowEqualDateBoundaries() {
+        TransactionHistoryFilter filter =
+            new TransactionHistoryFilter(
+                null,
+                null,
+                FROM,
+                FROM
+            );
+
+        assertThat(filter.from())
+            .isEqualTo(filter.to());
+    }
+
+    @Test
+    void shouldRejectReversedDateRange() {
+        assertThatThrownBy(() ->
+            new TransactionHistoryFilter(
+                null,
+                null,
+                TO,
+                FROM
+            )
+        )
+            .isInstanceOf(
+                InvalidTransactionHistoryFilterException.class
+            )
+            .hasMessage(
+                "from must not be after to"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryQueryTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/application/port/in/GetTransactionHistoryQueryTest.java
@@ -1,0 +1,86 @@
+package com.nursena.payflow.transaction.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class GetTransactionHistoryQueryTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    @Test
+    void shouldCreateValidQuery() {
+        GetTransactionHistoryQuery query =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                20
+            );
+
+        assertThat(query.ownerId())
+            .isEqualTo(OWNER_ID);
+
+        assertThat(query.page())
+            .isZero();
+
+        assertThat(query.size())
+            .isEqualTo(20);
+    }
+
+    @Test
+    void shouldRejectNegativePage() {
+        assertThatThrownBy(() ->
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                -1,
+                20
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "page must not be negative"
+            );
+    }
+
+    @Test
+    void shouldRejectZeroSize() {
+        assertThatThrownBy(() ->
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                0
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "size must be between 1 and 100"
+            );
+    }
+
+    @Test
+    void shouldRejectSizeAboveMaximum() {
+        assertThatThrownBy(() ->
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                101
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "size must be between 1 and 100"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryServiceTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/application/service/GetTransactionHistoryServiceTest.java
@@ -1,0 +1,182 @@
+package com.nursena.payflow.transaction.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryItem;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.application.port.in.GetTransactionHistoryQuery;
+import com.nursena.payflow.transaction.application.port.out.TransactionHistoryQueryPort;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GetTransactionHistoryServiceTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final UUID WALLET_ID =
+        UUID.fromString(
+            "11111111-1111-1111-1111-111111111111"
+        );
+
+    private static final UUID COUNTERPARTY_WALLET_ID =
+        UUID.fromString(
+            "22222222-2222-2222-2222-222222222222"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "b4077781-34f4-466f-8e61-b79ca906bc98"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-16T10:00:00Z"
+        );
+
+    private WalletRepositoryPort walletRepository;
+
+    private TransactionHistoryQueryPort
+        transactionHistoryQueryPort;
+
+    private GetTransactionHistoryService service;
+
+    @BeforeEach
+    void setUp() {
+        walletRepository =
+            mock(WalletRepositoryPort.class);
+
+        transactionHistoryQueryPort =
+            mock(TransactionHistoryQueryPort.class);
+
+        service = new GetTransactionHistoryService(
+            walletRepository,
+            transactionHistoryQueryPort
+        );
+    }
+
+    @Test
+    void shouldReturnAuthenticatedUsersTransactionHistory() {
+        Wallet wallet = mock(Wallet.class);
+
+        when(wallet.id())
+            .thenReturn(WALLET_ID);
+
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.of(wallet));
+
+        TransactionHistoryPage expectedPage =
+            historyPage();
+
+        TransactionHistoryFilter filter =
+            TransactionHistoryFilter.unfiltered();
+
+        when(
+            transactionHistoryQueryPort
+                .findByWalletId(
+                    WALLET_ID,
+                    0,
+                    20,
+                    filter
+                )
+        ).thenReturn(expectedPage);
+
+        TransactionHistoryPage result =
+            service.getTransactionHistory(
+                new GetTransactionHistoryQuery(
+                    OWNER_ID,
+                    0,
+                    20,
+                    filter
+                )
+            );
+
+        assertThat(result)
+            .isSameAs(expectedPage);
+
+        verify(walletRepository)
+            .findByOwnerId(OWNER_ID);
+
+        verify(transactionHistoryQueryPort)
+            .findByWalletId(
+                WALLET_ID,
+                0,
+                20,
+                filter
+            );
+    }
+
+    @Test
+    void shouldFailWhenAuthenticatedUserHasNoWallet() {
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.empty());
+
+        GetTransactionHistoryQuery query =
+            new GetTransactionHistoryQuery(
+                OWNER_ID,
+                0,
+                20
+            );
+
+        assertThatThrownBy(() ->
+            service.getTransactionHistory(query)
+        )
+            .isInstanceOf(
+                WalletNotFoundException.class
+            )
+            .hasMessage(
+                "Wallet could not be found."
+            );
+
+        verify(walletRepository)
+            .findByOwnerId(OWNER_ID);
+
+        verifyNoInteractions(
+            transactionHistoryQueryPort
+        );
+    }
+
+    private static TransactionHistoryPage historyPage() {
+        TransactionHistoryItem item =
+            new TransactionHistoryItem(
+                TRANSACTION_ID,
+                TransactionType.TRANSFER,
+                TransactionDirection.OUTGOING,
+                COUNTERPARTY_WALLET_ID,
+                new BigDecimal("125.50"),
+                Currency.TRY,
+                TransactionStatus.COMPLETED,
+                CREATED_AT,
+                CREATED_AT
+            );
+
+        return new TransactionHistoryPage(
+            List.of(item),
+            0,
+            20,
+            1,
+            1
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/application/service/TransferMoneyServiceTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/application/service/TransferMoneyServiceTest.java
@@ -1,0 +1,568 @@
+package com.nursena.payflow.transaction.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.ledger.application.port.out.LedgerRepositoryPort;
+import com.nursena.payflow.ledger.domain.model.DoubleEntryLedger;
+import com.nursena.payflow.ledger.domain.model.LedgerEntryType;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyCommand;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyResult;
+import com.nursena.payflow.transaction.application.port.out.PaymentTransactionRepositoryPort;
+import com.nursena.payflow.transaction.domain.exception.SelfTransferNotAllowedException;
+import com.nursena.payflow.transaction.domain.model.PaymentTransaction;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.wallet.application.port.out.WalletRepositoryPort;
+import com.nursena.payflow.wallet.domain.exception.InsufficientBalanceException;
+import com.nursena.payflow.wallet.domain.exception.WalletNotFoundException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Money;
+import com.nursena.payflow.wallet.domain.model.Wallet;
+import com.nursena.payflow.wallet.domain.model.WalletStatus;
+import com.nursena.payflow.transaction.domain.exception.IdempotencyConflictException;
+import com.nursena.payflow.transaction.domain.exception.IdempotencyRequestInProgressException;
+import com.nursena.payflow.transaction.domain.model.IdempotencyKey;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TransferMoneyServiceTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "b4077781-34f4-466f-8e61-b79ca906bc98"
+        );
+
+    private static final UUID SOURCE_WALLET_ID =
+        UUID.fromString(
+            "11111111-1111-1111-1111-111111111111"
+        );
+
+    private static final UUID TARGET_WALLET_ID =
+        UUID.fromString(
+            "22222222-2222-2222-2222-222222222222"
+        );
+
+    private static final UUID TARGET_OWNER_ID =
+        UUID.fromString(
+            "33333333-3333-3333-3333-333333333333"
+        );
+
+    private static final Instant NANOSECOND_TIME =
+        Instant.parse("2026-07-15T18:30:00.123456789Z");
+
+    private static final Instant NOW =
+        Instant.parse("2026-07-15T18:30:00Z");
+
+    @Mock
+    private WalletRepositoryPort walletRepository;
+
+    @Mock
+    private PaymentTransactionRepositoryPort
+        transactionRepository;
+
+    @Mock
+    private LedgerRepositoryPort ledgerRepository;
+
+    private TransferMoneyService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TransferMoneyService(
+            walletRepository,
+            transactionRepository,
+            ledgerRepository,
+            Clock.fixed(NOW, ZoneOffset.UTC)
+        );
+    }
+
+    @Test
+    void shouldTransferMoneyAndCreateBalancedLedger() {
+        Wallet sourceWallet = sourceWallet("200.00");
+        Wallet targetWallet = targetWallet("50.00");
+
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.of(sourceWallet));
+        when(
+            transactionRepository
+                .findBySourceWalletIdAndIdempotencyKey(
+                    SOURCE_WALLET_ID,
+                    new IdempotencyKey("request-1")
+                )
+        ).thenReturn(Optional.empty());
+
+        when(walletRepository.findById(TARGET_WALLET_ID))
+            .thenReturn(Optional.of(targetWallet));
+
+        when(transactionRepository.save(
+            any(PaymentTransaction.class)
+        )).thenAnswer(invocation -> {
+            PaymentTransaction transaction =
+                invocation.getArgument(0);
+
+            assertThat(transaction.status())
+                .isEqualTo(TransactionStatus.PENDING);
+
+            return transaction;
+        });
+
+        when(walletRepository.update(any(Wallet.class)))
+            .thenAnswer(invocation ->
+                invocation.getArgument(0)
+            );
+
+        when(ledgerRepository.save(
+            any(DoubleEntryLedger.class)
+        )).thenAnswer(invocation ->
+            invocation.getArgument(0)
+        );
+
+        when(transactionRepository.update(
+            any(PaymentTransaction.class)
+        )).thenAnswer(invocation ->
+            invocation.getArgument(0)
+        );
+
+        TransferMoneyResult result = service.transfer(
+            command("125.50", TARGET_WALLET_ID)
+        );
+
+        assertThat(sourceWallet.balance().amount())
+            .isEqualByComparingTo("74.50");
+
+        assertThat(targetWallet.balance().amount())
+            .isEqualByComparingTo("175.50");
+
+        assertThat(result.sourceWalletId())
+            .isEqualTo(SOURCE_WALLET_ID);
+
+        assertThat(result.targetWalletId())
+            .isEqualTo(TARGET_WALLET_ID);
+
+        assertThat(result.amount())
+            .isEqualByComparingTo("125.50");
+
+        assertThat(result.currency())
+            .isEqualTo(Currency.TRY);
+
+        assertThat(result.status())
+            .isEqualTo(TransactionStatus.COMPLETED);
+
+        assertThat(result.completedAt())
+            .isEqualTo(NOW);
+
+        ArgumentCaptor<DoubleEntryLedger> ledgerCaptor =
+            ArgumentCaptor.forClass(
+                DoubleEntryLedger.class
+            );
+
+        verify(ledgerRepository)
+            .save(ledgerCaptor.capture());
+
+        DoubleEntryLedger ledger =
+            ledgerCaptor.getValue();
+
+        assertThat(ledger.debitEntry().walletId())
+            .isEqualTo(SOURCE_WALLET_ID);
+
+        assertThat(ledger.debitEntry().type())
+            .isEqualTo(LedgerEntryType.DEBIT);
+
+        assertThat(ledger.creditEntry().walletId())
+            .isEqualTo(TARGET_WALLET_ID);
+
+        assertThat(ledger.creditEntry().type())
+            .isEqualTo(LedgerEntryType.CREDIT);
+
+        assertThat(ledger.debitEntry().amount())
+            .isEqualTo(ledger.creditEntry().amount());
+
+        verify(walletRepository).update(sourceWallet);
+        verify(walletRepository).update(targetWallet);
+    }
+
+    @Test
+    void shouldRejectOwnerWithoutWallet() {
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            service.transfer(
+                command("25.00", TARGET_WALLET_ID)
+            )
+        )
+            .isInstanceOf(WalletNotFoundException.class);
+
+        verify(walletRepository, never())
+            .findById(any(UUID.class));
+
+        verifyNoWrites();
+    }
+
+    @Test
+    void shouldRejectMissingTargetWallet() {
+        Wallet sourceWallet = sourceWallet("200.00");
+
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.of(sourceWallet));
+
+        when(walletRepository.findById(TARGET_WALLET_ID))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            service.transfer(
+                command("25.00", TARGET_WALLET_ID)
+            )
+        )
+            .isInstanceOf(WalletNotFoundException.class);
+
+        assertThat(sourceWallet.balance().amount())
+            .isEqualByComparingTo("200.00");
+
+        verifyNoWrites();
+    }
+
+    @Test
+    void shouldRejectInsufficientBalance() {
+        Wallet sourceWallet = sourceWallet("10.00");
+        Wallet targetWallet = targetWallet("50.00");
+
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.of(sourceWallet));
+
+        when(walletRepository.findById(TARGET_WALLET_ID))
+            .thenReturn(Optional.of(targetWallet));
+
+        assertThatThrownBy(() ->
+            service.transfer(
+                command("25.00", TARGET_WALLET_ID)
+            )
+        )
+            .isInstanceOf(
+                InsufficientBalanceException.class
+            );
+
+        assertThat(sourceWallet.balance().amount())
+            .isEqualByComparingTo("10.00");
+
+        assertThat(targetWallet.balance().amount())
+            .isEqualByComparingTo("50.00");
+
+        verifyNoWrites();
+    }
+
+    @Test
+    void shouldRejectTransferToSameWallet() {
+        Wallet sourceWallet = sourceWallet("200.00");
+
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.of(sourceWallet));
+
+        when(walletRepository.findById(SOURCE_WALLET_ID))
+            .thenReturn(Optional.of(sourceWallet));
+
+        assertThatThrownBy(() ->
+            service.transfer(
+                command("25.00", SOURCE_WALLET_ID)
+            )
+        )
+            .isInstanceOf(
+                SelfTransferNotAllowedException.class
+            );
+
+        assertThat(sourceWallet.balance().amount())
+            .isEqualByComparingTo("200.00");
+
+        verifyNoWrites();
+    }
+
+    private void verifyNoWrites() {
+        verify(transactionRepository, never())
+            .save(any(PaymentTransaction.class));
+
+        verify(walletRepository, never())
+            .update(any(Wallet.class));
+
+        verify(ledgerRepository, never())
+            .save(any(DoubleEntryLedger.class));
+
+        verify(transactionRepository, never())
+            .update(any(PaymentTransaction.class));
+    }
+
+    private static TransferMoneyCommand command(
+        String amount,
+        UUID targetWalletId
+    ) {
+        return new TransferMoneyCommand(
+            OWNER_ID,
+            targetWalletId,
+            new BigDecimal(amount),
+            "request-1"
+        );
+    }
+
+    private static Wallet sourceWallet(String balance) {
+        return Wallet.rehydrate(
+            SOURCE_WALLET_ID,
+            OWNER_ID,
+            Money.of(balance, Currency.TRY),
+            WalletStatus.ACTIVE,
+            NOW
+        );
+    }
+
+    private static Wallet targetWallet(String balance) {
+        return Wallet.rehydrate(
+            TARGET_WALLET_ID,
+            TARGET_OWNER_ID,
+            Money.of(balance, Currency.TRY),
+            WalletStatus.ACTIVE,
+            NOW
+        );
+    }
+
+    @Test
+    void shouldReplayCompletedTransferWithoutNewWrites() {
+        Wallet sourceWallet = sourceWallet("74.50");
+
+        PaymentTransaction completedTransaction =
+            completedTransaction(
+                "125.50",
+                TARGET_WALLET_ID
+            );
+
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.of(sourceWallet));
+
+        when(
+            transactionRepository
+                .findBySourceWalletIdAndIdempotencyKey(
+                    SOURCE_WALLET_ID,
+                    new IdempotencyKey("request-1")
+                )
+        ).thenReturn(
+            Optional.of(completedTransaction)
+        );
+
+        TransferMoneyResult result = service.transfer(
+            command("125.50", TARGET_WALLET_ID)
+        );
+
+        assertThat(result.transactionId())
+            .isEqualTo(TRANSACTION_ID);
+
+        assertThat(result.status())
+            .isEqualTo(TransactionStatus.COMPLETED);
+
+        assertThat(result.amount())
+            .isEqualByComparingTo("125.50");
+
+        verify(walletRepository, never())
+            .findById(any(UUID.class));
+
+        verifyNoWrites();
+    }
+
+    @Test
+    void shouldRejectReusedKeyWithDifferentAmount() {
+        Wallet sourceWallet = sourceWallet("74.50");
+
+        PaymentTransaction completedTransaction =
+            completedTransaction(
+                "125.50",
+                TARGET_WALLET_ID
+            );
+
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.of(sourceWallet));
+
+        when(
+            transactionRepository
+                .findBySourceWalletIdAndIdempotencyKey(
+                    SOURCE_WALLET_ID,
+                    new IdempotencyKey("request-1")
+                )
+        ).thenReturn(
+            Optional.of(completedTransaction)
+        );
+
+        assertThatThrownBy(() ->
+            service.transfer(
+                command("100.00", TARGET_WALLET_ID)
+            )
+        )
+            .isInstanceOf(
+                IdempotencyConflictException.class
+            );
+
+        verify(walletRepository, never())
+            .findById(any(UUID.class));
+
+        verifyNoWrites();
+    }
+
+    @Test
+    void shouldRejectReplayWhileTransferIsPending() {
+        Wallet sourceWallet = sourceWallet("200.00");
+
+        PaymentTransaction pendingTransaction =
+            pendingTransaction(
+                "125.50",
+                TARGET_WALLET_ID
+            );
+
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.of(sourceWallet));
+
+        when(
+            transactionRepository
+                .findBySourceWalletIdAndIdempotencyKey(
+                    SOURCE_WALLET_ID,
+                    new IdempotencyKey("request-1")
+                )
+        ).thenReturn(
+            Optional.of(pendingTransaction)
+        );
+
+        assertThatThrownBy(() ->
+            service.transfer(
+                command("125.50", TARGET_WALLET_ID)
+            )
+        )
+            .isInstanceOf(
+                IdempotencyRequestInProgressException.class
+            );
+
+        verify(walletRepository, never())
+            .findById(any(UUID.class));
+
+        verifyNoWrites();
+    }
+
+    @Test
+    void shouldNormalizeTransactionTimestampsToMicroseconds() {
+        TransferMoneyService timestampService =
+            new TransferMoneyService(
+                walletRepository,
+                transactionRepository,
+                ledgerRepository,
+                Clock.fixed(
+                    NANOSECOND_TIME,
+                    ZoneOffset.UTC
+                )
+            );
+
+        Wallet sourceWallet = sourceWallet("200.00");
+        Wallet targetWallet = targetWallet("50.00");
+
+        when(walletRepository.findByOwnerId(OWNER_ID))
+            .thenReturn(Optional.of(sourceWallet));
+
+        when(
+            transactionRepository
+                .findBySourceWalletIdAndIdempotencyKey(
+                    SOURCE_WALLET_ID,
+                    new IdempotencyKey("request-1")
+                )
+        ).thenReturn(Optional.empty());
+
+        when(walletRepository.findById(TARGET_WALLET_ID))
+            .thenReturn(Optional.of(targetWallet));
+
+        when(transactionRepository.save(
+            any(PaymentTransaction.class)
+        )).thenAnswer(invocation ->
+            invocation.getArgument(0)
+        );
+
+        when(walletRepository.update(any(Wallet.class)))
+            .thenAnswer(invocation ->
+                invocation.getArgument(0)
+            );
+
+        when(ledgerRepository.save(
+            any(DoubleEntryLedger.class)
+        )).thenAnswer(invocation ->
+            invocation.getArgument(0)
+        );
+
+        when(transactionRepository.update(
+            any(PaymentTransaction.class)
+        )).thenAnswer(invocation ->
+            invocation.getArgument(0)
+        );
+
+        TransferMoneyResult result =
+            timestampService.transfer(
+                command("25.00", TARGET_WALLET_ID)
+            );
+
+        Instant expected =
+            Instant.parse(
+                "2026-07-15T18:30:00.123456Z"
+            );
+
+        assertThat(result.createdAt())
+            .isEqualTo(expected);
+
+        assertThat(result.completedAt())
+            .isEqualTo(expected);
+    }
+
+    private static PaymentTransaction completedTransaction(
+        String amount,
+        UUID targetWalletId
+    ) {
+        return PaymentTransaction.rehydrate(
+            TRANSACTION_ID,
+            SOURCE_WALLET_ID,
+            targetWalletId,
+            Money.of(amount, Currency.TRY),
+            new IdempotencyKey("request-1"),
+            TransactionType.TRANSFER,
+            TransactionStatus.COMPLETED,
+            NOW.minusSeconds(1),
+            NOW
+        );
+    }
+
+    private static PaymentTransaction pendingTransaction(
+        String amount,
+        UUID targetWalletId
+    ) {
+        return PaymentTransaction.rehydrate(
+            TRANSACTION_ID,
+            SOURCE_WALLET_ID,
+            targetWalletId,
+            Money.of(amount, Currency.TRY),
+            new IdempotencyKey("request-1"),
+            TransactionType.TRANSFER,
+            TransactionStatus.PENDING,
+            NOW,
+            null
+        );
+    }
+
+}

--- a/src/test/java/com/nursena/payflow/transaction/domain/model/IdempotencyKeyTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/domain/model/IdempotencyKeyTest.java
@@ -1,0 +1,47 @@
+package com.nursena.payflow.transaction.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nursena.payflow.transaction.domain.exception.InvalidIdempotencyKeyException;
+import org.junit.jupiter.api.Test;
+
+class IdempotencyKeyTest {
+
+    @Test
+    void shouldTrimValidValue() {
+        IdempotencyKey key =
+            new IdempotencyKey("  transfer-request-123  ");
+
+        assertThat(key.value())
+            .isEqualTo("transfer-request-123");
+    }
+
+    @Test
+    void shouldRejectBlankValue() {
+        assertThatThrownBy(() ->
+            new IdempotencyKey("   ")
+        )
+            .isInstanceOf(
+                InvalidIdempotencyKeyException.class
+            )
+            .hasMessage(
+                "Idempotency key must contain "
+                    + "between 1 and 100 characters."
+            );
+    }
+
+    @Test
+    void shouldRejectValueLongerThanDatabaseLimit() {
+        String value = "a".repeat(
+            IdempotencyKey.MAX_LENGTH + 1
+        );
+
+        assertThatThrownBy(() ->
+            new IdempotencyKey(value)
+        )
+            .isInstanceOf(
+                InvalidIdempotencyKeyException.class
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/domain/model/PaymentTransactionTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/domain/model/PaymentTransactionTest.java
@@ -1,0 +1,167 @@
+package com.nursena.payflow.transaction.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.domain.exception.InvalidTransactionStateException;
+import com.nursena.payflow.transaction.domain.exception.InvalidTransferAmountException;
+import com.nursena.payflow.transaction.domain.exception.SelfTransferNotAllowedException;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Money;
+import org.junit.jupiter.api.Test;
+
+class PaymentTransactionTest {
+
+    private static final UUID SOURCE_WALLET_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final UUID TARGET_WALLET_ID =
+        UUID.fromString(
+            "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse("2026-07-15T12:00:00Z");
+
+    private static final Instant COMPLETED_AT =
+        Instant.parse("2026-07-15T12:00:01Z");
+
+    @Test
+    void shouldStartTransferAsPending() {
+        PaymentTransaction transaction =
+            startTransfer();
+
+        assertThat(transaction.id())
+            .isNotNull();
+
+        assertThat(transaction.sourceWalletId())
+            .isEqualTo(SOURCE_WALLET_ID);
+
+        assertThat(transaction.targetWalletId())
+            .isEqualTo(TARGET_WALLET_ID);
+
+        assertThat(transaction.amount())
+            .isEqualTo(
+                Money.of("125.50", Currency.TRY)
+            );
+
+        assertThat(transaction.type())
+            .isEqualTo(TransactionType.TRANSFER);
+
+        assertThat(transaction.status())
+            .isEqualTo(TransactionStatus.PENDING);
+
+        assertThat(transaction.createdAt())
+            .isEqualTo(CREATED_AT);
+
+        assertThat(transaction.completedAt())
+            .isNull();
+    }
+
+    @Test
+    void shouldCompletePendingTransfer() {
+        PaymentTransaction transaction =
+            startTransfer();
+
+        transaction.complete(COMPLETED_AT);
+
+        assertThat(transaction.status())
+            .isEqualTo(TransactionStatus.COMPLETED);
+
+        assertThat(transaction.completedAt())
+            .isEqualTo(COMPLETED_AT);
+    }
+
+    @Test
+    void shouldRejectCompletingTransferTwice() {
+        PaymentTransaction transaction =
+            startTransfer();
+
+        transaction.complete(COMPLETED_AT);
+
+        assertThatThrownBy(() ->
+            transaction.complete(COMPLETED_AT)
+        )
+            .isInstanceOf(
+                InvalidTransactionStateException.class
+            );
+    }
+
+    @Test
+    void shouldRejectTransferToSameWallet() {
+        assertThatThrownBy(() ->
+            PaymentTransaction.startTransfer(
+                SOURCE_WALLET_ID,
+                SOURCE_WALLET_ID,
+                Money.of("10.00", Currency.TRY),
+                new IdempotencyKey("request-1"),
+                CREATED_AT
+            )
+        )
+            .isInstanceOf(
+                SelfTransferNotAllowedException.class
+            )
+            .hasMessage(
+                "Source and target wallets "
+                    + "must be different."
+            );
+    }
+
+    @Test
+    void shouldRejectNonPositiveTransferAmount() {
+        assertThatThrownBy(() ->
+            PaymentTransaction.startTransfer(
+                SOURCE_WALLET_ID,
+                TARGET_WALLET_ID,
+                Money.of("0.00", Currency.TRY),
+                new IdempotencyKey("request-1"),
+                CREATED_AT
+            )
+        )
+            .isInstanceOf(
+                InvalidTransferAmountException.class
+            );
+    }
+
+    @Test
+    void shouldMatchOriginalTransferRequest() {
+        PaymentTransaction transaction =
+            startTransfer();
+
+        assertThat(
+            transaction.matchesTransferRequest(
+                TARGET_WALLET_ID,
+                Money.of("125.50", Currency.TRY)
+            )
+        ).isTrue();
+
+        assertThat(
+            transaction.matchesTransferRequest(
+                TARGET_WALLET_ID,
+                Money.of("125.51", Currency.TRY)
+            )
+        ).isFalse();
+
+        assertThat(
+            transaction.matchesTransferRequest(
+                UUID.randomUUID(),
+                Money.of("125.50", Currency.TRY)
+            )
+        ).isFalse();
+    }
+
+    private static PaymentTransaction startTransfer() {
+        return PaymentTransaction.startTransfer(
+            SOURCE_WALLET_ID,
+            TARGET_WALLET_ID,
+            Money.of("125.50", Currency.TRY),
+            new IdempotencyKey("request-1"),
+            CREATED_AT
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/integration/TransactionHistoryPersistenceIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/integration/TransactionHistoryPersistenceIntegrationTest.java
@@ -1,0 +1,447 @@
+package com.nursena.payflow.transaction.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransactionDirection;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryPage;
+import com.nursena.payflow.transaction.application.port.out.TransactionHistoryQueryPort;
+import com.nursena.payflow.transaction.application.model.TransactionHistoryFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class TransactionHistoryPersistenceIntegrationTest {
+
+    private static final UUID OWNER_ID =
+        UUID.fromString(
+            "10000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID COUNTERPARTY_OWNER_A_ID =
+        UUID.fromString(
+            "10000000-0000-0000-0000-000000000002"
+        );
+
+    private static final UUID COUNTERPARTY_OWNER_B_ID =
+        UUID.fromString(
+            "10000000-0000-0000-0000-000000000003"
+        );
+
+    private static final UUID WALLET_ID =
+        UUID.fromString(
+            "20000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID COUNTERPARTY_WALLET_A_ID =
+        UUID.fromString(
+            "20000000-0000-0000-0000-000000000002"
+        );
+
+    private static final UUID COUNTERPARTY_WALLET_B_ID =
+        UUID.fromString(
+            "20000000-0000-0000-0000-000000000003"
+        );
+
+    private static final UUID NEWEST_TRANSACTION_ID =
+        UUID.fromString(
+            "30000000-0000-0000-0000-000000000003"
+        );
+
+    private static final UUID SAME_TIME_HIGH_ID =
+        UUID.fromString(
+            "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        );
+
+    private static final UUID SAME_TIME_LOW_ID =
+        UUID.fromString(
+            "00000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID UNRELATED_TRANSACTION_ID =
+        UUID.fromString(
+            "40000000-0000-0000-0000-000000000001"
+        );
+
+    private static final Instant BASE_TIME =
+        Instant.parse(
+            "2026-07-16T10:00:00Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private TransactionHistoryQueryPort
+        transactionHistoryQueryPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM ledger_entries"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM payment_transactions"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM wallets"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldReturnIsolatedDeterministicallyOrderedHistory() {
+        insertUser(
+            OWNER_ID,
+            "history-owner@example.com"
+        );
+
+        insertUser(
+            COUNTERPARTY_OWNER_A_ID,
+            "history-counterparty-a@example.com"
+        );
+
+        insertUser(
+            COUNTERPARTY_OWNER_B_ID,
+            "history-counterparty-b@example.com"
+        );
+
+        insertWallet(
+            WALLET_ID,
+            OWNER_ID
+        );
+
+        insertWallet(
+            COUNTERPARTY_WALLET_A_ID,
+            COUNTERPARTY_OWNER_A_ID
+        );
+
+        insertWallet(
+            COUNTERPARTY_WALLET_B_ID,
+            COUNTERPARTY_OWNER_B_ID
+        );
+
+        insertTransaction(
+            NEWEST_TRANSACTION_ID,
+            COUNTERPARTY_WALLET_A_ID,
+            WALLET_ID,
+            "history-newest",
+            BASE_TIME.plusSeconds(60)
+        );
+
+        insertTransaction(
+            SAME_TIME_HIGH_ID,
+            WALLET_ID,
+            COUNTERPARTY_WALLET_B_ID,
+            "history-same-high",
+            BASE_TIME
+        );
+
+        insertTransaction(
+            SAME_TIME_LOW_ID,
+            COUNTERPARTY_WALLET_B_ID,
+            WALLET_ID,
+            "history-same-low",
+            BASE_TIME
+        );
+
+        insertTransaction(
+            UNRELATED_TRANSACTION_ID,
+            COUNTERPARTY_WALLET_A_ID,
+            COUNTERPARTY_WALLET_B_ID,
+            "history-unrelated",
+            BASE_TIME.plusSeconds(120)
+        );
+
+        TransactionHistoryPage firstPage =
+            transactionHistoryQueryPort
+                .findByWalletId(
+                    WALLET_ID,
+                    0,
+                    2,
+                    TransactionHistoryFilter.unfiltered()
+                );
+
+        assertThat(firstPage.totalElements())
+            .isEqualTo(3);
+
+        assertThat(firstPage.totalPages())
+            .isEqualTo(2);
+
+        assertThat(firstPage.page())
+            .isZero();
+
+        assertThat(firstPage.size())
+            .isEqualTo(2);
+
+        assertThat(firstPage.first())
+            .isTrue();
+
+        assertThat(firstPage.last())
+            .isFalse();
+
+        assertThat(firstPage.items())
+            .extracting(item ->
+                item.transactionId()
+            )
+            .containsExactly(
+                NEWEST_TRANSACTION_ID,
+                SAME_TIME_HIGH_ID
+            );
+
+        assertThat(
+            firstPage.items()
+                .get(0)
+                .direction()
+        ).isEqualTo(
+            TransactionDirection.INCOMING
+        );
+
+        assertThat(
+            firstPage.items()
+                .get(0)
+                .counterpartyWalletId()
+        ).isEqualTo(
+            COUNTERPARTY_WALLET_A_ID
+        );
+
+        assertThat(
+            firstPage.items()
+                .get(1)
+                .direction()
+        ).isEqualTo(
+            TransactionDirection.OUTGOING
+        );
+
+        assertThat(
+            firstPage.items()
+                .get(1)
+                .counterpartyWalletId()
+        ).isEqualTo(
+            COUNTERPARTY_WALLET_B_ID
+        );
+
+        TransactionHistoryPage secondPage =
+            transactionHistoryQueryPort
+                .findByWalletId(
+                    WALLET_ID,
+                    1,
+                    2,
+                    TransactionHistoryFilter.unfiltered()
+                );
+
+        assertThat(secondPage.items())
+            .extracting(item ->
+                item.transactionId()
+            )
+            .containsExactly(
+                SAME_TIME_LOW_ID
+            );
+
+        assertThat(secondPage.last())
+            .isTrue();
+
+        assertThat(
+            secondPage.items()
+                .getFirst()
+                .direction()
+        ).isEqualTo(
+            TransactionDirection.INCOMING
+        );
+
+        assertThat(
+            secondPage.items()
+                .getFirst()
+                .counterpartyWalletId()
+        ).isEqualTo(
+            COUNTERPARTY_WALLET_B_ID
+        );
+        TransactionHistoryPage outgoingPage =
+            transactionHistoryQueryPort
+                .findByWalletId(
+                    WALLET_ID,
+                    0,
+                    20,
+                    new TransactionHistoryFilter(
+                        TransactionDirection.OUTGOING,
+                        null,
+                        null,
+                        null
+                    )
+                );
+
+        assertThat(outgoingPage.items())
+            .extracting(item ->
+                item.transactionId()
+            )
+            .containsExactly(
+                SAME_TIME_HIGH_ID
+            );
+
+        TransactionHistoryPage incomingPage =
+            transactionHistoryQueryPort
+                .findByWalletId(
+                    WALLET_ID,
+                    0,
+                    20,
+                    new TransactionHistoryFilter(
+                        TransactionDirection.INCOMING,
+                        null,
+                        null,
+                        null
+                    )
+                );
+
+        assertThat(incomingPage.items())
+            .extracting(item ->
+                item.transactionId()
+            )
+            .containsExactly(
+                NEWEST_TRANSACTION_ID,
+                SAME_TIME_LOW_ID
+            );
+
+        TransactionHistoryPage dateFilteredPage =
+            transactionHistoryQueryPort
+                .findByWalletId(
+                    WALLET_ID,
+                    0,
+                    20,
+                    new TransactionHistoryFilter(
+                        null,
+                        null,
+                        BASE_TIME,
+                        BASE_TIME.plusSeconds(60)
+                    )
+                );
+
+        assertThat(dateFilteredPage.items())
+            .extracting(item ->
+                item.transactionId()
+            )
+            .containsExactly(
+                SAME_TIME_HIGH_ID,
+                SAME_TIME_LOW_ID
+            );
+    }
+
+    private void insertUser(
+        UUID userId,
+        String email
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            userId,
+            email,
+            "test-password-hash",
+            "USER",
+            "ACTIVE",
+            Timestamp.from(BASE_TIME),
+            Timestamp.from(BASE_TIME)
+        );
+    }
+
+    private void insertWallet(
+        UUID walletId,
+        UUID ownerId
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO wallets (
+                id,
+                owner_id,
+                balance,
+                currency,
+                status,
+                version,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            walletId,
+            ownerId,
+            new BigDecimal("500.00"),
+            "TRY",
+            "ACTIVE",
+            0L,
+            Timestamp.from(BASE_TIME),
+            Timestamp.from(BASE_TIME)
+        );
+    }
+
+    private void insertTransaction(
+        UUID transactionId,
+        UUID sourceWalletId,
+        UUID targetWalletId,
+        String idempotencyKey,
+        Instant createdAt
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO payment_transactions (
+                id,
+                source_wallet_id,
+                target_wallet_id,
+                transaction_type,
+                status,
+                amount,
+                currency,
+                idempotency_key,
+                failure_reason,
+                created_at,
+                completed_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            transactionId,
+            sourceWalletId,
+            targetWalletId,
+            "TRANSFER",
+            "COMPLETED",
+            new BigDecimal("125.50"),
+            "TRY",
+            idempotencyKey,
+            null,
+            Timestamp.from(createdAt),
+            Timestamp.from(
+                createdAt.plusSeconds(1)
+            )
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/integration/TransferIdempotencyConcurrencyIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/integration/TransferIdempotencyConcurrencyIntegrationTest.java
@@ -1,0 +1,703 @@
+package com.nursena.payflow.transaction.integration;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyCommand;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyResult;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyUseCase;
+import com.nursena.payflow.transaction.application.port.out.PaymentTransactionRepositoryPort;
+import com.nursena.payflow.transaction.domain.exception.IdempotencyConflictException;
+import com.nursena.payflow.transaction.domain.model.IdempotencyKey;
+import com.nursena.payflow.transaction.domain.model.PaymentTransaction;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Import(
+    TransferIdempotencyConcurrencyIntegrationTest
+        .RepositoryBarrierConfiguration.class
+)
+class TransferIdempotencyConcurrencyIntegrationTest {
+
+    private static final BigDecimal INITIAL_SOURCE_BALANCE =
+        new BigDecimal("300.00");
+
+    private static final BigDecimal TRANSFER_AMOUNT =
+        new BigDecimal("125.50");
+
+    private static final BigDecimal EXPECTED_SOURCE_BALANCE =
+        new BigDecimal("174.50");
+
+    private static final BigDecimal EXPECTED_TARGET_BALANCE =
+        new BigDecimal("125.50");
+
+    private static final String IDEMPOTENCY_KEY =
+        "concurrent-transfer-request-1";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TransferMoneyUseCase transferMoneyUseCase;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private CoordinatedPaymentTransactionRepository
+        transactionRepositoryBarrier;
+
+    @Test
+    void shouldPersistOnlyOneTransferForConcurrentDuplicateRequests()
+        throws Exception {
+
+        String password = "StrongPassword123!";
+
+        String sourceEmail =
+            uniqueEmail("concurrent-source");
+
+        String targetEmail =
+            uniqueEmail("concurrent-target");
+
+        registerUser(sourceEmail, password);
+        registerUser(targetEmail, password);
+
+        String sourceAccessToken =
+            authenticateUser(sourceEmail, password);
+
+        String targetAccessToken =
+            authenticateUser(targetEmail, password);
+
+        WalletInfo sourceWallet =
+            openWallet(sourceAccessToken);
+
+        WalletInfo targetWallet =
+            openWallet(targetAccessToken);
+
+        topUpWallet(
+            sourceAccessToken,
+            INITIAL_SOURCE_BALANCE
+        );
+
+        TransferMoneyCommand command =
+            new TransferMoneyCommand(
+                sourceWallet.ownerId(),
+                targetWallet.id(),
+                TRANSFER_AMOUNT,
+                IDEMPOTENCY_KEY
+            );
+
+        transactionRepositoryBarrier
+            .coordinateNextLookups(2);
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(2);
+
+        try {
+            Future<TransferAttempt> firstFuture =
+                executor.submit(() ->
+                    executeTransfer(command)
+                );
+
+            Future<TransferAttempt> secondFuture =
+                executor.submit(() ->
+                    executeTransfer(command)
+                );
+
+            boolean bothRequestsPassedInitialLookup =
+                transactionRepositoryBarrier
+                    .awaitCoordinatedLookups(
+                        10,
+                        SECONDS
+                    );
+
+            assertThat(
+                bothRequestsPassedInitialLookup
+            )
+                .as(
+                    "Both requests should observe no existing "
+                        + "transaction before either insert proceeds"
+                )
+                .isTrue();
+
+            transactionRepositoryBarrier
+                .releaseCoordinatedLookups();
+
+            TransferAttempt firstAttempt =
+                firstFuture.get(30, SECONDS);
+
+            TransferAttempt secondAttempt =
+                secondFuture.get(30, SECONDS);
+
+            List<TransferAttempt> attempts =
+                List.of(
+                    firstAttempt,
+                    secondAttempt
+                );
+
+            List<TransferAttempt> successfulAttempts =
+                attempts.stream()
+                    .filter(TransferAttempt::isSuccessful)
+                    .toList();
+
+            List<TransferAttempt> failedAttempts =
+                attempts.stream()
+                    .filter(attempt ->
+                        !attempt.isSuccessful()
+                    )
+                    .toList();
+
+            assertThat(successfulAttempts)
+                .hasSize(1);
+
+            assertThat(failedAttempts)
+                .hasSize(1);
+
+            TransferMoneyResult successfulResult =
+                successfulAttempts
+                    .getFirst()
+                    .result();
+
+            assertThat(successfulResult.transactionId())
+                .isNotNull();
+
+            assertThat(successfulResult.amount())
+                .isEqualByComparingTo(
+                    TRANSFER_AMOUNT
+                );
+
+            assertThat(
+                failedAttempts
+                    .getFirst()
+                    .failure()
+            )
+                .isInstanceOf(
+                    IdempotencyConflictException.class
+                )
+                .hasMessage(
+                    "Idempotency key has already been used "
+                        + "for another transfer request."
+                );
+
+            assertPersistedState(
+                sourceWallet.id(),
+                targetWallet.id(),
+                successfulResult.transactionId()
+            );
+        } finally {
+            transactionRepositoryBarrier
+                .releaseCoordinatedLookups();
+
+            executor.shutdownNow();
+
+            boolean terminated =
+                executor.awaitTermination(
+                    10,
+                    TimeUnit.SECONDS
+                );
+
+            assertThat(terminated)
+                .as(
+                    "Concurrent transfer executor "
+                        + "should terminate"
+                )
+                .isTrue();
+        }
+    }
+
+    private TransferAttempt executeTransfer(
+        TransferMoneyCommand command
+    ) {
+        try {
+            return TransferAttempt.success(
+                transferMoneyUseCase.transfer(command)
+            );
+        } catch (Throwable exception) {
+            return TransferAttempt.failure(exception);
+        }
+    }
+
+    private void assertPersistedState(
+        UUID sourceWalletId,
+        UUID targetWalletId,
+        UUID transactionId
+    ) {
+        assertThat(walletBalance(sourceWalletId))
+            .isEqualByComparingTo(
+                EXPECTED_SOURCE_BALANCE
+            );
+
+        assertThat(walletBalance(targetWalletId))
+            .isEqualByComparingTo(
+                EXPECTED_TARGET_BALANCE
+            );
+
+        assertThat(walletVersion(sourceWalletId))
+            .isEqualTo(2L);
+
+        assertThat(walletVersion(targetWalletId))
+            .isEqualTo(1L);
+
+        Long transactionCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM payment_transactions
+                WHERE source_wallet_id = ?
+                  AND idempotency_key = ?
+                """,
+                Long.class,
+                sourceWalletId,
+                IDEMPOTENCY_KEY
+            );
+
+        assertThat(transactionCount)
+            .isEqualTo(1L);
+
+        String transactionStatus =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT status
+                FROM payment_transactions
+                WHERE id = ?
+                """,
+                String.class,
+                transactionId
+            );
+
+        assertThat(transactionStatus)
+            .isEqualTo("COMPLETED");
+
+        Long ledgerEntryCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM ledger_entries
+                WHERE transaction_id = ?
+                """,
+                Long.class,
+                transactionId
+            );
+
+        assertThat(ledgerEntryCount)
+            .isEqualTo(2L);
+
+        Long debitCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM ledger_entries
+                WHERE transaction_id = ?
+                  AND wallet_id = ?
+                  AND entry_type = 'DEBIT'
+                  AND amount = ?
+                  AND currency = 'TRY'
+                """,
+                Long.class,
+                transactionId,
+                sourceWalletId,
+                TRANSFER_AMOUNT
+            );
+
+        assertThat(debitCount)
+            .isEqualTo(1L);
+
+        Long creditCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM ledger_entries
+                WHERE transaction_id = ?
+                  AND wallet_id = ?
+                  AND entry_type = 'CREDIT'
+                  AND amount = ?
+                  AND currency = 'TRY'
+                """,
+                Long.class,
+                transactionId,
+                targetWalletId,
+                TRANSFER_AMOUNT
+            );
+
+        assertThat(creditCount)
+            .isEqualTo(1L);
+    }
+
+    private BigDecimal walletBalance(
+        UUID walletId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT balance
+            FROM wallets
+            WHERE id = ?
+            """,
+            BigDecimal.class,
+            walletId
+        );
+    }
+
+    private Long walletVersion(
+        UUID walletId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT version
+            FROM wallets
+            WHERE id = ?
+            """,
+            Long.class,
+            walletId
+        );
+    }
+
+    private void registerUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RegistrationRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isCreated());
+    }
+
+    private String authenticateUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        MvcResult result = mockMvc.perform(
+                post("/api/v1/auth/login")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new LoginRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode response = objectMapper.readTree(
+            result
+                .getResponse()
+                .getContentAsString()
+        );
+
+        return response
+            .get("accessToken")
+            .asText();
+    }
+
+    private WalletInfo openWallet(
+        String accessToken
+    ) throws Exception {
+
+        MvcResult result = mockMvc.perform(
+                post("/api/v1/wallets")
+                    .header(
+                        HttpHeaders.AUTHORIZATION,
+                        bearer(accessToken)
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "currency": "TRY"
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        JsonNode response = objectMapper.readTree(
+            result
+                .getResponse()
+                .getContentAsString()
+        );
+
+        return new WalletInfo(
+            UUID.fromString(
+                response.get("id").asText()
+            ),
+            UUID.fromString(
+                response.get("ownerId").asText()
+            )
+        );
+    }
+
+    private void topUpWallet(
+        String accessToken,
+        BigDecimal amount
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/wallets/me/top-ups")
+                    .header(
+                        HttpHeaders.AUTHORIZATION,
+                        bearer(accessToken)
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new TopUpRequest(amount)
+                        )
+                    )
+            )
+            .andExpect(status().isOk());
+    }
+
+    private static String bearer(
+        String accessToken
+    ) {
+        return "Bearer " + accessToken;
+    }
+
+    private static String uniqueEmail(
+        String prefix
+    ) {
+        return prefix
+            + "-"
+            + UUID.randomUUID()
+            + "@example.com";
+    }
+
+    private record TransferAttempt(
+        TransferMoneyResult result,
+        Throwable failure
+    ) {
+
+        static TransferAttempt success(
+            TransferMoneyResult result
+        ) {
+            return new TransferAttempt(
+                result,
+                null
+            );
+        }
+
+        static TransferAttempt failure(
+            Throwable failure
+        ) {
+            return new TransferAttempt(
+                null,
+                failure
+            );
+        }
+
+        boolean isSuccessful() {
+            return result != null;
+        }
+    }
+
+    private record WalletInfo(
+        UUID id,
+        UUID ownerId
+    ) {
+    }
+
+    private record RegistrationRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record LoginRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record TopUpRequest(
+        BigDecimal amount
+    ) {
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class RepositoryBarrierConfiguration {
+
+        @Bean
+        @Primary
+        CoordinatedPaymentTransactionRepository
+        coordinatedPaymentTransactionRepository(
+            @Qualifier(
+                "paymentTransactionPersistenceAdapter"
+            )
+            PaymentTransactionRepositoryPort delegate
+        ) {
+
+            return new CoordinatedPaymentTransactionRepository(
+                delegate
+            );
+        }
+    }
+
+    static final class
+    CoordinatedPaymentTransactionRepository
+        implements PaymentTransactionRepositoryPort {
+
+        private final PaymentTransactionRepositoryPort delegate;
+
+        private volatile CountDownLatch observedLookups =
+            new CountDownLatch(0);
+
+        private volatile CountDownLatch releaseLookups =
+            new CountDownLatch(0);
+
+        CoordinatedPaymentTransactionRepository(
+            PaymentTransactionRepositoryPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void coordinateNextLookups(int participants) {
+            observedLookups =
+                new CountDownLatch(participants);
+
+            releaseLookups =
+                new CountDownLatch(1);
+        }
+
+        boolean awaitCoordinatedLookups(
+            long timeout,
+            TimeUnit unit
+        ) throws InterruptedException {
+
+            return observedLookups.await(
+                timeout,
+                unit
+            );
+        }
+
+        void releaseCoordinatedLookups() {
+            releaseLookups.countDown();
+        }
+
+        @Override
+        public Optional<PaymentTransaction>
+        findBySourceWalletIdAndIdempotencyKey(
+            UUID sourceWalletId,
+            IdempotencyKey idempotencyKey
+        ) {
+
+            Optional<PaymentTransaction> result =
+                delegate
+                    .findBySourceWalletIdAndIdempotencyKey(
+                        sourceWalletId,
+                        idempotencyKey
+                    );
+
+            CountDownLatch observed =
+                observedLookups;
+
+            CountDownLatch release =
+                releaseLookups;
+
+            observed.countDown();
+            awaitRelease(release);
+
+            return result;
+        }
+
+        @Override
+        public PaymentTransaction save(
+            PaymentTransaction transaction
+        ) {
+            return delegate.save(transaction);
+        }
+
+        @Override
+        public PaymentTransaction update(
+            PaymentTransaction transaction
+        ) {
+            return delegate.update(transaction);
+        }
+
+        private static void awaitRelease(
+            CountDownLatch release
+        ) {
+            try {
+                boolean released =
+                    release.await(
+                        10,
+                        SECONDS
+                    );
+
+                if (!released) {
+                    throw new IllegalStateException(
+                        "Idempotency lookup barrier timed out."
+                    );
+                }
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+
+                throw new IllegalStateException(
+                    "Idempotency lookup barrier "
+                        + "was interrupted.",
+                    exception
+                );
+            }
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/integration/TransferMoneyHttpIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/integration/TransferMoneyHttpIntegrationTest.java
@@ -1,0 +1,599 @@
+package com.nursena.payflow.transaction.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class TransferMoneyHttpIntegrationTest {
+
+    private static final BigDecimal INITIAL_SOURCE_BALANCE =
+        new BigDecimal("300.00");
+
+    private static final BigDecimal TRANSFER_AMOUNT =
+        new BigDecimal("125.50");
+
+    private static final BigDecimal EXPECTED_SOURCE_BALANCE =
+        new BigDecimal("174.50");
+
+    private static final BigDecimal EXPECTED_TARGET_BALANCE =
+        new BigDecimal("125.50");
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void shouldTransferReplayAndRejectConflictingPayload()
+        throws Exception {
+
+        String password = "StrongPassword123!";
+
+        String sourceEmail =
+            uniqueEmail("http-transfer-source");
+
+        String targetEmail =
+            uniqueEmail("http-transfer-target");
+
+        registerUser(sourceEmail, password);
+        registerUser(targetEmail, password);
+
+        String sourceAccessToken =
+            authenticateUser(
+                sourceEmail,
+                password
+            );
+
+        String targetAccessToken =
+            authenticateUser(
+                targetEmail,
+                password
+            );
+
+        WalletInfo sourceWallet =
+            openWallet(sourceAccessToken);
+
+        WalletInfo targetWallet =
+            openWallet(targetAccessToken);
+
+        topUpWallet(
+            sourceAccessToken,
+            INITIAL_SOURCE_BALANCE
+        );
+
+        String idempotencyKey =
+            "http-transfer-" + UUID.randomUUID();
+
+        MvcResult firstTransferResult =
+            transfer(
+                sourceAccessToken,
+                idempotencyKey,
+                targetWallet.id(),
+                TRANSFER_AMOUNT
+            )
+                .andExpect(status().isCreated())
+                .andExpect(
+                    jsonPath("$.transactionId")
+                        .isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath("$.sourceWalletId")
+                        .value(
+                            sourceWallet.id().toString()
+                        )
+                )
+                .andExpect(
+                    jsonPath("$.targetWalletId")
+                        .value(
+                            targetWallet.id().toString()
+                        )
+                )
+                .andExpect(
+                    jsonPath("$.amount")
+                        .value(125.50)
+                )
+                .andExpect(
+                    jsonPath("$.currency")
+                        .value("TRY")
+                )
+                .andExpect(
+                    jsonPath("$.status")
+                        .value("COMPLETED")
+                )
+                .andExpect(
+                    jsonPath("$.createdAt")
+                        .isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath("$.completedAt")
+                        .isNotEmpty()
+                )
+                .andReturn();
+
+        JsonNode firstResponse =
+            responseBody(firstTransferResult);
+
+        UUID transactionId = UUID.fromString(
+            firstResponse
+                .get("transactionId")
+                .asText()
+        );
+
+        assertPersistedTransfer(
+            transactionId,
+            sourceWallet.id(),
+            targetWallet.id(),
+            idempotencyKey
+        );
+
+        MvcResult replayResult =
+            transfer(
+                sourceAccessToken,
+                idempotencyKey,
+                targetWallet.id(),
+                TRANSFER_AMOUNT
+            )
+                .andExpect(status().isCreated())
+                .andExpect(
+                    jsonPath("$.transactionId")
+                        .value(
+                            transactionId.toString()
+                        )
+                )
+                .andExpect(
+                    jsonPath("$.status")
+                        .value("COMPLETED")
+                )
+                .andReturn();
+
+        JsonNode replayResponse =
+            responseBody(replayResult);
+
+        assertThat(
+            replayResponse
+                .get("createdAt")
+                .asText()
+        ).isEqualTo(
+            firstResponse
+                .get("createdAt")
+                .asText()
+        );
+
+        assertThat(
+            replayResponse
+                .get("completedAt")
+                .asText()
+        ).isEqualTo(
+            firstResponse
+                .get("completedAt")
+                .asText()
+        );
+
+        assertPersistedTransfer(
+            transactionId,
+            sourceWallet.id(),
+            targetWallet.id(),
+            idempotencyKey
+        );
+
+        transfer(
+            sourceAccessToken,
+            idempotencyKey,
+            targetWallet.id(),
+            new BigDecimal("100.00")
+        )
+            .andExpect(status().isConflict())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(409)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "IDEMPOTENCY_KEY_CONFLICT"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Idempotency key has already been used "
+                            + "for another transfer request."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value("/api/v1/transfers")
+            )
+            .andExpect(
+                jsonPath("$.violations")
+                    .isEmpty()
+            );
+
+        assertPersistedTransfer(
+            transactionId,
+            sourceWallet.id(),
+            targetWallet.id(),
+            idempotencyKey
+        );
+    }
+
+    private void assertPersistedTransfer(
+        UUID transactionId,
+        UUID sourceWalletId,
+        UUID targetWalletId,
+        String idempotencyKey
+    ) {
+        assertThat(
+            walletBalance(sourceWalletId)
+        ).isEqualByComparingTo(
+            EXPECTED_SOURCE_BALANCE
+        );
+
+        assertThat(
+            walletBalance(targetWalletId)
+        ).isEqualByComparingTo(
+            EXPECTED_TARGET_BALANCE
+        );
+
+        Long transactionCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM payment_transactions
+                WHERE source_wallet_id = ?
+                  AND idempotency_key = ?
+                """,
+                Long.class,
+                sourceWalletId,
+                idempotencyKey
+            );
+
+        assertThat(transactionCount)
+            .isEqualTo(1L);
+
+        String transactionStatus =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT status
+                FROM payment_transactions
+                WHERE id = ?
+                """,
+                String.class,
+                transactionId
+            );
+
+        assertThat(transactionStatus)
+            .isEqualTo("COMPLETED");
+
+        String transactionType =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT transaction_type
+                FROM payment_transactions
+                WHERE id = ?
+                """,
+                String.class,
+                transactionId
+            );
+
+        assertThat(transactionType)
+            .isEqualTo("TRANSFER");
+
+        Boolean hasCompletionTimestamp =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT completed_at IS NOT NULL
+                FROM payment_transactions
+                WHERE id = ?
+                """,
+                Boolean.class,
+                transactionId
+            );
+
+        assertThat(hasCompletionTimestamp)
+            .isTrue();
+
+        Long ledgerCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM ledger_entries
+                WHERE transaction_id = ?
+                """,
+                Long.class,
+                transactionId
+            );
+
+        assertThat(ledgerCount)
+            .isEqualTo(2L);
+
+        assertLedgerEntry(
+            transactionId,
+            sourceWalletId,
+            "DEBIT"
+        );
+
+        assertLedgerEntry(
+            transactionId,
+            targetWalletId,
+            "CREDIT"
+        );
+    }
+
+    private void assertLedgerEntry(
+        UUID transactionId,
+        UUID walletId,
+        String entryType
+    ) {
+        Long entryCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM ledger_entries
+                WHERE transaction_id = ?
+                  AND wallet_id = ?
+                  AND entry_type = ?
+                  AND amount = ?
+                  AND currency = 'TRY'
+                """,
+                Long.class,
+                transactionId,
+                walletId,
+                entryType,
+                TRANSFER_AMOUNT
+            );
+
+        assertThat(entryCount)
+            .isEqualTo(1L);
+    }
+
+    private BigDecimal walletBalance(
+        UUID walletId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT balance
+            FROM wallets
+            WHERE id = ?
+            """,
+            BigDecimal.class,
+            walletId
+        );
+    }
+
+    private void registerUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RegistrationRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isCreated());
+    }
+
+    private String authenticateUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        MvcResult result = mockMvc.perform(
+                post("/api/v1/auth/login")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new LoginRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.accessToken")
+                    .isNotEmpty()
+            )
+            .andExpect(
+                jsonPath("$.tokenType")
+                    .value("Bearer")
+            )
+            .andReturn();
+
+        return responseBody(result)
+            .get("accessToken")
+            .asText();
+    }
+
+    private WalletInfo openWallet(
+        String accessToken
+    ) throws Exception {
+
+        MvcResult result = mockMvc.perform(
+                post("/api/v1/wallets")
+                    .header(
+                        HttpHeaders.AUTHORIZATION,
+                        bearer(accessToken)
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "currency": "TRY"
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        JsonNode response =
+            responseBody(result);
+
+        return new WalletInfo(
+            UUID.fromString(
+                response.get("id").asText()
+            ),
+            UUID.fromString(
+                response
+                    .get("ownerId")
+                    .asText()
+            )
+        );
+    }
+
+    private void topUpWallet(
+        String accessToken,
+        BigDecimal amount
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/wallets/me/top-ups")
+                    .header(
+                        HttpHeaders.AUTHORIZATION,
+                        bearer(accessToken)
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new TopUpRequest(amount)
+                        )
+                    )
+            )
+            .andExpect(status().isOk());
+    }
+
+    private ResultActions transfer(
+        String accessToken,
+        String idempotencyKey,
+        UUID targetWalletId,
+        BigDecimal amount
+    ) throws Exception {
+
+        return mockMvc.perform(
+            post("/api/v1/transfers")
+                .header(
+                    HttpHeaders.AUTHORIZATION,
+                    bearer(accessToken)
+                )
+                .header(
+                    "Idempotency-Key",
+                    idempotencyKey
+                )
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    objectMapper.writeValueAsString(
+                        new TransferRequest(
+                            targetWalletId,
+                            amount
+                        )
+                    )
+                )
+        );
+    }
+
+    private JsonNode responseBody(
+        MvcResult result
+    ) throws Exception {
+
+        return objectMapper.readTree(
+            result
+                .getResponse()
+                .getContentAsString()
+        );
+    }
+
+    private static String bearer(
+        String accessToken
+    ) {
+        return "Bearer " + accessToken;
+    }
+
+    private static String uniqueEmail(
+        String prefix
+    ) {
+        return prefix
+            + "-"
+            + UUID.randomUUID()
+            + "@example.com";
+    }
+
+    private record WalletInfo(
+        UUID id,
+        UUID ownerId
+    ) {
+    }
+
+    private record RegistrationRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record LoginRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record TopUpRequest(
+        BigDecimal amount
+    ) {
+    }
+
+    private record TransferRequest(
+        UUID targetWalletId,
+        BigDecimal amount
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/integration/TransferMoneyIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/integration/TransferMoneyIntegrationTest.java
@@ -1,0 +1,505 @@
+package com.nursena.payflow.transaction.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyCommand;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyResult;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyUseCase;
+import com.nursena.payflow.transaction.domain.exception.IdempotencyConflictException;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class TransferMoneyIntegrationTest {
+
+    private static final BigDecimal INITIAL_SOURCE_BALANCE =
+        new BigDecimal("300.00");
+
+    private static final BigDecimal TRANSFER_AMOUNT =
+        new BigDecimal("125.50");
+
+    private static final BigDecimal EXPECTED_SOURCE_BALANCE =
+        new BigDecimal("174.50");
+
+    private static final BigDecimal EXPECTED_TARGET_BALANCE =
+        new BigDecimal("125.50");
+
+    private static final String IDEMPOTENCY_KEY =
+        "transfer-integration-request-1";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TransferMoneyUseCase transferMoneyUseCase;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void shouldPersistTransferLedgerAndReplayIdempotently()
+        throws Exception {
+
+        String password = "StrongPassword123!";
+
+        String sourceEmail =
+            uniqueEmail("transfer-source");
+
+        String targetEmail =
+            uniqueEmail("transfer-target");
+
+        registerUser(sourceEmail, password);
+        registerUser(targetEmail, password);
+
+        String sourceAccessToken =
+            authenticateUser(sourceEmail, password);
+
+        String targetAccessToken =
+            authenticateUser(targetEmail, password);
+
+        WalletInfo sourceWallet =
+            openWallet(sourceAccessToken);
+
+        WalletInfo targetWallet =
+            openWallet(targetAccessToken);
+
+        topUpWallet(
+            sourceAccessToken,
+            INITIAL_SOURCE_BALANCE
+        );
+
+        TransferMoneyCommand command =
+            new TransferMoneyCommand(
+                sourceWallet.ownerId(),
+                targetWallet.id(),
+                TRANSFER_AMOUNT,
+                IDEMPOTENCY_KEY
+            );
+
+        TransferMoneyResult firstResult =
+            transferMoneyUseCase.transfer(command);
+
+        assertThat(firstResult.transactionId())
+            .isNotNull();
+
+        assertThat(firstResult.sourceWalletId())
+            .isEqualTo(sourceWallet.id());
+
+        assertThat(firstResult.targetWalletId())
+            .isEqualTo(targetWallet.id());
+
+        assertThat(firstResult.amount())
+            .isEqualByComparingTo(TRANSFER_AMOUNT);
+
+        assertThat(firstResult.currency().name())
+            .isEqualTo("TRY");
+
+        assertThat(firstResult.status())
+            .isEqualTo(TransactionStatus.COMPLETED);
+
+        assertThat(firstResult.createdAt())
+            .isNotNull();
+
+        assertThat(firstResult.completedAt())
+            .isNotNull();
+
+        assertPersistedState(
+            firstResult.transactionId(),
+            sourceWallet.id(),
+            targetWallet.id()
+        );
+
+        TransferMoneyResult replayResult =
+            transferMoneyUseCase.transfer(command);
+
+        assertThat(replayResult.transactionId())
+            .isEqualTo(firstResult.transactionId());
+
+        assertThat(replayResult.status())
+            .isEqualTo(TransactionStatus.COMPLETED);
+
+        assertThat(replayResult.amount())
+            .isEqualByComparingTo(TRANSFER_AMOUNT);
+
+        assertThat(replayResult.createdAt())
+            .isEqualTo(firstResult.createdAt());
+
+        assertThat(replayResult.completedAt())
+            .isEqualTo(firstResult.completedAt());
+
+        assertPersistedState(
+            firstResult.transactionId(),
+            sourceWallet.id(),
+            targetWallet.id()
+        );
+
+        TransferMoneyCommand conflictingCommand =
+            new TransferMoneyCommand(
+                sourceWallet.ownerId(),
+                targetWallet.id(),
+                new BigDecimal("100.00"),
+                IDEMPOTENCY_KEY
+            );
+
+        assertThatThrownBy(() ->
+            transferMoneyUseCase.transfer(
+                conflictingCommand
+            )
+        )
+            .isInstanceOf(
+                IdempotencyConflictException.class
+            )
+            .hasMessage(
+                "Idempotency key has already been used "
+                    + "for another transfer request."
+            );
+
+        assertPersistedState(
+            firstResult.transactionId(),
+            sourceWallet.id(),
+            targetWallet.id()
+        );
+    }
+
+    private void assertPersistedState(
+        UUID transactionId,
+        UUID sourceWalletId,
+        UUID targetWalletId
+    ) {
+        assertThat(walletBalance(sourceWalletId))
+            .isEqualByComparingTo(
+                EXPECTED_SOURCE_BALANCE
+            );
+
+        assertThat(walletBalance(targetWalletId))
+            .isEqualByComparingTo(
+                EXPECTED_TARGET_BALANCE
+            );
+
+        Long transactionCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM payment_transactions
+                WHERE source_wallet_id = ?
+                  AND idempotency_key = ?
+                """,
+                Long.class,
+                sourceWalletId,
+                IDEMPOTENCY_KEY
+            );
+
+        assertThat(transactionCount)
+            .isEqualTo(1L);
+
+        String transactionStatus =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT status
+                FROM payment_transactions
+                WHERE id = ?
+                """,
+                String.class,
+                transactionId
+            );
+
+        assertThat(transactionStatus)
+            .isEqualTo("COMPLETED");
+
+        Boolean hasCompletionTimestamp =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT completed_at IS NOT NULL
+                FROM payment_transactions
+                WHERE id = ?
+                """,
+                Boolean.class,
+                transactionId
+            );
+
+        assertThat(hasCompletionTimestamp)
+            .isTrue();
+
+        Long ledgerEntryCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM ledger_entries
+                WHERE transaction_id = ?
+                """,
+                Long.class,
+                transactionId
+            );
+
+        assertThat(ledgerEntryCount)
+            .isEqualTo(2L);
+
+        assertLedgerEntry(
+            transactionId,
+            sourceWalletId,
+            "DEBIT"
+        );
+
+        assertLedgerEntry(
+            transactionId,
+            targetWalletId,
+            "CREDIT"
+        );
+    }
+
+    private void assertLedgerEntry(
+        UUID transactionId,
+        UUID walletId,
+        String entryType
+    ) {
+        Long entryCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM ledger_entries
+                WHERE transaction_id = ?
+                  AND wallet_id = ?
+                  AND entry_type = ?
+                """,
+                Long.class,
+                transactionId,
+                walletId,
+                entryType
+            );
+
+        assertThat(entryCount)
+            .isEqualTo(1L);
+
+        BigDecimal storedAmount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT amount
+                FROM ledger_entries
+                WHERE transaction_id = ?
+                  AND wallet_id = ?
+                  AND entry_type = ?
+                """,
+                BigDecimal.class,
+                transactionId,
+                walletId,
+                entryType
+            );
+
+        assertThat(storedAmount)
+            .isEqualByComparingTo(TRANSFER_AMOUNT);
+
+        String storedCurrency =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT currency
+                FROM ledger_entries
+                WHERE transaction_id = ?
+                  AND wallet_id = ?
+                  AND entry_type = ?
+                """,
+                String.class,
+                transactionId,
+                walletId,
+                entryType
+            );
+
+        assertThat(storedCurrency)
+            .isEqualTo("TRY");
+    }
+
+    private BigDecimal walletBalance(UUID walletId) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT balance
+            FROM wallets
+            WHERE id = ?
+            """,
+            BigDecimal.class,
+            walletId
+        );
+    }
+
+    private void registerUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RegistrationRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isCreated());
+    }
+
+    private String authenticateUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        MvcResult result = mockMvc.perform(
+                post("/api/v1/auth/login")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new LoginRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode response = objectMapper.readTree(
+            result
+                .getResponse()
+                .getContentAsString()
+        );
+
+        return response
+            .get("accessToken")
+            .asText();
+    }
+
+    private WalletInfo openWallet(
+        String accessToken
+    ) throws Exception {
+
+        MvcResult result = mockMvc.perform(
+                post("/api/v1/wallets")
+                    .header(
+                        HttpHeaders.AUTHORIZATION,
+                        bearer(accessToken)
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "currency": "TRY"
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        JsonNode response = objectMapper.readTree(
+            result
+                .getResponse()
+                .getContentAsString()
+        );
+
+        return new WalletInfo(
+            UUID.fromString(
+                response.get("id").asText()
+            ),
+            UUID.fromString(
+                response.get("ownerId").asText()
+            )
+        );
+    }
+
+    private void topUpWallet(
+        String accessToken,
+        BigDecimal amount
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/wallets/me/top-ups")
+                    .header(
+                        HttpHeaders.AUTHORIZATION,
+                        bearer(accessToken)
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new TopUpRequest(amount)
+                        )
+                    )
+            )
+            .andExpect(status().isOk());
+    }
+
+    private static String bearer(
+        String accessToken
+    ) {
+        return "Bearer " + accessToken;
+    }
+
+    private static String uniqueEmail(
+        String prefix
+    ) {
+        return prefix
+            + "-"
+            + UUID.randomUUID()
+            + "@example.com";
+    }
+
+    private record WalletInfo(
+        UUID id,
+        UUID ownerId
+    ) {
+    }
+
+    private record RegistrationRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record LoginRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record TopUpRequest(
+        BigDecimal amount
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/integration/TransferRollbackIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/integration/TransferRollbackIntegrationTest.java
@@ -1,0 +1,369 @@
+package com.nursena.payflow.transaction.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.ledger.application.port.out.LedgerRepositoryPort;
+import com.nursena.payflow.ledger.domain.model.DoubleEntryLedger;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyCommand;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyUseCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class TransferRollbackIntegrationTest {
+
+    private static final BigDecimal INITIAL_SOURCE_BALANCE =
+        new BigDecimal("300.00");
+
+    private static final BigDecimal TRANSFER_AMOUNT =
+        new BigDecimal("125.50");
+
+    private static final String IDEMPOTENCY_KEY =
+        "transfer-rollback-request-1";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TransferMoneyUseCase transferMoneyUseCase;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private LedgerRepositoryPort ledgerRepository;
+
+    @Test
+    void shouldRollbackEntireTransferWhenLedgerPersistenceFails()
+        throws Exception {
+
+        String password = "StrongPassword123!";
+
+        String sourceEmail =
+            uniqueEmail("rollback-source");
+
+        String targetEmail =
+            uniqueEmail("rollback-target");
+
+        registerUser(sourceEmail, password);
+        registerUser(targetEmail, password);
+
+        String sourceAccessToken =
+            authenticateUser(sourceEmail, password);
+
+        String targetAccessToken =
+            authenticateUser(targetEmail, password);
+
+        WalletInfo sourceWallet =
+            openWallet(sourceAccessToken);
+
+        WalletInfo targetWallet =
+            openWallet(targetAccessToken);
+
+        topUpWallet(
+            sourceAccessToken,
+            INITIAL_SOURCE_BALANCE
+        );
+
+        assertThat(walletBalance(sourceWallet.id()))
+            .isEqualByComparingTo(
+                INITIAL_SOURCE_BALANCE
+            );
+
+        assertThat(walletBalance(targetWallet.id()))
+            .isEqualByComparingTo(
+                BigDecimal.ZERO
+            );
+
+        assertThat(walletVersion(sourceWallet.id()))
+            .isEqualTo(1L);
+
+        assertThat(walletVersion(targetWallet.id()))
+            .isEqualTo(0L);
+
+        when(ledgerRepository.save(
+            any(DoubleEntryLedger.class)
+        )).thenThrow(
+            new IllegalStateException(
+                "Simulated ledger persistence failure."
+            )
+        );
+
+        TransferMoneyCommand command =
+            new TransferMoneyCommand(
+                sourceWallet.ownerId(),
+                targetWallet.id(),
+                TRANSFER_AMOUNT,
+                IDEMPOTENCY_KEY
+            );
+
+        assertThatThrownBy(() ->
+            transferMoneyUseCase.transfer(command)
+        )
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(
+                "Simulated ledger persistence failure."
+            );
+
+        assertThat(walletBalance(sourceWallet.id()))
+            .isEqualByComparingTo(
+                INITIAL_SOURCE_BALANCE
+            );
+
+        assertThat(walletBalance(targetWallet.id()))
+            .isEqualByComparingTo(
+                BigDecimal.ZERO
+            );
+
+        assertThat(walletVersion(sourceWallet.id()))
+            .isEqualTo(1L);
+
+        assertThat(walletVersion(targetWallet.id()))
+            .isEqualTo(0L);
+
+        Long transactionCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM payment_transactions
+                WHERE source_wallet_id = ?
+                  AND idempotency_key = ?
+                """,
+                Long.class,
+                sourceWallet.id(),
+                IDEMPOTENCY_KEY
+            );
+
+        assertThat(transactionCount)
+            .isZero();
+
+        Long ledgerEntryCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM ledger_entries
+                WHERE wallet_id IN (?, ?)
+                """,
+                Long.class,
+                sourceWallet.id(),
+                targetWallet.id()
+            );
+
+        assertThat(ledgerEntryCount)
+            .isZero();
+    }
+
+    private BigDecimal walletBalance(
+        UUID walletId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT balance
+            FROM wallets
+            WHERE id = ?
+            """,
+            BigDecimal.class,
+            walletId
+        );
+    }
+
+    private Long walletVersion(
+        UUID walletId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT version
+            FROM wallets
+            WHERE id = ?
+            """,
+            Long.class,
+            walletId
+        );
+    }
+
+    private void registerUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RegistrationRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isCreated());
+    }
+
+    private String authenticateUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        MvcResult result = mockMvc.perform(
+                post("/api/v1/auth/login")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new LoginRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode response = objectMapper.readTree(
+            result
+                .getResponse()
+                .getContentAsString()
+        );
+
+        return response
+            .get("accessToken")
+            .asText();
+    }
+
+    private WalletInfo openWallet(
+        String accessToken
+    ) throws Exception {
+
+        MvcResult result = mockMvc.perform(
+                post("/api/v1/wallets")
+                    .header(
+                        HttpHeaders.AUTHORIZATION,
+                        bearer(accessToken)
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "currency": "TRY"
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        JsonNode response = objectMapper.readTree(
+            result
+                .getResponse()
+                .getContentAsString()
+        );
+
+        return new WalletInfo(
+            UUID.fromString(
+                response.get("id").asText()
+            ),
+            UUID.fromString(
+                response.get("ownerId").asText()
+            )
+        );
+    }
+
+    private void topUpWallet(
+        String accessToken,
+        BigDecimal amount
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/wallets/me/top-ups")
+                    .header(
+                        HttpHeaders.AUTHORIZATION,
+                        bearer(accessToken)
+                    )
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new TopUpRequest(amount)
+                        )
+                    )
+            )
+            .andExpect(status().isOk());
+    }
+
+    private static String bearer(
+        String accessToken
+    ) {
+        return "Bearer " + accessToken;
+    }
+
+    private static String uniqueEmail(
+        String prefix
+    ) {
+        return prefix
+            + "-"
+            + UUID.randomUUID()
+            + "@example.com";
+    }
+
+    private record WalletInfo(
+        UUID id,
+        UUID ownerId
+    ) {
+    }
+
+    private record RegistrationRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record LoginRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record TopUpRequest(
+        BigDecimal amount
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/adapter/out/persistence/WalletPersistenceAdapterTest.java
@@ -333,4 +333,44 @@ class WalletPersistenceAdapterTest {
             .flush();
     }
 
+    @Test
+    void shouldFindWalletById() {
+        UUID walletId = UUID.fromString(
+            "461ffd4c-29cc-4dbf-82b5-c9af3e1da8db"
+        );
+
+        WalletJpaEntity entity = new WalletJpaEntity(
+            walletId,
+            OWNER_ID,
+            new BigDecimal("125.50"),
+            Currency.TRY,
+            WalletStatus.ACTIVE,
+            NOW,
+            NOW
+        );
+
+        when(repository.findById(walletId))
+            .thenReturn(Optional.of(entity));
+
+        Optional<Wallet> result =
+            adapter.findById(walletId);
+
+        assertThat(result).isPresent();
+
+        Wallet wallet = result.orElseThrow();
+
+        assertThat(wallet.id())
+            .isEqualTo(walletId);
+
+        assertThat(wallet.ownerId())
+            .isEqualTo(OWNER_ID);
+
+        assertThat(wallet.balance().amount())
+            .isEqualByComparingTo(
+                new BigDecimal("125.50")
+            );
+
+        verify(repository).findById(walletId);
+    }
+
 }


### PR DESCRIPTION
## Summary

Release PayFlow v0.2.0 with wallet transfers, double-entry ledger accounting,
transaction history, and the complete OpenAPI contract.

## Highlights

- add authenticated wallet-to-wallet transfers
- add idempotent transfer processing
- add optimistic-locking conflict handling
- add deterministic wallet update ordering
- add double-entry ledger persistence
- add transfer rollback and concurrency coverage
- add paginated transaction history
- add direction, status, and date-range filters
- add OpenAPI and Swagger UI configuration
- document all public and authenticated API operations
- verify the generated `/v3/api-docs` contract

## Database

- add payment transaction persistence
- add ledger entry persistence
- add transfer and ledger database constraints
- include Flyway migration `V4__enforce_transfer_ledger_constraints.sql`

## Verification

- unit tests
- controller tests
- PostgreSQL persistence integration tests
- HTTP integration tests
- concurrency and rollback integration tests
- generated OpenAPI contract integration test
- `./mvnw clean verify`

## Release version

`v0.2.0`