### PR TITLE
docs: add executable Postman collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Completed capabilities include:
 - public transaction-history responses that exclude idempotency keys
 - real PostgreSQL verification of filtering, ordering, and pagination
 
-The next delivery focus is OpenAPI examples, a Postman collection, and the `v0.2.0` release, followed by transactional outbox and Kafka-based post-transfer processing. See the [roadmap](docs/roadmap.md).
+OpenAPI documentation, the executable Postman collection, and the `v0.2.0` release are complete. The current delivery focus is transactional outbox persistence and Kafka-based post-transfer processing. See the [roadmap](docs/roadmap.md).
 
 ## Implemented API
 
@@ -197,6 +197,28 @@ Relevant error outcomes include:
 - `422 SELF_TRANSFER_NOT_ALLOWED`
 - `422 TRANSFER_CURRENCY_MISMATCH`
 - `422 WALLET_NOT_ACTIVE`
+
+## Postman collection
+
+An executable Postman workflow is available under [`postman/`](postman/).
+
+Import:
+
+- `postman/PayFlow.postman_collection.json`
+- `postman/PayFlow.local.postman_environment.json`
+
+Select the **PayFlow Local** environment and run the collection in this order:
+
+1. System
+2. Authentication
+3. Users
+4. Wallets
+5. Transfers
+6. Transactions
+
+The collection automatically generates unique test users, stores JWT access tokens and wallet identifiers, creates an idempotent transfer, verifies completed-request replay, and queries transaction history.
+
+See [`postman/README.md`](postman/README.md) for detailed instructions.
 
 ### Transaction history
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,9 +2,9 @@
 
 ## Current delivery focus
 
-The repository foundation, identity flow, wallet management, wallet-to-wallet transfer processing, double-entry ledger persistence, and authenticated transaction history are complete.
+The repository foundation, identity flow, wallet management, wallet-to-wallet transfer processing, double-entry ledger persistence, authenticated transaction history, OpenAPI documentation, executable Postman collection, and the `v0.2.0` release are complete.
 
-The next delivery increment focuses on API delivery and release readiness through OpenAPI examples, a Postman collection, and the `v0.2.0` release. Transactional outbox and Kafka-based post-transfer processing follow in the event-driven milestone.
+The current delivery increment focuses on transactional outbox persistence and Kafka-based post-transfer processing.
 
 ## Milestone 0 — Repository foundation
 
@@ -79,5 +79,5 @@ The next delivery increment focuses on API delivery and release readiness throug
 - [ ] API security hardening
 - [ ] Performance test scenarios
 - [ ] Architecture and ER diagram exports
-- [ ] OpenAPI examples and Postman collection
-- [ ] Release workflow and tagged release
+- [x] OpenAPI examples and Postman collection
+- [x] Release workflow and tagged release

--- a/postman/PayFlow.local.postman_environment.json
+++ b/postman/PayFlow.local.postman_environment.json
@@ -1,0 +1,129 @@
+{
+  "id": "14739ae7-d578-4e0b-af77-95e645978724",
+  "name": "PayFlow Local",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "accessToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "sourceAccessToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "targetAccessToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "sourceEmail",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "sourcePassword",
+      "value": "StrongPassword123!",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "targetEmail",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "targetPassword",
+      "value": "StrongPassword123!",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "sourceUserId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "targetUserId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "sourceWalletId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "targetWalletId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "idempotencyKey",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "transactionId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "topUpAmount",
+      "value": "300.00",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "transferAmount",
+      "value": "125.50",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "historyPage",
+      "value": "0",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "historySize",
+      "value": "20",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "historyFrom",
+      "value": "2020-01-01T00:00:00Z",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "historyTo",
+      "value": "2099-01-01T00:00:00Z",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2026-07-17T00:00:00.000Z",
+  "_postman_exported_using": "PayFlow repository workflow"
+}

