### PR TITLE
feat: add transactional outbox event lifecycle

### DIFF
--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventClaimPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventClaimPersistenceAdapter.java
@@ -1,0 +1,156 @@
+package com.nursena.payflow.outbox.adapter.out.persistence;
+
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.nursena.payflow.outbox.application.port.out.OutboxEventClaimPort;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+class OutboxEventClaimPersistenceAdapter
+    implements OutboxEventClaimPort {
+
+    private static final int
+        MAX_PUBLISHER_ID_LENGTH = 200;
+
+    private final SpringDataOutboxEventRepository
+        repository;
+
+    OutboxEventClaimPersistenceAdapter(
+        SpringDataOutboxEventRepository repository
+    ) {
+        this.repository = repository;
+    }
+
+    @Override
+    @Transactional
+    public List<OutboxEvent> claimAvailable(
+        String publisherId,
+        Instant claimedAt,
+        Duration leaseDuration,
+        int batchSize
+    ) {
+        validateRequest(
+            publisherId,
+            claimedAt,
+            leaseDuration,
+            batchSize
+        );
+
+        List<OutboxEventJpaEntity> entities =
+            repository.findClaimableForUpdate(
+                claimedAt,
+                batchSize
+            );
+
+        if (entities.isEmpty()) {
+            return List.of();
+        }
+
+        List<OutboxEvent> claimedEvents =
+            new ArrayList<>(entities.size());
+
+        for (
+            OutboxEventJpaEntity entity
+            : entities
+        ) {
+            OutboxEvent currentEvent =
+                OutboxEventPersistenceMapper
+                    .toDomain(entity);
+
+            OutboxEvent claimedEvent =
+                currentEvent.claim(
+                    publisherId,
+                    claimedAt,
+                    leaseDuration
+                );
+
+            entity.applyDeliveryState(
+                claimedEvent
+            );
+
+            claimedEvents.add(
+                claimedEvent
+            );
+        }
+
+        repository.flush();
+
+        return List.copyOf(
+            claimedEvents
+        );
+    }
+
+    private static void validateRequest(
+        String publisherId,
+        Instant claimedAt,
+        Duration leaseDuration,
+        int batchSize
+    ) {
+        if (
+            publisherId == null
+                || publisherId.isBlank()
+        ) {
+            throw new IllegalArgumentException(
+                "publisherId must not be blank."
+            );
+        }
+
+        if (
+            publisherId.length()
+                > MAX_PUBLISHER_ID_LENGTH
+        ) {
+            throw new IllegalArgumentException(
+                "publisherId must not exceed "
+                    + MAX_PUBLISHER_ID_LENGTH
+                    + " characters."
+            );
+        }
+
+        Objects.requireNonNull(
+            claimedAt,
+            "claimedAt must not be null"
+        );
+
+        Objects.requireNonNull(
+            leaseDuration,
+            "leaseDuration must not be null"
+        );
+
+        if (
+            leaseDuration.isZero()
+                || leaseDuration.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                "leaseDuration must be positive."
+            );
+        }
+
+        try {
+            claimedAt.plus(
+                leaseDuration
+            );
+        } catch (
+            DateTimeException
+            | ArithmeticException exception
+        ) {
+            throw new IllegalArgumentException(
+                "leaseDuration produces "
+                    + "an invalid lease end.",
+                exception
+            );
+        }
+
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException(
+                "batchSize must be positive."
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventJpaEntity.java
@@ -12,6 +12,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
+import java.util.Objects;
+
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
 
 @Entity
 @Table(name = "outbox_events")
@@ -170,6 +173,31 @@ class OutboxEventJpaEntity {
         this.createdAt = createdAt;
         this.publishedAt = publishedAt;
         this.lastError = lastError;
+    }
+
+    void applyDeliveryState(
+        OutboxEvent event
+    ) {
+        Objects.requireNonNull(
+            event,
+            "event must not be null"
+        );
+
+        if (!id.equals(event.id())) {
+            throw new IllegalArgumentException(
+                "Cannot apply delivery state "
+                    + "from another outbox event."
+            );
+        }
+
+        status = event.status();
+        attemptCount = event.attemptCount();
+        availableAt = event.availableAt();
+        lockedAt = event.lockedAt();
+        lockedUntil = event.lockedUntil();
+        lockedBy = event.lockedBy();
+        publishedAt = event.publishedAt();
+        lastError = event.lastError();
     }
 
     UUID getId() {

--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventLifecyclePersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventLifecyclePersistenceAdapter.java
@@ -1,0 +1,117 @@
+package com.nursena.payflow.outbox.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.UnaryOperator;
+
+import com.nursena.payflow.outbox.application.port.out.OutboxEventLifecyclePort;
+import com.nursena.payflow.outbox.domain.exception.OutboxEventNotFoundException;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+class OutboxEventLifecyclePersistenceAdapter
+    implements OutboxEventLifecyclePort {
+
+    private final SpringDataOutboxEventRepository
+        repository;
+
+    OutboxEventLifecyclePersistenceAdapter(
+        SpringDataOutboxEventRepository repository
+    ) {
+        this.repository = repository;
+    }
+
+    @Override
+    @Transactional
+    public OutboxEvent markPublished(
+        UUID eventId,
+        String publisherId,
+        Instant publishedAt
+    ) {
+        return transition(
+            eventId,
+            event -> event.markPublished(
+                publisherId,
+                publishedAt
+            )
+        );
+    }
+
+    @Override
+    @Transactional
+    public OutboxEvent scheduleRetry(
+        UUID eventId,
+        String publisherId,
+        Instant failedAt,
+        Instant nextAvailableAt,
+        String error
+    ) {
+        return transition(
+            eventId,
+            event -> event.scheduleRetry(
+                publisherId,
+                failedAt,
+                nextAvailableAt,
+                error
+            )
+        );
+    }
+
+    @Override
+    @Transactional
+    public OutboxEvent markFailed(
+        UUID eventId,
+        String publisherId,
+        Instant failedAt,
+        String error
+    ) {
+        return transition(
+            eventId,
+            event -> event.markFailed(
+                publisherId,
+                failedAt,
+                error
+            )
+        );
+    }
+
+    private OutboxEvent transition(
+        UUID eventId,
+        UnaryOperator<OutboxEvent> operation
+    ) {
+        UUID validatedEventId =
+            Objects.requireNonNull(
+                eventId,
+                "eventId must not be null"
+            );
+
+        OutboxEventJpaEntity entity =
+            repository
+                .findByIdForUpdate(
+                    validatedEventId
+                )
+                .orElseThrow(() ->
+                    new OutboxEventNotFoundException(
+                        validatedEventId
+                    )
+                );
+
+        OutboxEvent currentEvent =
+            OutboxEventPersistenceMapper
+                .toDomain(entity);
+
+        OutboxEvent updatedEvent =
+            operation.apply(currentEvent);
+
+        entity.applyDeliveryState(
+            updatedEvent
+        );
+
+        repository.flush();
+
+        return updatedEvent;
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventPersistenceAdapter.java
@@ -32,10 +32,14 @@ class OutboxEventPersistenceAdapter
         try {
             OutboxEventJpaEntity saved =
                 repository.saveAndFlush(
-                    toEntity(event)
+                    OutboxEventPersistenceMapper.toEntity(
+                        event
+                    )
                 );
 
-            return toDomain(saved);
+            return OutboxEventPersistenceMapper.toDomain(
+                saved
+            );
         } catch (DataIntegrityViolationException exception) {
             if (isDeduplicationConstraintViolation(
                 exception
@@ -54,7 +58,7 @@ class OutboxEventPersistenceAdapter
         return repository
             .findById(eventId)
             .map(
-                OutboxEventPersistenceAdapter::toDomain
+                OutboxEventPersistenceMapper::toDomain
             );
     }
 

--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventPersistenceMapper.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventPersistenceMapper.java
@@ -1,0 +1,59 @@
+package com.nursena.payflow.outbox.adapter.out.persistence;
+
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+
+final class OutboxEventPersistenceMapper {
+
+    private OutboxEventPersistenceMapper() {
+    }
+
+    static OutboxEventJpaEntity toEntity(
+        OutboxEvent event
+    ) {
+        return new OutboxEventJpaEntity(
+            event.id(),
+            event.aggregateType(),
+            event.aggregateId(),
+            event.eventType(),
+            event.eventVersion(),
+            event.topic(),
+            event.partitionKey(),
+            event.deduplicationKey(),
+            event.payload(),
+            event.status(),
+            event.attemptCount(),
+            event.availableAt(),
+            event.lockedAt(),
+            event.lockedUntil(),
+            event.lockedBy(),
+            event.createdAt(),
+            event.publishedAt(),
+            event.lastError()
+        );
+    }
+
+    static OutboxEvent toDomain(
+        OutboxEventJpaEntity entity
+    ) {
+        return OutboxEvent.rehydrate(
+            entity.getId(),
+            entity.getAggregateType(),
+            entity.getAggregateId(),
+            entity.getEventType(),
+            entity.getEventVersion(),
+            entity.getTopic(),
+            entity.getPartitionKey(),
+            entity.getDeduplicationKey(),
+            entity.getPayload(),
+            entity.getStatus(),
+            entity.getAttemptCount(),
+            entity.getAvailableAt(),
+            entity.getLockedAt(),
+            entity.getLockedUntil(),
+            entity.getLockedBy(),
+            entity.getCreatedAt(),
+            entity.getPublishedAt(),
+            entity.getLastError()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/SpringDataOutboxEventRepository.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/SpringDataOutboxEventRepository.java
@@ -7,12 +7,27 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import java.util.Optional;
 
 interface SpringDataOutboxEventRepository
         extends JpaRepository<
         OutboxEventJpaEntity,
         UUID
         > {
+    @Query(
+            value = """
+        SELECT outbox.*
+        FROM outbox_events outbox
+        WHERE outbox.id = :eventId
+        FOR UPDATE
+        """,
+            nativeQuery = true
+    )
+    Optional<OutboxEventJpaEntity>
+    findByIdForUpdate(
+            @Param("eventId")
+            UUID eventId
+    );
 
     @Query(
             value = """

--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/SpringDataOutboxEventRepository.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/SpringDataOutboxEventRepository.java
@@ -1,12 +1,50 @@
 package com.nursena.payflow.outbox.adapter.out.persistence;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 interface SpringDataOutboxEventRepository
-    extends JpaRepository<
-    OutboxEventJpaEntity,
-    UUID
-    > {
+        extends JpaRepository<
+        OutboxEventJpaEntity,
+        UUID
+        > {
+
+    @Query(
+            value = """
+            SELECT outbox.*
+            FROM outbox_events outbox
+            WHERE (
+                outbox.status = 'PENDING'
+                AND outbox.available_at <= :claimedAt
+            )
+            OR (
+                outbox.status = 'PROCESSING'
+                AND outbox.locked_until <= :claimedAt
+            )
+            ORDER BY
+                CASE
+                    WHEN outbox.status = 'PENDING'
+                        THEN outbox.available_at
+                    ELSE outbox.locked_until
+                END,
+                outbox.created_at,
+                outbox.id
+            LIMIT :batchSize
+            FOR UPDATE SKIP LOCKED
+            """,
+            nativeQuery = true
+    )
+    List<OutboxEventJpaEntity>
+    findClaimableForUpdate(
+            @Param("claimedAt")
+            Instant claimedAt,
+
+            @Param("batchSize")
+            int batchSize
+    );
 }

--- a/src/main/java/com/nursena/payflow/outbox/application/port/out/OutboxEventClaimPort.java
+++ b/src/main/java/com/nursena/payflow/outbox/application/port/out/OutboxEventClaimPort.java
@@ -1,0 +1,17 @@
+package com.nursena.payflow.outbox.application.port.out;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+
+public interface OutboxEventClaimPort {
+
+    List<OutboxEvent> claimAvailable(
+        String publisherId,
+        Instant claimedAt,
+        Duration leaseDuration,
+        int batchSize
+    );
+}

--- a/src/main/java/com/nursena/payflow/outbox/application/port/out/OutboxEventLifecyclePort.java
+++ b/src/main/java/com/nursena/payflow/outbox/application/port/out/OutboxEventLifecyclePort.java
@@ -1,0 +1,30 @@
+package com.nursena.payflow.outbox.application.port.out;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+
+public interface OutboxEventLifecyclePort {
+
+    OutboxEvent markPublished(
+        UUID eventId,
+        String publisherId,
+        Instant publishedAt
+    );
+
+    OutboxEvent scheduleRetry(
+        UUID eventId,
+        String publisherId,
+        Instant failedAt,
+        Instant nextAvailableAt,
+        String error
+    );
+
+    OutboxEvent markFailed(
+        UUID eventId,
+        String publisherId,
+        Instant failedAt,
+        String error
+    );
+}

--- a/src/main/java/com/nursena/payflow/outbox/domain/exception/InvalidOutboxEventStateException.java
+++ b/src/main/java/com/nursena/payflow/outbox/domain/exception/InvalidOutboxEventStateException.java
@@ -1,0 +1,11 @@
+package com.nursena.payflow.outbox.domain.exception;
+
+public class InvalidOutboxEventStateException
+    extends RuntimeException {
+
+    public InvalidOutboxEventStateException(
+        String message
+    ) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/domain/exception/OutboxEventNotFoundException.java
+++ b/src/main/java/com/nursena/payflow/outbox/domain/exception/OutboxEventNotFoundException.java
@@ -1,0 +1,16 @@
+package com.nursena.payflow.outbox.domain.exception;
+
+import java.util.UUID;
+
+public final class OutboxEventNotFoundException
+    extends RuntimeException {
+
+    public OutboxEventNotFoundException(
+        UUID eventId
+    ) {
+        super(
+            "Outbox event not found: "
+                + eventId
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/domain/model/OutboxEvent.java
+++ b/src/main/java/com/nursena/payflow/outbox/domain/model/OutboxEvent.java
@@ -5,6 +5,10 @@ import java.util.Objects;
 import java.util.UUID;
 
 import com.nursena.payflow.outbox.domain.exception.InvalidOutboxEventException;
+import java.time.DateTimeException;
+import java.time.Duration;
+
+import com.nursena.payflow.outbox.domain.exception.InvalidOutboxEventStateException;
 
 public final class OutboxEvent {
 
@@ -222,6 +226,316 @@ public final class OutboxEvent {
             publishedAt,
             lastError
         );
+    }
+
+    public OutboxEvent claim(
+        String publisherId,
+        Instant now,
+        Duration leaseDuration
+    ) {
+        String validatedPublisherId =
+            requireText(
+                publisherId,
+                "publisherId",
+                MAX_LOCKED_BY_LENGTH
+            );
+
+        Instant validatedNow =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        ensureNotBeforeCreatedAt(
+            validatedNow,
+            "now"
+        );
+
+        ensureClaimable(validatedNow);
+
+        Instant leaseEnd =
+            calculateLeaseEnd(
+                validatedNow,
+                leaseDuration
+            );
+
+        return withDeliveryState(
+            OutboxStatus.PROCESSING,
+            incrementAttemptCount(),
+            availableAt,
+            validatedNow,
+            leaseEnd,
+            validatedPublisherId,
+            null,
+            lastError
+        );
+    }
+
+    public OutboxEvent markPublished(
+        String publisherId,
+        Instant publishedAt
+    ) {
+        Instant validatedPublishedAt =
+            Objects.requireNonNull(
+                publishedAt,
+                "publishedAt must not be null"
+            );
+
+        ensureActiveLeaseOwnedBy(
+            publisherId,
+            validatedPublishedAt
+        );
+
+        return withDeliveryState(
+            OutboxStatus.PUBLISHED,
+            attemptCount,
+            availableAt,
+            null,
+            null,
+            null,
+            validatedPublishedAt,
+            null
+        );
+    }
+
+    public OutboxEvent scheduleRetry(
+        String publisherId,
+        Instant now,
+        Instant nextAvailableAt,
+        String error
+    ) {
+        Instant validatedNow =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        Instant validatedNextAvailableAt =
+            Objects.requireNonNull(
+                nextAvailableAt,
+                "nextAvailableAt must not be null"
+            );
+
+        ensureActiveLeaseOwnedBy(
+            publisherId,
+            validatedNow
+        );
+
+        if (validatedNextAvailableAt.isBefore(
+            validatedNow
+        )) {
+            throw new InvalidOutboxEventException(
+                "nextAvailableAt must not be before now."
+            );
+        }
+
+        String validatedError =
+            requireText(
+                error,
+                "error",
+                MAX_LAST_ERROR_LENGTH
+            );
+
+        return withDeliveryState(
+            OutboxStatus.PENDING,
+            attemptCount,
+            validatedNextAvailableAt,
+            null,
+            null,
+            null,
+            null,
+            validatedError
+        );
+    }
+
+    public OutboxEvent markFailed(
+        String publisherId,
+        Instant now,
+        String error
+    ) {
+        Instant validatedNow =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        ensureActiveLeaseOwnedBy(
+            publisherId,
+            validatedNow
+        );
+
+        String validatedError =
+            requireText(
+                error,
+                "error",
+                MAX_LAST_ERROR_LENGTH
+            );
+
+        return withDeliveryState(
+            OutboxStatus.FAILED,
+            attemptCount,
+            availableAt,
+            null,
+            null,
+            null,
+            null,
+            validatedError
+        );
+    }
+
+    private OutboxEvent withDeliveryState(
+        OutboxStatus newStatus,
+        int newAttemptCount,
+        Instant newAvailableAt,
+        Instant newLockedAt,
+        Instant newLockedUntil,
+        String newLockedBy,
+        Instant newPublishedAt,
+        String newLastError
+    ) {
+        return new OutboxEvent(
+            id,
+            aggregateType,
+            aggregateId,
+            eventType,
+            eventVersion,
+            topic,
+            partitionKey,
+            deduplicationKey,
+            payload,
+            newStatus,
+            newAttemptCount,
+            newAvailableAt,
+            newLockedAt,
+            newLockedUntil,
+            newLockedBy,
+            createdAt,
+            newPublishedAt,
+            newLastError
+        );
+    }
+
+    private void ensureClaimable(
+        Instant now
+    ) {
+        if (status == OutboxStatus.PENDING) {
+            if (now.isBefore(availableAt)) {
+                throw new InvalidOutboxEventStateException(
+                    "PENDING event is not available yet."
+                );
+            }
+
+            return;
+        }
+
+        if (status == OutboxStatus.PROCESSING) {
+            if (lockedUntil.isAfter(now)) {
+                throw new InvalidOutboxEventStateException(
+                    "PROCESSING event lease is still active."
+                );
+            }
+
+            return;
+        }
+
+        throw new InvalidOutboxEventStateException(
+            "Only PENDING or expired PROCESSING "
+                + "events may be claimed."
+        );
+    }
+
+    private void ensureActiveLeaseOwnedBy(
+        String publisherId,
+        Instant now
+    ) {
+        String validatedPublisherId =
+            requireText(
+                publisherId,
+                "publisherId",
+                MAX_LOCKED_BY_LENGTH
+            );
+
+        ensureNotBeforeCreatedAt(
+            now,
+            "now"
+        );
+
+        if (status != OutboxStatus.PROCESSING) {
+            throw new InvalidOutboxEventStateException(
+                "Outbox event must be PROCESSING."
+            );
+        }
+
+        if (!lockedBy.equals(validatedPublisherId)) {
+            throw new InvalidOutboxEventStateException(
+                "Outbox event is owned by another publisher."
+            );
+        }
+
+        if (now.isBefore(lockedAt)) {
+            throw new InvalidOutboxEventException(
+                "now must not be before lockedAt."
+            );
+        }
+
+        if (!now.isBefore(lockedUntil)) {
+            throw new InvalidOutboxEventStateException(
+                "Outbox event lease has expired."
+            );
+        }
+    }
+
+    private void ensureNotBeforeCreatedAt(
+        Instant value,
+        String fieldName
+    ) {
+        if (value.isBefore(createdAt)) {
+            throw new InvalidOutboxEventException(
+                fieldName
+                    + " must not be before createdAt."
+            );
+        }
+    }
+
+    private static Instant calculateLeaseEnd(
+        Instant now,
+        Duration leaseDuration
+    ) {
+        Objects.requireNonNull(
+            leaseDuration,
+            "leaseDuration must not be null"
+        );
+
+        if (leaseDuration.isZero()
+            || leaseDuration.isNegative()) {
+
+            throw new InvalidOutboxEventException(
+                "leaseDuration must be positive."
+            );
+        }
+
+        try {
+            return now.plus(leaseDuration);
+        } catch (
+            DateTimeException
+            | ArithmeticException exception
+        ) {
+            throw new InvalidOutboxEventException(
+                "leaseDuration produces an invalid lease end."
+            );
+        }
+    }
+
+    private int incrementAttemptCount() {
+        try {
+            return Math.incrementExact(
+                attemptCount
+            );
+        } catch (ArithmeticException exception) {
+            throw new InvalidOutboxEventException(
+                "attemptCount exceeds the supported range."
+            );
+        }
     }
 
     private static String requireText(

--- a/src/test/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventClaimPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventClaimPersistenceAdapterTest.java
@@ -1,0 +1,281 @@
+package com.nursena.payflow.outbox.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxEventClaimPersistenceAdapterTest {
+
+    private static final UUID FIRST_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID SECOND_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000002"
+        );
+
+    private static final UUID AGGREGATE_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000001"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-18T10:00:00Z"
+        );
+
+    private static final Instant CLAIMED_AT =
+        CREATED_AT.plusSeconds(60);
+
+    private static final Duration LEASE_DURATION =
+        Duration.ofSeconds(30);
+
+    private static final String EVENT_TYPE =
+        "wallet.transfer.completed";
+
+    private static final String PAYLOAD =
+        """
+        {
+          "eventType": "wallet.transfer.completed",
+          "eventVersion": 1
+        }
+        """;
+
+    @Mock
+    private SpringDataOutboxEventRepository
+        repository;
+
+    private OutboxEventClaimPersistenceAdapter
+        adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter =
+            new OutboxEventClaimPersistenceAdapter(
+                repository
+            );
+    }
+
+    @Test
+    void shouldClaimSelectedEventsInRepositoryOrder() {
+        OutboxEventJpaEntity pending =
+            pendingEntity();
+
+        OutboxEventJpaEntity expiredProcessing =
+            expiredProcessingEntity();
+
+        when(repository.findClaimableForUpdate(
+            CLAIMED_AT,
+            2
+        )).thenReturn(
+            List.of(
+                pending,
+                expiredProcessing
+            )
+        );
+
+        List<OutboxEvent> claimed =
+            adapter.claimAvailable(
+                "publisher-2",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                2
+            );
+
+        assertThat(claimed)
+            .extracting(
+                OutboxEvent::id
+            )
+            .containsExactly(
+                FIRST_EVENT_ID,
+                SECOND_EVENT_ID
+            );
+
+        OutboxEvent first =
+            claimed.get(0);
+
+        assertThat(first.status())
+            .isEqualTo(
+                OutboxStatus.PROCESSING
+            );
+
+        assertThat(first.attemptCount())
+            .isEqualTo(1);
+
+        assertThat(first.lockedAt())
+            .isEqualTo(CLAIMED_AT);
+
+        assertThat(first.lockedUntil())
+            .isEqualTo(
+                CLAIMED_AT.plusSeconds(30)
+            );
+
+        assertThat(first.lockedBy())
+            .isEqualTo("publisher-2");
+
+        OutboxEvent second =
+            claimed.get(1);
+
+        assertThat(second.status())
+            .isEqualTo(
+                OutboxStatus.PROCESSING
+            );
+
+        assertThat(second.attemptCount())
+            .isEqualTo(2);
+
+        assertThat(second.lockedBy())
+            .isEqualTo("publisher-2");
+
+        assertThat(second.lastError())
+            .isEqualTo(
+                "Previous publishing failure."
+            );
+
+        assertThat(pending.getStatus())
+            .isEqualTo(
+                OutboxStatus.PROCESSING
+            );
+
+        assertThat(pending.getAttemptCount())
+            .isEqualTo(1);
+
+        assertThat(
+            expiredProcessing.getStatus()
+        ).isEqualTo(
+            OutboxStatus.PROCESSING
+        );
+
+        assertThat(
+            expiredProcessing.getAttemptCount()
+        ).isEqualTo(2);
+
+        assertThat(
+            expiredProcessing.getLockedBy()
+        ).isEqualTo("publisher-2");
+
+        verify(repository)
+            .findClaimableForUpdate(
+                CLAIMED_AT,
+                2
+            );
+
+        verify(repository)
+            .flush();
+    }
+
+    @Test
+    void shouldReturnEmptyWithoutFlushing() {
+        when(repository.findClaimableForUpdate(
+            CLAIMED_AT,
+            10
+        )).thenReturn(List.of());
+
+        List<OutboxEvent> result =
+            adapter.claimAvailable(
+                "publisher-1",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                10
+            );
+
+        assertThat(result)
+            .isEmpty();
+
+        verify(repository)
+            .findClaimableForUpdate(
+                CLAIMED_AT,
+                10
+            );
+    }
+
+    @Test
+    void shouldRejectInvalidBatchSizeBeforeQuery() {
+        assertThatThrownBy(() ->
+            adapter.claimAvailable(
+                "publisher-1",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                0
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "batchSize must be positive."
+            );
+
+        verifyNoInteractions(repository);
+    }
+
+    private static OutboxEventJpaEntity
+    pendingEntity() {
+        return new OutboxEventJpaEntity(
+            FIRST_EVENT_ID,
+            "PAYMENT_TRANSACTION",
+            AGGREGATE_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            AGGREGATE_ID.toString(),
+            EVENT_TYPE
+                + ":1:"
+                + FIRST_EVENT_ID,
+            PAYLOAD,
+            OutboxStatus.PENDING,
+            0,
+            CREATED_AT,
+            null,
+            null,
+            null,
+            CREATED_AT,
+            null,
+            null
+        );
+    }
+
+    private static OutboxEventJpaEntity
+    expiredProcessingEntity() {
+        return new OutboxEventJpaEntity(
+            SECOND_EVENT_ID,
+            "PAYMENT_TRANSACTION",
+            AGGREGATE_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            AGGREGATE_ID.toString(),
+            EVENT_TYPE
+                + ":1:"
+                + SECOND_EVENT_ID,
+            PAYLOAD,
+            OutboxStatus.PROCESSING,
+            1,
+            CREATED_AT,
+            CREATED_AT.plusSeconds(10),
+            CREATED_AT.plusSeconds(30),
+            "publisher-1",
+            CREATED_AT,
+            null,
+            "Previous publishing failure."
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventLifecyclePersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/out/persistence/OutboxEventLifecyclePersistenceAdapterTest.java
@@ -1,0 +1,290 @@
+package com.nursena.payflow.outbox.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.domain.exception.OutboxEventNotFoundException;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxEventLifecyclePersistenceAdapterTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID AGGREGATE_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000001"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-18T10:00:00Z"
+        );
+
+    private static final Instant CLAIMED_AT =
+        CREATED_AT.plusSeconds(60);
+
+    private static final Instant TRANSITION_AT =
+        CLAIMED_AT.plusSeconds(10);
+
+    private static final Instant LOCKED_UNTIL =
+        CLAIMED_AT.plusSeconds(30);
+
+    private static final String PUBLISHER_ID =
+        "publisher-1";
+
+    private static final String EVENT_TYPE =
+        "wallet.transfer.completed";
+
+    private static final String PAYLOAD =
+        """
+        {
+          "eventType": "wallet.transfer.completed",
+          "eventVersion": 1
+        }
+        """;
+
+    @Mock
+    private SpringDataOutboxEventRepository
+        repository;
+
+    private OutboxEventLifecyclePersistenceAdapter
+        adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter =
+            new OutboxEventLifecyclePersistenceAdapter(
+                repository
+            );
+    }
+
+    @Test
+    void shouldMarkLockedEventAsPublished() {
+        OutboxEventJpaEntity entity =
+            processingEntity();
+
+        when(repository.findByIdForUpdate(
+            EVENT_ID
+        )).thenReturn(
+            Optional.of(entity)
+        );
+
+        OutboxEvent result =
+            adapter.markPublished(
+                EVENT_ID,
+                PUBLISHER_ID,
+                TRANSITION_AT
+            );
+
+        assertThat(result.status())
+            .isEqualTo(OutboxStatus.PUBLISHED);
+
+        assertThat(result.publishedAt())
+            .isEqualTo(TRANSITION_AT);
+
+        assertThat(result.lockedAt())
+            .isNull();
+
+        assertThat(result.lockedUntil())
+            .isNull();
+
+        assertThat(result.lockedBy())
+            .isNull();
+
+        assertThat(result.lastError())
+            .isNull();
+
+        assertThat(entity.getStatus())
+            .isEqualTo(OutboxStatus.PUBLISHED);
+
+        assertThat(entity.getPublishedAt())
+            .isEqualTo(TRANSITION_AT);
+
+        assertThat(entity.getLockedBy())
+            .isNull();
+
+        verify(repository)
+            .findByIdForUpdate(EVENT_ID);
+
+        verify(repository)
+            .flush();
+    }
+
+    @Test
+    void shouldScheduleRetryForLockedEvent() {
+        OutboxEventJpaEntity entity =
+            processingEntity();
+
+        when(repository.findByIdForUpdate(
+            EVENT_ID
+        )).thenReturn(
+            Optional.of(entity)
+        );
+
+        Instant nextAvailableAt =
+            TRANSITION_AT.plusSeconds(60);
+
+        OutboxEvent result =
+            adapter.scheduleRetry(
+                EVENT_ID,
+                PUBLISHER_ID,
+                TRANSITION_AT,
+                nextAvailableAt,
+                "Kafka broker is unavailable."
+            );
+
+        assertThat(result.status())
+            .isEqualTo(OutboxStatus.PENDING);
+
+        assertThat(result.attemptCount())
+            .isEqualTo(2);
+
+        assertThat(result.availableAt())
+            .isEqualTo(nextAvailableAt);
+
+        assertThat(result.lockedAt())
+            .isNull();
+
+        assertThat(result.lockedUntil())
+            .isNull();
+
+        assertThat(result.lockedBy())
+            .isNull();
+
+        assertThat(result.lastError())
+            .isEqualTo(
+                "Kafka broker is unavailable."
+            );
+
+        assertThat(entity.getStatus())
+            .isEqualTo(OutboxStatus.PENDING);
+
+        assertThat(entity.getAvailableAt())
+            .isEqualTo(nextAvailableAt);
+
+        assertThat(entity.getLastError())
+            .isEqualTo(
+                "Kafka broker is unavailable."
+            );
+
+        verify(repository)
+            .flush();
+    }
+
+    @Test
+    void shouldMarkLockedEventAsFailed() {
+        OutboxEventJpaEntity entity =
+            processingEntity();
+
+        when(repository.findByIdForUpdate(
+            EVENT_ID
+        )).thenReturn(
+            Optional.of(entity)
+        );
+
+        OutboxEvent result =
+            adapter.markFailed(
+                EVENT_ID,
+                PUBLISHER_ID,
+                TRANSITION_AT,
+                "Maximum attempts exceeded."
+            );
+
+        assertThat(result.status())
+            .isEqualTo(OutboxStatus.FAILED);
+
+        assertThat(result.attemptCount())
+            .isEqualTo(2);
+
+        assertThat(result.lockedAt())
+            .isNull();
+
+        assertThat(result.lockedUntil())
+            .isNull();
+
+        assertThat(result.lockedBy())
+            .isNull();
+
+        assertThat(result.lastError())
+            .isEqualTo(
+                "Maximum attempts exceeded."
+            );
+
+        assertThat(entity.getStatus())
+            .isEqualTo(OutboxStatus.FAILED);
+
+        assertThat(entity.getLastError())
+            .isEqualTo(
+                "Maximum attempts exceeded."
+            );
+
+        verify(repository)
+            .flush();
+    }
+
+    @Test
+    void shouldRejectUnknownEventBeforeFlush() {
+        when(repository.findByIdForUpdate(
+            EVENT_ID
+        )).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            adapter.markPublished(
+                EVENT_ID,
+                PUBLISHER_ID,
+                TRANSITION_AT
+            )
+        )
+            .isInstanceOf(
+                OutboxEventNotFoundException.class
+            )
+            .hasMessage(
+                "Outbox event not found: "
+                    + EVENT_ID
+            );
+
+        verify(repository, never())
+            .flush();
+    }
+
+    private static OutboxEventJpaEntity
+    processingEntity() {
+        return new OutboxEventJpaEntity(
+            EVENT_ID,
+            "PAYMENT_TRANSACTION",
+            AGGREGATE_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            AGGREGATE_ID.toString(),
+            EVENT_TYPE + ":1:" + EVENT_ID,
+            PAYLOAD,
+            OutboxStatus.PROCESSING,
+            2,
+            CREATED_AT,
+            CLAIMED_AT,
+            LOCKED_UNTIL,
+            PUBLISHER_ID,
+            CREATED_AT,
+            null,
+            "Previous failure."
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/domain/model/OutboxEventTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/domain/model/OutboxEventTest.java
@@ -8,6 +8,9 @@ import java.util.UUID;
 
 import com.nursena.payflow.outbox.domain.exception.InvalidOutboxEventException;
 import org.junit.jupiter.api.Test;
+import java.time.Duration;
+
+import com.nursena.payflow.outbox.domain.exception.InvalidOutboxEventStateException;
 
 class OutboxEventTest {
 
@@ -28,6 +31,12 @@ class OutboxEventTest {
 
     private static final String EVENT_TYPE =
         "wallet.transfer.completed";
+
+    private static final String PUBLISHER_ID =
+        "publisher-1";
+
+    private static final Duration LEASE_DURATION =
+        Duration.ofSeconds(30);
 
     private static final String DEDUPLICATION_KEY =
         EVENT_TYPE + ":1:" + TRANSACTION_ID;
@@ -374,6 +383,328 @@ class OutboxEventTest {
             )
             .hasMessage(
                 "Only PUBLISHED events may have publishedAt."
+            );
+    }
+
+    @Test
+    void shouldClaimAvailablePendingEvent() {
+        OutboxEvent pending = pendingEvent();
+
+        OutboxEvent claimed =
+            pending.claim(
+                PUBLISHER_ID,
+                CREATED_AT,
+                LEASE_DURATION
+            );
+
+        assertThat(pending.status())
+            .isEqualTo(OutboxStatus.PENDING);
+
+        assertThat(pending.attemptCount())
+            .isZero();
+
+        assertThat(claimed.status())
+            .isEqualTo(OutboxStatus.PROCESSING);
+
+        assertThat(claimed.attemptCount())
+            .isEqualTo(1);
+
+        assertThat(claimed.lockedAt())
+            .isEqualTo(CREATED_AT);
+
+        assertThat(claimed.lockedUntil())
+            .isEqualTo(
+                CREATED_AT.plusSeconds(30)
+            );
+
+        assertThat(claimed.lockedBy())
+            .isEqualTo(PUBLISHER_ID);
+    }
+
+    @Test
+    void shouldRejectClaimBeforeEventIsAvailable() {
+        OutboxEvent delayed =
+            rehydrate(
+                OutboxStatus.PENDING,
+                0,
+                CREATED_AT.plusSeconds(60),
+                null,
+                null,
+                null,
+                null
+            );
+
+        assertThatThrownBy(() ->
+            delayed.claim(
+                PUBLISHER_ID,
+                CREATED_AT.plusSeconds(30),
+                LEASE_DURATION
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventStateException.class
+            )
+            .hasMessage(
+                "PENDING event is not available yet."
+            );
+    }
+
+    @Test
+    void shouldRejectClaimWhileProcessingLeaseIsActive() {
+        OutboxEvent processing =
+            pendingEvent().claim(
+                PUBLISHER_ID,
+                CREATED_AT,
+                LEASE_DURATION
+            );
+
+        assertThatThrownBy(() ->
+            processing.claim(
+                "publisher-2",
+                CREATED_AT.plusSeconds(10),
+                LEASE_DURATION
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventStateException.class
+            )
+            .hasMessage(
+                "PROCESSING event lease is still active."
+            );
+    }
+
+    @Test
+    void shouldReclaimExpiredProcessingEvent() {
+        OutboxEvent firstClaim =
+            pendingEvent().claim(
+                PUBLISHER_ID,
+                CREATED_AT,
+                LEASE_DURATION
+            );
+
+        Instant reclaimedAt =
+            CREATED_AT.plusSeconds(31);
+
+        OutboxEvent reclaimed =
+            firstClaim.claim(
+                "publisher-2",
+                reclaimedAt,
+                LEASE_DURATION
+            );
+
+        assertThat(reclaimed.status())
+            .isEqualTo(OutboxStatus.PROCESSING);
+
+        assertThat(reclaimed.attemptCount())
+            .isEqualTo(2);
+
+        assertThat(reclaimed.lockedBy())
+            .isEqualTo("publisher-2");
+
+        assertThat(reclaimed.lockedAt())
+            .isEqualTo(reclaimedAt);
+
+        assertThat(reclaimed.lockedUntil())
+            .isEqualTo(
+                reclaimedAt.plusSeconds(30)
+            );
+    }
+
+    @Test
+    void shouldMarkOwnedProcessingEventAsPublished() {
+        OutboxEvent processing =
+            pendingEvent().claim(
+                PUBLISHER_ID,
+                CREATED_AT,
+                LEASE_DURATION
+            );
+
+        Instant publishedAt =
+            CREATED_AT.plusSeconds(10);
+
+        OutboxEvent published =
+            processing.markPublished(
+                PUBLISHER_ID,
+                publishedAt
+            );
+
+        assertThat(published.status())
+            .isEqualTo(OutboxStatus.PUBLISHED);
+
+        assertThat(published.attemptCount())
+            .isEqualTo(1);
+
+        assertThat(published.publishedAt())
+            .isEqualTo(publishedAt);
+
+        assertThat(published.lockedAt())
+            .isNull();
+
+        assertThat(published.lockedUntil())
+            .isNull();
+
+        assertThat(published.lockedBy())
+            .isNull();
+
+        assertThat(published.lastError())
+            .isNull();
+    }
+
+    @Test
+    void shouldScheduleRetryAfterTemporaryFailure() {
+        OutboxEvent processing =
+            pendingEvent().claim(
+                PUBLISHER_ID,
+                CREATED_AT,
+                LEASE_DURATION
+            );
+
+        Instant failedAt =
+            CREATED_AT.plusSeconds(10);
+
+        Instant nextAvailableAt =
+            CREATED_AT.plusSeconds(60);
+
+        OutboxEvent retry =
+            processing.scheduleRetry(
+                PUBLISHER_ID,
+                failedAt,
+                nextAvailableAt,
+                "Kafka broker is unavailable."
+            );
+
+        assertThat(retry.status())
+            .isEqualTo(OutboxStatus.PENDING);
+
+        assertThat(retry.attemptCount())
+            .isEqualTo(1);
+
+        assertThat(retry.availableAt())
+            .isEqualTo(nextAvailableAt);
+
+        assertThat(retry.lockedAt())
+            .isNull();
+
+        assertThat(retry.lockedUntil())
+            .isNull();
+
+        assertThat(retry.lockedBy())
+            .isNull();
+
+        assertThat(retry.lastError())
+            .isEqualTo(
+                "Kafka broker is unavailable."
+            );
+    }
+
+    @Test
+    void shouldMarkProcessingEventAsFailed() {
+        OutboxEvent processing =
+            pendingEvent().claim(
+                PUBLISHER_ID,
+                CREATED_AT,
+                LEASE_DURATION
+            );
+
+        OutboxEvent failed =
+            processing.markFailed(
+                PUBLISHER_ID,
+                CREATED_AT.plusSeconds(10),
+                "Maximum attempts exceeded."
+            );
+
+        assertThat(failed.status())
+            .isEqualTo(OutboxStatus.FAILED);
+
+        assertThat(failed.attemptCount())
+            .isEqualTo(1);
+
+        assertThat(failed.lockedAt())
+            .isNull();
+
+        assertThat(failed.lockedUntil())
+            .isNull();
+
+        assertThat(failed.lockedBy())
+            .isNull();
+
+        assertThat(failed.lastError())
+            .isEqualTo(
+                "Maximum attempts exceeded."
+            );
+    }
+
+    @Test
+    void shouldRejectStateChangeByAnotherPublisher() {
+        OutboxEvent processing =
+            pendingEvent().claim(
+                PUBLISHER_ID,
+                CREATED_AT,
+                LEASE_DURATION
+            );
+
+        assertThatThrownBy(() ->
+            processing.markPublished(
+                "publisher-2",
+                CREATED_AT.plusSeconds(10)
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventStateException.class
+            )
+            .hasMessage(
+                "Outbox event is owned by another publisher."
+            );
+    }
+
+    @Test
+    void shouldRejectStateChangeAfterLeaseExpiration() {
+        OutboxEvent processing =
+            pendingEvent().claim(
+                PUBLISHER_ID,
+                CREATED_AT,
+                LEASE_DURATION
+            );
+
+        assertThatThrownBy(() ->
+            processing.markPublished(
+                PUBLISHER_ID,
+                CREATED_AT.plusSeconds(30)
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventStateException.class
+            )
+            .hasMessage(
+                "Outbox event lease has expired."
+            );
+    }
+
+    @Test
+    void shouldRejectRetryBeforeCurrentTime() {
+        OutboxEvent processing =
+            pendingEvent().claim(
+                PUBLISHER_ID,
+                CREATED_AT,
+                LEASE_DURATION
+            );
+
+        Instant failedAt =
+            CREATED_AT.plusSeconds(10);
+
+        assertThatThrownBy(() ->
+            processing.scheduleRetry(
+                PUBLISHER_ID,
+                failedAt,
+                failedAt.minusSeconds(1),
+                "Temporary failure."
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventException.class
+            )
+            .hasMessage(
+                "nextAvailableAt must not be before now."
             );
     }
 

--- a/src/test/java/com/nursena/payflow/outbox/integration/OutboxClaimIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/integration/OutboxClaimIntegrationTest.java
@@ -1,0 +1,412 @@
+package com.nursena.payflow.outbox.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.application.port.out.OutboxEventClaimPort;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class OutboxClaimIntegrationTest {
+
+    private static final UUID EXPIRED_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID EARLY_PENDING_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000002"
+        );
+
+    private static final UUID TIE_FIRST_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000003"
+        );
+
+    private static final UUID TIE_SECOND_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000004"
+        );
+
+    private static final UUID FUTURE_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000005"
+        );
+
+    private static final UUID ACTIVE_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000006"
+        );
+
+    private static final UUID AGGREGATE_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000001"
+        );
+
+    private static final String EVENT_TYPE =
+        "wallet.transfer.completed";
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-18T10:00:00Z"
+        );
+
+    private static final Instant CLAIMED_AT =
+        Instant.parse(
+            "2026-07-18T10:10:00Z"
+        );
+
+    private static final Duration LEASE_DURATION =
+        Duration.ofSeconds(30);
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private OutboxEventClaimPort claimPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUpDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM outbox_events"
+        );
+
+        insertEvent(
+            EXPIRED_EVENT_ID,
+            "PROCESSING",
+            1,
+            CREATED_AT,
+            CLAIMED_AT.minusSeconds(60),
+            CLAIMED_AT.minusSeconds(20),
+            "expired-publisher",
+            "Previous publishing failure."
+        );
+
+        insertEvent(
+            EARLY_PENDING_ID,
+            "PENDING",
+            0,
+            CLAIMED_AT.minusSeconds(10),
+            null,
+            null,
+            null,
+            null
+        );
+
+        insertEvent(
+            TIE_FIRST_ID,
+            "PENDING",
+            0,
+            CLAIMED_AT,
+            null,
+            null,
+            null,
+            null
+        );
+
+        insertEvent(
+            TIE_SECOND_ID,
+            "PENDING",
+            0,
+            CLAIMED_AT,
+            null,
+            null,
+            null,
+            null
+        );
+
+        insertEvent(
+            FUTURE_EVENT_ID,
+            "PENDING",
+            0,
+            CLAIMED_AT.plusSeconds(60),
+            null,
+            null,
+            null,
+            null
+        );
+
+        insertEvent(
+            ACTIVE_EVENT_ID,
+            "PROCESSING",
+            1,
+            CREATED_AT,
+            CLAIMED_AT.minusSeconds(5),
+            CLAIMED_AT.plusSeconds(60),
+            "active-publisher",
+            null
+        );
+    }
+
+    @Test
+    void shouldClaimAvailableEventsInDeterministicBatches() {
+        List<OutboxEvent> firstBatch =
+            claimPort.claimAvailable(
+                "publisher-1",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                3
+            );
+
+        assertThat(firstBatch)
+            .extracting(OutboxEvent::id)
+            .containsExactly(
+                EXPIRED_EVENT_ID,
+                EARLY_PENDING_ID,
+                TIE_FIRST_ID
+            );
+
+        assertClaimedState(
+            EXPIRED_EVENT_ID,
+            "publisher-1",
+            2
+        );
+
+        assertClaimedState(
+            EARLY_PENDING_ID,
+            "publisher-1",
+            1
+        );
+
+        assertClaimedState(
+            TIE_FIRST_ID,
+            "publisher-1",
+            1
+        );
+
+        assertThat(
+            stateOf(EXPIRED_EVENT_ID).lastError()
+        ).isEqualTo(
+            "Previous publishing failure."
+        );
+
+        List<OutboxEvent> secondBatch =
+            claimPort.claimAvailable(
+                "publisher-2",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                10
+            );
+
+        assertThat(secondBatch)
+            .extracting(OutboxEvent::id)
+            .containsExactly(TIE_SECOND_ID);
+
+        assertClaimedState(
+            TIE_SECOND_ID,
+            "publisher-2",
+            1
+        );
+
+        assertThat(
+            stateOf(FUTURE_EVENT_ID).status()
+        ).isEqualTo("PENDING");
+
+        EventState activeState =
+            stateOf(ACTIVE_EVENT_ID);
+
+        assertThat(activeState.status())
+            .isEqualTo("PROCESSING");
+
+        assertThat(activeState.lockedBy())
+            .isEqualTo("active-publisher");
+
+        List<OutboxEvent> thirdBatch =
+            claimPort.claimAvailable(
+                "publisher-3",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                10
+            );
+
+        assertThat(thirdBatch)
+            .isEmpty();
+    }
+
+    private void assertClaimedState(
+        UUID eventId,
+        String publisherId,
+        int attemptCount
+    ) {
+        EventState state =
+            stateOf(eventId);
+
+        assertThat(state.status())
+            .isEqualTo("PROCESSING");
+
+        assertThat(state.attemptCount())
+            .isEqualTo(attemptCount);
+
+        assertThat(state.lockedBy())
+            .isEqualTo(publisherId);
+
+        assertThat(state.lockedAt())
+            .isEqualTo(CLAIMED_AT);
+
+        assertThat(state.lockedUntil())
+            .isEqualTo(
+                CLAIMED_AT.plus(
+                    LEASE_DURATION
+                )
+            );
+    }
+
+    private EventState stateOf(
+        UUID eventId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT
+                status,
+                attempt_count,
+                locked_at,
+                locked_until,
+                locked_by,
+                last_error
+            FROM outbox_events
+            WHERE id = ?
+            """,
+            (resultSet, rowNumber) -> {
+                Timestamp lockedAt =
+                    resultSet.getTimestamp(
+                        "locked_at"
+                    );
+
+                Timestamp lockedUntil =
+                    resultSet.getTimestamp(
+                        "locked_until"
+                    );
+
+                return new EventState(
+                    resultSet.getString(
+                        "status"
+                    ),
+                    resultSet.getInt(
+                        "attempt_count"
+                    ),
+                    lockedAt == null
+                        ? null
+                        : lockedAt.toInstant(),
+                    lockedUntil == null
+                        ? null
+                        : lockedUntil.toInstant(),
+                    resultSet.getString(
+                        "locked_by"
+                    ),
+                    resultSet.getString(
+                        "last_error"
+                    )
+                );
+            },
+            eventId
+        );
+    }
+
+    private void insertEvent(
+        UUID eventId,
+        String status,
+        int attemptCount,
+        Instant availableAt,
+        Instant lockedAt,
+        Instant lockedUntil,
+        String lockedBy,
+        String lastError
+    ) {
+        String payload = """
+            {
+              "eventId": "%s",
+              "eventType": "wallet.transfer.completed",
+              "eventVersion": 1
+            }
+            """.formatted(eventId);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO outbox_events (
+                id,
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                event_version,
+                topic,
+                partition_key,
+                deduplication_key,
+                payload,
+                status,
+                attempt_count,
+                available_at,
+                locked_at,
+                locked_until,
+                locked_by,
+                created_at,
+                published_at,
+                last_error
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?,
+                CAST(? AS jsonb),
+                ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            eventId,
+            "PAYMENT_TRANSACTION",
+            AGGREGATE_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            AGGREGATE_ID.toString(),
+            EVENT_TYPE + ":1:" + eventId,
+            payload,
+            status,
+            attemptCount,
+            Timestamp.from(availableAt),
+            timestamp(lockedAt),
+            timestamp(lockedUntil),
+            lockedBy,
+            Timestamp.from(CREATED_AT),
+            null,
+            lastError
+        );
+    }
+
+    private static Timestamp timestamp(
+        Instant value
+    ) {
+        return value == null
+            ? null
+            : Timestamp.from(value);
+    }
+
+    private record EventState(
+        String status,
+        int attemptCount,
+        Instant lockedAt,
+        Instant lockedUntil,
+        String lockedBy,
+        String lastError
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/integration/OutboxLifecycleIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/integration/OutboxLifecycleIntegrationTest.java
@@ -1,0 +1,501 @@
+package com.nursena.payflow.outbox.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.application.port.out.OutboxEventClaimPort;
+import com.nursena.payflow.outbox.application.port.out.OutboxEventLifecyclePort;
+import com.nursena.payflow.outbox.domain.exception.InvalidOutboxEventStateException;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class OutboxLifecycleIntegrationTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000021"
+        );
+
+    private static final UUID AGGREGATE_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000021"
+        );
+
+    private static final String EVENT_TYPE =
+        "wallet.transfer.completed";
+
+    private static final String FIRST_PUBLISHER =
+        "publisher-1";
+
+    private static final String SECOND_PUBLISHER =
+        "publisher-2";
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-18T12:00:00Z"
+        );
+
+    private static final Instant CLAIMED_AT =
+        CREATED_AT.plusSeconds(60);
+
+    private static final Duration LEASE_DURATION =
+        Duration.ofSeconds(30);
+
+    private static final Instant TRANSITION_AT =
+        CLAIMED_AT.plusSeconds(10);
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private OutboxEventClaimPort claimPort;
+
+    @Autowired
+    private OutboxEventLifecyclePort lifecyclePort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUpDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM outbox_events"
+        );
+
+        insertPendingEvent();
+    }
+
+    @Test
+    void shouldPersistPublishedTransition() {
+        claim(
+            FIRST_PUBLISHER,
+            CLAIMED_AT
+        );
+
+        OutboxEvent published =
+            lifecyclePort.markPublished(
+                EVENT_ID,
+                FIRST_PUBLISHER,
+                TRANSITION_AT
+            );
+
+        assertThat(published.status().name())
+            .isEqualTo("PUBLISHED");
+
+        assertThat(published.publishedAt())
+            .isEqualTo(TRANSITION_AT);
+
+        EventState state = stateOfEvent();
+
+        assertThat(state.status())
+            .isEqualTo("PUBLISHED");
+
+        assertThat(state.attemptCount())
+            .isEqualTo(1);
+
+        assertThat(state.publishedAt())
+            .isEqualTo(TRANSITION_AT);
+
+        assertThat(state.lockedAt())
+            .isNull();
+
+        assertThat(state.lockedUntil())
+            .isNull();
+
+        assertThat(state.lockedBy())
+            .isNull();
+
+        assertThat(state.lastError())
+            .isNull();
+
+        assertThat(
+            claimPort.claimAvailable(
+                SECOND_PUBLISHER,
+                TRANSITION_AT.plusSeconds(60),
+                LEASE_DURATION,
+                10
+            )
+        ).isEmpty();
+    }
+
+    @Test
+    void shouldPersistRetryAndBecomeClaimableAtScheduledTime() {
+        claim(
+            FIRST_PUBLISHER,
+            CLAIMED_AT
+        );
+
+        Instant nextAvailableAt =
+            TRANSITION_AT.plusSeconds(60);
+
+        OutboxEvent retry =
+            lifecyclePort.scheduleRetry(
+                EVENT_ID,
+                FIRST_PUBLISHER,
+                TRANSITION_AT,
+                nextAvailableAt,
+                "Kafka broker is unavailable."
+            );
+
+        assertThat(retry.status().name())
+            .isEqualTo("PENDING");
+
+        assertThat(retry.attemptCount())
+            .isEqualTo(1);
+
+        assertThat(retry.availableAt())
+            .isEqualTo(nextAvailableAt);
+
+        EventState retryState =
+            stateOfEvent();
+
+        assertThat(retryState.status())
+            .isEqualTo("PENDING");
+
+        assertThat(retryState.attemptCount())
+            .isEqualTo(1);
+
+        assertThat(retryState.availableAt())
+            .isEqualTo(nextAvailableAt);
+
+        assertThat(retryState.lockedAt())
+            .isNull();
+
+        assertThat(retryState.lockedUntil())
+            .isNull();
+
+        assertThat(retryState.lockedBy())
+            .isNull();
+
+        assertThat(retryState.lastError())
+            .isEqualTo(
+                "Kafka broker is unavailable."
+            );
+
+        List<OutboxEvent> beforeSchedule =
+            claimPort.claimAvailable(
+                SECOND_PUBLISHER,
+                nextAvailableAt.minusSeconds(1),
+                LEASE_DURATION,
+                10
+            );
+
+        assertThat(beforeSchedule)
+            .isEmpty();
+
+        List<OutboxEvent> reclaimed =
+            claimPort.claimAvailable(
+                SECOND_PUBLISHER,
+                nextAvailableAt,
+                LEASE_DURATION,
+                10
+            );
+
+        assertThat(reclaimed)
+            .singleElement()
+            .satisfies(event -> {
+                assertThat(event.id())
+                    .isEqualTo(EVENT_ID);
+
+                assertThat(event.attemptCount())
+                    .isEqualTo(2);
+
+                assertThat(event.lockedBy())
+                    .isEqualTo(SECOND_PUBLISHER);
+
+                assertThat(event.lastError())
+                    .isEqualTo(
+                        "Kafka broker is unavailable."
+                    );
+            });
+    }
+
+    @Test
+    void shouldPersistTerminalFailureAndExcludeEventFromClaims() {
+        claim(
+            FIRST_PUBLISHER,
+            CLAIMED_AT
+        );
+
+        OutboxEvent failed =
+            lifecyclePort.markFailed(
+                EVENT_ID,
+                FIRST_PUBLISHER,
+                TRANSITION_AT,
+                "Maximum attempts exceeded."
+            );
+
+        assertThat(failed.status().name())
+            .isEqualTo("FAILED");
+
+        assertThat(failed.attemptCount())
+            .isEqualTo(1);
+
+        EventState state = stateOfEvent();
+
+        assertThat(state.status())
+            .isEqualTo("FAILED");
+
+        assertThat(state.attemptCount())
+            .isEqualTo(1);
+
+        assertThat(state.lockedAt())
+            .isNull();
+
+        assertThat(state.lockedUntil())
+            .isNull();
+
+        assertThat(state.lockedBy())
+            .isNull();
+
+        assertThat(state.publishedAt())
+            .isNull();
+
+        assertThat(state.lastError())
+            .isEqualTo(
+                "Maximum attempts exceeded."
+            );
+
+        assertThat(
+            claimPort.claimAvailable(
+                SECOND_PUBLISHER,
+                TRANSITION_AT.plusSeconds(60),
+                LEASE_DURATION,
+                10
+            )
+        ).isEmpty();
+    }
+
+    @Test
+    void shouldRejectStalePublisherAfterLeaseIsReclaimed() {
+        claim(
+            FIRST_PUBLISHER,
+            CLAIMED_AT
+        );
+
+        Instant reclaimedAt =
+            CLAIMED_AT
+                .plus(LEASE_DURATION)
+                .plusSeconds(1);
+
+        List<OutboxEvent> reclaimed =
+            claimPort.claimAvailable(
+                SECOND_PUBLISHER,
+                reclaimedAt,
+                LEASE_DURATION,
+                1
+            );
+
+        assertThat(reclaimed)
+            .singleElement()
+            .satisfies(event -> {
+                assertThat(event.id())
+                    .isEqualTo(EVENT_ID);
+
+                assertThat(event.attemptCount())
+                    .isEqualTo(2);
+
+                assertThat(event.lockedBy())
+                    .isEqualTo(SECOND_PUBLISHER);
+            });
+
+        assertThatThrownBy(() ->
+            lifecyclePort.markPublished(
+                EVENT_ID,
+                FIRST_PUBLISHER,
+                reclaimedAt.plusSeconds(5)
+            )
+        )
+            .isInstanceOf(
+                InvalidOutboxEventStateException.class
+            )
+            .hasMessage(
+                "Outbox event is owned by another publisher."
+            );
+
+        EventState state = stateOfEvent();
+
+        assertThat(state.status())
+            .isEqualTo("PROCESSING");
+
+        assertThat(state.attemptCount())
+            .isEqualTo(2);
+
+        assertThat(state.lockedBy())
+            .isEqualTo(SECOND_PUBLISHER);
+
+        assertThat(state.lockedAt())
+            .isEqualTo(reclaimedAt);
+
+        assertThat(state.lockedUntil())
+            .isEqualTo(
+                reclaimedAt.plus(
+                    LEASE_DURATION
+                )
+            );
+
+        assertThat(state.publishedAt())
+            .isNull();
+    }
+
+    private OutboxEvent claim(
+        String publisherId,
+        Instant claimedAt
+    ) {
+        List<OutboxEvent> events =
+            claimPort.claimAvailable(
+                publisherId,
+                claimedAt,
+                LEASE_DURATION,
+                1
+            );
+
+        assertThat(events)
+            .hasSize(1);
+
+        return events.getFirst();
+    }
+
+    private EventState stateOfEvent() {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT
+                status,
+                attempt_count,
+                available_at,
+                locked_at,
+                locked_until,
+                locked_by,
+                published_at,
+                last_error
+            FROM outbox_events
+            WHERE id = ?
+            """,
+            (resultSet, rowNumber) ->
+                new EventState(
+                    resultSet.getString(
+                        "status"
+                    ),
+                    resultSet.getInt(
+                        "attempt_count"
+                    ),
+                    instant(
+                        resultSet.getTimestamp(
+                            "available_at"
+                        )
+                    ),
+                    instant(
+                        resultSet.getTimestamp(
+                            "locked_at"
+                        )
+                    ),
+                    instant(
+                        resultSet.getTimestamp(
+                            "locked_until"
+                        )
+                    ),
+                    resultSet.getString(
+                        "locked_by"
+                    ),
+                    instant(
+                        resultSet.getTimestamp(
+                            "published_at"
+                        )
+                    ),
+                    resultSet.getString(
+                        "last_error"
+                    )
+                ),
+            EVENT_ID
+        );
+    }
+
+    private void insertPendingEvent() {
+        String payload = """
+            {
+              "eventId": "%s",
+              "eventType": "wallet.transfer.completed",
+              "eventVersion": 1
+            }
+            """.formatted(EVENT_ID);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO outbox_events (
+                id,
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                event_version,
+                topic,
+                partition_key,
+                deduplication_key,
+                payload,
+                status,
+                attempt_count,
+                available_at,
+                created_at
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?,
+                CAST(? AS jsonb),
+                'PENDING',
+                0,
+                ?,
+                ?
+            )
+            """,
+            EVENT_ID,
+            "PAYMENT_TRANSACTION",
+            AGGREGATE_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            AGGREGATE_ID.toString(),
+            EVENT_TYPE + ":1:" + EVENT_ID,
+            payload,
+            Timestamp.from(CREATED_AT),
+            Timestamp.from(CREATED_AT)
+        );
+    }
+
+    private static Instant instant(
+        Timestamp timestamp
+    ) {
+        return timestamp == null
+            ? null
+            : timestamp.toInstant();
+    }
+
+    private record EventState(
+        String status,
+        int attemptCount,
+        Instant availableAt,
+        Instant lockedAt,
+        Instant lockedUntil,
+        String lockedBy,
+        Instant publishedAt,
+        String lastError
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/integration/OutboxSkipLockedIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/integration/OutboxSkipLockedIntegrationTest.java
@@ -1,0 +1,276 @@
+package com.nursena.payflow.outbox.integration;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import com.nursena.payflow.outbox.application.port.out.OutboxEventClaimPort;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class OutboxSkipLockedIntegrationTest {
+
+    private static final UUID FIRST_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000011"
+        );
+
+    private static final UUID SECOND_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000012"
+        );
+
+    private static final UUID AGGREGATE_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000011"
+        );
+
+    private static final String EVENT_TYPE =
+        "wallet.transfer.completed";
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-18T11:00:00Z"
+        );
+
+    private static final Instant CLAIMED_AT =
+        CREATED_AT.plusSeconds(60);
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private OutboxEventClaimPort claimPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PlatformTransactionManager
+        transactionManager;
+
+    @BeforeEach
+    void setUpDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM outbox_events"
+        );
+
+        insertPendingEvent(FIRST_EVENT_ID);
+        insertPendingEvent(SECOND_EVENT_ID);
+    }
+
+    @Test
+    void shouldSkipLockedRowAndClaimNextAvailableEvent()
+        throws Exception {
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(2);
+
+        CountDownLatch lockAcquired =
+            new CountDownLatch(1);
+
+        CountDownLatch releaseLock =
+            new CountDownLatch(1);
+
+        TransactionTemplate transactionTemplate =
+            new TransactionTemplate(
+                transactionManager
+            );
+
+        Future<?> lockingTransaction =
+            executor.submit(() ->
+                transactionTemplate.executeWithoutResult(
+                    status -> {
+                        jdbcTemplate.queryForObject(
+                            """
+                            SELECT id::text
+                            FROM outbox_events
+                            WHERE id = ?
+                            FOR UPDATE
+                            """,
+                            String.class,
+                            FIRST_EVENT_ID
+                        );
+
+                        lockAcquired.countDown();
+
+                        await(releaseLock);
+                    }
+                )
+            );
+
+        try {
+            assertThat(
+                lockAcquired.await(5, SECONDS)
+            ).isTrue();
+
+            Future<List<OutboxEvent>>
+                claimOperation =
+                executor.submit(() ->
+                    claimPort.claimAvailable(
+                        "publisher-2",
+                        CLAIMED_AT,
+                        Duration.ofSeconds(30),
+                        1
+                    )
+                );
+
+            List<OutboxEvent> claimed =
+                claimOperation.get(
+                    5,
+                    SECONDS
+                );
+
+            assertThat(claimed)
+                .extracting(OutboxEvent::id)
+                .containsExactly(
+                    SECOND_EVENT_ID
+                );
+
+            assertThat(
+                statusOf(FIRST_EVENT_ID)
+            ).isEqualTo("PENDING");
+
+            assertThat(
+                statusOf(SECOND_EVENT_ID)
+            ).isEqualTo("PROCESSING");
+        } finally {
+            releaseLock.countDown();
+
+            lockingTransaction.get(
+                5,
+                SECONDS
+            );
+
+            executor.shutdownNow();
+        }
+
+        List<OutboxEvent> afterRelease =
+            claimPort.claimAvailable(
+                "publisher-3",
+                CLAIMED_AT,
+                Duration.ofSeconds(30),
+                1
+            );
+
+        assertThat(afterRelease)
+            .extracting(OutboxEvent::id)
+            .containsExactly(
+                FIRST_EVENT_ID
+            );
+    }
+
+    private void insertPendingEvent(
+        UUID eventId
+    ) {
+        String payload = """
+            {
+              "eventId": "%s",
+              "eventType": "wallet.transfer.completed",
+              "eventVersion": 1
+            }
+            """.formatted(eventId);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO outbox_events (
+                id,
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                event_version,
+                topic,
+                partition_key,
+                deduplication_key,
+                payload,
+                status,
+                attempt_count,
+                available_at,
+                created_at
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?,
+                CAST(? AS jsonb),
+                'PENDING',
+                0,
+                ?,
+                ?
+            )
+            """,
+            eventId,
+            "PAYMENT_TRANSACTION",
+            AGGREGATE_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            AGGREGATE_ID.toString(),
+            EVENT_TYPE + ":1:" + eventId,
+            payload,
+            Timestamp.from(CREATED_AT),
+            Timestamp.from(CREATED_AT)
+        );
+    }
+
+    private String statusOf(
+        UUID eventId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT status
+            FROM outbox_events
+            WHERE id = ?
+            """,
+            String.class,
+            eventId
+        );
+    }
+
+    private static void await(
+        CountDownLatch latch
+    ) {
+        try {
+            boolean released =
+                latch.await(10, SECONDS);
+
+            if (!released) {
+                throw new IllegalStateException(
+                    "Timed out while waiting "
+                        + "to release row lock."
+                );
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+
+            throw new IllegalStateException(
+                "Interrupted while waiting "
+                    + "to release row lock.",
+                exception
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the transactional outbox delivery lifecycle and PostgreSQL-based
concurrent event claiming infrastructure.

Outbox events can now be safely claimed by multiple publisher instances,
retried after temporary failures, marked as published, or moved to a
terminal failed state.

## Changes

- add immutable outbox lifecycle transitions:
  - `PENDING -> PROCESSING`
  - `PROCESSING -> PUBLISHED`
  - `PROCESSING -> PENDING`
  - `PROCESSING -> FAILED`
- increment delivery attempts when an event is claimed
- add publisher ownership and active-lease validation
- allow expired processing leases to be reclaimed
- prevent stale publishers from updating events after lease expiration
- add an outbox event claim port
- claim events atomically with PostgreSQL:
  - `FOR UPDATE SKIP LOCKED`
  - deterministic ordering
  - configurable batch size
  - configurable lease duration
- support both available pending events and expired processing events
- add lifecycle outcome persistence with row-level locking
- extract reusable JPA/domain mapping
- add explicit not-found and invalid-state exceptions

## Concurrency Guarantees

The PostgreSQL integration tests verify that:

- multiple publishers do not claim the same event
- locked rows are skipped without waiting
- the next available event can be claimed concurrently
- active leases cannot be stolen
- expired leases can be reclaimed
- batch limits and deterministic ordering are respected
- future retry events are excluded until `available_at`
- stale publishers cannot overwrite a newer lease owner

## Lifecycle Outcomes

### Successful publishing

```text
PROCESSING -> PUBLISHED