### PR TITLE
feat: add Alertmanager notification delivery

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -91,6 +91,32 @@ services:
       - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./observability/prometheus/rules:/etc/prometheus/rules:ro
       - prometheus-data:/prometheus
+    depends_on:
+      alertmanager:
+        condition: service_started
+
+  mailpit:
+    profiles: ["monitoring"]
+    image: axllent/mailpit:v1.30.4
+    ports:
+      - "8025:8025"
+    expose:
+      - "1025"
+
+  alertmanager:
+    profiles: ["monitoring"]
+    image: prom/alertmanager:v0.33.1
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+      - --storage.path=/alertmanager
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./observability/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager-data:/alertmanager
+    depends_on:
+      mailpit:
+        condition: service_started
 
   grafana:
     profiles: ["monitoring"]
@@ -117,3 +143,4 @@ volumes:
   redis-data:
   prometheus-data:
   grafana-data:
+  alertmanager-data:

--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -1,0 +1,21 @@
+# Local Alert Notifications
+
+PayFlow uses Prometheus Alertmanager to route transactional outbox alerts and
+Mailpit to capture email notifications in the local development environment.
+
+The local notification flow is:
+
+```text
+PayFlow metrics
+    |
+    v
+Prometheus alert rules
+    |
+    v
+Alertmanager
+    |
+    v
+Mailpit SMTP
+    |
+    v
+Mailpit web interface

--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -19,3 +19,13 @@ Mailpit SMTP
     |
     v
 Mailpit web interface
+
+## Notification flow
+## Local endpoints
+## Alert routing
+## Grouping and inhibition
+## Configuration validation
+## Notification smoke test
+## Health checks
+## Troubleshooting
+## Local development scope

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -192,3 +192,8 @@ docker compose `
 ~~~
 
 Do not add `--volumes` unless the local PostgreSQL, Redis, Prometheus, and Grafana data should also be deleted.
+
+## Alert notifications
+
+Alert routing, inhibition, Mailpit delivery, and the notification smoke test
+are documented in [Local Alert Notifications](alerting.md).

--- a/observability/alertmanager/alertmanager.yml
+++ b/observability/alertmanager/alertmanager.yml
@@ -1,0 +1,15 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: "null"
+  group_by:
+    - alertname
+    - service
+    - component
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+receivers:
+  - name: "null"

--- a/observability/alertmanager/alertmanager.yml
+++ b/observability/alertmanager/alertmanager.yml
@@ -1,5 +1,8 @@
 global:
   resolve_timeout: 5m
+  smtp_smarthost: "mailpit:1025"
+  smtp_from: "alertmanager@payflow.local"
+  smtp_require_tls: false
 
 route:
   receiver: "null"
@@ -7,9 +10,42 @@ route:
     - alertname
     - service
     - component
-  group_wait: 30s
-  group_interval: 5m
+    - severity
+  group_wait: 10s
+  group_interval: 30s
   repeat_interval: 4h
+  routes:
+    - receiver: critical-email
+      matchers:
+        - severity="critical"
+
+    - receiver: warning-email
+      matchers:
+        - severity="warning"
+
+inhibit_rules:
+  - source_matchers:
+      - alertname="PayFlowMetricsTargetDown"
+      - severity="critical"
+    target_matchers:
+      - severity="warning"
+    equal:
+      - service
+      - component
 
 receivers:
   - name: "null"
