### PR TITLE
feat: add transactional outbox observability

### DIFF
--- a/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxBacklogMetrics.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxBacklogMetrics.java
@@ -1,0 +1,126 @@
+package com.nursena.payflow.outbox.adapter.in.scheduling;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.nursena.payflow.outbox.application.model.OutboxBacklogSnapshot;
+import com.nursena.payflow.outbox.application.port.out.OutboxBacklogQueryPort;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+final class OutboxBacklogMetrics {
+
+    static final String BACKLOG_SIZE_METRIC =
+        "payflow.outbox.backlog.size";
+
+    static final String OLDEST_EVENT_AGE_METRIC =
+        "payflow.outbox.backlog.oldest.age";
+
+    private final OutboxBacklogQueryPort queryPort;
+    private final Clock clock;
+
+    private final AtomicReference<
+        OutboxBacklogSnapshot
+        > snapshot =
+        new AtomicReference<>(
+            OutboxBacklogSnapshot.empty()
+        );
+
+    OutboxBacklogMetrics(
+        OutboxBacklogQueryPort queryPort,
+        MeterRegistry meterRegistry,
+        Clock clock
+    ) {
+        this.queryPort =
+            Objects.requireNonNull(
+                queryPort,
+                "queryPort must not be null"
+            );
+
+        Objects.requireNonNull(
+            meterRegistry,
+            "meterRegistry must not be null"
+        );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+
+        Gauge.builder(
+                BACKLOG_SIZE_METRIC,
+                snapshot,
+                state ->
+                    state.get()
+                        .eventCount()
+            )
+            .description(
+                "Number of active transactional "
+                    + "outbox events."
+            )
+            .register(
+                meterRegistry
+            );
+
+        Gauge.builder(
+                OLDEST_EVENT_AGE_METRIC,
+                snapshot,
+                state ->
+                    oldestEventAgeSeconds(
+                        state.get()
+                    )
+            )
+            .description(
+                "Age of the oldest active "
+                    + "transactional outbox event."
+            )
+            .baseUnit("seconds")
+            .register(
+                meterRegistry
+            );
+    }
+
+    void refresh() {
+        OutboxBacklogSnapshot loadedSnapshot =
+            Objects.requireNonNull(
+                queryPort.loadSnapshot(),
+                "queryPort must not return null"
+            );
+
+        snapshot.set(
+            loadedSnapshot
+        );
+    }
+
+    private double oldestEventAgeSeconds(
+        OutboxBacklogSnapshot currentSnapshot
+    ) {
+        return currentSnapshot
+            .oldestCreatedAt()
+            .map(
+                this::ageInSeconds
+            )
+            .orElse(0.0);
+    }
+
+    private double ageInSeconds(
+        Instant oldestCreatedAt
+    ) {
+        Duration age =
+            Duration.between(
+                oldestCreatedAt,
+                clock.instant()
+            );
+
+        if (age.isNegative()) {
+            return 0.0;
+        }
+
+        return age.toMillis()
+            / 1000.0;
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfiguration.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfiguration.java
@@ -1,6 +1,8 @@
 package com.nursena.payflow.outbox.adapter.in.scheduling;
 
+import com.nursena.payflow.outbox.application.port.out.OutboxBacklogQueryPort;
 import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -8,6 +10,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Clock;
+
 
 @Configuration(proxyBeanMethods = false)
 @EnableScheduling
@@ -20,17 +24,30 @@ import io.micrometer.core.instrument.MeterRegistry;
     havingValue = "true"
 )
 class OutboxPollingConfiguration {
-
+    @Bean
+    OutboxBacklogMetrics outboxBacklogMetrics(
+        OutboxBacklogQueryPort queryPort,
+        MeterRegistry meterRegistry,
+        Clock clock
+    ) {
+        return new OutboxBacklogMetrics(
+            queryPort,
+            meterRegistry,
+            clock
+        );
+    }
     @Bean
     OutboxPublishingScheduler
     outboxPublishingScheduler(
         PublishOutboxEventsUseCase useCase,
         OutboxPollingMetrics metrics,
+        OutboxBacklogMetrics backlogMetrics,
         OutboxPollingProperties properties
     ) {
         return new OutboxPublishingScheduler(
             useCase,
             metrics,
+            backlogMetrics,
             properties
         );
     }

--- a/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfiguration.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfiguration.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 @Configuration(proxyBeanMethods = false)
 @EnableScheduling
 @EnableConfigurationProperties(
@@ -23,11 +25,21 @@ class OutboxPollingConfiguration {
     OutboxPublishingScheduler
     outboxPublishingScheduler(
         PublishOutboxEventsUseCase useCase,
+        OutboxPollingMetrics metrics,
         OutboxPollingProperties properties
     ) {
         return new OutboxPublishingScheduler(
             useCase,
+            metrics,
             properties
+        );
+    }
+    @Bean
+    OutboxPollingMetrics outboxPollingMetrics(
+        MeterRegistry meterRegistry
+    ) {
+        return new OutboxPollingMetrics(
+            meterRegistry
         );
     }
 }

--- a/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingMetrics.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingMetrics.java
@@ -1,0 +1,198 @@
+package com.nursena.payflow.outbox.adapter.in.scheduling;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsResult;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+final class OutboxPollingMetrics {
+
+    static final String POLLING_DURATION_METRIC =
+        "payflow.outbox.polling.duration";
+
+    static final String EVENTS_METRIC =
+        "payflow.outbox.events";
+
+    private static final String OUTCOME_TAG =
+        "outcome";
+
+    private final MeterRegistry meterRegistry;
+
+    private final Timer successfulCycleTimer;
+    private final Timer failedCycleTimer;
+
+    private final Counter claimedEvents;
+    private final Counter publishedEvents;
+    private final Counter retriedEvents;
+    private final Counter failedEvents;
+    private final Counter unresolvedEvents;
+
+    OutboxPollingMetrics(
+        MeterRegistry meterRegistry
+    ) {
+        this.meterRegistry =
+            Objects.requireNonNull(
+                meterRegistry,
+                "meterRegistry must not be null"
+            );
+
+        successfulCycleTimer =
+            pollingTimer(
+                meterRegistry,
+                "success"
+            );
+
+        failedCycleTimer =
+            pollingTimer(
+                meterRegistry,
+                "failure"
+            );
+
+        claimedEvents =
+            eventCounter(
+                meterRegistry,
+                "claimed"
+            );
+
+        publishedEvents =
+            eventCounter(
+                meterRegistry,
+                "published"
+            );
+
+        retriedEvents =
+            eventCounter(
+                meterRegistry,
+                "retried"
+            );
+
+        failedEvents =
+            eventCounter(
+                meterRegistry,
+                "failed"
+            );
+
+        unresolvedEvents =
+            eventCounter(
+                meterRegistry,
+                "unresolved"
+            );
+    }
+
+    PublishOutboxEventsResult record(
+        Supplier<PublishOutboxEventsResult>
+            pollingCycle
+    ) {
+        Objects.requireNonNull(
+            pollingCycle,
+            "pollingCycle must not be null"
+        );
+
+        Timer.Sample sample =
+            Timer.start(meterRegistry);
+
+        try {
+            PublishOutboxEventsResult result =
+                Objects.requireNonNull(
+                    pollingCycle.get(),
+                    "pollingCycle must not return null"
+                );
+
+            recordEvents(result);
+
+            sample.stop(
+                successfulCycleTimer
+            );
+
+            return result;
+        } catch (RuntimeException exception) {
+            sample.stop(
+                failedCycleTimer
+            );
+
+            throw exception;
+        }
+    }
+
+    private void recordEvents(
+        PublishOutboxEventsResult result
+    ) {
+        increment(
+            claimedEvents,
+            result.claimedCount()
+        );
+
+        increment(
+            publishedEvents,
+            result.publishedCount()
+        );
+
+        increment(
+            retriedEvents,
+            result.retriedCount()
+        );
+
+        increment(
+            failedEvents,
+            result.failedCount()
+        );
+
+        increment(
+            unresolvedEvents,
+            result.unresolvedCount()
+        );
+    }
+
+    private static Timer pollingTimer(
+        MeterRegistry meterRegistry,
+        String outcome
+    ) {
+        return Timer.builder(
+                POLLING_DURATION_METRIC
+            )
+            .description(
+                "Duration of transactional "
+                    + "outbox polling cycles."
+            )
+            .tag(
+                OUTCOME_TAG,
+                outcome
+            )
+            .register(
+                meterRegistry
+            );
+    }
+
+    private static Counter eventCounter(
+        MeterRegistry meterRegistry,
+        String outcome
+    ) {
+        return Counter.builder(
+                EVENTS_METRIC
+            )
+            .description(
+                "Number of transactional "
+                    + "outbox event outcomes."
+            )
+            .baseUnit("events")
+            .tag(
+                OUTCOME_TAG,
+                outcome
+            )
+            .register(
+                meterRegistry
+            );
+    }
+
+    private static void increment(
+        Counter counter,
+        int amount
+    ) {
+        if (amount > 0) {
+            counter.increment(amount);
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPublishingScheduler.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPublishingScheduler.java
@@ -7,6 +7,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 
+import java.util.Objects;
+
 public final class OutboxPublishingScheduler {
 
     private static final Logger LOGGER =
@@ -18,14 +20,31 @@ public final class OutboxPublishingScheduler {
         publishOutboxEventsUseCase;
 
     private final PublishOutboxEventsCommand command;
+    private final OutboxPollingMetrics metrics;
 
     public OutboxPublishingScheduler(
         PublishOutboxEventsUseCase
             publishOutboxEventsUseCase,
+        OutboxPollingMetrics metrics,
         OutboxPollingProperties properties
     ) {
         this.publishOutboxEventsUseCase =
-            publishOutboxEventsUseCase;
+            Objects.requireNonNull(
+                publishOutboxEventsUseCase,
+                "publishOutboxEventsUseCase "
+                    + "must not be null"
+            );
+
+        this.metrics =
+            Objects.requireNonNull(
+                metrics,
+                "metrics must not be null"
+            );
+
+        Objects.requireNonNull(
+            properties,
+            "properties must not be null"
+        );
 
         this.command =
             new PublishOutboxEventsCommand(
@@ -44,9 +63,10 @@ public final class OutboxPublishingScheduler {
     public void publishAvailableEvents() {
         try {
             PublishOutboxEventsResult result =
-                publishOutboxEventsUseCase
-                    .publishAvailable(command);
-
+                metrics.record(() ->
+                    publishOutboxEventsUseCase
+                        .publishAvailable(command)
+                );
             logResult(result);
         } catch (RuntimeException exception) {
             LOGGER.error(

--- a/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPublishingScheduler.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPublishingScheduler.java
@@ -21,11 +21,13 @@ public final class OutboxPublishingScheduler {
 
     private final PublishOutboxEventsCommand command;
     private final OutboxPollingMetrics metrics;
+    private final OutboxBacklogMetrics backlogMetrics;
 
     public OutboxPublishingScheduler(
         PublishOutboxEventsUseCase
             publishOutboxEventsUseCase,
         OutboxPollingMetrics metrics,
+        OutboxBacklogMetrics backlogMetrics,
         OutboxPollingProperties properties
     ) {
         this.publishOutboxEventsUseCase =
@@ -39,6 +41,12 @@ public final class OutboxPublishingScheduler {
             Objects.requireNonNull(
                 metrics,
                 "metrics must not be null"
+            );
+
+        this.backlogMetrics =
+            Objects.requireNonNull(
+                backlogMetrics,
+                "backlogMetrics must not be null"
             );
 
         Objects.requireNonNull(
@@ -67,11 +75,27 @@ public final class OutboxPublishingScheduler {
                     publishOutboxEventsUseCase
                         .publishAvailable(command)
                 );
+
             logResult(result);
         } catch (RuntimeException exception) {
             LOGGER.error(
                 "Outbox polling cycle failed. "
                     + "publisherId={}",
+                command.publisherId(),
+                exception
+            );
+        } finally {
+            refreshBacklogMetrics();
+        }
+    }
+
+    private void refreshBacklogMetrics() {
+        try {
+            backlogMetrics.refresh();
+        } catch (RuntimeException exception) {
+            LOGGER.warn(
+                "Outbox backlog metrics could not "
+                    + "be refreshed. publisherId={}",
                 command.publisherId(),
                 exception
             );

--- a/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/JdbcOutboxBacklogQueryAdapter.java
+++ b/src/main/java/com/nursena/payflow/outbox/adapter/out/persistence/JdbcOutboxBacklogQueryAdapter.java
@@ -1,0 +1,71 @@
+package com.nursena.payflow.outbox.adapter.out.persistence;
+
+import java.sql.Timestamp;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.nursena.payflow.outbox.application.model.OutboxBacklogSnapshot;
+import com.nursena.payflow.outbox.application.port.out.OutboxBacklogQueryPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JdbcOutboxBacklogQueryAdapter
+    implements OutboxBacklogQueryPort {
+
+    private static final String LOAD_SNAPSHOT_SQL = """
+        SELECT
+            COUNT(*) AS event_count,
+            MIN(created_at) AS oldest_created_at
+        FROM outbox_events
+        WHERE status IN (
+            'PENDING',
+            'PROCESSING'
+        )
+        """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    JdbcOutboxBacklogQueryAdapter(
+        JdbcTemplate jdbcTemplate
+    ) {
+        this.jdbcTemplate =
+            Objects.requireNonNull(
+                jdbcTemplate,
+                "jdbcTemplate must not be null"
+            );
+    }
+
+    @Override
+    public OutboxBacklogSnapshot loadSnapshot() {
+        OutboxBacklogSnapshot snapshot =
+            jdbcTemplate.queryForObject(
+                LOAD_SNAPSHOT_SQL,
+                (resultSet, rowNumber) -> {
+                    long eventCount =
+                        resultSet.getLong(
+                            "event_count"
+                        );
+
+                    Timestamp oldestCreatedAt =
+                        resultSet.getTimestamp(
+                            "oldest_created_at"
+                        );
+
+                    return new OutboxBacklogSnapshot(
+                        eventCount,
+                        Optional.ofNullable(
+                            oldestCreatedAt
+                        ).map(
+                            Timestamp::toInstant
+                        )
+                    );
+                }
+            );
+
+        return Objects.requireNonNull(
+            snapshot,
+            "Backlog query must return a snapshot."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/application/model/OutboxBacklogSnapshot.java
+++ b/src/main/java/com/nursena/payflow/outbox/application/model/OutboxBacklogSnapshot.java
@@ -1,0 +1,52 @@
+package com.nursena.payflow.outbox.application.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+public record OutboxBacklogSnapshot(
+    long eventCount,
+    Optional<Instant> oldestCreatedAt
+) {
+
+    public OutboxBacklogSnapshot {
+        if (eventCount < 0) {
+            throw new IllegalArgumentException(
+                "eventCount must not be negative."
+            );
+        }
+
+        oldestCreatedAt =
+            Objects.requireNonNull(
+                oldestCreatedAt,
+                "oldestCreatedAt must not be null"
+            );
+
+        if (
+            eventCount == 0
+                && oldestCreatedAt.isPresent()
+        ) {
+            throw new IllegalArgumentException(
+                "Empty backlog must not have "
+                    + "an oldest event."
+            );
+        }
+
+        if (
+            eventCount > 0
+                && oldestCreatedAt.isEmpty()
+        ) {
+            throw new IllegalArgumentException(
+                "Non-empty backlog must have "
+                    + "an oldest event."
+            );
+        }
+    }
+
+    public static OutboxBacklogSnapshot empty() {
+        return new OutboxBacklogSnapshot(
+            0,
+            Optional.empty()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/outbox/application/port/out/OutboxBacklogQueryPort.java
+++ b/src/main/java/com/nursena/payflow/outbox/application/port/out/OutboxBacklogQueryPort.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.outbox.application.port.out;
+
+import com.nursena.payflow.outbox.application.model.OutboxBacklogSnapshot;
+
+public interface OutboxBacklogQueryPort {
+
+    OutboxBacklogSnapshot loadSnapshot();
+}

--- a/src/main/resources/db/migration/V6__index_active_outbox_backlog.sql
+++ b/src/main/resources/db/migration/V6__index_active_outbox_backlog.sql
@@ -1,0 +1,6 @@
+CREATE INDEX idx_outbox_events_active_created_at
+    ON outbox_events (created_at)
+    WHERE status IN (
+        'PENDING',
+        'PROCESSING'
+    );

--- a/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxBacklogMetricsTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxBacklogMetricsTest.java
@@ -1,0 +1,156 @@
+package com.nursena.payflow.outbox.adapter.in.scheduling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import com.nursena.payflow.outbox.application.model.OutboxBacklogSnapshot;
+import com.nursena.payflow.outbox.application.port.out.OutboxBacklogQueryPort;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxBacklogMetricsTest {
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-19T12:00:00Z"
+        );
+
+    @Mock
+    private OutboxBacklogQueryPort queryPort;
+
+    private SimpleMeterRegistry meterRegistry;
+    private OutboxBacklogMetrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry =
+            new SimpleMeterRegistry();
+
+        metrics =
+            new OutboxBacklogMetrics(
+                queryPort,
+                meterRegistry,
+                Clock.fixed(
+                    NOW,
+                    ZoneOffset.UTC
+                )
+            );
+    }
+
+    @AfterEach
+    void tearDown() {
+        meterRegistry.close();
+    }
+
+    @Test
+    void shouldExposeZeroValuesBeforeFirstRefresh() {
+        assertBacklogSize(0.0);
+        assertOldestAge(0.0);
+    }
+
+    @Test
+    void shouldRefreshBacklogSizeAndOldestEventAge() {
+        when(queryPort.loadSnapshot())
+            .thenReturn(
+                new OutboxBacklogSnapshot(
+                    3,
+                    Optional.of(
+                        NOW.minusSeconds(45)
+                    )
+                )
+            );
+
+        metrics.refresh();
+
+        assertBacklogSize(3.0);
+        assertOldestAge(45.0);
+    }
+
+    @Test
+    void shouldResetMetricsForEmptyBacklog() {
+        when(queryPort.loadSnapshot())
+            .thenReturn(
+                new OutboxBacklogSnapshot(
+                    2,
+                    Optional.of(
+                        NOW.minusSeconds(30)
+                    )
+                ),
+                OutboxBacklogSnapshot.empty()
+            );
+
+        metrics.refresh();
+        metrics.refresh();
+
+        assertBacklogSize(0.0);
+        assertOldestAge(0.0);
+    }
+
+    @Test
+    void shouldPreserveLastSnapshotWhenRefreshFails() {
+        when(queryPort.loadSnapshot())
+            .thenReturn(
+                new OutboxBacklogSnapshot(
+                    2,
+                    Optional.of(
+                        NOW.minusSeconds(30)
+                    )
+                )
+            )
+            .thenThrow(
+                new IllegalStateException(
+                    "Database is unavailable."
+                )
+            );
+
+        metrics.refresh();
+
+        assertThatThrownBy(
+            metrics::refresh
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            );
+
+        assertBacklogSize(2.0);
+        assertOldestAge(30.0);
+    }
+
+    private void assertBacklogSize(
+        double expected
+    ) {
+        assertThat(
+            meterRegistry.get(
+                    OutboxBacklogMetrics
+                        .BACKLOG_SIZE_METRIC
+                )
+                .gauge()
+                .value()
+        ).isEqualTo(expected);
+    }
+
+    private void assertOldestAge(
+        double expected
+    ) {
+        assertThat(
+            meterRegistry.get(
+                    OutboxBacklogMetrics
+                        .OLDEST_EVENT_AGE_METRIC
+                )
+                .gauge()
+                .value()
+        ).isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfigurationTest.java
@@ -3,10 +3,13 @@ package com.nursena.payflow.outbox.adapter.in.scheduling;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.time.Clock;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
+import com.nursena.payflow.outbox.application.port.out.OutboxBacklogQueryPort;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -31,6 +34,11 @@ class OutboxPollingConfigurationTest {
                     .doesNotHaveBean(
                         OutboxPollingMetrics.class
                     );
+
+                assertThat(context)
+                    .doesNotHaveBean(
+                        OutboxBacklogMetrics.class
+                    );
             });
     }
 
@@ -51,6 +59,11 @@ class OutboxPollingConfigurationTest {
                 assertThat(context)
                     .hasSingleBean(
                         OutboxPollingMetrics.class
+                    );
+
+                assertThat(context)
+                    .hasSingleBean(
+                        OutboxBacklogMetrics.class
                     );
 
                 OutboxPollingProperties properties =
@@ -82,8 +95,18 @@ class OutboxPollingConfigurationTest {
                 )
             )
             .withBean(
+                OutboxBacklogQueryPort.class,
+                () -> mock(
+                    OutboxBacklogQueryPort.class
+                )
+            )
+            .withBean(
                 MeterRegistry.class,
                 SimpleMeterRegistry::new
+            )
+            .withBean(
+                Clock.class,
+                Clock::systemUTC
             )
             .withPropertyValues(
                 "payflow.outbox.polling.enabled="

--- a/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingConfigurationTest.java
@@ -3,9 +3,13 @@ package com.nursena.payflow.outbox.adapter.in.scheduling;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 class OutboxPollingConfigurationTest {
 
@@ -21,6 +25,11 @@ class OutboxPollingConfigurationTest {
                 assertThat(context)
                     .doesNotHaveBean(
                         OutboxPollingProperties.class
+                    );
+
+                assertThat(context)
+                    .doesNotHaveBean(
+                        OutboxPollingMetrics.class
                     );
             });
     }
@@ -39,6 +48,11 @@ class OutboxPollingConfigurationTest {
                         OutboxPollingProperties.class
                     );
 
+                assertThat(context)
+                    .hasSingleBean(
+                        OutboxPollingMetrics.class
+                    );
+
                 OutboxPollingProperties properties =
                     context.getBean(
                         OutboxPollingProperties.class
@@ -54,8 +68,7 @@ class OutboxPollingConfigurationTest {
             });
     }
 
-    private static ApplicationContextRunner
-    contextRunner(
+    private static ApplicationContextRunner contextRunner(
         boolean enabled
     ) {
         return new ApplicationContextRunner()
@@ -67,6 +80,10 @@ class OutboxPollingConfigurationTest {
                 () -> mock(
                     PublishOutboxEventsUseCase.class
                 )
+            )
+            .withBean(
+                MeterRegistry.class,
+                SimpleMeterRegistry::new
             )
             .withPropertyValues(
                 "payflow.outbox.polling.enabled="

--- a/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingMetricsTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPollingMetricsTest.java
@@ -1,0 +1,193 @@
+package com.nursena.payflow.outbox.adapter.in.scheduling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsResult;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OutboxPollingMetricsTest {
+
+    private SimpleMeterRegistry meterRegistry;
+    private OutboxPollingMetrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry =
+            new SimpleMeterRegistry();
+
+        metrics =
+            new OutboxPollingMetrics(
+                meterRegistry
+            );
+    }
+
+    @AfterEach
+    void tearDown() {
+        meterRegistry.close();
+    }
+
+    @Test
+    void shouldRecordSuccessfulPollingCycleAndEventOutcomes() {
+        PublishOutboxEventsResult expected =
+            new PublishOutboxEventsResult(
+                5,
+                2,
+                1,
+                1,
+                1
+            );
+
+        PublishOutboxEventsResult actual =
+            metrics.record(() -> expected);
+
+        assertThat(actual)
+            .isSameAs(expected);
+
+        assertTimerCount(
+            "success",
+            1
+        );
+
+        assertTimerCount(
+            "failure",
+            0
+        );
+
+        assertEventCount(
+            "claimed",
+            5
+        );
+
+        assertEventCount(
+            "published",
+            2
+        );
+
+        assertEventCount(
+            "retried",
+            1
+        );
+
+        assertEventCount(
+            "failed",
+            1
+        );
+
+        assertEventCount(
+            "unresolved",
+            1
+        );
+    }
+
+    @Test
+    void shouldRecordFailedPollingCycleAndRethrowFailure() {
+        IllegalStateException failure =
+            new IllegalStateException(
+                "Database is unavailable."
+            );
+
+        assertThatThrownBy(() ->
+            metrics.record(() -> {
+                throw failure;
+            })
+        )
+            .isSameAs(failure);
+
+        assertTimerCount(
+            "success",
+            0
+        );
+
+        assertTimerCount(
+            "failure",
+            1
+        );
+
+        assertEventCount(
+            "claimed",
+            0
+        );
+
+        assertEventCount(
+            "published",
+            0
+        );
+
+        assertEventCount(
+            "retried",
+            0
+        );
+
+        assertEventCount(
+            "failed",
+            0
+        );
+
+        assertEventCount(
+            "unresolved",
+            0
+        );
+    }
+
+    @Test
+    void shouldNotIncrementEventCountersForEmptyCycle() {
+        metrics.record(
+            PublishOutboxEventsResult::empty
+        );
+
+        assertTimerCount(
+            "success",
+            1
+        );
+
+        assertEventCount(
+            "claimed",
+            0
+        );
+
+        assertEventCount(
+            "published",
+            0
+        );
+    }
+
+    private void assertTimerCount(
+        String outcome,
+        long expected
+    ) {
+        assertThat(
+            meterRegistry.get(
+                    OutboxPollingMetrics
+                        .POLLING_DURATION_METRIC
+                )
+                .tag(
+                    "outcome",
+                    outcome
+                )
+                .timer()
+                .count()
+        ).isEqualTo(expected);
+    }
+
+    private void assertEventCount(
+        String outcome,
+        double expected
+    ) {
+        assertThat(
+            meterRegistry.get(
+                    OutboxPollingMetrics
+                        .EVENTS_METRIC
+                )
+                .tag(
+                    "outcome",
+                    outcome
+                )
+                .counter()
+                .count()
+        ).isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPublishingSchedulerTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPublishingSchedulerTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
 
 @ExtendWith(MockitoExtension.class)
 class OutboxPublishingSchedulerTest {
@@ -23,11 +25,19 @@ class OutboxPublishingSchedulerTest {
 
     private OutboxPublishingScheduler scheduler;
 
+    private SimpleMeterRegistry meterRegistry;
+
     @BeforeEach
     void setUp() {
+        meterRegistry =
+            new SimpleMeterRegistry();
+
         scheduler =
             new OutboxPublishingScheduler(
                 useCase,
+                new OutboxPollingMetrics(
+                    meterRegistry
+                ),
                 new OutboxPollingProperties(
                     true,
                     "publisher-1",

--- a/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPublishingSchedulerTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/adapter/in/scheduling/OutboxPublishingSchedulerTest.java
@@ -4,24 +4,33 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
 
-import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsCommand;
-import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsResult;
-import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nursena.payflow.outbox.application.model.OutboxBacklogSnapshot;
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsCommand;
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsResult;
+import com.nursena.payflow.outbox.application.port.in.PublishOutboxEventsUseCase;
+import com.nursena.payflow.outbox.application.port.out.OutboxBacklogQueryPort;
+
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.jupiter.api.AfterEach;
 
 @ExtendWith(MockitoExtension.class)
 class OutboxPublishingSchedulerTest {
 
     @Mock
     private PublishOutboxEventsUseCase useCase;
+
+    @Mock
+    private OutboxBacklogQueryPort backlogQueryPort;
 
     private OutboxPublishingScheduler scheduler;
 
@@ -32,20 +41,41 @@ class OutboxPublishingSchedulerTest {
         meterRegistry =
             new SimpleMeterRegistry();
 
+        when(backlogQueryPort.loadSnapshot())
+            .thenReturn(
+                OutboxBacklogSnapshot.empty()
+            );
+
+        OutboxPollingProperties properties =
+            new OutboxPollingProperties(
+                true,
+                "publisher-1",
+                100,
+                Duration.ofSeconds(30),
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(5)
+            );
+
+        OutboxBacklogMetrics backlogMetrics =
+            new OutboxBacklogMetrics(
+                backlogQueryPort,
+                meterRegistry,
+                Clock.fixed(
+                    Instant.parse(
+                        "2026-07-19T12:00:00Z"
+                    ),
+                    ZoneOffset.UTC
+                )
+            );
+
         scheduler =
             new OutboxPublishingScheduler(
                 useCase,
                 new OutboxPollingMetrics(
                     meterRegistry
                 ),
-                new OutboxPollingProperties(
-                    true,
-                    "publisher-1",
-                    100,
-                    Duration.ofSeconds(30),
-                    Duration.ofSeconds(1),
-                    Duration.ofSeconds(5)
-                )
+                backlogMetrics,
+                properties
             );
     }
 
@@ -73,6 +103,9 @@ class OutboxPublishingSchedulerTest {
 
         verify(useCase)
             .publishAvailable(command);
+
+        verify(backlogQueryPort)
+            .loadSnapshot();
     }
 
     @Test
@@ -97,5 +130,8 @@ class OutboxPublishingSchedulerTest {
 
         verify(useCase)
             .publishAvailable(command);
+
+        verify(backlogQueryPort)
+            .loadSnapshot();
     }
 }

--- a/src/test/java/com/nursena/payflow/outbox/integration/OutboxBacklogQueryIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/outbox/integration/OutboxBacklogQueryIntegrationTest.java
@@ -1,0 +1,216 @@
+package com.nursena.payflow.outbox.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.outbox.application.model.OutboxBacklogSnapshot;
+import com.nursena.payflow.outbox.application.port.out.OutboxBacklogQueryPort;
+import com.nursena.payflow.outbox.domain.model.OutboxStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class OutboxBacklogQueryIntegrationTest {
+
+    private static final Instant ACTIVE_OLDEST =
+        Instant.parse(
+            "2026-07-19T10:05:00Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private OutboxBacklogQueryPort queryPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM outbox_events"
+        );
+    }
+
+    @Test
+    void shouldReturnEmptySnapshotWhenNoEventsExist() {
+        OutboxBacklogSnapshot snapshot =
+            queryPort.loadSnapshot();
+
+        assertThat(snapshot.eventCount())
+            .isZero();
+
+        assertThat(snapshot.oldestCreatedAt())
+            .isEmpty();
+    }
+
+    @Test
+    void shouldCountOnlyPendingAndProcessingEvents() {
+        insertEvent(
+            "50000000-0000-0000-0000-000000000201",
+            OutboxStatus.PUBLISHED,
+            Instant.parse(
+                "2026-07-19T10:00:00Z"
+            )
+        );
+
+        insertEvent(
+            "50000000-0000-0000-0000-000000000202",
+            OutboxStatus.FAILED,
+            Instant.parse(
+                "2026-07-19T10:01:00Z"
+            )
+        );
+
+        insertEvent(
+            "50000000-0000-0000-0000-000000000203",
+            OutboxStatus.PENDING,
+            ACTIVE_OLDEST
+        );
+
+        insertEvent(
+            "50000000-0000-0000-0000-000000000204",
+            OutboxStatus.PROCESSING,
+            Instant.parse(
+                "2026-07-19T10:10:00Z"
+            )
+        );
+
+        OutboxBacklogSnapshot snapshot =
+            queryPort.loadSnapshot();
+
+        assertThat(snapshot.eventCount())
+            .isEqualTo(2);
+
+        assertThat(snapshot.oldestCreatedAt())
+            .contains(ACTIVE_OLDEST);
+    }
+
+    private void insertEvent(
+        String idValue,
+        OutboxStatus status,
+        Instant createdAt
+    ) {
+        UUID id =
+            UUID.fromString(idValue);
+
+        boolean processing =
+            status == OutboxStatus.PROCESSING;
+
+        boolean published =
+            status == OutboxStatus.PUBLISHED;
+
+        int attemptCount =
+            status == OutboxStatus.PENDING
+                ? 0
+                : 1;
+
+        Instant lockedAt =
+            processing
+                ? createdAt.plusSeconds(1)
+                : null;
+
+        Instant lockedUntil =
+            processing
+                ? createdAt.plusSeconds(31)
+                : null;
+
+        String lockedBy =
+            processing
+                ? "backlog-test-publisher"
+                : null;
+
+        Instant publishedAt =
+            published
+                ? createdAt.plusSeconds(5)
+                : null;
+
+        String lastError =
+            status == OutboxStatus.FAILED
+                ? "Terminal test failure."
+                : null;
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO outbox_events (
+                id,
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                event_version,
+                topic,
+                partition_key,
+                deduplication_key,
+                payload,
+                status,
+                attempt_count,
+                available_at,
+                locked_at,
+                locked_until,
+                locked_by,
+                created_at,
+                published_at,
+                last_error
+            )
+            VALUES (
+                ?,
+                'PAYMENT_TRANSACTION',
+                ?,
+                'wallet.transfer.completed',
+                1,
+                'wallet.transfer.completed',
+                ?,
+                ?,
+                CAST(? AS JSONB),
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?
+            )
+            """,
+            id,
+            id,
+            id.toString(),
+            "wallet.transfer.completed:1:" + id,
+            "{\"eventId\":\"" + id + "\"}",
+            status.name(),
+            attemptCount,
+            timestamp(createdAt),
+            timestamp(lockedAt),
+            timestamp(lockedUntil),
+            lockedBy,
+            timestamp(createdAt),
+            timestamp(publishedAt),
+            lastError
+        );
+    }
+
+    private static Timestamp timestamp(
+        Instant value
+    ) {
+        return value == null
+            ? null
+            : Timestamp.from(value);
+    }
+}


### PR DESCRIPTION
## Summary

- add Micrometer metrics for transactional outbox polling cycles
- record successful and failed polling-cycle durations
- record claimed, published, retried, failed and unresolved event outcomes
- expose active outbox backlog size
- expose the age of the oldest active outbox event
- refresh backlog snapshots after polling cycles
- keep Prometheus scrapes independent from database queries
- add a partial PostgreSQL index for active backlog queries
- add unit, Spring context and PostgreSQL integration tests

## Metrics

### Polling duration

`payflow.outbox.polling.duration`

Tags:

- `outcome=success`
- `outcome=failure`

The timer also exposes polling-cycle execution counts.

### Event outcomes

`payflow.outbox.events`

Tags:

- `outcome=claimed`
- `outcome=published`
- `outcome=retried`
- `outcome=failed`
- `outcome=unresolved`

Only bounded, low-cardinality tags are used. Event IDs and publisher IDs
are intentionally not used as metric tags.

### Backlog gauges

- `payflow.outbox.backlog.size`
- `payflow.outbox.backlog.oldest.age`

The active backlog consists of:

- `PENDING`
- `PROCESSING`

`PUBLISHED` and terminal `FAILED` events are excluded.

## Architecture

```text
OutboxPublishingScheduler
        ├── OutboxPollingMetrics
        │       └── Micrometer timers and counters
        │
        └── OutboxBacklogMetrics
                ↓
        OutboxBacklogQueryPort
                ↓
        JdbcOutboxBacklogQueryAdapter
                ↓
        PostgreSQL