### PR TITLE
feat: publish transactional outbox events to Kafka

### DIFF
--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/kafka/KafkaOutboxMessagePublisherAdapter.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/kafka/KafkaOutboxMessagePublisherAdapter.java
@@ -1,0 +1,108 @@
+package com.nursena.payflow.outbox.adapter.out.kafka;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.nursena.payflow.outbox.application.port.out.OutboxMessagePublisherPort;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import org.springframework.kafka.core.KafkaOperations;
+
+public final class KafkaOutboxMessagePublisherAdapter
+    implements OutboxMessagePublisherPort {
+
+    private final KafkaOperations<String, String>
+        kafkaOperations;
+
+    private final Duration sendTimeout;
+
+    KafkaOutboxMessagePublisherAdapter(
+        KafkaOperations<String, String>
+            kafkaOperations,
+        Duration sendTimeout
+    ) {
+        this.kafkaOperations =
+            Objects.requireNonNull(
+                kafkaOperations,
+                "kafkaOperations must not be null"
+            );
+
+        this.sendTimeout =
+            Objects.requireNonNull(
+                sendTimeout,
+                "sendTimeout must not be null"
+            );
+    }
+
+    @Override
+    public void publish(
+        OutboxEvent event
+    ) {
+        Objects.requireNonNull(
+            event,
+            "event must not be null"
+        );
+
+        try {
+            kafkaOperations
+                .send(
+                    event.topic(),
+                    event.partitionKey(),
+                    event.payload()
+                )
+                .get(
+                    sendTimeout.toMillis(),
+                    TimeUnit.MILLISECONDS
+                );
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+
+            throw publishingFailure(
+                event,
+                "Kafka send was interrupted.",
+                exception
+            );
+        } catch (TimeoutException exception) {
+            throw publishingFailure(
+                event,
+                "Kafka broker acknowledgement "
+                    + "timed out.",
+                exception
+            );
+        } catch (ExecutionException exception) {
+            Throwable cause =
+                exception.getCause() == null
+                    ? exception
+                    : exception.getCause();
+
+            throw publishingFailure(
+                event,
+                "Kafka broker rejected or failed "
+                    + "the send operation.",
+                cause
+            );
+        } catch (RuntimeException exception) {
+            throw publishingFailure(
+                event,
+                "Kafka send could not be started.",
+                exception
+            );
+        }
+    }
+
+    private static OutboxMessagePublishingException
+    publishingFailure(
+        OutboxEvent event,
+        String reason,
+        Throwable cause
+    ) {
+        return new OutboxMessagePublishingException(
+            event.id(),
+            event.topic(),
+            reason,
+            cause
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/kafka/OutboxKafkaPublisherConfiguration.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/kafka/OutboxKafkaPublisherConfiguration.java
@@ -1,0 +1,28 @@
+package com.nursena.payflow.outbox.adapter.out.kafka;
+
+import com.nursena.payflow.outbox.application.port.out.OutboxMessagePublisherPort;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(
+    OutboxKafkaPublisherProperties.class
+)
+class OutboxKafkaPublisherConfiguration {
+
+    @Bean
+    OutboxMessagePublisherPort
+    outboxMessagePublisherPort(
+        KafkaTemplate<String, String>
+            kafkaTemplate,
+        OutboxKafkaPublisherProperties
+            properties
+    ) {
+        return new KafkaOutboxMessagePublisherAdapter(
+            kafkaTemplate,
+            properties.sendTimeout()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/kafka/OutboxKafkaPublisherProperties.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/kafka/OutboxKafkaPublisherProperties.java
@@ -1,0 +1,37 @@
+package com.nursena.payflow.outbox.adapter.out.kafka;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(
+    prefix = "payflow.outbox.kafka"
+)
+public record OutboxKafkaPublisherProperties(
+    Duration sendTimeout
+) {
+
+    public OutboxKafkaPublisherProperties {
+        Objects.requireNonNull(
+            sendTimeout,
+            "sendTimeout must not be null"
+        );
+
+        if (
+            sendTimeout.isZero()
+                || sendTimeout.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                "sendTimeout must be positive."
+            );
+        }
+
+        if (sendTimeout.toMillis() == 0) {
+            throw new IllegalArgumentException(
+                "sendTimeout must be at least "
+                    + "one millisecond."
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/kafka/OutboxMessagePublishingException.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/kafka/OutboxMessagePublishingException.java
@@ -1,0 +1,38 @@
+package com.nursena.payflow.outbox.adapter.out.kafka;
+
+import java.util.UUID;
+
+public final class OutboxMessagePublishingException
+    extends RuntimeException {
+
+    private final UUID eventId;
+    private final String topic;
+
+    OutboxMessagePublishingException(
+        UUID eventId,
+        String topic,
+        String reason,
+        Throwable cause
+    ) {
+        super(
+            "Failed to publish outbox event "
+                + eventId
+                + " to Kafka topic '"
+                + topic
+                + "'. "
+                + reason,
+            cause
+        );
+
+        this.eventId = eventId;
+        this.topic = topic;
+    }
+
+    public UUID eventId() {
+        return eventId;
+    }
+
+    public String topic() {
+        return topic;
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/configuration/OutboxOrchestrationConfiguration.java
+++ b/src/main/java/com/nursena/payflow/outbox/configuration/OutboxOrchestrationConfiguration.java
@@ -5,6 +5,13 @@ import java.time.Duration;
 import com.nursena.payflow.outbox.application.policy.OutboxRetryPolicy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import java.time.Clock;
+
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
+import com.nursena.payflow.outbox.application.port.out.OutboxEventClaimPort;
+import com.nursena.payflow.outbox.application.port.out.OutboxEventLifecyclePort;
+import com.nursena.payflow.outbox.application.port.out.OutboxMessagePublisherPort;
+import com.nursena.payflow.outbox.application.service.PublishOutboxEventsService;
 
 @Configuration(proxyBeanMethods = false)
 public class OutboxOrchestrationConfiguration {
@@ -23,6 +30,24 @@ public class OutboxOrchestrationConfiguration {
             MAX_ATTEMPTS,
             INITIAL_RETRY_DELAY,
             MAXIMUM_RETRY_DELAY
+        );
+    }
+
+    @Bean
+    PublishOutboxEventsUseCase
+    publishOutboxEventsUseCase(
+        OutboxEventClaimPort claimPort,
+        OutboxMessagePublisherPort publisherPort,
+        OutboxEventLifecyclePort lifecyclePort,
+        OutboxRetryPolicy retryPolicy,
+        Clock clock
+    ) {
+        return new PublishOutboxEventsService(
+            claimPort,
+            publisherPort,
+            lifecyclePort,
+            retryPolicy,
+            clock
         );
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,8 +24,11 @@ spring:
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     producer:
+      acks: all
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      properties:
+        "[enable.idempotence]": true
     consumer:
       group-id: ${KAFKA_CONSUMER_GROUP:payflow}
       auto-offset-reset: earliest
@@ -65,3 +68,6 @@ payflow:
     jwt:
       issuer: https://api.payflow.local
       access-token-ttl: 15m
+  outbox:
+    kafka:
+      send-timeout: ${OUTBOX_KAFKA_SEND_TIMEOUT:10s}

--- a/src/test/java/com/nursena/payflow/outbox/adapter/out/kafka/KafkaOutboxMessagePublisherAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/out/kafka/KafkaOutboxMessagePublisherAdapterTest.java
@@ -1,0 +1,227 @@
+package com.nursena.payflow.outbox.adapter.out.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+import org.apache.kafka.common.KafkaException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaOperations;
+import org.springframework.kafka.support.SendResult;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaOutboxMessagePublisherAdapterTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000001"
+        );
+
+    private static final UUID AGGREGATE_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000001"
+        );
+
+    private static final String TOPIC =
+        "wallet.transfer.completed";
+
+    private static final String PARTITION_KEY =
+        AGGREGATE_ID.toString();
+
+    private static final String PAYLOAD = """
+        {
+          "eventId": "50000000-0000-0000-0000-000000000001",
+          "eventType": "wallet.transfer.completed",
+          "eventVersion": 1
+        }
+        """;
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-18T18:00:00Z"
+        );
+
+    @Mock
+    private KafkaOperations<String, String>
+        kafkaOperations;
+
+    private KafkaOutboxMessagePublisherAdapter
+        adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter =
+            new KafkaOutboxMessagePublisherAdapter(
+                kafkaOperations,
+                Duration.ofSeconds(5)
+            );
+    }
+
+    @Test
+    void shouldPublishAndWaitForBrokerResult() {
+        SendResult<String, String> sendResult =
+            mock(SendResult.class);
+
+        when(kafkaOperations.send(
+            TOPIC,
+            PARTITION_KEY,
+            PAYLOAD
+        )).thenReturn(
+            CompletableFuture.completedFuture(
+                sendResult
+            )
+        );
+
+        adapter.publish(processingEvent());
+
+        verify(kafkaOperations)
+            .send(
+                TOPIC,
+                PARTITION_KEY,
+                PAYLOAD
+            );
+    }
+
+    @Test
+    void shouldTranslateAsynchronousKafkaFailure() {
+        CompletableFuture<
+            SendResult<String, String>
+            > failedFuture =
+            CompletableFuture.failedFuture(
+                new KafkaException(
+                    "Broker is unavailable."
+                )
+            );
+
+        when(kafkaOperations.send(
+            TOPIC,
+            PARTITION_KEY,
+            PAYLOAD
+        )).thenReturn(failedFuture);
+
+        assertThatThrownBy(() ->
+            adapter.publish(processingEvent())
+        )
+            .isInstanceOf(
+                OutboxMessagePublishingException.class
+            )
+            .hasMessageContaining(
+                EVENT_ID.toString()
+            )
+            .hasRootCauseMessage(
+                "Broker is unavailable."
+            );
+    }
+
+    @Test
+    void shouldTranslateBrokerTimeout() throws Exception {
+        @SuppressWarnings("unchecked")
+        CompletableFuture<
+            SendResult<String, String>
+            > sendFuture =
+            mock(CompletableFuture.class);
+
+        when(kafkaOperations.send(
+            TOPIC,
+            PARTITION_KEY,
+            PAYLOAD
+        )).thenReturn(sendFuture);
+
+        when(sendFuture.get(
+            5_000,
+            TimeUnit.MILLISECONDS
+        )).thenThrow(
+            new TimeoutException(
+                "Kafka acknowledgement timed out."
+            )
+        );
+
+        assertThatThrownBy(() ->
+            adapter.publish(processingEvent())
+        )
+            .isInstanceOf(
+                OutboxMessagePublishingException.class
+            )
+            .hasMessageContaining(
+                "acknowledgement timed out"
+            );
+    }
+
+    @Test
+    void shouldRestoreInterruptStatus() throws Exception {
+        @SuppressWarnings("unchecked")
+        CompletableFuture<
+            SendResult<String, String>
+            > sendFuture =
+            mock(CompletableFuture.class);
+
+        when(kafkaOperations.send(
+            TOPIC,
+            PARTITION_KEY,
+            PAYLOAD
+        )).thenReturn(sendFuture);
+
+        when(sendFuture.get(
+            5_000,
+            TimeUnit.MILLISECONDS
+        )).thenThrow(
+            new InterruptedException(
+                "Publisher thread interrupted."
+            )
+        );
+
+        try {
+            assertThatThrownBy(() ->
+                adapter.publish(processingEvent())
+            )
+                .isInstanceOf(
+                    OutboxMessagePublishingException.class
+                );
+
+            assertThat(
+                Thread.currentThread()
+                    .isInterrupted()
+            ).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    private static OutboxEvent processingEvent() {
+        return OutboxEvent.rehydrate(
+            EVENT_ID,
+            "PAYMENT_TRANSACTION",
+            AGGREGATE_ID,
+            TOPIC,
+            1,
+            TOPIC,
+            PARTITION_KEY,
+            TOPIC + ":1:" + AGGREGATE_ID,
+            PAYLOAD,
+            OutboxStatus.PROCESSING,
+            1,
+            NOW,
+            NOW,
+            NOW.plusSeconds(30),
+            "publisher-1",
+            NOW.minusSeconds(60),
+            null,
+            null
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/adapter/out/kafka/OutboxKafkaPublisherPropertiesTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/out/kafka/OutboxKafkaPublisherPropertiesTest.java
@@ -1,0 +1,37 @@
+package com.nursena.payflow.outbox.adapter.out.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class OutboxKafkaPublisherPropertiesTest {
+
+    @Test
+    void shouldCreateValidProperties() {
+        OutboxKafkaPublisherProperties properties =
+            new OutboxKafkaPublisherProperties(
+                Duration.ofSeconds(10)
+            );
+
+        assertThat(properties.sendTimeout())
+            .isEqualTo(Duration.ofSeconds(10));
+    }
+
+    @Test
+    void shouldRejectNonPositiveTimeout() {
+        assertThatThrownBy(() ->
+            new OutboxKafkaPublisherProperties(
+                Duration.ZERO
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "sendTimeout must be positive."
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/integration/KafkaOutboxMessagePublisherIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/integration/KafkaOutboxMessagePublisherIntegrationTest.java
@@ -1,0 +1,220 @@
+package com.nursena.payflow.outbox.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import com.nursena.payflow.outbox.application.port.out.OutboxMessagePublisherPort;
+import com.nursena.payflow.outbox.domain.model.OutboxEvent;
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+
+@SpringBootTest
+@Testcontainers
+class KafkaOutboxMessagePublisherIntegrationTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000101"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000101"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-18T18:00:00Z"
+        );
+
+    private static final String TOPIC =
+        "wallet.transfer.completed";
+
+    private static final String PARTITION_KEY =
+        TRANSACTION_ID.toString();
+
+    private static final String CONSUMER_GROUP =
+        "outbox-kafka-publisher-integration-test";
+
+    private static final String PAYLOAD = """
+        {
+          "eventId": "50000000-0000-0000-0000-000000000101",
+          "eventType": "wallet.transfer.completed",
+          "eventVersion": 1,
+          "occurredAt": "2026-07-18T18:00:00Z",
+          "transactionId": "60000000-0000-0000-0000-000000000101",
+          "amount": "125.50",
+          "currency": "TRY"
+        }
+        """;
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final KafkaContainer KAFKA =
+        new KafkaContainer(
+            "apache/kafka:4.1.2"
+        );
+
+    @Autowired
+    private OutboxMessagePublisherPort publisherPort;
+
+    @BeforeAll
+    static void createTopic() throws Exception {
+        Map<String, Object> adminProperties =
+            Map.of(
+                AdminClientConfig
+                    .BOOTSTRAP_SERVERS_CONFIG,
+                KAFKA.getBootstrapServers()
+            );
+
+        try (
+            Admin admin =
+                Admin.create(adminProperties)
+        ) {
+            NewTopic topic =
+                new NewTopic(
+                    TOPIC,
+                    1,
+                    (short) 1
+                );
+
+            admin.createTopics(
+                    List.of(topic)
+                )
+                .all()
+                .get(
+                    30,
+                    TimeUnit.SECONDS
+                );
+        }
+    }
+
+    @Test
+    void shouldPublishRawOutboxPayloadWithExpectedTopicAndKey() {
+        try (
+            Consumer<String, String> consumer =
+                createConsumer()
+        ) {
+            consumer.subscribe(
+                List.of(TOPIC)
+            );
+
+            publisherPort.publish(
+                processingEvent()
+            );
+
+            ConsumerRecord<String, String> record =
+                KafkaTestUtils.getSingleRecord(
+                    consumer,
+                    TOPIC,
+                    Duration.ofSeconds(20)
+                );
+
+            assertThat(record.topic())
+                .isEqualTo(TOPIC);
+
+            assertThat(record.partition())
+                .isZero();
+
+            assertThat(record.key())
+                .isEqualTo(PARTITION_KEY);
+
+            assertThat(record.value())
+                .isEqualTo(PAYLOAD);
+        }
+    }
+
+    private static Consumer<String, String>
+    createConsumer() {
+        Map<String, Object> properties =
+            new HashMap<>();
+
+        properties.put(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            KAFKA.getBootstrapServers()
+        );
+
+        properties.put(
+            ConsumerConfig.GROUP_ID_CONFIG,
+            CONSUMER_GROUP
+        );
+
+        properties.put(
+            ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
+            false
+        );
+
+        properties.put(
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+            "earliest"
+        );
+
+        properties.put(
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+            StringDeserializer.class
+        );
+
+        properties.put(
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+            StringDeserializer.class
+        );
+
+        return new KafkaConsumer<>(
+            properties
+        );
+    }
+
+    private static OutboxEvent processingEvent() {
+        return OutboxEvent.rehydrate(
+            EVENT_ID,
+            "PAYMENT_TRANSACTION",
+            TRANSACTION_ID,
+            TOPIC,
+            1,
+            TOPIC,
+            PARTITION_KEY,
+            TOPIC + ":1:" + TRANSACTION_ID,
+            PAYLOAD,
+            OutboxStatus.PROCESSING,
+            1,
+            CREATED_AT,
+            CREATED_AT,
+            CREATED_AT.plusSeconds(30),
+            "publisher-integration-test",
+            CREATED_AT.minusSeconds(60),
+            null,
+            null
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add a Kafka adapter for `OutboxMessagePublisherPort`
- publish outbox payloads using the event topic and partition key
- wait for Kafka broker acknowledgement before reporting success
- translate Kafka send failures, timeouts, and interruptions into an application exception
- preserve the thread interruption status when publishing is interrupted
- configure the producer to use string serializers for raw outbox JSON payloads
- enable idempotent Kafka producer behavior with `acks=all`
- wire the outbox publishing use case into the Spring application context
- add configurable Kafka acknowledgement timeout
- verify publishing against a real Apache Kafka broker

## Publishing behavior

The adapter sends:

- topic: `OutboxEvent.topic`
- key: `OutboxEvent.partitionKey`
- value: the raw JSON stored in `OutboxEvent.payload`

The call completes successfully only after Kafka returns a broker acknowledgement.

## Failure behavior

- asynchronous Kafka send failures are translated to `OutboxMessagePublishingException`
- acknowledgement timeouts are propagated to the orchestration layer
- interrupted sends restore the current thread's interrupt flag
- orchestration can then schedule a retry or mark the event as failed

## Producer configuration

- key serializer: `StringSerializer`
- value serializer: `StringSerializer`
- acknowledgements: `all`
- idempotence: enabled

Using `StringSerializer` ensures that the JSON payload stored by the
transactional outbox is published without additional JSON serialization.

## Tests

- successful acknowledged publishing
- asynchronous broker failure translation
- acknowledgement timeout translation
- interrupted publisher thread behavior
- publisher properties validation
- Spring application wiring
- real Apache Kafka 4.1.2 Testcontainers integration
- topic, partition key, and raw JSON payload verification
- full Maven verification

## Transaction boundaries

Kafka communication remains outside the database claim transaction.

- event claiming completes in a short database transaction
- Kafka publishing occurs after the claim transaction commits
- lifecycle results are persisted in separate short transactions

This preserves the expected at-least-once delivery model without holding
database locks during broker communication.

## Out of scope

- polling scheduler
- publisher instance identity
- externalized batch and lease configuration
- retry policy externalization
- Kafka consumers
- consumer-side idempotency