+
+  - name: critical-email
+    email_configs:
+      - to: "oncall@payflow.local"
+        send_resolved: true
+        headers:
+          Subject: '[PayFlow][CRITICAL][{{ .Status }}] {{ .CommonLabels.alertname }}'
+
+  - name: warning-email
+    email_configs:
+      - to: "engineering@payflow.local"
+        send_resolved: true
+        headers:
+          Subject: '[PayFlow][WARNING][{{ .Status }}] {{ .CommonLabels.alertname }}'

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -6,6 +6,12 @@ global:
 rule_files:
   - /etc/prometheus/rules/*.yml
 
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+
 scrape_configs:
   - job_name: payflow
     metrics_path: /actuator/prometheus

--- a/scripts/observability/test-alertmanager-notifications.ps1
+++ b/scripts/observability/test-alertmanager-notifications.ps1
@@ -1,0 +1,263 @@
+#requires -Version 5.1
+
+[CmdletBinding()]
+param(
+    [string] $AlertmanagerBaseUrl = "http://localhost:9093",
+
+    [string] $MailpitBaseUrl = "http://localhost:8025",
+
+    [ValidateRange(30, 300)]
+    [int] $TimeoutSeconds = 120
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Assert-EndpointReady {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Uri,
+
+        [Parameter(Mandatory)]
+        [string] $Name
+    )
+
+    $response = Invoke-WebRequest `
+        -UseBasicParsing `
+        -Uri $Uri
+
+    if ($response.StatusCode -ne 200) {
+        throw "$Name returned HTTP $($response.StatusCode)."
+    }
+}
+
+function Send-AlertmanagerAlert {
+    param(
+        [Parameter(Mandatory)]
+        [hashtable] $Alert
+    )
+
+    $payload = ConvertTo-Json `
+        -InputObject @($Alert) `
+        -Depth 10 `
+        -Compress
+
+    if (-not $payload.TrimStart().StartsWith("[")) {
+        throw "Alertmanager payload must be a top-level JSON array."
+    }
+
+    Invoke-RestMethod `
+        -Method Post `
+        -Uri "$AlertmanagerBaseUrl/api/v2/alerts" `
+        -ContentType "application/json" `
+        -Body (
+            [System.Text.Encoding]::UTF8.GetBytes(
+                $payload
+            )
+        ) |
+        Out-Null
+}
+
+function Get-MailpitMessages {
+    $response = Invoke-RestMethod `
+        -Uri "$MailpitBaseUrl/api/v1/messages"
+
+    return @($response.messages)
+}
+
+function Wait-ForMailpitMessage {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Subject,
+
+        [Parameter(Mandatory)]
+        [string] $ExpectedRecipient
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+
+    do {
+        $message = Get-MailpitMessages |
+            Where-Object {
+                $_.Subject -eq $Subject
+            } |
+            Select-Object -First 1
+
+        if ($null -ne $message) {
+            $recipients = @(
+                $message.To |
+                    ForEach-Object {
+                        $_.Address
+                    }
+            )
+
+            if ($recipients -notcontains $ExpectedRecipient) {
+                throw (
+                    "Message '$Subject' was delivered to an unexpected " +
+                    "recipient: $($recipients -join ', ')."
+                )
+            }
+
+            if (
+                $message.From.Address -ne
+                "alertmanager@payflow.local"
+            ) {
+                throw (
+                    "Message '$Subject' has unexpected sender " +
+                    "'$($message.From.Address)'."
+                )
+            }
+
+            return $message
+        }
+
+        Start-Sleep -Seconds 2
+    } while ((Get-Date) -lt $deadline)
+
+    throw (
+        "Mailpit did not receive '$Subject' within " +
+        "$TimeoutSeconds seconds."
+    )
+}
+
+function New-SyntheticAlert {
+    param(
+        [Parameter(Mandatory)]
+        [string] $AlertName,
+
+        [Parameter(Mandatory)]
+        [string] $Severity,
+
+        [Parameter(Mandatory)]
+        [DateTimeOffset] $StartsAt,
+
+        [Parameter(Mandatory)]
+        [DateTimeOffset] $EndsAt,
+
+        [Parameter(Mandatory)]
+        [string] $Description
+    )
+
+    return @{
+        labels = @{
+            alertname = $AlertName
+            severity = $Severity
+            service = "payflow"
+            component = "transactional-outbox"
+        }
+        annotations = @{
+            summary = "Synthetic PayFlow notification smoke test"
+            description = $Description
+        }
+        startsAt = $StartsAt.ToString("o")
+        endsAt = $EndsAt.ToString("o")
+        generatorURL = "http://localhost:9090/alerts"
+    }
+}
+
+Assert-EndpointReady `
+    -Uri "$AlertmanagerBaseUrl/-/ready" `
+    -Name "Alertmanager"
+
+Assert-EndpointReady `
+    -Uri $MailpitBaseUrl `
+    -Name "Mailpit"
+
+$runId = [Guid]::NewGuid().ToString("N").Substring(0, 8)
+
+$testCases = @(
+    [PSCustomObject]@{
+        Severity = "warning"
+        SubjectSeverity = "WARNING"
+        Recipient = "engineering@payflow.local"
+        AlertName = "PayFlowSyntheticWarning-$runId"
+        StartsAt = [DateTimeOffset]::UtcNow
+    },
+    [PSCustomObject]@{
+        Severity = "critical"
+        SubjectSeverity = "CRITICAL"
+        Recipient = "oncall@payflow.local"
+        AlertName = "PayFlowSyntheticCritical-$runId"
+        StartsAt = [DateTimeOffset]::UtcNow
+    }
+)
+
+Write-Host "Sending synthetic firing alerts..."
+
+foreach ($testCase in $testCases) {
+    $alert = New-SyntheticAlert `
+        -AlertName $testCase.AlertName `
+        -Severity $testCase.Severity `
+        -StartsAt $testCase.StartsAt `
+        -EndsAt $testCase.StartsAt.AddMinutes(10) `
+        -Description (
+            "Validates $($testCase.Severity) firing notification delivery."
+        )
+
+    Send-AlertmanagerAlert `
+        -Alert $alert
+}
+
+$firingResults = foreach ($testCase in $testCases) {
+    $subject = (
+        "[PayFlow][$($testCase.SubjectSeverity)]" +
+        "[firing] $($testCase.AlertName)"
+    )
+
+    $message = Wait-ForMailpitMessage `
+        -Subject $subject `
+        -ExpectedRecipient $testCase.Recipient
+
+    [PSCustomObject]@{
+        Severity = $testCase.Severity
+        State = "firing"
+        Subject = $message.Subject
+        Recipient = $testCase.Recipient
+    }
+}
+
+Write-Host "Sending synthetic resolved alerts..."
+
+foreach ($testCase in $testCases) {
+    $resolvedAt = [DateTimeOffset]::UtcNow
+
+    $alert = New-SyntheticAlert `
+        -AlertName $testCase.AlertName `
+        -Severity $testCase.Severity `
+        -StartsAt $testCase.StartsAt `
+        -EndsAt $resolvedAt.AddSeconds(-1) `
+        -Description (
+            "Validates $($testCase.Severity) resolved notification delivery."
+        )
+
+    Send-AlertmanagerAlert `
+        -Alert $alert
+}
+
+$resolvedResults = foreach ($testCase in $testCases) {
+    $subject = (
+        "[PayFlow][$($testCase.SubjectSeverity)]" +
+        "[resolved] $($testCase.AlertName)"
+    )
+
+    $message = Wait-ForMailpitMessage `
+        -Subject $subject `
+        -ExpectedRecipient $testCase.Recipient
+
+    [PSCustomObject]@{
+        Severity = $testCase.Severity
+        State = "resolved"
+        Subject = $message.Subject
+        Recipient = $testCase.Recipient
+    }
+}
+
+@($firingResults) + @($resolvedResults) |
+    Format-Table `
+        Severity, `
+        State, `
+        Recipient, `
+        Subject `
+        -AutoSize
+
+Write-Host "Alertmanager notification smoke test passed."


### PR DESCRIPTION
## Summary

- add Alertmanager and Mailpit to the local monitoring stack
- configure Prometheus to forward firing alerts to Alertmanager
- route critical and warning alerts to separate email receivers
- send both firing and resolved notifications
- inhibit warning notifications while the PayFlow metrics target is down
- add a reusable notification delivery smoke test
- document local alert routing, validation, and troubleshooting

## Notification flow

```text
PayFlow
  → Prometheus
  → Alertmanager
  → Mailpit SMTP
  → Mailpit inbox