### PR TITLE
feat: add configurable transactional outbox polling

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -61,6 +61,12 @@ services:
       DB_PASSWORD: payflow
       REDIS_HOST: redis
       KAFKA_BOOTSTRAP_SERVERS: kafka:19092
+      OUTBOX_POLLING_ENABLED: "true"
+      OUTBOX_PUBLISHER_ID: payflow-compose
+      OUTBOX_POLLING_BATCH_SIZE: 100
+      OUTBOX_POLLING_LEASE_DURATION: 30s
+      OUTBOX_POLLING_FIXED_DELAY: 1s
+      OUTBOX_POLLING_INITIAL_DELAY: 5s
     ports:
       - "8080:8080"
     depends_on:

--- a/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfiguration.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfiguration.java
@@ -1,0 +1,33 @@
+package com.nursena.payflow.outbox.adapter.in.scheduling;
+
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration(proxyBeanMethods = false)
+@EnableScheduling
+@EnableConfigurationProperties(
+    OutboxPollingProperties.class
+)
+class OutboxPollingConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(
+        prefix = "payflow.outbox.polling",
+        name = "enabled",
+        havingValue = "true"
+    )
+    OutboxPublishingScheduler
+    outboxPublishingScheduler(
+        PublishOutboxEventsUseCase useCase,
+        OutboxPollingProperties properties
+    ) {
+        return new OutboxPublishingScheduler(
+            useCase,
+            properties
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfiguration.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfiguration.java
@@ -12,14 +12,14 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableConfigurationProperties(
     OutboxPollingProperties.class
 )
+@ConditionalOnProperty(
+    prefix = "payflow.outbox.polling",
+    name = "enabled",
+    havingValue = "true"
+)
 class OutboxPollingConfiguration {
 
     @Bean
-    @ConditionalOnProperty(
-        prefix = "payflow.outbox.polling",
-        name = "enabled",
-        havingValue = "true"
-    )
     OutboxPublishingScheduler
     outboxPublishingScheduler(
         PublishOutboxEventsUseCase useCase,

--- a/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingProperties.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingProperties.java
@@ -1,0 +1,94 @@
+package com.nursena.payflow.outbox.adapter.in.scheduling;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(
+    prefix = "payflow.outbox.polling"
+)
+public record OutboxPollingProperties(
+    boolean enabled,
+    String publisherId,
+    int batchSize,
+    Duration leaseDuration,
+    Duration fixedDelay,
+    Duration initialDelay
+) {
+
+    private static final int
+        MAX_PUBLISHER_ID_LENGTH = 200;
+
+    public OutboxPollingProperties {
+        if (
+            publisherId == null
+                || publisherId.isBlank()
+        ) {
+            throw new IllegalArgumentException(
+                "publisherId must not be blank."
+            );
+        }
+
+        if (
+            publisherId.length()
+                > MAX_PUBLISHER_ID_LENGTH
+        ) {
+            throw new IllegalArgumentException(
+                "publisherId must not exceed "
+                    + MAX_PUBLISHER_ID_LENGTH
+                    + " characters."
+            );
+        }
+
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException(
+                "batchSize must be positive."
+            );
+        }
+
+        leaseDuration =
+            requirePositive(
+                leaseDuration,
+                "leaseDuration"
+            );
+
+        fixedDelay =
+            requirePositive(
+                fixedDelay,
+                "fixedDelay"
+            );
+
+        Objects.requireNonNull(
+            initialDelay,
+            "initialDelay must not be null"
+        );
+
+        if (initialDelay.isNegative()) {
+            throw new IllegalArgumentException(
+                "initialDelay must not be negative."
+            );
+        }
+    }
+
+    private static Duration requirePositive(
+        Duration value,
+        String fieldName
+    ) {
+        Objects.requireNonNull(
+            value,
+            fieldName + " must not be null"
+        );
+
+        if (
+            value.isZero()
+                || value.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                fieldName + " must be positive."
+            );
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPublishingScheduler.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPublishingScheduler.java
@@ -1,0 +1,84 @@
+package com.nursena.payflow.outbox.adapter.in.scheduling;
+
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsCommand;
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsResult;
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+
+public final class OutboxPublishingScheduler {
+
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(
+            OutboxPublishingScheduler.class
+        );
+
+    private final PublishOutboxEventsUseCase
+        publishOutboxEventsUseCase;
+
+    private final PublishOutboxEventsCommand command;
+
+    public OutboxPublishingScheduler(
+        PublishOutboxEventsUseCase
+            publishOutboxEventsUseCase,
+        OutboxPollingProperties properties
+    ) {
+        this.publishOutboxEventsUseCase =
+            publishOutboxEventsUseCase;
+
+        this.command =
+            new PublishOutboxEventsCommand(
+                properties.publisherId(),
+                properties.batchSize(),
+                properties.leaseDuration()
+            );
+    }
+
+    @Scheduled(
+        fixedDelayString =
+            "${payflow.outbox.polling.fixed-delay}",
+        initialDelayString =
+            "${payflow.outbox.polling.initial-delay}"
+    )
+    public void publishAvailableEvents() {
+        try {
+            PublishOutboxEventsResult result =
+                publishOutboxEventsUseCase
+                    .publishAvailable(command);
+
+            logResult(result);
+        } catch (RuntimeException exception) {
+            LOGGER.error(
+                "Outbox polling cycle failed. "
+                    + "publisherId={}",
+                command.publisherId(),
+                exception
+            );
+        }
+    }
+
+    private static void logResult(
+        PublishOutboxEventsResult result
+    ) {
+        if (result.claimedCount() == 0) {
+            LOGGER.debug(
+                "No available outbox events were found."
+            );
+
+            return;
+        }
+
+        LOGGER.info(
+            "Outbox polling cycle completed. "
+                + "claimed={}, published={}, "
+                + "retried={}, failed={}, "
+                + "unresolved={}",
+            result.claimedCount(),
+            result.publishedCount(),
+            result.retriedCount(),
+            result.failedCount(),
+            result.unresolvedCount()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/configuration/OutboxOrchestrationConfiguration.java
+++ b/src/main/java/com/nursena/payflow/outbox/configuration/OutboxOrchestrationConfiguration.java
@@ -1,35 +1,31 @@
 package com.nursena.payflow.outbox.configuration;
 
-import java.time.Duration;
-
-import com.nursena.payflow.outbox.application.policy.OutboxRetryPolicy;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import java.time.Clock;
 
+import com.nursena.payflow.outbox.application.policy.OutboxRetryPolicy;
 import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
 import com.nursena.payflow.outbox.application.port.out.OutboxEventClaimPort;
 import com.nursena.payflow.outbox.application.port.out.OutboxEventLifecyclePort;
 import com.nursena.payflow.outbox.application.port.out.OutboxMessagePublisherPort;
 import com.nursena.payflow.outbox.application.service.PublishOutboxEventsService;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(
+    OutboxRetryProperties.class
+)
 public class OutboxOrchestrationConfiguration {
 
-    private static final int MAX_ATTEMPTS = 5;
-
-    private static final Duration INITIAL_RETRY_DELAY =
-        Duration.ofSeconds(10);
-
-    private static final Duration MAXIMUM_RETRY_DELAY =
-        Duration.ofMinutes(1);
-
     @Bean
-    OutboxRetryPolicy outboxRetryPolicy() {
+    OutboxRetryPolicy outboxRetryPolicy(
+        OutboxRetryProperties properties
+    ) {
         return new OutboxRetryPolicy(
-            MAX_ATTEMPTS,
-            INITIAL_RETRY_DELAY,
-            MAXIMUM_RETRY_DELAY
+            properties.maxAttempts(),
+            properties.initialDelay(),
+            properties.maximumDelay()
         );
     }
 

--- a/src/main/java/com/nursena/payflow/outbox/configuration/OutboxRetryProperties.java
+++ b/src/main/java/com/nursena/payflow/outbox/configuration/OutboxRetryProperties.java
@@ -1,0 +1,67 @@
+package com.nursena.payflow.outbox.configuration;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(
+    prefix = "payflow.outbox.retry"
+)
+public record OutboxRetryProperties(
+    int maxAttempts,
+    Duration initialDelay,
+    Duration maximumDelay
+) {
+
+    public OutboxRetryProperties {
+        if (maxAttempts <= 0) {
+            throw new IllegalArgumentException(
+                "maxAttempts must be positive."
+            );
+        }
+
+        initialDelay =
+            requirePositive(
+                initialDelay,
+                "initialDelay"
+            );
+
+        maximumDelay =
+            requirePositive(
+                maximumDelay,
+                "maximumDelay"
+            );
+
+        if (
+            maximumDelay.compareTo(initialDelay)
+                < 0
+        ) {
+            throw new IllegalArgumentException(
+                "maximumDelay must not be less "
+                    + "than initialDelay."
+            );
+        }
+    }
+
+    private static Duration requirePositive(
+        Duration value,
+        String fieldName
+    ) {
+        Objects.requireNonNull(
+            value,
+            fieldName + " must not be null"
+        );
+
+        if (
+            value.isZero()
+                || value.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                fieldName + " must be positive."
+            );
+        }
+
+        return value;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,3 +71,14 @@ payflow:
   outbox:
     kafka:
       send-timeout: ${OUTBOX_KAFKA_SEND_TIMEOUT:10s}
+    retry:
+      max-attempts: ${OUTBOX_RETRY_MAX_ATTEMPTS:5}
+      initial-delay: ${OUTBOX_RETRY_INITIAL_DELAY:10s}
+      maximum-delay: ${OUTBOX_RETRY_MAXIMUM_DELAY:1m}
+    polling:
+      enabled: ${OUTBOX_POLLING_ENABLED:false}
+      publisher-id: ${OUTBOX_PUBLISHER_ID:${HOSTNAME:payflow-local}}
+      batch-size: ${OUTBOX_POLLING_BATCH_SIZE:100}
+      lease-duration: ${OUTBOX_POLLING_LEASE_DURATION:30s}
+      fixed-delay: ${OUTBOX_POLLING_FIXED_DELAY:1s}
+      initial-delay: ${OUTBOX_POLLING_INITIAL_DELAY:5s}

--- a/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfigurationTest.java
@@ -1,0 +1,82 @@
+package com.nursena.payflow.outbox.adapter.in.scheduling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class OutboxPollingConfigurationTest {
+
+    @Test
+    void shouldNotCreatePollingBeansWhenDisabled() {
+        contextRunner(false)
+            .run(context -> {
+                assertThat(context)
+                    .doesNotHaveBean(
+                        OutboxPublishingScheduler.class
+                    );
+
+                assertThat(context)
+                    .doesNotHaveBean(
+                        OutboxPollingProperties.class
+                    );
+            });
+    }
+
+    @Test
+    void shouldCreatePollingBeansWhenEnabled() {
+        contextRunner(true)
+            .run(context -> {
+                assertThat(context)
+                    .hasSingleBean(
+                        OutboxPublishingScheduler.class
+                    );
+
+                assertThat(context)
+                    .hasSingleBean(
+                        OutboxPollingProperties.class
+                    );
+
+                OutboxPollingProperties properties =
+                    context.getBean(
+                        OutboxPollingProperties.class
+                    );
+
+                assertThat(properties.publisherId())
+                    .isEqualTo(
+                        "publisher-context-test"
+                    );
+
+                assertThat(properties.batchSize())
+                    .isEqualTo(25);
+            });
+    }
+
+    private static ApplicationContextRunner
+    contextRunner(
+        boolean enabled
+    ) {
+        return new ApplicationContextRunner()
+            .withUserConfiguration(
+                OutboxPollingConfiguration.class
+            )
+            .withBean(
+                PublishOutboxEventsUseCase.class,
+                () -> mock(
+                    PublishOutboxEventsUseCase.class
+                )
+            )
+            .withPropertyValues(
+                "payflow.outbox.polling.enabled="
+                    + enabled,
+                "payflow.outbox.polling.publisher-id="
+                    + "publisher-context-test",
+                "payflow.outbox.polling.batch-size=25",
+                "payflow.outbox.polling.lease-duration=30s",
+                "payflow.outbox.polling.fixed-delay=1h",
+                "payflow.outbox.polling.initial-delay=1h"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingPropertiesTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingPropertiesTest.java
@@ -1,0 +1,103 @@
+package com.nursena.payflow.outbox.adapter.in.scheduling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class OutboxPollingPropertiesTest {
+
+    @Test
+    void shouldCreateValidProperties() {
+        OutboxPollingProperties properties =
+            properties();
+
+        assertThat(properties.enabled())
+            .isTrue();
+
+        assertThat(properties.publisherId())
+            .isEqualTo("publisher-1");
+
+        assertThat(properties.batchSize())
+            .isEqualTo(100);
+
+        assertThat(properties.leaseDuration())
+            .isEqualTo(Duration.ofSeconds(30));
+
+        assertThat(properties.fixedDelay())
+            .isEqualTo(Duration.ofSeconds(1));
+
+        assertThat(properties.initialDelay())
+            .isEqualTo(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void shouldAllowZeroInitialDelay() {
+        OutboxPollingProperties properties =
+            new OutboxPollingProperties(
+                true,
+                "publisher-1",
+                100,
+                Duration.ofSeconds(30),
+                Duration.ofSeconds(1),
+                Duration.ZERO
+            );
+
+        assertThat(properties.initialDelay())
+            .isZero();
+    }
+
+    @Test
+    void shouldRejectBlankPublisherId() {
+        assertThatThrownBy(() ->
+            new OutboxPollingProperties(
+                true,
+                " ",
+                100,
+                Duration.ofSeconds(30),
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(5)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "publisherId must not be blank."
+            );
+    }
+
+    @Test
+    void shouldRejectNonPositiveBatchSize() {
+        assertThatThrownBy(() ->
+            new OutboxPollingProperties(
+                true,
+                "publisher-1",
+                0,
+                Duration.ofSeconds(30),
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(5)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "batchSize must be positive."
+            );
+    }
+
+    private static OutboxPollingProperties
+    properties() {
+        return new OutboxPollingProperties(
+            true,
+            "publisher-1",
+            100,
+            Duration.ofSeconds(30),
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(5)
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPublishingSchedulerTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPublishingSchedulerTest.java
@@ -1,0 +1,91 @@
+package com.nursena.payflow.outbox.adapter.in.scheduling;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsCommand;
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsResult;
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxPublishingSchedulerTest {
+
+    @Mock
+    private PublishOutboxEventsUseCase useCase;
+
+    private OutboxPublishingScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler =
+            new OutboxPublishingScheduler(
+                useCase,
+                new OutboxPollingProperties(
+                    true,
+                    "publisher-1",
+                    100,
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(1),
+                    Duration.ofSeconds(5)
+                )
+            );
+    }
+
+    @Test
+    void shouldPublishAvailableEventsUsingConfiguredCommand() {
+        PublishOutboxEventsCommand command =
+            new PublishOutboxEventsCommand(
+                "publisher-1",
+                100,
+                Duration.ofSeconds(30)
+            );
+
+        when(useCase.publishAvailable(command))
+            .thenReturn(
+                new PublishOutboxEventsResult(
+                    3,
+                    2,
+                    1,
+                    0,
+                    0
+                )
+            );
+
+        scheduler.publishAvailableEvents();
+
+        verify(useCase)
+            .publishAvailable(command);
+    }
+
+    @Test
+    void shouldContainUnexpectedPollingFailure() {
+        PublishOutboxEventsCommand command =
+            new PublishOutboxEventsCommand(
+                "publisher-1",
+                100,
+                Duration.ofSeconds(30)
+            );
+
+        when(useCase.publishAvailable(command))
+            .thenThrow(
+                new IllegalStateException(
+                    "Database is unavailable."
+                )
+            );
+
+        assertThatCode(
+            scheduler::publishAvailableEvents
+        ).doesNotThrowAnyException();
+
+        verify(useCase)
+            .publishAvailable(command);
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/configuration/OutboxRetryPropertiesTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/configuration/OutboxRetryPropertiesTest.java
@@ -1,0 +1,65 @@
+package com.nursena.payflow.outbox.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class OutboxRetryPropertiesTest {
+
+    @Test
+    void shouldCreateValidProperties() {
+        OutboxRetryProperties properties =
+            new OutboxRetryProperties(
+                5,
+                Duration.ofSeconds(10),
+                Duration.ofMinutes(1)
+            );
+
+        assertThat(properties.maxAttempts())
+            .isEqualTo(5);
+
+        assertThat(properties.initialDelay())
+            .isEqualTo(Duration.ofSeconds(10));
+
+        assertThat(properties.maximumDelay())
+            .isEqualTo(Duration.ofMinutes(1));
+    }
+
+    @Test
+    void shouldRejectNonPositiveMaximumAttempts() {
+        assertThatThrownBy(() ->
+            new OutboxRetryProperties(
+                0,
+                Duration.ofSeconds(10),
+                Duration.ofMinutes(1)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "maxAttempts must be positive."
+            );
+    }
+
+    @Test
+    void shouldRejectMaximumDelayBelowInitialDelay() {
+        assertThatThrownBy(() ->
+            new OutboxRetryProperties(
+                5,
+                Duration.ofMinutes(1),
+                Duration.ofSeconds(10)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "maximumDelay must not be less "
+                    + "than initialDelay."
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- add a configurable polling scheduler for transactional outbox events
- invoke the outbox publishing application port from a scheduled adapter
- externalize polling and retry configuration
- conditionally enable the entire polling infrastructure
- keep polling disabled by default
- enable polling in the local Docker Compose environment
- contain unexpected polling-cycle failures so later executions can continue
- add unit and Spring context tests

## Architecture

The scheduler depends only on the application input port:

OutboxPublishingScheduler
        ↓
PublishOutboxEventsUseCase
        ↓
claim, publish and lifecycle orchestration

The scheduling adapter does not depend directly on:

- KafkaTemplate
- persistence repositories
- transaction managers
- outbox lifecycle adapters

## Polling configuration

The following values are configurable:

- enabled
- publisher ID
- batch size
- lease duration
- fixed delay
- initial delay

Polling is disabled by default so regular application and integration-test
contexts do not start background publishing unexpectedly.

## Retry configuration

The retry policy is now configured through application properties:

- maximum attempts
- initial retry delay
- maximum retry delay

Configuration values are validated before the application starts.

## Failure behavior

An unexpected polling-cycle exception is logged and contained by the
scheduler. This prevents a temporary database or infrastructure failure from
terminating future scheduled executions.

Individual event publishing failures continue to be handled by the existing
orchestration retry and terminal-failure logic.

## Conditional wiring

When `payflow.outbox.polling.enabled=false`:

- the polling configuration is not loaded
- the polling properties bean is not created
- the scheduler bean is not created
- Spring scheduling is not enabled for this feature

When enabled, the scheduler and validated properties are registered.

## Docker Compose

The local Compose application service enables polling with:

- publisher ID: `payflow-compose`
- batch size: `100`
- lease duration: `30s`
- fixed delay: `1s`
- initial delay: `5s`

The static publisher ID is appropriate for the single application instance
used by the local Compose environment. Multi-instance deployments should use
a unique instance or pod identifier.

## Tests

- polling properties validation
- retry properties validation
- command construction from configured polling values
- successful polling invocation
- containment of unexpected polling failures
- disabled Spring context behavior
- enabled Spring context behavior
- full Maven verification
- Docker Compose configuration validation

## Transaction boundaries

The scheduler itself is not transactional.

- claiming uses its existing short database transaction
- Kafka publishing occurs outside the claim transaction
- lifecycle outcomes use separate short transactions

This avoids holding database locks while waiting for Kafka broker
acknowledgements.

## Out of scope

- distributed scheduler coordination beyond database leases
- Kubernetes publisher identity configuration
- metrics and alerting dashboards
- consumer implementation
- consumer-side event deduplication