### PR TITLE
feat: orchestrate transactional outbox publishing

### DIFF
--- a/src/main/java/com/nursena/payflow/outbox/application/model/OutboxRetryDecision.java
+++ b/src/main/java/com/nursena/payflow/outbox/application/model/OutboxRetryDecision.java
@@ -1,0 +1,52 @@
+package com.nursena.payflow.outbox.application.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record OutboxRetryDecision(
+    boolean shouldRetry,
+    Instant nextAvailableAt
+) {
+
+    public OutboxRetryDecision {
+        if (
+            shouldRetry
+                && nextAvailableAt == null
+        ) {
+            throw new IllegalArgumentException(
+                "Retry decision must have "
+                    + "nextAvailableAt."
+            );
+        }
+
+        if (
+            !shouldRetry
+                && nextAvailableAt != null
+        ) {
+            throw new IllegalArgumentException(
+                "Terminal failure must not have "
+                    + "nextAvailableAt."
+            );
+        }
+    }
+
+    public static OutboxRetryDecision retryAt(
+        Instant nextAvailableAt
+    ) {
+        return new OutboxRetryDecision(
+            true,
+            Objects.requireNonNull(
+                nextAvailableAt,
+                "nextAvailableAt must not be null"
+            )
+        );
+    }
+
+    public static OutboxRetryDecision
+    terminalFailure() {
+        return new OutboxRetryDecision(
+            false,
+            null
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/application/policy/OutboxRetryPolicy.java
+++ b/src/main/java/com/nursena/payflow/outbox/application/policy/OutboxRetryPolicy.java
@@ -1,0 +1,172 @@
+package com.nursena.payflow.outbox.application.policy;
+
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+import com.nursena.payflow.outbox.application.model.OutboxRetryDecision;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+
+public final class OutboxRetryPolicy {
+
+    private final int maxAttempts;
+    private final Duration initialDelay;
+    private final Duration maximumDelay;
+
+    public OutboxRetryPolicy(
+        int maxAttempts,
+        Duration initialDelay,
+        Duration maximumDelay
+    ) {
+        if (maxAttempts <= 0) {
+            throw new IllegalArgumentException(
+                "maxAttempts must be positive."
+            );
+        }
+
+        this.initialDelay =
+            requirePositiveDuration(
+                initialDelay,
+                "initialDelay"
+            );
+
+        this.maximumDelay =
+            requirePositiveDuration(
+                maximumDelay,
+                "maximumDelay"
+            );
+
+        if (
+            this.maximumDelay.compareTo(
+                this.initialDelay
+            ) < 0
+        ) {
+            throw new IllegalArgumentException(
+                "maximumDelay must not be "
+                    + "less than initialDelay."
+            );
+        }
+
+        this.maxAttempts = maxAttempts;
+    }
+
+    public OutboxRetryDecision decide(
+        OutboxEvent event,
+        Instant failedAt
+    ) {
+        Objects.requireNonNull(
+            event,
+            "event must not be null"
+        );
+
+        Instant validatedFailedAt =
+            Objects.requireNonNull(
+                failedAt,
+                "failedAt must not be null"
+            );
+
+        if (
+            event.status()
+                != OutboxStatus.PROCESSING
+        ) {
+            throw new IllegalArgumentException(
+                "event must be PROCESSING."
+            );
+        }
+
+        if (event.attemptCount() <= 0) {
+            throw new IllegalArgumentException(
+                "event attemptCount must be positive."
+            );
+        }
+
+        if (
+            event.attemptCount()
+                >= maxAttempts
+        ) {
+            return OutboxRetryDecision
+                .terminalFailure();
+        }
+
+        Duration delay =
+            calculateDelay(
+                event.attemptCount()
+            );
+
+        try {
+            return OutboxRetryDecision.retryAt(
+                validatedFailedAt.plus(delay)
+            );
+        } catch (
+            DateTimeException
+            | ArithmeticException exception
+        ) {
+            throw new IllegalArgumentException(
+                "Retry delay produces an invalid "
+                    + "nextAvailableAt.",
+                exception
+            );
+        }
+    }
+
+    private Duration calculateDelay(
+        int attemptCount
+    ) {
+        Duration delay = initialDelay;
+
+        for (
+            int attempt = 1;
+            attempt < attemptCount;
+            attempt++
+        ) {
+            if (
+                delay.compareTo(
+                    maximumDelay
+                ) >= 0
+            ) {
+                return maximumDelay;
+            }
+
+            try {
+                Duration doubled =
+                    delay.multipliedBy(2);
+
+                delay =
+                    doubled.compareTo(
+                        maximumDelay
+                    ) > 0
+                        ? maximumDelay
+                        : doubled;
+            } catch (ArithmeticException exception) {
+                return maximumDelay;
+            }
+        }
+
+        return delay;
+    }
+
+    private static Duration
+    requirePositiveDuration(
+        Duration value,
+        String fieldName
+    ) {
+        Objects.requireNonNull(
+            value,
+            fieldName + " must not be null"
+        );
+
+        if (
+            value.isZero()
+                || value.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                fieldName
+                    + " must be positive."
+            );
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/application/port/in/PublishOutboxEventsCommand.java
+++ b/src/main/java/com/nursena/payflow/outbox/application/port/in/PublishOutboxEventsCommand.java
@@ -1,0 +1,56 @@
+package com.nursena.payflow.outbox.application.port.in;
+
+import java.time.Duration;
+import java.util.Objects;
+
+public record PublishOutboxEventsCommand(
+    String publisherId,
+    int batchSize,
+    Duration leaseDuration
+) {
+
+    private static final int
+        MAX_PUBLISHER_ID_LENGTH = 200;
+
+    public PublishOutboxEventsCommand {
+        if (
+            publisherId == null
+                || publisherId.isBlank()
+        ) {
+            throw new IllegalArgumentException(
+                "publisherId must not be blank."
+            );
+        }
+
+        if (
+            publisherId.length()
+                > MAX_PUBLISHER_ID_LENGTH
+        ) {
+            throw new IllegalArgumentException(
+                "publisherId must not exceed "
+                    + MAX_PUBLISHER_ID_LENGTH
+                    + " characters."
+            );
+        }
+
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException(
+                "batchSize must be positive."
+            );
+        }
+
+        Objects.requireNonNull(
+            leaseDuration,
+            "leaseDuration must not be null"
+        );
+
+        if (
+            leaseDuration.isZero()
+                || leaseDuration.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                "leaseDuration must be positive."
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/application/port/in/PublishOutboxEventsResult.java
+++ b/src/main/java/com/nursena/payflow/outbox/application/port/in/PublishOutboxEventsResult.java
@@ -1,0 +1,72 @@
+package com.nursena.payflow.outbox.application.port.in;
+
+public record PublishOutboxEventsResult(
+    int claimedCount,
+    int publishedCount,
+    int retriedCount,
+    int failedCount,
+    int unresolvedCount
+) {
+
+    public PublishOutboxEventsResult {
+        ensureNonNegative(
+            claimedCount,
+            "claimedCount"
+        );
+
+        ensureNonNegative(
+            publishedCount,
+            "publishedCount"
+        );
+
+        ensureNonNegative(
+            retriedCount,
+            "retriedCount"
+        );
+
+        ensureNonNegative(
+            failedCount,
+            "failedCount"
+        );
+
+        ensureNonNegative(
+            unresolvedCount,
+            "unresolvedCount"
+        );
+
+        long outcomeCount =
+            (long) publishedCount
+                + retriedCount
+                + failedCount
+                + unresolvedCount;
+
+        if (outcomeCount != claimedCount) {
+            throw new IllegalArgumentException(
+                "Outcome counts must equal "
+                    + "claimedCount."
+            );
+        }
+    }
+
+    public static PublishOutboxEventsResult empty() {
+        return new PublishOutboxEventsResult(
+            0,
+            0,
+            0,
+            0,
+            0
+        );
+    }
+
+    private static void ensureNonNegative(
+        int value,
+        String fieldName
+    ) {
+        if (value < 0) {
+            throw new IllegalArgumentException(
+                fieldName
+                    + " must not be negative."
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/application/port/in/PublishOutboxEventsUseCase.java
+++ b/src/main/java/com/nursena/payflow/outbox/application/port/in/PublishOutboxEventsUseCase.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.outbox.application.port.in;
+
+public interface PublishOutboxEventsUseCase {
+
+    PublishOutboxEventsResult publishAvailable(
+        PublishOutboxEventsCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/outbox/application/port/out/OutboxMessagePublisherPort.java
+++ b/src/main/java/com/nursena/payflow/outbox/application/port/out/OutboxMessagePublisherPort.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.outbox.application.port.out;
+
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+
+public interface OutboxMessagePublisherPort {
+
+    void publish(
+        OutboxEvent event
+    );
+}

--- a/src/main/java/com/nursena/payflow/outbox/application/service/PublishOutboxEventsService.java
+++ b/src/main/java/com/nursena/payflow/outbox/application/service/PublishOutboxEventsService.java
@@ -1,0 +1,252 @@
+package com.nursena.payflow.outbox.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
+
+import com.nursena.payflow.outbox.application.model.OutboxRetryDecision;
+import com.nursena.payflow.outbox.application.policy.OutboxRetryPolicy;
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsCommand;
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsResult;
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
+import com.nursena.payflow.outbox.application.port.out.OutboxEventClaimPort;
+import com.nursena.payflow.outbox.application.port.out.OutboxEventLifecyclePort;
+import com.nursena.payflow.outbox.application.port.out.OutboxMessagePublisherPort;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PublishOutboxEventsService
+    implements PublishOutboxEventsUseCase {
+
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(
+            PublishOutboxEventsService.class
+        );
+
+    private static final int MAX_ERROR_LENGTH = 1000;
+
+    private final OutboxEventClaimPort claimPort;
+    private final OutboxMessagePublisherPort publisherPort;
+    private final OutboxEventLifecyclePort lifecyclePort;
+    private final OutboxRetryPolicy retryPolicy;
+    private final Clock clock;
+
+    public PublishOutboxEventsService(
+        OutboxEventClaimPort claimPort,
+        OutboxMessagePublisherPort publisherPort,
+        OutboxEventLifecyclePort lifecyclePort,
+        OutboxRetryPolicy retryPolicy,
+        Clock clock
+    ) {
+        this.claimPort = claimPort;
+        this.publisherPort = publisherPort;
+        this.lifecyclePort = lifecyclePort;
+        this.retryPolicy = retryPolicy;
+        this.clock = clock;
+    }
+
+    @Override
+    public PublishOutboxEventsResult publishAvailable(
+        PublishOutboxEventsCommand command
+    ) {
+        Objects.requireNonNull(
+            command,
+            "command must not be null"
+        );
+
+        Instant claimedAt = currentTime();
+
+        List<OutboxEvent> claimedEvents =
+            claimPort.claimAvailable(
+                command.publisherId(),
+                claimedAt,
+                command.leaseDuration(),
+                command.batchSize()
+            );
+
+        if (claimedEvents.isEmpty()) {
+            return PublishOutboxEventsResult.empty();
+        }
+
+        int publishedCount = 0;
+        int retriedCount = 0;
+        int failedCount = 0;
+        int unresolvedCount = 0;
+
+        for (OutboxEvent event : claimedEvents) {
+            PublishOutcome outcome =
+                publishOne(
+                    event,
+                    command.publisherId()
+                );
+
+            switch (outcome) {
+                case PUBLISHED ->
+                    publishedCount++;
+
+                case RETRIED ->
+                    retriedCount++;
+
+                case FAILED ->
+                    failedCount++;
+
+                case UNRESOLVED ->
+                    unresolvedCount++;
+            }
+        }
+
+        return new PublishOutboxEventsResult(
+            claimedEvents.size(),
+            publishedCount,
+            retriedCount,
+            failedCount,
+            unresolvedCount
+        );
+    }
+
+    private PublishOutcome publishOne(
+        OutboxEvent event,
+        String publisherId
+    ) {
+        try {
+            publisherPort.publish(event);
+        } catch (RuntimeException exception) {
+            return handlePublishingFailure(
+                event,
+                publisherId,
+                exception
+            );
+        }
+
+        try {
+            lifecyclePort.markPublished(
+                event.id(),
+                publisherId,
+                currentTime()
+            );
+
+            return PublishOutcome.PUBLISHED;
+        } catch (RuntimeException exception) {
+            logUnresolvedOutcome(
+                event,
+                publisherId,
+                exception
+            );
+
+            return PublishOutcome.UNRESOLVED;
+        }
+    }
+
+    private PublishOutcome handlePublishingFailure(
+        OutboxEvent event,
+        String publisherId,
+        RuntimeException publishingFailure
+    ) {
+        Instant failedAt = currentTime();
+
+        try {
+            OutboxRetryDecision decision =
+                retryPolicy.decide(
+                    event,
+                    failedAt
+                );
+
+            String error =
+                failureMessage(
+                    publishingFailure
+                );
+
+            if (decision.shouldRetry()) {
+                lifecyclePort.scheduleRetry(
+                    event.id(),
+                    publisherId,
+                    failedAt,
+                    decision.nextAvailableAt(),
+                    error
+                );
+
+                return PublishOutcome.RETRIED;
+            }
+
+            lifecyclePort.markFailed(
+                event.id(),
+                publisherId,
+                failedAt,
+                error
+            );
+
+            return PublishOutcome.FAILED;
+        } catch (RuntimeException outcomeFailure) {
+            logUnresolvedOutcome(
+                event,
+                publisherId,
+                outcomeFailure
+            );
+
+            return PublishOutcome.UNRESOLVED;
+        }
+    }
+
+    private static String failureMessage(
+        RuntimeException exception
+    ) {
+        String exceptionType =
+            exception.getClass()
+                .getSimpleName();
+
+        if (exceptionType.isBlank()) {
+            exceptionType =
+                exception.getClass()
+                    .getName();
+        }
+
+        String detail = exception.getMessage();
+
+        String error =
+            detail == null
+                || detail.isBlank()
+                ? exceptionType
+                : exceptionType + ": " + detail;
+
+        if (error.length() <= MAX_ERROR_LENGTH) {
+            return error;
+        }
+
+        return error.substring(
+            0,
+            MAX_ERROR_LENGTH
+        );
+    }
+
+    private static void logUnresolvedOutcome(
+        OutboxEvent event,
+        String publisherId,
+        RuntimeException exception
+    ) {
+        LOGGER.error(
+            "Outbox event outcome could not be persisted. "
+                + "eventId={}, publisherId={}",
+            event.id(),
+            publisherId,
+            exception
+        );
+    }
+
+    private Instant currentTime() {
+        return clock.instant()
+            .truncatedTo(
+                ChronoUnit.MICROS
+            );
+    }
+
+    private enum PublishOutcome {
+        PUBLISHED,
+        RETRIED,
+        FAILED,
+        UNRESOLVED
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/configuration/OutboxOrchestrationConfiguration.java
+++ b/src/main/java/com/nursena/payflow/outbox/configuration/OutboxOrchestrationConfiguration.java
@@ -1,0 +1,28 @@
+package com.nursena.payflow.outbox.configuration;
+
+import java.time.Duration;
+
+import com.nursena.payflow.outbox.application.policy.OutboxRetryPolicy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class OutboxOrchestrationConfiguration {
+
+    private static final int MAX_ATTEMPTS = 5;
+
+    private static final Duration INITIAL_RETRY_DELAY =
+        Duration.ofSeconds(10);
+
+    private static final Duration MAXIMUM_RETRY_DELAY =
+        Duration.ofMinutes(1);
+
+    @Bean
+    OutboxRetryPolicy outboxRetryPolicy() {
+        return new OutboxRetryPolicy(
+            MAX_ATTEMPTS,
+            INITIAL_RETRY_DELAY,
+            MAXIMUM_RETRY_DELAY
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/application/policy/OutboxRetryPolicyTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/application/policy/OutboxRetryPolicyTest.java
@@ -1,0 +1,163 @@
+package com.nursena.payflow.outbox.application.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.application.model.OutboxRetryDecision;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+import org.junit.jupiter.api.Test;
+
+class OutboxRetryPolicyTest {
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-18T12:00:00Z"
+        );
+
+    private static final Instant FAILED_AT =
+        CREATED_AT.plusSeconds(60);
+
+    private final OutboxRetryPolicy policy =
+        new OutboxRetryPolicy(
+            5,
+            Duration.ofSeconds(10),
+            Duration.ofSeconds(60)
+        );
+
+    @Test
+    void shouldUseInitialDelayAfterFirstAttempt() {
+        OutboxRetryDecision decision =
+            policy.decide(
+                processingEvent(1),
+                FAILED_AT
+            );
+
+        assertThat(decision.shouldRetry())
+            .isTrue();
+
+        assertThat(decision.nextAvailableAt())
+            .isEqualTo(
+                FAILED_AT.plusSeconds(10)
+            );
+    }
+
+    @Test
+    void shouldApplyExponentialBackoff() {
+        OutboxRetryDecision decision =
+            policy.decide(
+                processingEvent(3),
+                FAILED_AT
+            );
+
+        assertThat(decision.shouldRetry())
+            .isTrue();
+
+        assertThat(decision.nextAvailableAt())
+            .isEqualTo(
+                FAILED_AT.plusSeconds(40)
+            );
+    }
+
+    @Test
+    void shouldCapDelayAtMaximum() {
+        OutboxRetryDecision decision =
+            policy.decide(
+                processingEvent(4),
+                FAILED_AT
+            );
+
+        assertThat(decision.shouldRetry())
+            .isTrue();
+
+        assertThat(decision.nextAvailableAt())
+            .isEqualTo(
+                FAILED_AT.plusSeconds(60)
+            );
+    }
+
+    @Test
+    void shouldReturnTerminalFailureAtMaximumAttempts() {
+        OutboxRetryDecision decision =
+            policy.decide(
+                processingEvent(5),
+                FAILED_AT
+            );
+
+        assertThat(decision.shouldRetry())
+            .isFalse();
+
+        assertThat(decision.nextAvailableAt())
+            .isNull();
+    }
+
+    @Test
+    void shouldRejectEventThatIsNotProcessing() {
+        OutboxEvent pending =
+            OutboxEvent.pending(
+                UUID.randomUUID(),
+                "PAYMENT_TRANSACTION",
+                UUID.randomUUID(),
+                "wallet.transfer.completed",
+                1,
+                "wallet.transfer.completed",
+                "partition-1",
+                UUID.randomUUID().toString(),
+                """
+                {
+                  "eventType": "wallet.transfer.completed"
+                }
+                """,
+                CREATED_AT
+            );
+
+        assertThatThrownBy(() ->
+            policy.decide(
+                pending,
+                FAILED_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "event must be PROCESSING."
+            );
+    }
+
+    private static OutboxEvent processingEvent(
+        int attemptCount
+    ) {
+        UUID eventId = UUID.randomUUID();
+
+        return OutboxEvent.rehydrate(
+            eventId,
+            "PAYMENT_TRANSACTION",
+            UUID.randomUUID(),
+            "wallet.transfer.completed",
+            1,
+            "wallet.transfer.completed",
+            "partition-1",
+            "wallet.transfer.completed:1:"
+                + eventId,
+            """
+            {
+              "eventType": "wallet.transfer.completed"
+            }
+            """,
+            OutboxStatus.PROCESSING,
+            attemptCount,
+            CREATED_AT,
+            CREATED_AT.plusSeconds(30),
+            CREATED_AT.plusSeconds(90),
+            "publisher-1",
+            CREATED_AT,
+            null,
+            null
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/application/port/in/PublishOutboxEventsCommandTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/application/port/in/PublishOutboxEventsCommandTest.java
@@ -1,0 +1,83 @@
+package com.nursena.payflow.outbox.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class PublishOutboxEventsCommandTest {
+
+    @Test
+    void shouldCreateValidCommand() {
+        PublishOutboxEventsCommand command =
+            new PublishOutboxEventsCommand(
+                "publisher-1",
+                25,
+                Duration.ofSeconds(30)
+            );
+
+        assertThat(command.publisherId())
+            .isEqualTo("publisher-1");
+
+        assertThat(command.batchSize())
+            .isEqualTo(25);
+
+        assertThat(command.leaseDuration())
+            .isEqualTo(
+                Duration.ofSeconds(30)
+            );
+    }
+
+    @Test
+    void shouldRejectBlankPublisherId() {
+        assertThatThrownBy(() ->
+            new PublishOutboxEventsCommand(
+                " ",
+                25,
+                Duration.ofSeconds(30)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "publisherId must not be blank."
+            );
+    }
+
+    @Test
+    void shouldRejectNonPositiveBatchSize() {
+        assertThatThrownBy(() ->
+            new PublishOutboxEventsCommand(
+                "publisher-1",
+                0,
+                Duration.ofSeconds(30)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "batchSize must be positive."
+            );
+    }
+
+    @Test
+    void shouldRejectNonPositiveLeaseDuration() {
+        assertThatThrownBy(() ->
+            new PublishOutboxEventsCommand(
+                "publisher-1",
+                25,
+                Duration.ZERO
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "leaseDuration must be positive."
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/application/port/in/PublishOutboxEventsResultTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/application/port/in/PublishOutboxEventsResultTest.java
@@ -1,0 +1,71 @@
+package com.nursena.payflow.outbox.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class PublishOutboxEventsResultTest {
+
+    @Test
+    void shouldCreateBalancedResult() {
+        PublishOutboxEventsResult result =
+            new PublishOutboxEventsResult(
+                5,
+                2,
+                1,
+                1,
+                1
+            );
+
+        assertThat(result.claimedCount())
+            .isEqualTo(5);
+
+        assertThat(result.publishedCount())
+            .isEqualTo(2);
+
+        assertThat(result.retriedCount())
+            .isEqualTo(1);
+
+        assertThat(result.failedCount())
+            .isEqualTo(1);
+
+        assertThat(result.unresolvedCount())
+            .isEqualTo(1);
+    }
+
+    @Test
+    void shouldCreateEmptyResult() {
+        assertThat(
+            PublishOutboxEventsResult.empty()
+        ).isEqualTo(
+            new PublishOutboxEventsResult(
+                0,
+                0,
+                0,
+                0,
+                0
+            )
+        );
+    }
+
+    @Test
+    void shouldRejectUnbalancedOutcomeCounts() {
+        assertThatThrownBy(() ->
+            new PublishOutboxEventsResult(
+                5,
+                2,
+                1,
+                1,
+                0
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "Outcome counts must equal "
+                    + "claimedCount."
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/application/service/PublishOutboxEventsServiceTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/application/service/PublishOutboxEventsServiceTest.java
@@ -1,0 +1,487 @@
+package com.nursena.payflow.outbox.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.application.policy.OutboxRetryPolicy;
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsCommand;
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsResult;
+import com.nursena.payflow.outbox.application.port.out.OutboxEventClaimPort;
+import com.nursena.payflow.outbox.application.port.out.OutboxEventLifecyclePort;
+import com.nursena.payflow.outbox.application.port.out.OutboxMessagePublisherPort;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.ArgumentCaptor;
+
+
+@ExtendWith(MockitoExtension.class)
+class PublishOutboxEventsServiceTest {
+
+    private static final UUID FIRST_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID SECOND_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000002"
+        );
+
+    private static final UUID THIRD_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000003"
+        );
+
+    private static final UUID FOURTH_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000004"
+        );
+
+    private static final UUID FIFTH_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000005"
+        );
+
+    private static final UUID AGGREGATE_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000001"
+        );
+
+    private static final Instant CLOCK_TIME =
+        Instant.parse(
+            "2026-07-18T13:00:00.123456789Z"
+        );
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-18T13:00:00.123456Z"
+        );
+
+    private static final Duration LEASE_DURATION =
+        Duration.ofSeconds(30);
+
+    private static final String PUBLISHER_ID =
+        "publisher-1";
+
+    private static final String EVENT_TYPE =
+        "wallet.transfer.completed";
+
+    private static final PublishOutboxEventsCommand
+        COMMAND =
+        new PublishOutboxEventsCommand(
+            PUBLISHER_ID,
+            10,
+            LEASE_DURATION
+        );
+
+    @Mock
+    private OutboxEventClaimPort claimPort;
+
+    @Mock
+    private OutboxMessagePublisherPort publisherPort;
+
+    @Mock
+    private OutboxEventLifecyclePort lifecyclePort;
+
+    private PublishOutboxEventsService service;
+
+    @BeforeEach
+    void setUp() {
+        OutboxRetryPolicy retryPolicy =
+            new OutboxRetryPolicy(
+                3,
+                Duration.ofSeconds(10),
+                Duration.ofSeconds(40)
+            );
+
+        service =
+            new PublishOutboxEventsService(
+                claimPort,
+                publisherPort,
+                lifecyclePort,
+                retryPolicy,
+                Clock.fixed(
+                    CLOCK_TIME,
+                    ZoneOffset.UTC
+                )
+            );
+    }
+
+    @Test
+    void shouldReturnEmptyResultWhenNothingIsClaimed() {
+        when(claimPort.claimAvailable(
+            PUBLISHER_ID,
+            NOW,
+            LEASE_DURATION,
+            10
+        )).thenReturn(List.of());
+
+        PublishOutboxEventsResult result =
+            service.publishAvailable(COMMAND);
+
+        assertThat(result)
+            .isEqualTo(
+                PublishOutboxEventsResult.empty()
+            );
+
+        verifyNoInteractions(
+            publisherPort,
+            lifecyclePort
+        );
+    }
+
+    @Test
+    void shouldPublishAndCompleteAllClaimedEvents() {
+        OutboxEvent first =
+            processingEvent(
+                FIRST_EVENT_ID,
+                1
+            );
+
+        OutboxEvent second =
+            processingEvent(
+                SECOND_EVENT_ID,
+                1
+            );
+
+        when(claimPort.claimAvailable(
+            PUBLISHER_ID,
+            NOW,
+            LEASE_DURATION,
+            10
+        )).thenReturn(
+            List.of(first, second)
+        );
+
+        PublishOutboxEventsResult result =
+            service.publishAvailable(COMMAND);
+
+        assertThat(result)
+            .isEqualTo(
+                new PublishOutboxEventsResult(
+                    2,
+                    2,
+                    0,
+                    0,
+                    0
+                )
+            );
+
+        verify(publisherPort)
+            .publish(first);
+
+        verify(publisherPort)
+            .publish(second);
+
+        verify(lifecyclePort)
+            .markPublished(
+                FIRST_EVENT_ID,
+                PUBLISHER_ID,
+                NOW
+            );
+
+        verify(lifecyclePort)
+            .markPublished(
+                SECOND_EVENT_ID,
+                PUBLISHER_ID,
+                NOW
+            );
+    }
+
+    @Test
+    void shouldIsolateMixedBatchOutcomes() {
+        OutboxEvent retryEvent =
+            processingEvent(
+                FIRST_EVENT_ID,
+                1
+            );
+
+        OutboxEvent publishedEvent =
+            processingEvent(
+                SECOND_EVENT_ID,
+                1
+            );
+
+        OutboxEvent failedEvent =
+            processingEvent(
+                THIRD_EVENT_ID,
+                3
+            );
+
+        OutboxEvent unresolvedEvent =
+            processingEvent(
+                FOURTH_EVENT_ID,
+                1
+            );
+
+        when(claimPort.claimAvailable(
+            PUBLISHER_ID,
+            NOW,
+            LEASE_DURATION,
+            10
+        )).thenReturn(
+            List.of(
+                retryEvent,
+                publishedEvent,
+                failedEvent,
+                unresolvedEvent
+            )
+        );
+
+        doAnswer(invocation -> {
+            OutboxEvent event =
+                invocation.getArgument(0);
+
+            if (FIRST_EVENT_ID.equals(event.id())) {
+                throw new IllegalStateException(
+                    "Broker is unavailable."
+                );
+            }
+
+            if (THIRD_EVENT_ID.equals(event.id())) {
+                throw new IllegalStateException(
+                    "Invalid broker response."
+                );
+            }
+
+            return null;
+        })
+            .when(publisherPort)
+            .publish(
+                any(OutboxEvent.class)
+            );
+
+        when(lifecyclePort.markPublished(
+            any(UUID.class),
+            anyString(),
+            any(Instant.class)
+        )).thenAnswer(invocation -> {
+            UUID eventId =
+                invocation.getArgument(0);
+
+            String publisherId =
+                invocation.getArgument(1);
+
+            Instant publishedAt =
+                invocation.getArgument(2);
+
+            if (FOURTH_EVENT_ID.equals(eventId)) {
+                throw new IllegalStateException(
+                    "Database is unavailable."
+                );
+            }
+
+            return processingEvent(
+                eventId,
+                1
+            ).markPublished(
+                publisherId,
+                publishedAt
+            );
+        });
+
+        PublishOutboxEventsResult result =
+            service.publishAvailable(COMMAND);
+        ArgumentCaptor<OutboxEvent>
+            publishedEventCaptor =
+            ArgumentCaptor.forClass(
+                OutboxEvent.class
+            );
+
+        verify(
+            publisherPort,
+            times(4)
+        ).publish(
+            publishedEventCaptor.capture()
+        );
+
+        assertThat(
+            publishedEventCaptor
+                .getAllValues()
+        )
+            .extracting(
+                OutboxEvent::id
+            )
+            .containsExactly(
+                FIRST_EVENT_ID,
+                SECOND_EVENT_ID,
+                THIRD_EVENT_ID,
+                FOURTH_EVENT_ID
+            );
+
+        assertThat(result)
+            .isEqualTo(
+                new PublishOutboxEventsResult(
+                    4,
+                    1,
+                    1,
+                    1,
+                    1
+                )
+            );
+
+        verify(lifecyclePort)
+            .scheduleRetry(
+                FIRST_EVENT_ID,
+                PUBLISHER_ID,
+                NOW,
+                NOW.plusSeconds(10),
+                "IllegalStateException: "
+                    + "Broker is unavailable."
+            );
+
+        verify(lifecyclePort)
+            .markPublished(
+                SECOND_EVENT_ID,
+                PUBLISHER_ID,
+                NOW
+            );
+
+        verify(lifecyclePort)
+            .markFailed(
+                THIRD_EVENT_ID,
+                PUBLISHER_ID,
+                NOW,
+                "IllegalStateException: "
+                    + "Invalid broker response."
+            );
+
+        verify(publisherPort)
+            .publish(unresolvedEvent);
+    }
+
+    @Test
+    void shouldContinueWhenRetryOutcomeCannotBePersisted() {
+        OutboxEvent unresolvedEvent =
+            processingEvent(
+                FOURTH_EVENT_ID,
+                1
+            );
+
+        OutboxEvent successfulEvent =
+            processingEvent(
+                FIFTH_EVENT_ID,
+                1
+            );
+
+        when(claimPort.claimAvailable(
+            PUBLISHER_ID,
+            NOW,
+            LEASE_DURATION,
+            10
+        )).thenReturn(
+            List.of(
+                unresolvedEvent,
+                successfulEvent
+            )
+        );
+
+        doAnswer(invocation -> {
+            OutboxEvent event =
+                invocation.getArgument(0);
+
+            if (FOURTH_EVENT_ID.equals(event.id())) {
+                throw new IllegalStateException(
+                    "Broker is unavailable."
+                );
+            }
+
+            return null;
+        })
+            .when(publisherPort)
+            .publish(
+                any(OutboxEvent.class)
+            );
+
+        doThrow(
+            new IllegalStateException(
+                "Database is unavailable."
+            )
+        )
+            .when(lifecyclePort)
+            .scheduleRetry(
+                FOURTH_EVENT_ID,
+                PUBLISHER_ID,
+                NOW,
+                NOW.plusSeconds(10),
+                "IllegalStateException: "
+                    + "Broker is unavailable."
+            );
+
+        PublishOutboxEventsResult result =
+            service.publishAvailable(COMMAND);
+
+        assertThat(result)
+            .isEqualTo(
+                new PublishOutboxEventsResult(
+                    2,
+                    1,
+                    0,
+                    0,
+                    1
+                )
+            );
+
+        verify(publisherPort)
+            .publish(successfulEvent);
+
+        verify(lifecyclePort)
+            .markPublished(
+                FIFTH_EVENT_ID,
+                PUBLISHER_ID,
+                NOW
+            );
+    }
+
+    private static OutboxEvent processingEvent(
+        UUID eventId,
+        int attemptCount
+    ) {
+        return OutboxEvent.rehydrate(
+            eventId,
+            "PAYMENT_TRANSACTION",
+            AGGREGATE_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            AGGREGATE_ID.toString(),
+            EVENT_TYPE + ":1:" + eventId,
+            """
+            {
+              "eventId": "%s",
+              "eventType": "wallet.transfer.completed",
+              "eventVersion": 1
+            }
+            """.formatted(eventId),
+            OutboxStatus.PROCESSING,
+            attemptCount,
+            NOW,
+            NOW,
+            NOW.plus(LEASE_DURATION),
+            PUBLISHER_ID,
+            NOW.minusSeconds(60),
+            null,
+            null
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- define application contracts for transactional outbox publishing
- add validated batch, publisher, and lease command parameters
- add publishing result counters for published, retried, failed, and unresolved outcomes
- introduce an outbound message publisher port independent of Kafka
- implement deterministic exponential retry and terminal-failure decisions
- orchestrate claimed outbox events independently within a batch
- persist publish, retry, and terminal failure lifecycle outcomes
- continue processing remaining events when one event fails
- expose lifecycle persistence failures as unresolved outcomes

## Transaction boundaries

The orchestration service intentionally does not open a transaction around
the complete batch.

- claiming is completed in the persistence adapter's short transaction
- message publishing occurs outside a database transaction
- each lifecycle update is persisted through its own short transaction

This prevents database locks from remaining open during broker communication.

## Spring wiring

`PublishOutboxEventsService` is intentionally not registered as a Spring bean
in this change because the real `OutboxMessagePublisherPort` adapter does not
exist yet.

The service will be wired when the Kafka publisher adapter is introduced,
avoiding a fake or no-op production publisher implementation.

## Retry behavior

- retry delays use exponential backoff
- retry delay is capped at a configured maximum
- events reaching the maximum attempt count transition to `FAILED`
- lifecycle write failures remain `UNRESOLVED`
- one event failure does not stop the rest of the batch

## Tests

- command validation tests
- result invariant tests
- retry and terminal-failure policy tests
- successful batch publishing tests
- mixed batch outcome tests
- lifecycle failure isolation tests
- full Maven verification

## Out of scope

- Kafka producer adapter
- Kafka topic and producer configuration
- polling scheduler
- publisher instance configuration
- externalized outbox retry properties
- consumer-side idempotency