### PR TITLE
feat: add transactional outbox persistence

### DIFF
--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventJpaEntity.java
@@ -1,0 +1,246 @@
+package com.nursena.payflow.outbox.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "outbox_events")
+class OutboxEventJpaEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(
+        name = "aggregate_type",
+        nullable = false,
+        updatable = false,
+        length = 100
+    )
+    private String aggregateType;
+
+    @Column(
+        name = "aggregate_id",
+        nullable = false,
+        updatable = false
+    )
+    private UUID aggregateId;
+
+    @Column(
+        name = "event_type",
+        nullable = false,
+        updatable = false,
+        length = 200
+    )
+    private String eventType;
+
+    @Column(
+        name = "event_version",
+        nullable = false,
+        updatable = false
+    )
+    private int eventVersion;
+
+    @Column(
+        nullable = false,
+        updatable = false,
+        length = 200
+    )
+    private String topic;
+
+    @Column(
+        name = "partition_key",
+        nullable = false,
+        updatable = false,
+        length = 100
+    )
+    private String partitionKey;
+
+    @Column(
+        name = "deduplication_key",
+        nullable = false,
+        updatable = false,
+        unique = true,
+        length = 300
+    )
+    private String deduplicationKey;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(
+        nullable = false,
+        updatable = false,
+        columnDefinition = "jsonb"
+    )
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+        nullable = false,
+        length = 20
+    )
+    private OutboxStatus status;
+
+    @Column(
+        name = "attempt_count",
+        nullable = false
+    )
+    private int attemptCount;
+
+    @Column(
+        name = "available_at",
+        nullable = false
+    )
+    private Instant availableAt;
+
+    @Column(name = "locked_at")
+    private Instant lockedAt;
+
+    @Column(name = "locked_until")
+    private Instant lockedUntil;
+
+    @Column(
+        name = "locked_by",
+        length = 200
+    )
+    private String lockedBy;
+
+    @Column(
+        name = "created_at",
+        nullable = false,
+        updatable = false
+    )
+    private Instant createdAt;
+
+    @Column(name = "published_at")
+    private Instant publishedAt;
+
+    @Column(
+        name = "last_error",
+        length = 1000
+    )
+    private String lastError;
+
+    protected OutboxEventJpaEntity() {
+    }
+
+    OutboxEventJpaEntity(
+        UUID id,
+        String aggregateType,
+        UUID aggregateId,
+        String eventType,
+        int eventVersion,
+        String topic,
+        String partitionKey,
+        String deduplicationKey,
+        String payload,
+        OutboxStatus status,
+        int attemptCount,
+        Instant availableAt,
+        Instant lockedAt,
+        Instant lockedUntil,
+        String lockedBy,
+        Instant createdAt,
+        Instant publishedAt,
+        String lastError
+    ) {
+        this.id = id;
+        this.aggregateType = aggregateType;
+        this.aggregateId = aggregateId;
+        this.eventType = eventType;
+        this.eventVersion = eventVersion;
+        this.topic = topic;
+        this.partitionKey = partitionKey;
+        this.deduplicationKey = deduplicationKey;
+        this.payload = payload;
+        this.status = status;
+        this.attemptCount = attemptCount;
+        this.availableAt = availableAt;
+        this.lockedAt = lockedAt;
+        this.lockedUntil = lockedUntil;
+        this.lockedBy = lockedBy;
+        this.createdAt = createdAt;
+        this.publishedAt = publishedAt;
+        this.lastError = lastError;
+    }
+
+    UUID getId() {
+        return id;
+    }
+
+    String getAggregateType() {
+        return aggregateType;
+    }
+
+    UUID getAggregateId() {
+        return aggregateId;
+    }
+
+    String getEventType() {
+        return eventType;
+    }
+
+    int getEventVersion() {
+        return eventVersion;
+    }
+
+    String getTopic() {
+        return topic;
+    }
+
+    String getPartitionKey() {
+        return partitionKey;
+    }
+
+    String getDeduplicationKey() {
+        return deduplicationKey;
+    }
+
+    String getPayload() {
+        return payload;
+    }
+
+    OutboxStatus getStatus() {
+        return status;
+    }
+
+    int getAttemptCount() {
+        return attemptCount;
+    }
+
+    Instant getAvailableAt() {
+        return availableAt;
+    }
+
+    Instant getLockedAt() {
+        return lockedAt;
+    }
+
+    Instant getLockedUntil() {
+        return lockedUntil;
+    }
+
+    String getLockedBy() {
+        return lockedBy;
+    }
+
+    Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    Instant getPublishedAt() {
+        return publishedAt;
+    }
+
+    String getLastError() {
+        return lastError;
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventPersistenceAdapter.java
@@ -1,0 +1,131 @@
+package com.nursena.payflow.outbox.adapter.out.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.application.port.out.OutboxEventRepositoryPort;
+import com.nursena.payflow.outbox.domain.exception.DuplicateOutboxEventException;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+@Component
+class OutboxEventPersistenceAdapter
+    implements OutboxEventRepositoryPort {
+
+    private static final String DEDUPLICATION_CONSTRAINT =
+        "uq_outbox_events_deduplication_key";
+
+    private final SpringDataOutboxEventRepository repository;
+
+    OutboxEventPersistenceAdapter(
+        SpringDataOutboxEventRepository repository
+    ) {
+        this.repository = repository;
+    }
+
+    @Override
+    public OutboxEvent save(
+        OutboxEvent event
+    ) {
+        try {
+            OutboxEventJpaEntity saved =
+                repository.saveAndFlush(
+                    toEntity(event)
+                );
+
+            return toDomain(saved);
+        } catch (DataIntegrityViolationException exception) {
+            if (isDeduplicationConstraintViolation(
+                exception
+            )) {
+                throw new DuplicateOutboxEventException();
+            }
+
+            throw exception;
+        }
+    }
+
+    @Override
+    public Optional<OutboxEvent> findById(
+        UUID eventId
+    ) {
+        return repository
+            .findById(eventId)
+            .map(
+                OutboxEventPersistenceAdapter::toDomain
+            );
+    }
+
+    private static OutboxEventJpaEntity toEntity(
+        OutboxEvent event
+    ) {
+        return new OutboxEventJpaEntity(
+            event.id(),
+            event.aggregateType(),
+            event.aggregateId(),
+            event.eventType(),
+            event.eventVersion(),
+            event.topic(),
+            event.partitionKey(),
+            event.deduplicationKey(),
+            event.payload(),
+            event.status(),
+            event.attemptCount(),
+            event.availableAt(),
+            event.lockedAt(),
+            event.lockedUntil(),
+            event.lockedBy(),
+            event.createdAt(),
+            event.publishedAt(),
+            event.lastError()
+        );
+    }
+
+    private static OutboxEvent toDomain(
+        OutboxEventJpaEntity entity
+    ) {
+        return OutboxEvent.rehydrate(
+            entity.getId(),
+            entity.getAggregateType(),
+            entity.getAggregateId(),
+            entity.getEventType(),
+            entity.getEventVersion(),
+            entity.getTopic(),
+            entity.getPartitionKey(),
+            entity.getDeduplicationKey(),
+            entity.getPayload(),
+            entity.getStatus(),
+            entity.getAttemptCount(),
+            entity.getAvailableAt(),
+            entity.getLockedAt(),
+            entity.getLockedUntil(),
+            entity.getLockedBy(),
+            entity.getCreatedAt(),
+            entity.getPublishedAt(),
+            entity.getLastError()
+        );
+    }
+
+    private static boolean
+    isDeduplicationConstraintViolation(
+        Throwable throwable
+    ) {
+        Throwable current = throwable;
+
+        while (current != null) {
+            if (current
+                instanceof ConstraintViolationException violation) {
+
+                return DEDUPLICATION_CONSTRAINT.equals(
+                    violation.getConstraintName()
+                );
+            }
+
+            current = current.getCause();
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/SpringDataOutboxEventRepository.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/SpringDataOutboxEventRepository.java
@@ -1,0 +1,12 @@
+package com.nursena.payflow.outbox.adapter.out.persistence;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface SpringDataOutboxEventRepository
+    extends JpaRepository<
+    OutboxEventJpaEntity,
+    UUID
+    > {
+}

--- a/src/main/java/com/nursena/payflow/outbox/application/port/out/OutboxEventRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/outbox/application/port/out/OutboxEventRepositoryPort.java
@@ -1,0 +1,17 @@
+package com.nursena.payflow.outbox.application.port.out;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+
+public interface OutboxEventRepositoryPort {
+
+    OutboxEvent save(
+        OutboxEvent event
+    );
+
+    Optional<OutboxEvent> findById(
+        UUID eventId
+    );
+}

--- a/src/main/java/com/nursena/payflow/outbox/domain/exception/DuplicateOutboxEventException.java
+++ b/src/main/java/com/nursena/payflow/outbox/domain/exception/DuplicateOutboxEventException.java
@@ -1,0 +1,12 @@
+package com.nursena.payflow.outbox.domain.exception;
+
+public class DuplicateOutboxEventException
+    extends RuntimeException {
+
+    public DuplicateOutboxEventException() {
+        super(
+            "An outbox event already exists "
+                + "for the same deduplication key."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/domain/exception/InvalidOutboxEventException.java
+++ b/src/main/java/com/nursena/payflow/outbox/domain/exception/InvalidOutboxEventException.java
@@ -1,0 +1,11 @@
+package com.nursena.payflow.outbox.domain.exception;
+
+public class InvalidOutboxEventException
+    extends RuntimeException {
+
+    public InvalidOutboxEventException(
+        String message
+    ) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/domain/model/OutboxEvent.java
+++ b/src/main/java/com/nursena/payflow/outbox/domain/model/OutboxEvent.java
@@ -1,0 +1,455 @@
+package com.nursena.payflow.outbox.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.domain.exception.InvalidOutboxEventException;
+
+public final class OutboxEvent {
+
+    private static final int MAX_AGGREGATE_TYPE_LENGTH = 100;
+    private static final int MAX_EVENT_TYPE_LENGTH = 200;
+    private static final int MAX_TOPIC_LENGTH = 200;
+    private static final int MAX_PARTITION_KEY_LENGTH = 100;
+    private static final int MAX_DEDUPLICATION_KEY_LENGTH = 300;
+    private static final int MAX_LOCKED_BY_LENGTH = 200;
+    private static final int MAX_LAST_ERROR_LENGTH = 1000;
+
+    private final UUID id;
+    private final String aggregateType;
+    private final UUID aggregateId;
+    private final String eventType;
+    private final int eventVersion;
+    private final String topic;
+    private final String partitionKey;
+    private final String deduplicationKey;
+    private final String payload;
+    private final OutboxStatus status;
+    private final int attemptCount;
+    private final Instant availableAt;
+    private final Instant lockedAt;
+    private final Instant lockedUntil;
+    private final String lockedBy;
+    private final Instant createdAt;
+    private final Instant publishedAt;
+    private final String lastError;
+
+    private OutboxEvent(
+        UUID id,
+        String aggregateType,
+        UUID aggregateId,
+        String eventType,
+        int eventVersion,
+        String topic,
+        String partitionKey,
+        String deduplicationKey,
+        String payload,
+        OutboxStatus status,
+        int attemptCount,
+        Instant availableAt,
+        Instant lockedAt,
+        Instant lockedUntil,
+        String lockedBy,
+        Instant createdAt,
+        Instant publishedAt,
+        String lastError
+    ) {
+        this.id = Objects.requireNonNull(
+            id,
+            "id must not be null"
+        );
+
+        this.aggregateType = requireText(
+            aggregateType,
+            "aggregateType",
+            MAX_AGGREGATE_TYPE_LENGTH
+        );
+
+        this.aggregateId = Objects.requireNonNull(
+            aggregateId,
+            "aggregateId must not be null"
+        );
+
+        this.eventType = requireText(
+            eventType,
+            "eventType",
+            MAX_EVENT_TYPE_LENGTH
+        );
+
+        ensurePositiveEventVersion(eventVersion);
+        this.eventVersion = eventVersion;
+
+        this.topic = requireText(
+            topic,
+            "topic",
+            MAX_TOPIC_LENGTH
+        );
+
+        this.partitionKey = requireText(
+            partitionKey,
+            "partitionKey",
+            MAX_PARTITION_KEY_LENGTH
+        );
+
+        this.deduplicationKey = requireText(
+            deduplicationKey,
+            "deduplicationKey",
+            MAX_DEDUPLICATION_KEY_LENGTH
+        );
+
+        this.payload = requirePayload(payload);
+
+        this.status = Objects.requireNonNull(
+            status,
+            "status must not be null"
+        );
+
+        ensureNonNegativeAttemptCount(attemptCount);
+        this.attemptCount = attemptCount;
+
+        this.createdAt = Objects.requireNonNull(
+            createdAt,
+            "createdAt must not be null"
+        );
+
+        this.availableAt = Objects.requireNonNull(
+            availableAt,
+            "availableAt must not be null"
+        );
+
+        ensureValidAvailability(
+            this.availableAt,
+            this.createdAt
+        );
+
+        validateProcessingState(
+            status,
+            lockedAt,
+            lockedUntil,
+            lockedBy
+        );
+
+        validatePublicationState(
+            status,
+            publishedAt,
+            this.createdAt
+        );
+
+        this.lockedAt = lockedAt;
+        this.lockedUntil = lockedUntil;
+        this.lockedBy = lockedBy;
+        this.publishedAt = publishedAt;
+
+        this.lastError = optionalText(
+            lastError,
+            "lastError",
+            MAX_LAST_ERROR_LENGTH
+        );
+    }
+
+    public static OutboxEvent pending(
+        UUID id,
+        String aggregateType,
+        UUID aggregateId,
+        String eventType,
+        int eventVersion,
+        String topic,
+        String partitionKey,
+        String deduplicationKey,
+        String payload,
+        Instant createdAt
+    ) {
+        return new OutboxEvent(
+            id,
+            aggregateType,
+            aggregateId,
+            eventType,
+            eventVersion,
+            topic,
+            partitionKey,
+            deduplicationKey,
+            payload,
+            OutboxStatus.PENDING,
+            0,
+            createdAt,
+            null,
+            null,
+            null,
+            createdAt,
+            null,
+            null
+        );
+    }
+
+    public static OutboxEvent rehydrate(
+        UUID id,
+        String aggregateType,
+        UUID aggregateId,
+        String eventType,
+        int eventVersion,
+        String topic,
+        String partitionKey,
+        String deduplicationKey,
+        String payload,
+        OutboxStatus status,
+        int attemptCount,
+        Instant availableAt,
+        Instant lockedAt,
+        Instant lockedUntil,
+        String lockedBy,
+        Instant createdAt,
+        Instant publishedAt,
+        String lastError
+    ) {
+        return new OutboxEvent(
+            id,
+            aggregateType,
+            aggregateId,
+            eventType,
+            eventVersion,
+            topic,
+            partitionKey,
+            deduplicationKey,
+            payload,
+            status,
+            attemptCount,
+            availableAt,
+            lockedAt,
+            lockedUntil,
+            lockedBy,
+            createdAt,
+            publishedAt,
+            lastError
+        );
+    }
+
+    private static String requireText(
+        String value,
+        String fieldName,
+        int maximumLength
+    ) {
+        if (value == null || value.isBlank()) {
+            throw new InvalidOutboxEventException(
+                fieldName + " must not be blank."
+            );
+        }
+
+        if (value.length() > maximumLength) {
+            throw new InvalidOutboxEventException(
+                fieldName
+                    + " must not exceed "
+                    + maximumLength
+                    + " characters."
+            );
+        }
+
+        return value;
+    }
+
+    private static String optionalText(
+        String value,
+        String fieldName,
+        int maximumLength
+    ) {
+        if (value == null) {
+            return null;
+        }
+
+        return requireText(
+            value,
+            fieldName,
+            maximumLength
+        );
+    }
+
+    private static String requirePayload(
+        String payload
+    ) {
+        if (payload == null
+            || payload.isBlank()
+            || "{}".equals(payload.trim())) {
+
+            throw new InvalidOutboxEventException(
+                "payload must contain a non-empty JSON object."
+            );
+        }
+
+        return payload;
+    }
+
+    private static void ensurePositiveEventVersion(
+        int eventVersion
+    ) {
+        if (eventVersion <= 0) {
+            throw new InvalidOutboxEventException(
+                "eventVersion must be positive."
+            );
+        }
+    }
+
+    private static void ensureNonNegativeAttemptCount(
+        int attemptCount
+    ) {
+        if (attemptCount < 0) {
+            throw new InvalidOutboxEventException(
+                "attemptCount must not be negative."
+            );
+        }
+    }
+
+    private static void ensureValidAvailability(
+        Instant availableAt,
+        Instant createdAt
+    ) {
+        if (availableAt.isBefore(createdAt)) {
+            throw new InvalidOutboxEventException(
+                "availableAt must not be before createdAt."
+            );
+        }
+    }
+
+    private static void validateProcessingState(
+        OutboxStatus status,
+        Instant lockedAt,
+        Instant lockedUntil,
+        String lockedBy
+    ) {
+        if (status == OutboxStatus.PROCESSING) {
+            if (lockedAt == null
+                || lockedUntil == null
+                || lockedBy == null
+                || lockedBy.isBlank()) {
+
+                throw new InvalidOutboxEventException(
+                    "PROCESSING event must have complete "
+                        + "lock metadata."
+                );
+            }
+
+            requireText(
+                lockedBy,
+                "lockedBy",
+                MAX_LOCKED_BY_LENGTH
+            );
+
+            if (!lockedUntil.isAfter(lockedAt)) {
+                throw new InvalidOutboxEventException(
+                    "lockedUntil must be after lockedAt."
+                );
+            }
+
+            return;
+        }
+
+        if (lockedAt != null
+            || lockedUntil != null
+            || lockedBy != null) {
+
+            throw new InvalidOutboxEventException(
+                "Only PROCESSING events may have "
+                    + "lock metadata."
+            );
+        }
+    }
+
+    private static void validatePublicationState(
+        OutboxStatus status,
+        Instant publishedAt,
+        Instant createdAt
+    ) {
+        if (status == OutboxStatus.PUBLISHED) {
+            if (publishedAt == null) {
+                throw new InvalidOutboxEventException(
+                    "PUBLISHED event must have publishedAt."
+                );
+            }
+
+            if (publishedAt.isBefore(createdAt)) {
+                throw new InvalidOutboxEventException(
+                    "publishedAt must not be before createdAt."
+                );
+            }
+
+            return;
+        }
+
+        if (publishedAt != null) {
+            throw new InvalidOutboxEventException(
+                "Only PUBLISHED events may have publishedAt."
+            );
+        }
+    }
+
+    public UUID id() {
+        return id;
+    }
+
+    public String aggregateType() {
+        return aggregateType;
+    }
+
+    public UUID aggregateId() {
+        return aggregateId;
+    }
+
+    public String eventType() {
+        return eventType;
+    }
+
+    public int eventVersion() {
+        return eventVersion;
+    }
+
+    public String topic() {
+        return topic;
+    }
+
+    public String partitionKey() {
+        return partitionKey;
+    }
+
+    public String deduplicationKey() {
+        return deduplicationKey;
+    }
+
+    public String payload() {
+        return payload;
+    }
+
+    public OutboxStatus status() {
+        return status;
+    }
+
+    public int attemptCount() {
+        return attemptCount;
+    }
+
+    public Instant availableAt() {
+        return availableAt;
+    }
+
+    public Instant lockedAt() {
+        return lockedAt;
+    }
+
+    public Instant lockedUntil() {
+        return lockedUntil;
+    }
+
+    public String lockedBy() {
+        return lockedBy;
+    }
+
+    public Instant createdAt() {
+        return createdAt;
+    }
+
+    public Instant publishedAt() {
+        return publishedAt;
+    }
+
+    public String lastError() {
+        return lastError;
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/domain/model/OutboxStatus.java
+++ b/src/main/java/com/nursena/payflow/outbox/domain/model/OutboxStatus.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.outbox.domain.model;
+
+public enum OutboxStatus {
+    PENDING,
+    PROCESSING,
+    PUBLISHED,
+    FAILED
+}

--- a/src/main/resources/db/migration/V5__create_transactional_outbox.sql
+++ b/src/main/resources/db/migration/V5__create_transactional_outbox.sql
@@ -1,0 +1,103 @@
+CREATE TABLE outbox_events (
+    id UUID PRIMARY KEY,
+    aggregate_type VARCHAR(100) NOT NULL,
+    aggregate_id UUID NOT NULL,
+    event_type VARCHAR(200) NOT NULL,
+    event_version INTEGER NOT NULL,
+    topic VARCHAR(200) NOT NULL,
+    partition_key VARCHAR(100) NOT NULL,
+    deduplication_key VARCHAR(300) NOT NULL,
+    payload JSONB NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    attempt_count INTEGER NOT NULL,
+    available_at TIMESTAMPTZ NOT NULL,
+    locked_at TIMESTAMPTZ,
+    locked_until TIMESTAMPTZ,
+    locked_by VARCHAR(200),
+    created_at TIMESTAMPTZ NOT NULL,
+    published_at TIMESTAMPTZ,
+    last_error VARCHAR(1000),
+
+    CONSTRAINT uq_outbox_events_deduplication_key
+        UNIQUE (deduplication_key),
+
+    CONSTRAINT chk_outbox_events_event_version
+        CHECK (event_version > 0),
+
+    CONSTRAINT chk_outbox_events_attempt_count
+        CHECK (attempt_count >= 0),
+
+    CONSTRAINT chk_outbox_events_status
+        CHECK (
+            status IN (
+                'PENDING',
+                'PROCESSING',
+                'PUBLISHED',
+                'FAILED'
+            )
+        ),
+
+    CONSTRAINT chk_outbox_events_payload
+        CHECK (
+            jsonb_typeof(payload) = 'object'
+            AND payload <> '{}'::jsonb
+        ),
+
+    CONSTRAINT chk_outbox_events_availability
+        CHECK (available_at >= created_at),
+
+    CONSTRAINT chk_outbox_events_processing_lock
+        CHECK (
+            (
+                status = 'PROCESSING'
+                AND locked_at IS NOT NULL
+                AND locked_until IS NOT NULL
+                AND locked_by IS NOT NULL
+                AND locked_until > locked_at
+            )
+            OR
+            (
+                status <> 'PROCESSING'
+                AND locked_at IS NULL
+                AND locked_until IS NULL
+                AND locked_by IS NULL
+            )
+        ),
+
+    CONSTRAINT chk_outbox_events_publication
+        CHECK (
+            (
+                status = 'PUBLISHED'
+                AND published_at IS NOT NULL
+                AND published_at >= created_at
+            )
+            OR
+            (
+                status <> 'PUBLISHED'
+                AND published_at IS NULL
+            )
+        )
+);
+
+CREATE INDEX idx_outbox_events_pending_available
+    ON outbox_events (
+        available_at,
+        created_at,
+        id
+    )
+    WHERE status = 'PENDING';
+
+CREATE INDEX idx_outbox_events_processing_lease
+    ON outbox_events (
+        locked_until,
+        created_at,
+        id
+    )
+    WHERE status = 'PROCESSING';
+
+CREATE INDEX idx_outbox_events_aggregate
+    ON outbox_events (
+        aggregate_type,
+        aggregate_id,
+        created_at DESC
+    );

--- a/src/test/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventPersistenceAdapterTest.java
@@ -1,0 +1,269 @@
+package com.nursena.payflow.outbox.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.domain.exception.DuplicateOutboxEventException;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxEventPersistenceAdapterTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000001"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-17T19:00:00Z"
+        );
+
+    private static final String EVENT_TYPE =
+        "wallet.transfer.completed";
+
+    private static final String DEDUPLICATION_KEY =
+        EVENT_TYPE + ":1:" + TRANSACTION_ID;
+
+    private static final String PAYLOAD = """
+        {
+          "eventId": "50000000-0000-0000-0000-000000000001",
+          "eventType": "wallet.transfer.completed",
+          "eventVersion": 1,
+          "transactionId": "60000000-0000-0000-0000-000000000001"
+        }
+        """;
+
+    @Mock
+    private SpringDataOutboxEventRepository repository;
+
+    private OutboxEventPersistenceAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter =
+            new OutboxEventPersistenceAdapter(
+                repository
+            );
+    }
+
+    @Test
+    void shouldSaveAndRestorePendingEvent() {
+        OutboxEvent event = pendingEvent();
+
+        when(repository.saveAndFlush(
+            any(OutboxEventJpaEntity.class)
+        )).thenAnswer(invocation ->
+            invocation.getArgument(0)
+        );
+
+        OutboxEvent saved =
+            adapter.save(event);
+
+        assertThat(saved.id())
+            .isEqualTo(EVENT_ID);
+
+        assertThat(saved.aggregateType())
+            .isEqualTo("PAYMENT_TRANSACTION");
+
+        assertThat(saved.aggregateId())
+            .isEqualTo(TRANSACTION_ID);
+
+        assertThat(saved.eventType())
+            .isEqualTo(EVENT_TYPE);
+
+        assertThat(saved.eventVersion())
+            .isEqualTo(1);
+
+        assertThat(saved.topic())
+            .isEqualTo(EVENT_TYPE);
+
+        assertThat(saved.partitionKey())
+            .isEqualTo(TRANSACTION_ID.toString());
+
+        assertThat(saved.deduplicationKey())
+            .isEqualTo(DEDUPLICATION_KEY);
+
+        assertThat(saved.payload())
+            .isEqualTo(PAYLOAD);
+
+        assertThat(saved.status())
+            .isEqualTo(OutboxStatus.PENDING);
+
+        assertThat(saved.attemptCount())
+            .isZero();
+
+        assertThat(saved.availableAt())
+            .isEqualTo(CREATED_AT);
+
+        assertThat(saved.createdAt())
+            .isEqualTo(CREATED_AT);
+
+        verify(repository)
+            .saveAndFlush(
+                any(OutboxEventJpaEntity.class)
+            );
+    }
+
+    @Test
+    void shouldFindAndRestoreEventById() {
+        when(repository.findById(EVENT_ID))
+            .thenReturn(
+                Optional.of(
+                    pendingEntity()
+                )
+            );
+
+        Optional<OutboxEvent> result =
+            adapter.findById(EVENT_ID);
+
+        assertThat(result)
+            .isPresent();
+
+        OutboxEvent event =
+            result.orElseThrow();
+
+        assertThat(event.id())
+            .isEqualTo(EVENT_ID);
+
+        assertThat(event.aggregateId())
+            .isEqualTo(TRANSACTION_ID);
+
+        assertThat(event.status())
+            .isEqualTo(OutboxStatus.PENDING);
+
+        assertThat(event.payload())
+            .isEqualTo(PAYLOAD);
+
+        verify(repository)
+            .findById(EVENT_ID);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenEventDoesNotExist() {
+        when(repository.findById(EVENT_ID))
+            .thenReturn(Optional.empty());
+
+        Optional<OutboxEvent> result =
+            adapter.findById(EVENT_ID);
+
+        assertThat(result)
+            .isEmpty();
+
+        verify(repository)
+            .findById(EVENT_ID);
+    }
+
+    @Test
+    void shouldTranslateDuplicateDeduplicationConstraint() {
+        ConstraintViolationException violation =
+            new ConstraintViolationException(
+                "duplicate deduplication key",
+                new SQLException(),
+                "uq_outbox_events_deduplication_key"
+            );
+
+        when(repository.saveAndFlush(
+            any(OutboxEventJpaEntity.class)
+        )).thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate deduplication key",
+                violation
+            )
+        );
+
+        assertThatThrownBy(() ->
+            adapter.save(pendingEvent())
+        )
+            .isInstanceOf(
+                DuplicateOutboxEventException.class
+            )
+            .hasMessage(
+                "An outbox event already exists "
+                    + "for the same deduplication key."
+            );
+    }
+
+    @Test
+    void shouldNotTranslateUnrelatedConstraintViolation() {
+        ConstraintViolationException violation =
+            new ConstraintViolationException(
+                "unrelated constraint",
+                new SQLException(),
+                "some_other_constraint"
+            );
+
+        DataIntegrityViolationException databaseException =
+            new DataIntegrityViolationException(
+                "unrelated constraint",
+                violation
+            );
+
+        when(repository.saveAndFlush(
+            any(OutboxEventJpaEntity.class)
+        )).thenThrow(databaseException);
+
+        assertThatThrownBy(() ->
+            adapter.save(pendingEvent())
+        ).isSameAs(databaseException);
+    }
+
+    private static OutboxEvent pendingEvent() {
+        return OutboxEvent.pending(
+            EVENT_ID,
+            "PAYMENT_TRANSACTION",
+            TRANSACTION_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            TRANSACTION_ID.toString(),
+            DEDUPLICATION_KEY,
+            PAYLOAD,
+            CREATED_AT
+        );
+    }
+
+    private static OutboxEventJpaEntity pendingEntity() {
+        return new OutboxEventJpaEntity(
+            EVENT_ID,
+            "PAYMENT_TRANSACTION",
+            TRANSACTION_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            TRANSACTION_ID.toString(),
+            DEDUPLICATION_KEY,
+            PAYLOAD,
+            OutboxStatus.PENDING,
+            0,
+            CREATED_AT,
+            null,
+            null,
+            null,
+            CREATED_AT,
+            null,
+            null
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/domain/model/OutboxEventTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/domain/model/OutboxEventTest.java
@@ -1,0 +1,425 @@
+package com.nursena.payflow.outbox.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.domain.exception.InvalidOutboxEventException;
+import org.junit.jupiter.api.Test;
+
+class OutboxEventTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000001"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-17T19:00:00Z"
+        );
+
+    private static final String EVENT_TYPE =
+        "wallet.transfer.completed";
+
+    private static final String DEDUPLICATION_KEY =
+        EVENT_TYPE + ":1:" + TRANSACTION_ID;
+
+    private static final String PAYLOAD = """
+        {
+          "eventId": "50000000-0000-0000-0000-000000000001",
+          "eventType": "wallet.transfer.completed",
+          "eventVersion": 1
+        }
+        """;
+
+    @Test
+    void shouldCreatePendingEvent() {
+        OutboxEvent event = pendingEvent();
+
+        assertThat(event.id())
+            .isEqualTo(EVENT_ID);
+
+        assertThat(event.aggregateType())
+            .isEqualTo("PAYMENT_TRANSACTION");
+
+        assertThat(event.aggregateId())
+            .isEqualTo(TRANSACTION_ID);
+
+        assertThat(event.eventType())
+            .isEqualTo(EVENT_TYPE);
+
+        assertThat(event.eventVersion())
+            .isEqualTo(1);
+
+        assertThat(event.topic())
+            .isEqualTo(EVENT_TYPE);
+
+        assertThat(event.partitionKey())
+            .isEqualTo(TRANSACTION_ID.toString());
+
+        assertThat(event.deduplicationKey())
+            .isEqualTo(DEDUPLICATION_KEY);
+
+        assertThat(event.payload())
+            .isEqualTo(PAYLOAD);
+
+        assertThat(event.status())
+            .isEqualTo(OutboxStatus.PENDING);
+
+        assertThat(event.attemptCount())
+            .isZero();
+
+        assertThat(event.availableAt())
+            .isEqualTo(CREATED_AT);
+
+        assertThat(event.createdAt())
+            .isEqualTo(CREATED_AT);
+
+        assertThat(event.lockedAt())
+            .isNull();
+
+        assertThat(event.lockedUntil())
+            .isNull();
+
+        assertThat(event.lockedBy())
+            .isNull();
+
+        assertThat(event.publishedAt())
+            .isNull();
+
+        assertThat(event.lastError())
+            .isNull();
+    }
+
+    @Test
+    void shouldRehydrateValidProcessingEvent() {
+        Instant lockedAt =
+            CREATED_AT.plusSeconds(10);
+
+        Instant lockedUntil =
+            lockedAt.plusSeconds(30);
+
+        OutboxEvent event = OutboxEvent.rehydrate(
+            EVENT_ID,
+            "PAYMENT_TRANSACTION",
+            TRANSACTION_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            TRANSACTION_ID.toString(),
+            DEDUPLICATION_KEY,
+            PAYLOAD,
+            OutboxStatus.PROCESSING,
+            1,
+            CREATED_AT,
+            lockedAt,
+            lockedUntil,
+            "publisher-1",
+            CREATED_AT,
+            null,
+            null
+        );
+
+        assertThat(event.status())
+            .isEqualTo(OutboxStatus.PROCESSING);
+
+        assertThat(event.attemptCount())
+            .isEqualTo(1);
+
+        assertThat(event.lockedAt())
+            .isEqualTo(lockedAt);
+
+        assertThat(event.lockedUntil())
+            .isEqualTo(lockedUntil);
+
+        assertThat(event.lockedBy())
+            .isEqualTo("publisher-1");
+    }
+
+    @Test
+    void shouldRehydrateValidPublishedEvent() {
+        Instant publishedAt =
+            CREATED_AT.plusSeconds(15);
+
+        OutboxEvent event = OutboxEvent.rehydrate(
+            EVENT_ID,
+            "PAYMENT_TRANSACTION",
+            TRANSACTION_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            TRANSACTION_ID.toString(),
+            DEDUPLICATION_KEY,
+            PAYLOAD,
+            OutboxStatus.PUBLISHED,
+            1,
+            CREATED_AT,
+            null,
+            null,
+            null,
+            CREATED_AT,
+            publishedAt,
+            null
+        );
+
+        assertThat(event.status())
+            .isEqualTo(OutboxStatus.PUBLISHED);
+
+        assertThat(event.publishedAt())
+            .isEqualTo(publishedAt);
+    }
+
+    @Test
+    void shouldRejectBlankEventType() {
+        assertThatThrownBy(() ->
+            OutboxEvent.pending(
+                EVENT_ID,
+                "PAYMENT_TRANSACTION",
+                TRANSACTION_ID,
+                " ",
+                1,
+                EVENT_TYPE,
+                TRANSACTION_ID.toString(),
+                DEDUPLICATION_KEY,
+                PAYLOAD,
+                CREATED_AT
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventException.class
+            )
+            .hasMessage(
+                "eventType must not be blank."
+            );
+    }
+
+    @Test
+    void shouldRejectNonPositiveEventVersion() {
+        assertThatThrownBy(() ->
+            OutboxEvent.pending(
+                EVENT_ID,
+                "PAYMENT_TRANSACTION",
+                TRANSACTION_ID,
+                EVENT_TYPE,
+                0,
+                EVENT_TYPE,
+                TRANSACTION_ID.toString(),
+                DEDUPLICATION_KEY,
+                PAYLOAD,
+                CREATED_AT
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventException.class
+            )
+            .hasMessage(
+                "eventVersion must be positive."
+            );
+    }
+
+    @Test
+    void shouldRejectEmptyPayload() {
+        assertThatThrownBy(() ->
+            OutboxEvent.pending(
+                EVENT_ID,
+                "PAYMENT_TRANSACTION",
+                TRANSACTION_ID,
+                EVENT_TYPE,
+                1,
+                EVENT_TYPE,
+                TRANSACTION_ID.toString(),
+                DEDUPLICATION_KEY,
+                "{}",
+                CREATED_AT
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventException.class
+            )
+            .hasMessage(
+                "payload must contain a non-empty JSON object."
+            );
+    }
+
+    @Test
+    void shouldRejectNegativeAttemptCount() {
+        assertThatThrownBy(() ->
+            rehydrate(
+                OutboxStatus.PENDING,
+                -1,
+                CREATED_AT,
+                null,
+                null,
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventException.class
+            )
+            .hasMessage(
+                "attemptCount must not be negative."
+            );
+    }
+
+    @Test
+    void shouldRejectAvailabilityBeforeCreation() {
+        assertThatThrownBy(() ->
+            rehydrate(
+                OutboxStatus.PENDING,
+                0,
+                CREATED_AT.minusSeconds(1),
+                null,
+                null,
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventException.class
+            )
+            .hasMessage(
+                "availableAt must not be before createdAt."
+            );
+    }
+
+    @Test
+    void shouldRejectProcessingWithoutCompleteLock() {
+        assertThatThrownBy(() ->
+            rehydrate(
+                OutboxStatus.PROCESSING,
+                1,
+                CREATED_AT,
+                CREATED_AT.plusSeconds(1),
+                null,
+                "publisher-1",
+                null
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventException.class
+            )
+            .hasMessage(
+                "PROCESSING event must have complete "
+                    + "lock metadata."
+            );
+    }
+
+    @Test
+    void shouldRejectLockMetadataForPendingEvent() {
+        assertThatThrownBy(() ->
+            rehydrate(
+                OutboxStatus.PENDING,
+                0,
+                CREATED_AT,
+                CREATED_AT.plusSeconds(1),
+                CREATED_AT.plusSeconds(31),
+                "publisher-1",
+                null
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventException.class
+            )
+            .hasMessage(
+                "Only PROCESSING events may have "
+                    + "lock metadata."
+            );
+    }
+
+    @Test
+    void shouldRejectPublishedEventWithoutTimestamp() {
+        assertThatThrownBy(() ->
+            rehydrate(
+                OutboxStatus.PUBLISHED,
+                1,
+                CREATED_AT,
+                null,
+                null,
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventException.class
+            )
+            .hasMessage(
+                "PUBLISHED event must have publishedAt."
+            );
+    }
+
+    @Test
+    void shouldRejectPublishedAtForPendingEvent() {
+        assertThatThrownBy(() ->
+            rehydrate(
+                OutboxStatus.PENDING,
+                0,
+                CREATED_AT,
+                null,
+                null,
+                null,
+                CREATED_AT.plusSeconds(1)
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventException.class
+            )
+            .hasMessage(
+                "Only PUBLISHED events may have publishedAt."
+            );
+    }
+
+    private static OutboxEvent pendingEvent() {
+        return OutboxEvent.pending(
+            EVENT_ID,
+            "PAYMENT_TRANSACTION",
+            TRANSACTION_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            TRANSACTION_ID.toString(),
+            DEDUPLICATION_KEY,
+            PAYLOAD,
+            CREATED_AT
+        );
+    }
+
+    private static OutboxEvent rehydrate(
+        OutboxStatus status,
+        int attemptCount,
+        Instant availableAt,
+        Instant lockedAt,
+        Instant lockedUntil,
+        String lockedBy,
+        Instant publishedAt
+    ) {
+        return OutboxEvent.rehydrate(
+            EVENT_ID,
+            "PAYMENT_TRANSACTION",
+            TRANSACTION_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            TRANSACTION_ID.toString(),
+            DEDUPLICATION_KEY,
+            PAYLOAD,
+            status,
+            attemptCount,
+            availableAt,
+            lockedAt,
+            lockedUntil,
+            lockedBy,
+            CREATED_AT,
+            publishedAt,
+            null
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/integration/OutboxPersistenceIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/integration/OutboxPersistenceIntegrationTest.java
@@ -1,0 +1,273 @@
+package com.nursena.payflow.outbox.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.application.port.out.OutboxEventRepositoryPort;
+import com.nursena.payflow.outbox.domain.exception.DuplicateOutboxEventException;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class OutboxPersistenceIntegrationTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID SECOND_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000002"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000001"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-17T19:00:00Z"
+        );
+
+    private static final String EVENT_TYPE =
+        "wallet.transfer.completed";
+
+    private static final String DEDUPLICATION_KEY =
+        EVENT_TYPE + ":1:" + TRANSACTION_ID;
+
+    private static final String PAYLOAD = """
+        {
+          "eventId": "50000000-0000-0000-0000-000000000001",
+          "eventType": "wallet.transfer.completed",
+          "eventVersion": 1,
+          "occurredAt": "2026-07-17T19:00:00Z",
+          "transactionId": "60000000-0000-0000-0000-000000000001",
+          "amount": "125.50",
+          "currency": "TRY"
+        }
+        """;
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private OutboxEventRepositoryPort repositoryPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM outbox_events"
+        );
+    }
+
+    @Test
+    void shouldPersistAndRestorePendingEvent() {
+        OutboxEvent saved =
+            repositoryPort.save(
+                pendingEvent(
+                    EVENT_ID,
+                    DEDUPLICATION_KEY
+                )
+            );
+
+        Optional<OutboxEvent> result =
+            repositoryPort.findById(
+                EVENT_ID
+            );
+
+        assertThat(result)
+            .isPresent();
+
+        OutboxEvent restored =
+            result.orElseThrow();
+
+        assertThat(saved.id())
+            .isEqualTo(EVENT_ID);
+
+        assertThat(restored.id())
+            .isEqualTo(EVENT_ID);
+
+        assertThat(restored.aggregateType())
+            .isEqualTo("PAYMENT_TRANSACTION");
+
+        assertThat(restored.aggregateId())
+            .isEqualTo(TRANSACTION_ID);
+
+        assertThat(restored.eventType())
+            .isEqualTo(EVENT_TYPE);
+
+        assertThat(restored.eventVersion())
+            .isEqualTo(1);
+
+        assertThat(restored.topic())
+            .isEqualTo(EVENT_TYPE);
+
+        assertThat(restored.partitionKey())
+            .isEqualTo(TRANSACTION_ID.toString());
+
+        assertThat(restored.deduplicationKey())
+            .isEqualTo(DEDUPLICATION_KEY);
+
+        assertThat(restored.status())
+            .isEqualTo(OutboxStatus.PENDING);
+
+        assertThat(restored.attemptCount())
+            .isZero();
+
+        assertThat(restored.availableAt())
+            .isEqualTo(CREATED_AT);
+
+        assertThat(restored.createdAt())
+            .isEqualTo(CREATED_AT);
+
+        assertThat(restored.lockedAt())
+            .isNull();
+
+        assertThat(restored.lockedUntil())
+            .isNull();
+
+        assertThat(restored.lockedBy())
+            .isNull();
+
+        assertThat(restored.publishedAt())
+            .isNull();
+
+        assertThat(restored.lastError())
+            .isNull();
+    }
+
+    @Test
+    void shouldPersistPayloadAsJsonObject() {
+        repositoryPort.save(
+            pendingEvent(
+                EVENT_ID,
+                DEDUPLICATION_KEY
+            )
+        );
+
+        String payloadType =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT jsonb_typeof(payload)
+                FROM outbox_events
+                WHERE id = ?
+                """,
+                String.class,
+                EVENT_ID
+            );
+
+        String transactionId =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT payload ->> 'transactionId'
+                FROM outbox_events
+                WHERE id = ?
+                """,
+                String.class,
+                EVENT_ID
+            );
+
+        String amount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT payload ->> 'amount'
+                FROM outbox_events
+                WHERE id = ?
+                """,
+                String.class,
+                EVENT_ID
+            );
+
+        assertThat(payloadType)
+            .isEqualTo("object");
+
+        assertThat(transactionId)
+            .isEqualTo(
+                TRANSACTION_ID.toString()
+            );
+
+        assertThat(amount)
+            .isEqualTo("125.50");
+    }
+
+    @Test
+    void shouldTranslateDuplicateDeduplicationKey() {
+        repositoryPort.save(
+            pendingEvent(
+                EVENT_ID,
+                DEDUPLICATION_KEY
+            )
+        );
+
+        OutboxEvent duplicate =
+            pendingEvent(
+                SECOND_EVENT_ID,
+                DEDUPLICATION_KEY
+            );
+
+        assertThatThrownBy(() ->
+            repositoryPort.save(duplicate)
+        )
+            .isInstanceOf(
+                DuplicateOutboxEventException.class
+            )
+            .hasMessage(
+                "An outbox event already exists "
+                    + "for the same deduplication key."
+            );
+    }
+
+    @Test
+    void shouldReturnEmptyForUnknownEvent() {
+        Optional<OutboxEvent> result =
+            repositoryPort.findById(
+                UUID.fromString(
+                    "ffffffff-ffff-ffff-ffff-ffffffffffff"
+                )
+            );
+
+        assertThat(result)
+            .isEmpty();
+    }
+
+    private static OutboxEvent pendingEvent(
+        UUID eventId,
+        String deduplicationKey
+    ) {
+        return OutboxEvent.pending(
+            eventId,
+            "PAYMENT_TRANSACTION",
+            TRANSACTION_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            TRANSACTION_ID.toString(),
+            deduplicationKey,
+            PAYLOAD,
+            CREATED_AT
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/integration/OutboxSchemaIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/integration/OutboxSchemaIntegrationTest.java
@@ -1,0 +1,384 @@
+package com.nursena.payflow.outbox.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class OutboxSchemaIntegrationTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID SECOND_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000002"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000001"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-17T19:00:00Z"
+        );
+
+    private static final String DEDUPLICATION_KEY =
+        "wallet.transfer.completed:1:" + TRANSACTION_ID;
+
+    private static final String PAYLOAD = """
+        {
+          "eventId": "50000000-0000-0000-0000-000000000001",
+          "eventType": "wallet.transfer.completed",
+          "eventVersion": 1,
+          "occurredAt": "2026-07-17T19:00:00Z",
+          "transactionId": "60000000-0000-0000-0000-000000000001",
+          "sourceWalletId": "70000000-0000-0000-0000-000000000001",
+          "targetWalletId": "70000000-0000-0000-0000-000000000002",
+          "amount": "125.50",
+          "currency": "TRY"
+        }
+        """;
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM outbox_events"
+        );
+    }
+
+    @Test
+    void shouldPersistValidPendingEvent() {
+        insertPendingEvent(
+            EVENT_ID,
+            DEDUPLICATION_KEY
+        );
+
+        Integer count = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM outbox_events
+            WHERE id = ?
+            """,
+            Integer.class,
+            EVENT_ID
+        );
+
+        String status = jdbcTemplate.queryForObject(
+            """
+            SELECT status
+            FROM outbox_events
+            WHERE id = ?
+            """,
+            String.class,
+            EVENT_ID
+        );
+
+        String transactionId = jdbcTemplate.queryForObject(
+            """
+            SELECT payload ->> 'transactionId'
+            FROM outbox_events
+            WHERE id = ?
+            """,
+            String.class,
+            EVENT_ID
+        );
+
+        assertThat(count)
+            .isEqualTo(1);
+
+        assertThat(status)
+            .isEqualTo("PENDING");
+
+        assertThat(transactionId)
+            .isEqualTo(
+                TRANSACTION_ID.toString()
+            );
+    }
+
+    @Test
+    void shouldRejectDuplicateDeduplicationKey() {
+        insertPendingEvent(
+            EVENT_ID,
+            DEDUPLICATION_KEY
+        );
+
+        assertConstraintViolation(
+            () -> insertPendingEvent(
+                SECOND_EVENT_ID,
+                DEDUPLICATION_KEY
+            ),
+            "uq_outbox_events_deduplication_key"
+        );
+    }
+
+    @Test
+    void shouldRejectInvalidEventVersion() {
+        insertPendingEvent(
+            EVENT_ID,
+            DEDUPLICATION_KEY
+        );
+
+        assertConstraintViolation(
+            () -> jdbcTemplate.update(
+                """
+                UPDATE outbox_events
+                SET event_version = 0
+                WHERE id = ?
+                """,
+                EVENT_ID
+            ),
+            "chk_outbox_events_event_version"
+        );
+    }
+
+    @Test
+    void shouldRejectNegativeAttemptCount() {
+        insertPendingEvent(
+            EVENT_ID,
+            DEDUPLICATION_KEY
+        );
+
+        assertConstraintViolation(
+            () -> jdbcTemplate.update(
+                """
+                UPDATE outbox_events
+                SET attempt_count = -1
+                WHERE id = ?
+                """,
+                EVENT_ID
+            ),
+            "chk_outbox_events_attempt_count"
+        );
+    }
+
+    @Test
+    void shouldRejectUnsupportedStatus() {
+        insertPendingEvent(
+            EVENT_ID,
+            DEDUPLICATION_KEY
+        );
+
+        assertConstraintViolation(
+            () -> jdbcTemplate.update(
+                """
+                UPDATE outbox_events
+                SET status = 'UNKNOWN'
+                WHERE id = ?
+                """,
+                EVENT_ID
+            ),
+            "chk_outbox_events_status"
+        );
+    }
+
+    @Test
+    void shouldRejectEmptyPayload() {
+        insertPendingEvent(
+            EVENT_ID,
+            DEDUPLICATION_KEY
+        );
+
+        assertConstraintViolation(
+            () -> jdbcTemplate.update(
+                """
+                UPDATE outbox_events
+                SET payload = '{}'::jsonb
+                WHERE id = ?
+                """,
+                EVENT_ID
+            ),
+            "chk_outbox_events_payload"
+        );
+    }
+
+    @Test
+    void shouldRejectAvailabilityBeforeCreation() {
+        insertPendingEvent(
+            EVENT_ID,
+            DEDUPLICATION_KEY
+        );
+
+        assertConstraintViolation(
+            () -> jdbcTemplate.update(
+                """
+                UPDATE outbox_events
+                SET available_at = ?
+                WHERE id = ?
+                """,
+                Timestamp.from(
+                    CREATED_AT.minusSeconds(1)
+                ),
+                EVENT_ID
+            ),
+            "chk_outbox_events_availability"
+        );
+    }
+
+    @Test
+    void shouldRequireLeaseForProcessingEvent() {
+        insertPendingEvent(
+            EVENT_ID,
+            DEDUPLICATION_KEY
+        );
+
+        assertConstraintViolation(
+            () -> jdbcTemplate.update(
+                """
+                UPDATE outbox_events
+                SET status = 'PROCESSING'
+                WHERE id = ?
+                """,
+                EVENT_ID
+            ),
+            "chk_outbox_events_processing_lock"
+        );
+    }
+
+    @Test
+    void shouldRequirePublishedAtForPublishedEvent() {
+        insertPendingEvent(
+            EVENT_ID,
+            DEDUPLICATION_KEY
+        );
+
+        assertConstraintViolation(
+            () -> jdbcTemplate.update(
+                """
+                UPDATE outbox_events
+                SET status = 'PUBLISHED'
+                WHERE id = ?
+                """,
+                EVENT_ID
+            ),
+            "chk_outbox_events_publication"
+        );
+    }
+
+    private void insertPendingEvent(
+        UUID eventId,
+        String deduplicationKey
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO outbox_events (
+                id,
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                event_version,
+                topic,
+                partition_key,
+                deduplication_key,
+                payload,
+                status,
+                attempt_count,
+                available_at,
+                locked_at,
+                locked_until,
+                locked_by,
+                created_at,
+                published_at,
+                last_error
+            )
+            VALUES (
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                CAST(? AS JSONB),
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?
+            )
+            """,
+            eventId,
+            "PAYMENT_TRANSACTION",
+            TRANSACTION_ID,
+            "wallet.transfer.completed",
+            1,
+            "wallet.transfer.completed",
+            TRANSACTION_ID.toString(),
+            deduplicationKey,
+            PAYLOAD,
+            "PENDING",
+            0,
+            Timestamp.from(CREATED_AT),
+            null,
+            null,
+            null,
+            Timestamp.from(CREATED_AT),
+            null,
+            null
+        );
+    }
+
+    private static void assertConstraintViolation(
+        ThrowingCallable operation,
+        String constraintName
+    ) {
+        Throwable thrown = catchThrowable(
+            operation
+        );
+
+        assertThat(thrown)
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+
+        assertThat(rootCause(thrown).getMessage())
+            .contains(constraintName);
+    }
+
+    private static Throwable rootCause(
+        Throwable throwable
+    ) {
+        Throwable current = throwable;
+
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+
+        return current;
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the PostgreSQL persistence foundation for the transactional
outbox pattern documented in ADR 0004.

## Changes

- add the V5 Flyway migration for `outbox_events`
- add database constraints for:
  - supported outbox statuses
  - positive event versions
  - non-negative attempt counts
  - valid JSON object payloads
  - processing lease consistency
  - publication timestamp consistency
  - deduplication-key uniqueness
- add partial indexes for pending events and expired processing leases
- add the `OutboxEvent` domain model and `OutboxStatus`
- add domain validation for outbox state invariants
- add `OutboxEventRepositoryPort`
- add the JPA entity, Spring Data repository and persistence adapter
- map PostgreSQL duplicate-key violations to
  `DuplicateOutboxEventException`
- persist payloads as PostgreSQL `JSONB`

## Testing

- domain unit tests
- persistence adapter unit tests
- PostgreSQL schema constraint tests with Testcontainers
- PostgreSQL persistence round-trip tests
- JSONB object mapping verification
- duplicate deduplication-key translation verification
- full Maven verification:

```text
./mvnw clean verify