--- a/postman/PayFlow.postman_collection.json
+++ b/postman/PayFlow.postman_collection.json
@@ -1,0 +1,907 @@
+{
+  "info": {
+    "_postman_id": "9c519cd7-2f77-464b-a5b6-308f7167afb1",
+    "name": "PayFlow API",
+    "description": "Executable local workflow for the PayFlow simulated digital-wallet API. No real money is processed.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "if (!pm.environment.get('baseUrl')) pm.environment.set('baseUrl', 'http://localhost:8080');",
+          "if (!pm.environment.get('topUpAmount')) pm.environment.set('topUpAmount', '300.00');",
+          "if (!pm.environment.get('transferAmount')) pm.environment.set('transferAmount', '125.50');"
+        ]
+      }
+    }
+  ],
+  "item": [
+    {
+      "name": "System",
+      "item": [
+        {
+          "name": "Health Check",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "auth": {
+              "type": "noauth"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/system/health",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "system",
+                "health"
+              ]
+            },
+            "description": "Returns the public PayFlow health response."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Authentication",
+      "item": [
+        {
+          "name": "Register Source User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "noauth"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/register",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "register"
+              ]
+            },
+            "description": "Registers a unique source user and saves sourceUserId.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{sourceEmail}}\",\n  \"password\": \"{{sourcePassword}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const suffix = `${Date.now()}-${Math.floor(Math.random() * 100000)}`;",
+                  "pm.environment.set('sourceEmail', `source-${suffix}@example.com`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});",
+                  "const response = pm.response.json();",
+                  "pm.environment.set('sourceUserId', response.userId);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Login Source User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "noauth"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            },
+            "description": "Authenticates the source user and saves its JWT.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{sourceEmail}}\",\n  \"password\": \"{{sourcePassword}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});",
+                  "const response = pm.response.json();",
+                  "pm.environment.set('sourceAccessToken', response.accessToken);",
+                  "pm.environment.set('accessToken', response.accessToken);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Register Target User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "noauth"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/register",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "register"
+              ]
+            },
+            "description": "Registers a unique target user and saves targetUserId.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{targetEmail}}\",\n  \"password\": \"{{targetPassword}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const suffix = `${Date.now()}-${Math.floor(Math.random() * 100000)}`;",
+                  "pm.environment.set('targetEmail', `target-${suffix}@example.com`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});",
+                  "const response = pm.response.json();",
+                  "pm.environment.set('targetUserId', response.userId);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Login Target User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "noauth"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            },
+            "description": "Authenticates the target user and saves its JWT.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{targetEmail}}\",\n  \"password\": \"{{targetPassword}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});",
+                  "const response = pm.response.json();",
+                  "pm.environment.set('targetAccessToken', response.accessToken);"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Users",
+      "item": [
+        {
+          "name": "Get Source User Profile",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{sourceAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/users/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "users",
+                "me"
+              ]
+            },
+            "description": "Returns the authenticated source user's profile."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Wallets",
+      "item": [
+        {
+          "name": "Open Source Wallet",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{sourceAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wallets",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "wallets"
+              ]
+            },
+            "description": "Creates the source wallet and saves sourceWalletId.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"currency\": \"TRY\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});",
+                  "pm.environment.set('sourceWalletId', pm.response.json().id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Open Target Wallet",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{targetAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wallets",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "wallets"
+              ]
+            },
+            "description": "Creates the target wallet and saves targetWalletId.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"currency\": \"TRY\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});",
+                  "pm.environment.set('targetWalletId', pm.response.json().id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Top Up Source Wallet",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{sourceAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wallets/me/top-ups",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "wallets",
+                "me",
+                "top-ups"
+              ]
+            },
+            "description": "Credits a simulated amount to the source wallet.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"amount\": \"{{topUpAmount}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get Source Wallet",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{sourceAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wallets/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "wallets",
+                "me"
+              ]
+            },
+            "description": "Returns the source user's wallet."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});",
+                  "pm.environment.set('sourceWalletId', pm.response.json().id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get Target Wallet",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{targetAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wallets/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "wallets",
+                "me"
+              ]
+            },
+            "description": "Returns the target user's wallet."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});",
+                  "pm.environment.set('targetWalletId', pm.response.json().id);"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Transfers",
+      "item": [
+        {
+          "name": "Create Transfer",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Idempotency-Key",
+                "value": "{{idempotencyKey}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{sourceAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/transfers",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "transfers"
+              ]
+            },
+            "description": "Creates an idempotent source-to-target transfer with a fresh key.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"targetWalletId\": \"{{targetWalletId}}\",\n  \"amount\": \"{{transferAmount}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.environment.set('idempotencyKey', `transfer-${Date.now()}-${Math.floor(Math.random() * 100000)}`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});",
+                  "const response = pm.response.json();",
+                  "pm.expect(response.status).to.eql('COMPLETED');",
+                  "pm.environment.set('transactionId', response.transactionId);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Replay Last Transfer",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Idempotency-Key",
+                "value": "{{idempotencyKey}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{sourceAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/transfers",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "transfers"
+              ]
+            },
+            "description": "Replays the last request with the same key and payload.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"targetWalletId\": \"{{targetWalletId}}\",\n  \"amount\": \"{{transferAmount}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});",
+                  "pm.expect(pm.response.json().transactionId).to.eql(pm.environment.get('transactionId'));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Transactions",
+      "item": [
+        {
+          "name": "Get Transaction History",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{sourceAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/transactions/me?page={{historyPage}}&size={{historySize}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "transactions",
+                "me"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "{{historyPage}}"
+                },
+                {
+                  "key": "size",
+                  "value": "{{historySize}}"
+                }
+              ]
+            },
+            "description": "Returns the default transaction-history page."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});",
+                  "pm.expect(pm.response.json().items).to.be.an('array');"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get Filtered Outgoing Transactions",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{sourceAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/transactions/me?page={{historyPage}}&size={{historySize}}&direction=OUTGOING&status=COMPLETED&from={{historyFrom}}&to={{historyTo}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "transactions",
+                "me"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "{{historyPage}}"
+                },
+                {
+                  "key": "size",
+                  "value": "{{historySize}}"
+                },
+                {
+                  "key": "direction",
+                  "value": "OUTGOING"
+                },
+                {
+                  "key": "status",
+                  "value": "COMPLETED"
+                },
+                {
+                  "key": "from",
+                  "value": "{{historyFrom}}"
+                },
+                {
+                  "key": "to",
+                  "value": "{{historyTo}}"
+                }
+              ]
+            },
+            "description": "Uses direction, status, inclusive from, and exclusive to filters."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Response is JSON', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
+                  "});",
+                  "pm.response.json().items.forEach(function (entry) {",
+                  "    pm.expect(entry.direction).to.eql('OUTGOING');",
+                  "    pm.expect(entry.status).to.eql('COMPLETED');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/postman/README.md
+++ b/postman/README.md
@@ -1,0 +1,50 @@
+# PayFlow Postman Collection
+
+This collection provides an executable local workflow for the PayFlow simulated digital-wallet API.
+
+## Import
+
+Import both files into Postman:
+
+- `PayFlow.postman_collection.json`
+- `PayFlow.local.postman_environment.json`
+
+Select the **PayFlow Local** environment.
+
+## Prerequisites
+
+```bash
+docker compose up -d postgres redis kafka
+./mvnw spring-boot:run
+```
+
+Windows PowerShell:
+
+```powershell
+docker compose up -d postgres redis kafka
+.\mvnw.cmd spring-boot:run
+```
+
+## Recommended run order
+
+1. System
+2. Authentication
+3. Users
+4. Wallets
+5. Transfers
+6. Transactions
+
+The registration requests generate unique source and target emails. Login requests save JWTs. Wallet requests save wallet IDs. `Create Transfer` generates an `Idempotency-Key`.
+
+## Replay verification
+
+Run `Create Transfer`, then run `Replay Last Transfer` without rerunning the first request. The replay must return the same transaction ID without changing balances again.
+
+## Security
+
+The repository contains no real JWTs, personal credentials, or production secrets. Do not commit a Postman environment exported after it contains live or sensitive values.
+
+## API documentation
+
+- Swagger UI: `http://localhost:8080/swagger-ui.html`
+- OpenAPI JSON: `http://localhost:8080/v3/api-docs`


### PR DESCRIPTION
## Summary

- add an executable Postman collection for all PayFlow API operations
- add a local Postman environment with safe test defaults
- automate unique source and target user registration
- capture JWT access tokens and wallet identifiers
- generate transfer idempotency keys automatically
- verify completed-transfer replay behavior
- add transaction-history requests and filters
- document the Postman workflow
- update README and roadmap delivery status

## Collection workflow

1. System
2. Authentication
3. Users
4. Wallets
5. Transfers
6. Transactions

## Verification

- 15 requests executed
- 30 Postman tests passed
- 0 failed
- 0 skipped
- JSON collection validation
- Maven clean verify