### PR TITLE
feat: integrate completed transfers with transactional outbox

### DIFF
--- a/src/main/java/com/nursena/payflow/transaction/adapter/out/outbox/TransferCompletedEventSerializationException.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/out/outbox/TransferCompletedEventSerializationException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.transaction.adapter.out.outbox;
+
+public final class TransferCompletedEventSerializationException
+    extends RuntimeException {
+
+    public TransferCompletedEventSerializationException(
+        Throwable cause
+    ) {
+        super(
+            "Transfer completed event could not be serialized.",
+            cause
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/out/outbox/TransferCompletedOutboxAdapter.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/out/outbox/TransferCompletedOutboxAdapter.java
@@ -1,0 +1,91 @@
+package com.nursena.payflow.transaction.adapter.out.outbox;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.outbox.application.port.out.OutboxEventRepositoryPort;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import com.nursena.payflow.transaction.application.port.out.TransferCompletedEventRecorderPort;
+import org.springframework.stereotype.Component;
+
+@Component
+class TransferCompletedOutboxAdapter
+    implements TransferCompletedEventRecorderPort {
+
+    private static final String AGGREGATE_TYPE =
+        "PAYMENT_TRANSACTION";
+
+    private static final String TOPIC =
+        TransferCompletedEvent.TYPE;
+
+    private final OutboxEventRepositoryPort
+        outboxEventRepository;
+
+    private final ObjectMapper objectMapper;
+
+    TransferCompletedOutboxAdapter(
+        OutboxEventRepositoryPort outboxEventRepository,
+        ObjectMapper objectMapper
+    ) {
+        this.outboxEventRepository =
+            outboxEventRepository;
+
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void record(
+        TransferCompletedEvent event
+    ) {
+        Objects.requireNonNull(
+            event,
+            "event must not be null"
+        );
+
+        OutboxEvent outboxEvent =
+            OutboxEvent.pending(
+                event.eventId(),
+                AGGREGATE_TYPE,
+                event.transactionId(),
+                event.eventType(),
+                event.eventVersion(),
+                TOPIC,
+                event.transactionId().toString(),
+                deduplicationKey(event),
+                serialize(event),
+                event.occurredAt()
+            );
+
+        outboxEventRepository.save(
+            outboxEvent
+        );
+    }
+
+    private String serialize(
+        TransferCompletedEvent event
+    ) {
+        try {
+            return objectMapper
+                .writeValueAsString(event);
+        } catch (
+            JsonProcessingException exception
+        ) {
+            throw new
+                TransferCompletedEventSerializationException(
+                exception
+            );
+        }
+    }
+
+    private static String deduplicationKey(
+        TransferCompletedEvent event
+    ) {
+        return event.eventType()
+            + ":"
+            + event.eventVersion()
+            + ":"
+            + event.transactionId();
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/model/TransferCompletedEvent.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/model/TransferCompletedEvent.java
@@ -1,0 +1,122 @@
+package com.nursena.payflow.transaction.application.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.domain.model.PaymentTransaction;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+
+public record TransferCompletedEvent(
+    UUID eventId,
+    String eventType,
+    int eventVersion,
+    Instant occurredAt,
+    UUID transactionId,
+    UUID sourceWalletId,
+    UUID targetWalletId,
+    String amount,
+    String currency
+) {
+
+    public static final String TYPE =
+        "wallet.transfer.completed";
+
+    public static final int VERSION = 1;
+
+    public TransferCompletedEvent {
+        Objects.requireNonNull(
+            eventId,
+            "eventId must not be null"
+        );
+
+        Objects.requireNonNull(
+            occurredAt,
+            "occurredAt must not be null"
+        );
+
+        Objects.requireNonNull(
+            transactionId,
+            "transactionId must not be null"
+        );
+
+        Objects.requireNonNull(
+            sourceWalletId,
+            "sourceWalletId must not be null"
+        );
+
+        Objects.requireNonNull(
+            targetWalletId,
+            "targetWalletId must not be null"
+        );
+
+        if (!TYPE.equals(eventType)) {
+            throw new IllegalArgumentException(
+                "eventType must be "
+                    + TYPE
+                    + "."
+            );
+        }
+
+        if (eventVersion != VERSION) {
+            throw new IllegalArgumentException(
+                "eventVersion must be "
+                    + VERSION
+                    + "."
+            );
+        }
+
+        if (amount == null || amount.isBlank()) {
+            throw new IllegalArgumentException(
+                "amount must not be blank."
+            );
+        }
+
+        if (currency == null || currency.isBlank()) {
+            throw new IllegalArgumentException(
+                "currency must not be blank."
+            );
+        }
+    }
+
+    public static TransferCompletedEvent from(
+        PaymentTransaction transaction
+    ) {
+        Objects.requireNonNull(
+            transaction,
+            "transaction must not be null"
+        );
+
+        if (transaction.status()
+            != TransactionStatus.COMPLETED) {
+
+            throw new IllegalArgumentException(
+                "transaction must be completed."
+            );
+        }
+
+        if (transaction.completedAt() == null) {
+            throw new IllegalArgumentException(
+                "completed transaction must have completedAt."
+            );
+        }
+
+        return new TransferCompletedEvent(
+            UUID.randomUUID(),
+            TYPE,
+            VERSION,
+            transaction.completedAt(),
+            transaction.id(),
+            transaction.sourceWalletId(),
+            transaction.targetWalletId(),
+            transaction
+                .amount()
+                .amount()
+                .toPlainString(),
+            transaction
+                .amount()
+                .currency()
+                .name()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/port/out/TransferCompletedEventRecorderPort.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/port/out/TransferCompletedEventRecorderPort.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.transaction.application.port.out;
+
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+
+public interface TransferCompletedEventRecorderPort {
+
+    void record(
+        TransferCompletedEvent event
+    );
+}

--- a/src/main/java/com/nursena/payflow/transaction/application/service/TransferMoneyService.java
+++ b/src/main/java/com/nursena/payflow/transaction/application/service/TransferMoneyService.java
@@ -23,11 +23,15 @@ import com.nursena.payflow.wallet.domain.model.Money;
 import com.nursena.payflow.wallet.domain.model.Wallet;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import com.nursena.payflow.transaction.application.port.out.TransferCompletedEventRecorderPort;
 
 @Service
 public class TransferMoneyService
     implements TransferMoneyUseCase {
 
+    private final TransferCompletedEventRecorderPort
+        completedEventRecorder;
     private final WalletRepositoryPort walletRepository;
     private final PaymentTransactionRepositoryPort
         transactionRepository;
@@ -38,11 +42,14 @@ public class TransferMoneyService
         WalletRepositoryPort walletRepository,
         PaymentTransactionRepositoryPort transactionRepository,
         LedgerRepositoryPort ledgerRepository,
+        TransferCompletedEventRecorderPort completedEventRecorder,
         Clock clock
     ) {
         this.walletRepository = walletRepository;
         this.transactionRepository = transactionRepository;
         this.ledgerRepository = ledgerRepository;
+        this.completedEventRecorder =
+            completedEventRecorder;
         this.clock = clock;
     }
 
@@ -133,6 +140,12 @@ public class TransferMoneyService
             transactionRepository.update(
                 savedTransaction
             );
+
+        completedEventRecorder.record(
+            TransferCompletedEvent.from(
+                completedTransaction
+            )
+        );
 
         return TransferMoneyResult.from(
             completedTransaction

--- a/src/test/java/com/nursena/payflow/transaction/adapter/out/outbox/TransferCompletedOutboxAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/adapter/out/outbox/TransferCompletedOutboxAdapterTest.java
@@ -1,0 +1,272 @@
+package com.nursena.payflow.transaction.adapter.out.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.nursena.payflow.outbox.application.port.out.OutboxEventRepositoryPort;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TransferCompletedOutboxAdapterTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID SOURCE_WALLET_ID =
+        UUID.fromString(
+            "70000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID TARGET_WALLET_ID =
+        UUID.fromString(
+            "70000000-0000-0000-0000-000000000002"
+        );
+
+    private static final Instant OCCURRED_AT =
+        Instant.parse(
+            "2026-07-17T19:00:00Z"
+        );
+
+    @Mock
+    private OutboxEventRepositoryPort
+        outboxEventRepository;
+
+    private ObjectMapper objectMapper;
+
+    private TransferCompletedOutboxAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper =
+            JsonMapper.builder()
+                .addModule(
+                    new JavaTimeModule()
+                )
+                .disable(
+                    SerializationFeature
+                        .WRITE_DATES_AS_TIMESTAMPS
+                )
+                .build();
+
+        adapter =
+            new TransferCompletedOutboxAdapter(
+                outboxEventRepository,
+                objectMapper
+            );
+    }
+
+    @Test
+    void shouldConvertAndRecordTransferEvent()
+        throws Exception {
+
+        when(outboxEventRepository.save(
+            any(OutboxEvent.class)
+        )).thenAnswer(invocation ->
+            invocation.getArgument(0)
+        );
+
+        adapter.record(event());
+
+        ArgumentCaptor<OutboxEvent> captor =
+            ArgumentCaptor.forClass(
+                OutboxEvent.class
+            );
+
+        verify(outboxEventRepository)
+            .save(captor.capture());
+
+        OutboxEvent outboxEvent =
+            captor.getValue();
+
+        assertThat(outboxEvent.id())
+            .isEqualTo(EVENT_ID);
+
+        assertThat(outboxEvent.aggregateType())
+            .isEqualTo(
+                "PAYMENT_TRANSACTION"
+            );
+
+        assertThat(outboxEvent.aggregateId())
+            .isEqualTo(TRANSACTION_ID);
+
+        assertThat(outboxEvent.eventType())
+            .isEqualTo(
+                TransferCompletedEvent.TYPE
+            );
+
+        assertThat(outboxEvent.eventVersion())
+            .isEqualTo(
+                TransferCompletedEvent.VERSION
+            );
+
+        assertThat(outboxEvent.topic())
+            .isEqualTo(
+                "wallet.transfer.completed"
+            );
+
+        assertThat(outboxEvent.partitionKey())
+            .isEqualTo(
+                TRANSACTION_ID.toString()
+            );
+
+        assertThat(
+            outboxEvent.deduplicationKey()
+        ).isEqualTo(
+            "wallet.transfer.completed:1:"
+                + TRANSACTION_ID
+        );
+
+        assertThat(outboxEvent.status())
+            .isEqualTo(OutboxStatus.PENDING);
+
+        assertThat(outboxEvent.attemptCount())
+            .isZero();
+
+        assertThat(outboxEvent.availableAt())
+            .isEqualTo(OCCURRED_AT);
+
+        assertThat(outboxEvent.createdAt())
+            .isEqualTo(OCCURRED_AT);
+
+        JsonNode payload =
+            objectMapper.readTree(
+                outboxEvent.payload()
+            );
+
+        assertThat(payload.size())
+            .isEqualTo(9);
+
+        assertThat(
+            payload.get("eventId").asText()
+        ).isEqualTo(
+            EVENT_ID.toString()
+        );
+
+        assertThat(
+            payload.get("eventType").asText()
+        ).isEqualTo(
+            "wallet.transfer.completed"
+        );
+
+        assertThat(
+            payload.get("eventVersion").asInt()
+        ).isEqualTo(1);
+
+        assertThat(
+            payload.get("occurredAt").asText()
+        ).isEqualTo(
+            "2026-07-17T19:00:00Z"
+        );
+
+        assertThat(
+            payload.get("transactionId").asText()
+        ).isEqualTo(
+            TRANSACTION_ID.toString()
+        );
+
+        assertThat(
+            payload.get("sourceWalletId").asText()
+        ).isEqualTo(
+            SOURCE_WALLET_ID.toString()
+        );
+
+        assertThat(
+            payload.get("targetWalletId").asText()
+        ).isEqualTo(
+            TARGET_WALLET_ID.toString()
+        );
+
+        assertThat(payload.get("amount").asText())
+            .isEqualTo("125.50");
+
+        assertThat(
+            payload.get("currency").asText()
+        ).isEqualTo("TRY");
+
+        assertThat(payload.has("idempotencyKey"))
+            .isFalse();
+    }
+
+    @Test
+    void shouldFailBeforePersistenceWhenSerializationFails()
+        throws Exception {
+
+        ObjectMapper failingObjectMapper =
+            mock(ObjectMapper.class);
+
+        JsonProcessingException failure =
+            new JsonProcessingException(
+                "Simulated serialization failure."
+            ) {
+            };
+
+        when(failingObjectMapper.writeValueAsString(
+            any()
+        )).thenThrow(failure);
+
+        TransferCompletedOutboxAdapter
+            failingAdapter =
+            new TransferCompletedOutboxAdapter(
+                outboxEventRepository,
+                failingObjectMapper
+            );
+
+        assertThatThrownBy(() ->
+            failingAdapter.record(event())
+        )
+            .isInstanceOf(
+                TransferCompletedEventSerializationException.class
+            )
+            .hasMessage(
+                "Transfer completed event "
+                    + "could not be serialized."
+            )
+            .hasCause(failure);
+
+        verify(outboxEventRepository, never())
+            .save(any(OutboxEvent.class));
+    }
+
+    private static TransferCompletedEvent event() {
+        return new TransferCompletedEvent(
+            EVENT_ID,
+            TransferCompletedEvent.TYPE,
+            TransferCompletedEvent.VERSION,
+            OCCURRED_AT,
+            TRANSACTION_ID,
+            SOURCE_WALLET_ID,
+            TARGET_WALLET_ID,
+            "125.50",
+            "TRY"
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/application/model/TransferCompletedEventTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/application/model/TransferCompletedEventTest.java
@@ -1,0 +1,261 @@
+package com.nursena.payflow.transaction.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.nursena.payflow.transaction.domain.model.IdempotencyKey;
+import com.nursena.payflow.transaction.domain.model.PaymentTransaction;
+import com.nursena.payflow.transaction.domain.model.TransactionStatus;
+import com.nursena.payflow.transaction.domain.model.TransactionType;
+import com.nursena.payflow.wallet.domain.model.Currency;
+import com.nursena.payflow.wallet.domain.model.Money;
+import org.junit.jupiter.api.Test;
+
+class TransferCompletedEventTest {
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID SOURCE_WALLET_ID =
+        UUID.fromString(
+            "70000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID TARGET_WALLET_ID =
+        UUID.fromString(
+            "70000000-0000-0000-0000-000000000002"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-17T18:59:59Z"
+        );
+
+    private static final Instant COMPLETED_AT =
+        Instant.parse(
+            "2026-07-17T19:00:00Z"
+        );
+
+    private static final ObjectMapper OBJECT_MAPPER =
+        JsonMapper.builder()
+            .addModule(new JavaTimeModule())
+            .disable(
+                SerializationFeature
+                    .WRITE_DATES_AS_TIMESTAMPS
+            )
+            .build();
+
+    @Test
+    void shouldCreateEventFromCompletedTransfer() {
+        TransferCompletedEvent event =
+            TransferCompletedEvent.from(
+                completedTransaction()
+            );
+
+        assertThat(event.eventId())
+            .isNotNull();
+
+        assertThat(event.eventType())
+            .isEqualTo(
+                "wallet.transfer.completed"
+            );
+
+        assertThat(event.eventVersion())
+            .isEqualTo(1);
+
+        assertThat(event.occurredAt())
+            .isEqualTo(COMPLETED_AT);
+
+        assertThat(event.transactionId())
+            .isEqualTo(TRANSACTION_ID);
+
+        assertThat(event.sourceWalletId())
+            .isEqualTo(SOURCE_WALLET_ID);
+
+        assertThat(event.targetWalletId())
+            .isEqualTo(TARGET_WALLET_ID);
+
+        assertThat(event.amount())
+            .isEqualTo("125.50");
+
+        assertThat(event.currency())
+            .isEqualTo("TRY");
+    }
+
+    @Test
+    void shouldSerializeStablePublicContract()
+        throws Exception {
+
+        TransferCompletedEvent event =
+            TransferCompletedEvent.from(
+                completedTransaction()
+            );
+
+        JsonNode payload =
+            OBJECT_MAPPER.readTree(
+                OBJECT_MAPPER.writeValueAsString(
+                    event
+                )
+            );
+
+        assertThat(payload.size())
+            .isEqualTo(9);
+
+        assertThat(payload.get("eventId").isTextual())
+            .isTrue();
+
+        assertThat(
+            UUID.fromString(
+                payload.get("eventId").asText()
+            )
+        ).isEqualTo(event.eventId());
+
+        assertThat(
+            payload.get("eventType").asText()
+        ).isEqualTo(
+            "wallet.transfer.completed"
+        );
+
+        assertThat(
+            payload.get("eventVersion").asInt()
+        ).isEqualTo(1);
+
+        assertThat(
+            payload.get("occurredAt").asText()
+        ).isEqualTo(
+            "2026-07-17T19:00:00Z"
+        );
+
+        assertThat(
+            payload.get("transactionId").asText()
+        ).isEqualTo(
+            TRANSACTION_ID.toString()
+        );
+
+        assertThat(
+            payload.get("sourceWalletId").asText()
+        ).isEqualTo(
+            SOURCE_WALLET_ID.toString()
+        );
+
+        assertThat(
+            payload.get("targetWalletId").asText()
+        ).isEqualTo(
+            TARGET_WALLET_ID.toString()
+        );
+
+        assertThat(payload.get("amount").isTextual())
+            .isTrue();
+
+        assertThat(payload.get("amount").asText())
+            .isEqualTo("125.50");
+
+        assertThat(payload.get("currency").isTextual())
+            .isTrue();
+
+        assertThat(payload.get("currency").asText())
+            .isEqualTo("TRY");
+
+        assertThat(payload.has("idempotencyKey"))
+            .isFalse();
+
+        assertThat(payload.has("password"))
+            .isFalse();
+
+        assertThat(payload.has("ownerId"))
+            .isFalse();
+    }
+
+    @Test
+    void shouldRejectTransactionThatIsNotCompleted() {
+        PaymentTransaction pending =
+            PaymentTransaction.rehydrate(
+                TRANSACTION_ID,
+                SOURCE_WALLET_ID,
+                TARGET_WALLET_ID,
+                Money.of(
+                    "125.50",
+                    Currency.TRY
+                ),
+                new IdempotencyKey(
+                    "request-1"
+                ),
+                TransactionType.TRANSFER,
+                TransactionStatus.PENDING,
+                CREATED_AT,
+                null
+            );
+
+        assertThatThrownBy(() ->
+            TransferCompletedEvent.from(pending)
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "transaction must be completed."
+            );
+    }
+
+    @Test
+    void shouldRejectCompletedTransactionWithoutTimestamp() {
+        PaymentTransaction invalid =
+            PaymentTransaction.rehydrate(
+                TRANSACTION_ID,
+                SOURCE_WALLET_ID,
+                TARGET_WALLET_ID,
+                Money.of(
+                    "125.50",
+                    Currency.TRY
+                ),
+                new IdempotencyKey(
+                    "request-1"
+                ),
+                TransactionType.TRANSFER,
+                TransactionStatus.COMPLETED,
+                CREATED_AT,
+                null
+            );
+
+        assertThatThrownBy(() ->
+            TransferCompletedEvent.from(invalid)
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "completed transaction must have completedAt."
+            );
+    }
+
+    private static PaymentTransaction
+    completedTransaction() {
+
+        return PaymentTransaction.rehydrate(
+            TRANSACTION_ID,
+            SOURCE_WALLET_ID,
+            TARGET_WALLET_ID,
+            Money.of(
+                "125.50",
+                Currency.TRY
+            ),
+            new IdempotencyKey(
+                "request-1"
+            ),
+            TransactionType.TRANSFER,
+            TransactionStatus.COMPLETED,
+            CREATED_AT,
+            COMPLETED_AT
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/transaction/application/service/TransferMoneyServiceTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/application/service/TransferMoneyServiceTest.java
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import com.nursena.payflow.transaction.application.port.out.TransferCompletedEventRecorderPort;
 
 @ExtendWith(MockitoExtension.class)
 class TransferMoneyServiceTest {
@@ -85,6 +87,10 @@ class TransferMoneyServiceTest {
     @Mock
     private LedgerRepositoryPort ledgerRepository;
 
+    @Mock
+    private TransferCompletedEventRecorderPort
+        completedEventRecorder;
+
     private TransferMoneyService service;
 
     @BeforeEach
@@ -93,6 +99,7 @@ class TransferMoneyServiceTest {
             walletRepository,
             transactionRepository,
             ledgerRepository,
+            completedEventRecorder,
             Clock.fixed(NOW, ZoneOffset.UTC)
         );
     }
@@ -200,6 +207,49 @@ class TransferMoneyServiceTest {
 
         verify(walletRepository).update(sourceWallet);
         verify(walletRepository).update(targetWallet);
+
+        ArgumentCaptor<TransferCompletedEvent>
+            eventCaptor =
+            ArgumentCaptor.forClass(
+                TransferCompletedEvent.class
+            );
+
+        verify(completedEventRecorder)
+            .record(eventCaptor.capture());
+
+        TransferCompletedEvent event =
+            eventCaptor.getValue();
+
+        assertThat(event.eventId())
+            .isNotNull();
+
+        assertThat(event.eventType())
+            .isEqualTo(
+                TransferCompletedEvent.TYPE
+            );
+
+        assertThat(event.eventVersion())
+            .isEqualTo(
+                TransferCompletedEvent.VERSION
+            );
+
+        assertThat(event.occurredAt())
+            .isEqualTo(NOW);
+
+        assertThat(event.transactionId())
+            .isEqualTo(result.transactionId());
+
+        assertThat(event.sourceWalletId())
+            .isEqualTo(SOURCE_WALLET_ID);
+
+        assertThat(event.targetWalletId())
+            .isEqualTo(TARGET_WALLET_ID);
+
+        assertThat(event.amount())
+            .isEqualTo("125.50");
+
+        assertThat(event.currency())
+            .isEqualTo("TRY");
     }
 
     @Test
@@ -309,6 +359,10 @@ class TransferMoneyServiceTest {
 
         verify(transactionRepository, never())
             .update(any(PaymentTransaction.class));
+        verify(completedEventRecorder, never())
+            .record(
+                any(TransferCompletedEvent.class)
+            );
     }
 
     private static TransferMoneyCommand command(
@@ -468,6 +522,7 @@ class TransferMoneyServiceTest {
                 walletRepository,
                 transactionRepository,
                 ledgerRepository,
+                completedEventRecorder,
                 Clock.fixed(
                     NANOSECOND_TIME,
                     ZoneOffset.UTC

--- a/src/test/java/com/nursena/payflow/transaction/integration/TransferIdempotencyConcurrencyIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/integration/TransferIdempotencyConcurrencyIntegrationTest.java
@@ -360,8 +360,90 @@ class TransferIdempotencyConcurrencyIntegrationTest {
                 TRANSFER_AMOUNT
             );
 
+        Long outboxEventCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM outbox_events
+                WHERE aggregate_type = 'PAYMENT_TRANSACTION'
+                  AND aggregate_id = ?
+                  AND event_type = 'wallet.transfer.completed'
+                  AND event_version = 1
+                """,
+                Long.class,
+                transactionId
+            );
+
+        assertThat(outboxEventCount)
+            .isEqualTo(1L);
+
+        String outboxStatus =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT status
+                FROM outbox_events
+                WHERE aggregate_id = ?
+                """,
+                String.class,
+                transactionId
+            );
+
+        assertThat(outboxStatus)
+            .isEqualTo("PENDING");
+
+        String partitionKey =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT partition_key
+                FROM outbox_events
+                WHERE aggregate_id = ?
+                """,
+                String.class,
+                transactionId
+            );
+
+        assertThat(partitionKey)
+            .isEqualTo(
+                transactionId.toString()
+            );
+
+        String deduplicationKey =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT deduplication_key
+                FROM outbox_events
+                WHERE aggregate_id = ?
+                """,
+                String.class,
+                transactionId
+            );
+
+        assertThat(deduplicationKey)
+            .isEqualTo(
+                "wallet.transfer.completed:1:"
+                    + transactionId
+            );
+
+        String payloadTransactionId =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT payload ->> 'transactionId'
+                FROM outbox_events
+                WHERE aggregate_id = ?
+                """,
+                String.class,
+                transactionId
+            );
+
+        assertThat(payloadTransactionId)
+            .isEqualTo(
+                transactionId.toString()
+            );
+
         assertThat(creditCount)
             .isEqualTo(1L);
+
+
     }
 
     private BigDecimal walletBalance(

--- a/src/test/java/com/nursena/payflow/transaction/integration/TransferMoneyIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/integration/TransferMoneyIntegrationTest.java
@@ -195,7 +195,7 @@ class TransferMoneyIntegrationTest {
         UUID transactionId,
         UUID sourceWalletId,
         UUID targetWalletId
-    ) {
+    ) throws Exception {
         assertThat(walletBalance(sourceWalletId))
             .isEqualByComparingTo(
                 EXPECTED_SOURCE_BALANCE
@@ -249,7 +249,11 @@ class TransferMoneyIntegrationTest {
 
         assertThat(hasCompletionTimestamp)
             .isTrue();
-
+        assertOutboxEvent(
+            transactionId,
+            sourceWalletId,
+            targetWalletId
+        );
         Long ledgerEntryCount =
             jdbcTemplate.queryForObject(
                 """
@@ -500,6 +504,172 @@ class TransferMoneyIntegrationTest {
 
     private record TopUpRequest(
         BigDecimal amount
+    ) {
+    }
+    private void assertOutboxEvent(
+        UUID transactionId,
+        UUID sourceWalletId,
+        UUID targetWalletId
+    ) throws Exception {
+
+        Long outboxCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM outbox_events
+                WHERE aggregate_type = 'PAYMENT_TRANSACTION'
+                  AND aggregate_id = ?
+                  AND event_type = 'wallet.transfer.completed'
+                  AND event_version = 1
+                """,
+                Long.class,
+                transactionId
+            );
+
+        assertThat(outboxCount)
+            .isEqualTo(1L);
+
+        OutboxMetadata metadata =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT
+                    outbox.id::text AS outbox_id,
+                    outbox.topic,
+                    outbox.partition_key,
+                    outbox.deduplication_key,
+                    outbox.status,
+                    outbox.payload::text AS payload,
+                    (
+                        (
+                            outbox.payload
+                                ->> 'occurredAt'
+                        )::timestamptz
+                        = payment.completed_at
+                    ) AS occurred_at_matches
+                FROM outbox_events outbox
+                JOIN payment_transactions payment
+                  ON payment.id = outbox.aggregate_id
+                WHERE outbox.aggregate_id = ?
+                """,
+                (resultSet, rowNumber) ->
+                    new OutboxMetadata(
+                        resultSet.getString(
+                            "outbox_id"
+                        ),
+                        resultSet.getString(
+                            "topic"
+                        ),
+                        resultSet.getString(
+                            "partition_key"
+                        ),
+                        resultSet.getString(
+                            "deduplication_key"
+                        ),
+                        resultSet.getString(
+                            "status"
+                        ),
+                        resultSet.getString(
+                            "payload"
+                        ),
+                        resultSet.getBoolean(
+                            "occurred_at_matches"
+                        )
+                    ),
+                transactionId
+            );
+
+        assertThat(metadata)
+            .isNotNull();
+
+        assertThat(metadata.topic())
+            .isEqualTo(
+                "wallet.transfer.completed"
+            );
+
+        assertThat(metadata.partitionKey())
+            .isEqualTo(
+                transactionId.toString()
+            );
+
+        assertThat(metadata.deduplicationKey())
+            .isEqualTo(
+                "wallet.transfer.completed:1:"
+                    + transactionId
+            );
+
+        assertThat(metadata.status())
+            .isEqualTo("PENDING");
+
+        assertThat(metadata.occurredAtMatches())
+            .isTrue();
+
+        JsonNode payload =
+            objectMapper.readTree(
+                metadata.payload()
+            );
+
+        assertThat(payload.size())
+            .isEqualTo(9);
+
+        assertThat(
+            payload.get("eventId").asText()
+        ).isEqualTo(
+            metadata.outboxId()
+        );
+
+        assertThat(
+            payload.get("eventType").asText()
+        ).isEqualTo(
+            "wallet.transfer.completed"
+        );
+
+        assertThat(
+            payload.get("eventVersion").asInt()
+        ).isEqualTo(1);
+
+        assertThat(
+            payload.get("transactionId").asText()
+        ).isEqualTo(
+            transactionId.toString()
+        );
+
+        assertThat(
+            payload.get("sourceWalletId").asText()
+        ).isEqualTo(
+            sourceWalletId.toString()
+        );
+
+        assertThat(
+            payload.get("targetWalletId").asText()
+        ).isEqualTo(
+            targetWalletId.toString()
+        );
+
+        assertThat(
+            payload.get("amount").isTextual()
+        ).isTrue();
+
+        assertThat(
+            payload.get("amount").asText()
+        ).isEqualTo("125.50");
+
+        assertThat(
+            payload.get("currency").asText()
+        ).isEqualTo("TRY");
+
+        assertThat(
+            payload.has("idempotencyKey")
+        ).isFalse();
+    }
+
+    private record OutboxMetadata(
+        String outboxId,
+        String topic,
+        String partitionKey,
+        String deduplicationKey,
+        String status,
+        String payload,
+        boolean occurredAtMatches
     ) {
     }
 }

--- a/src/test/java/com/nursena/payflow/transaction/integration/TransferOutboxRollbackIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/integration/TransferOutboxRollbackIntegrationTest.java
@@ -1,0 +1,358 @@
+package com.nursena.payflow.transaction.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.application.port.out.OutboxEventRepositoryPort;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyCommand;
+import com.nursena.payflow.transaction.application.port.in.TransferMoneyUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class TransferOutboxRollbackIntegrationTest {
+
+    private static final UUID SOURCE_OWNER_ID =
+        UUID.fromString(
+            "81000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID TARGET_OWNER_ID =
+        UUID.fromString(
+            "81000000-0000-0000-0000-000000000002"
+        );
+
+    private static final UUID SOURCE_WALLET_ID =
+        UUID.fromString(
+            "82000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID TARGET_WALLET_ID =
+        UUID.fromString(
+            "82000000-0000-0000-0000-000000000002"
+        );
+
+    private static final BigDecimal
+        INITIAL_SOURCE_BALANCE =
+        new BigDecimal("300.00");
+
+    private static final BigDecimal TRANSFER_AMOUNT =
+        new BigDecimal("125.50");
+
+    private static final String IDEMPOTENCY_KEY =
+        "outbox-rollback-request-1";
+
+    private static final Instant BASE_TIME =
+        Instant.parse(
+            "2026-07-18T10:00:00Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private TransferMoneyUseCase transferMoneyUseCase;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private OutboxEventRepositoryPort
+        outboxEventRepository;
+
+    @BeforeEach
+    void setUpDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM outbox_events"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM ledger_entries"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM payment_transactions"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM wallets"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+
+        insertUser(
+            SOURCE_OWNER_ID,
+            "outbox-rollback-source@example.com"
+        );
+
+        insertUser(
+            TARGET_OWNER_ID,
+            "outbox-rollback-target@example.com"
+        );
+
+        insertWallet(
+            SOURCE_WALLET_ID,
+            SOURCE_OWNER_ID,
+            INITIAL_SOURCE_BALANCE,
+            1L
+        );
+
+        insertWallet(
+            TARGET_WALLET_ID,
+            TARGET_OWNER_ID,
+            BigDecimal.ZERO,
+            0L
+        );
+    }
+
+    @Test
+    void shouldRollbackEntireTransferWhenOutboxPersistenceFails() {
+        when(outboxEventRepository.save(
+            any(OutboxEvent.class)
+        )).thenThrow(
+            new IllegalStateException(
+                "Simulated outbox persistence failure."
+            )
+        );
+
+        TransferMoneyCommand command =
+            new TransferMoneyCommand(
+                SOURCE_OWNER_ID,
+                TARGET_WALLET_ID,
+                TRANSFER_AMOUNT,
+                IDEMPOTENCY_KEY
+            );
+
+        assertThatThrownBy(() ->
+            transferMoneyUseCase.transfer(command)
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "Simulated outbox persistence failure."
+            );
+
+        ArgumentCaptor<OutboxEvent> eventCaptor =
+            ArgumentCaptor.forClass(
+                OutboxEvent.class
+            );
+
+        verify(outboxEventRepository)
+            .save(eventCaptor.capture());
+
+        OutboxEvent attemptedEvent =
+            eventCaptor.getValue();
+
+        assertThat(attemptedEvent.aggregateType())
+            .isEqualTo(
+                "PAYMENT_TRANSACTION"
+            );
+
+        assertThat(attemptedEvent.eventType())
+            .isEqualTo(
+                TransferCompletedEvent.TYPE
+            );
+
+        assertThat(attemptedEvent.eventVersion())
+            .isEqualTo(
+                TransferCompletedEvent.VERSION
+            );
+
+        assertThat(attemptedEvent.status())
+            .isEqualTo(
+                OutboxStatus.PENDING
+            );
+
+        assertThat(
+            attemptedEvent.partitionKey()
+        ).isEqualTo(
+            attemptedEvent
+                .aggregateId()
+                .toString()
+        );
+
+        assertThat(
+            attemptedEvent.deduplicationKey()
+        ).isEqualTo(
+            "wallet.transfer.completed:1:"
+                + attemptedEvent.aggregateId()
+        );
+
+        assertThat(
+            walletBalance(SOURCE_WALLET_ID)
+        ).isEqualByComparingTo(
+            INITIAL_SOURCE_BALANCE
+        );
+
+        assertThat(
+            walletBalance(TARGET_WALLET_ID)
+        ).isEqualByComparingTo(
+            BigDecimal.ZERO
+        );
+
+        assertThat(
+            walletVersion(SOURCE_WALLET_ID)
+        ).isEqualTo(1L);
+
+        assertThat(
+            walletVersion(TARGET_WALLET_ID)
+        ).isEqualTo(0L);
+
+        Long transactionCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM payment_transactions
+                WHERE source_wallet_id = ?
+                  AND idempotency_key = ?
+                """,
+                Long.class,
+                SOURCE_WALLET_ID,
+                IDEMPOTENCY_KEY
+            );
+
+        assertThat(transactionCount)
+            .isZero();
+
+        Long ledgerEntryCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM ledger_entries
+                WHERE wallet_id IN (?, ?)
+                """,
+                Long.class,
+                SOURCE_WALLET_ID,
+                TARGET_WALLET_ID
+            );
+
+        assertThat(ledgerEntryCount)
+            .isZero();
+
+        Long outboxEventCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM outbox_events
+                """,
+                Long.class
+            );
+
+        assertThat(outboxEventCount)
+            .isZero();
+    }
+
+    private BigDecimal walletBalance(
+        UUID walletId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT balance
+            FROM wallets
+            WHERE id = ?
+            """,
+            BigDecimal.class,
+            walletId
+        );
+    }
+
+    private Long walletVersion(
+        UUID walletId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT version
+            FROM wallets
+            WHERE id = ?
+            """,
+            Long.class,
+            walletId
+        );
+    }
+
+    private void insertUser(
+        UUID userId,
+        String email
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            userId,
+            email,
+            "test-password-hash",
+            "USER",
+            "ACTIVE",
+            Timestamp.from(BASE_TIME),
+            Timestamp.from(BASE_TIME)
+        );
+    }
+
+    private void insertWallet(
+        UUID walletId,
+        UUID ownerId,
+        BigDecimal balance,
+        long version
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO wallets (
+                id,
+                owner_id,
+                balance,
+                currency,
+                status,
+                version,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            walletId,
+            ownerId,
+            balance,
+            "TRY",
+            "ACTIVE",
+            version,
+            Timestamp.from(BASE_TIME),
+            Timestamp.from(BASE_TIME)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Integrates completed wallet transfers with the transactional outbox
persistence foundation introduced in PR #28.

A completed transfer and its corresponding outbox event are now written
within the same PostgreSQL transaction.

## Changes

- add the versioned `wallet.transfer.completed` event contract
- keep financial amounts as decimal strings in the event payload
- exclude HTTP idempotency keys from the public event contract
- add the semantic `TransferCompletedEventRecorderPort`
- add an outbox adapter that:
  - serializes the event as JSON
  - creates a pending `OutboxEvent`
  - uses the transaction ID as the aggregate and partition key
  - generates a deterministic deduplication key
- record the event after the payment transaction reaches `COMPLETED`
- keep event recording inside the existing Spring transaction
- prevent additional events during idempotency replay

## Atomicity Guarantees

The integration tests verify that:

- wallet updates, payment transaction, ledger entries and outbox event
  commit together
- an outbox persistence failure rolls back:
  - wallet balances and versions
  - payment transaction
  - ledger entries
- idempotency replay does not create a second outbox event
- concurrent duplicate requests persist only:
  - one payment transaction
  - two balanced ledger entries
  - one outbox event

## Event Contract

```json
{
  "eventId": "uuid",
  "eventType": "wallet.transfer.completed",
  "eventVersion": 1,
  "occurredAt": "ISO-8601 timestamp",
  "transactionId": "uuid",
  "sourceWalletId": "uuid",
  "targetWalletId": "uuid",
  "amount": "125.50",
  "currency": "TRY"
}