### PR TITLE
chore: start v0.4.0 development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 


### PR DESCRIPTION
## Summary

- update the Maven project version to `0.4.0-SNAPSHOT`
- start the next PayFlow development cycle after the `v0.3.0` release

## Validation

- Maven clean verification completed successfully
- no production behavior was changed