### PR TITLE
feat: add idempotent Kafka consumer processing

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -67,6 +67,9 @@ services:
       OUTBOX_POLLING_LEASE_DURATION: 30s
       OUTBOX_POLLING_FIXED_DELAY: 1s
       OUTBOX_POLLING_INITIAL_DELAY: 5s
+      TRANSFER_COMPLETED_CONSUMER_ENABLED: "true"
+      TRANSFER_COMPLETED_CONSUMER_GROUP: payflow-transfer-completed-audit-v1
+      TRANSFER_COMPLETED_CONSUMER_NAME: transfer-completed-audit
     ports:
       - "8080:8080"
     depends_on:

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/InvalidTransferCompletedKafkaRecordException.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/InvalidTransferCompletedKafkaRecordException.java
@@ -1,0 +1,12 @@
+package com.nursena.payflow.eventprocessing.adapter.in.kafka;
+
+public final class
+InvalidTransferCompletedKafkaRecordException
+    extends RuntimeException {
+
+    InvalidTransferCompletedKafkaRecordException(
+        String message
+    ) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedEventDeserializationException.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedEventDeserializationException.java
@@ -1,0 +1,25 @@
+package com.nursena.payflow.eventprocessing.adapter.in.kafka;
+
+public final class
+TransferCompletedEventDeserializationException
+    extends RuntimeException {
+
+    TransferCompletedEventDeserializationException(
+        String topic,
+        int partition,
+        long offset,
+        Throwable cause
+    ) {
+        super(
+            "Could not deserialize transfer completed "
+                + "event from topic "
+                + topic
+                + ", partition "
+                + partition
+                + ", offset "
+                + offset
+                + ".",
+            cause
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaConsumerConfiguration.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaConsumerConfiguration.java
@@ -1,0 +1,40 @@
+package com.nursena.payflow.eventprocessing.adapter.in.kafka;
+
+import java.time.Clock;
+
+import com.nursena.payflow.eventprocessing.application.port.in.ProcessTransferCompletedEventUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.ProcessedKafkaEventRepositoryPort;
+import com.nursena.payflow.eventprocessing.application.port.out.TransferCompletedEventHandlerPort;
+import com.nursena.payflow.eventprocessing.application.service.ProcessTransferCompletedEventService;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@Configuration(proxyBeanMethods = false)
+@EnableKafka
+@EnableConfigurationProperties(
+    TransferCompletedKafkaConsumerProperties.class
+)
+class TransferCompletedKafkaConsumerConfiguration {
+
+    @Bean("transferCompletedAuditEventProcessor")
+    ProcessTransferCompletedEventUseCase
+    transferCompletedAuditEventProcessor(
+        ProcessedKafkaEventRepositoryPort repository,
+        @Qualifier("transferCompletedAuditHandler")
+        TransferCompletedEventHandlerPort handler,
+        TransferCompletedKafkaConsumerProperties
+            properties,
+        Clock clock
+    ) {
+        return new ProcessTransferCompletedEventService(
+            properties.consumerName(),
+            repository,
+            handler,
+            clock
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaConsumerProperties.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaConsumerProperties.java
@@ -1,0 +1,61 @@
+package com.nursena.payflow.eventprocessing.adapter.in.kafka;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(
+    prefix =
+        "payflow.event-processing.transfer-completed"
+)
+record TransferCompletedKafkaConsumerProperties(
+    boolean enabled,
+    String topic,
+    String groupId,
+    String consumerName
+) {
+
+    private static final int MAX_TOPIC_LENGTH = 200;
+
+    private static final int MAX_CONSUMER_NAME_LENGTH =
+        200;
+
+    TransferCompletedKafkaConsumerProperties {
+        validateText(
+            topic,
+            "topic",
+            MAX_TOPIC_LENGTH
+        );
+
+        validateText(
+            groupId,
+            "groupId",
+            Integer.MAX_VALUE
+        );
+
+        validateText(
+            consumerName,
+            "consumerName",
+            MAX_CONSUMER_NAME_LENGTH
+        );
+    }
+
+    private static void validateText(
+        String value,
+        String fieldName,
+        int maximumLength
+    ) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(
+                fieldName + " must not be blank."
+            );
+        }
+
+        if (value.length() > maximumLength) {
+            throw new IllegalArgumentException(
+                fieldName
+                    + " must not exceed "
+                    + maximumLength
+                    + " characters."
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaListener.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaListener.java
@@ -1,0 +1,124 @@
+package com.nursena.payflow.eventprocessing.adapter.in.kafka;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.eventprocessing.application.model.ProcessTransferCompletedEventCommand;
+import com.nursena.payflow.eventprocessing.application.port.in.ProcessTransferCompletedEventUseCase;
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+class TransferCompletedKafkaListener {
+
+    private final ProcessTransferCompletedEventUseCase
+        useCase;
+
+    private final ObjectMapper objectMapper;
+
+    TransferCompletedKafkaListener(
+        @Qualifier(
+            "transferCompletedAuditEventProcessor"
+        )
+        ProcessTransferCompletedEventUseCase useCase,
+        ObjectMapper objectMapper
+    ) {
+        this.useCase =
+            Objects.requireNonNull(
+                useCase,
+                "useCase must not be null"
+            );
+
+        this.objectMapper =
+            Objects.requireNonNull(
+                objectMapper,
+                "objectMapper must not be null"
+            );
+    }
+
+    @KafkaListener(
+        id = "transferCompletedAuditKafkaListener",
+        idIsGroup = false,
+        topics =
+            "${payflow.event-processing.transfer-completed.topic}",
+        groupId =
+            "${payflow.event-processing.transfer-completed.group-id}",
+        autoStartup =
+            "${payflow.event-processing.transfer-completed.enabled}"
+    )
+    void consume(
+        ConsumerRecord<String, String> record
+    ) {
+        Objects.requireNonNull(
+            record,
+            "record must not be null"
+        );
+
+        TransferCompletedEvent event =
+            deserialize(record);
+
+        validatePartitionKey(
+            record.key(),
+            event
+        );
+
+        useCase.process(
+            new ProcessTransferCompletedEventCommand(
+                event,
+                record.topic(),
+                record.partition(),
+                record.offset()
+            )
+        );
+    }
+
+    private TransferCompletedEvent deserialize(
+        ConsumerRecord<String, String> record
+    ) {
+        if (record.value() == null
+            || record.value().isBlank()) {
+
+            throw new
+                InvalidTransferCompletedKafkaRecordException(
+                "Kafka record value must not be blank."
+            );
+        }
+
+        try {
+            return objectMapper.readValue(
+                record.value(),
+                TransferCompletedEvent.class
+            );
+        } catch (
+            JsonProcessingException exception
+        ) {
+            throw new
+                TransferCompletedEventDeserializationException(
+                record.topic(),
+                record.partition(),
+                record.offset(),
+                exception
+            );
+        }
+    }
+
+    private static void validatePartitionKey(
+        String partitionKey,
+        TransferCompletedEvent event
+    ) {
+        String expectedKey =
+            event.transactionId().toString();
+
+        if (!expectedKey.equals(partitionKey)) {
+            throw new
+                InvalidTransferCompletedKafkaRecordException(
+                "Kafka record key must equal "
+                    + "transactionId."
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcProcessedKafkaEventRepositoryAdapter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcProcessedKafkaEventRepositoryAdapter.java
@@ -1,0 +1,83 @@
+package com.nursena.payflow.eventprocessing.adapter.out.persistence;
+
+import java.sql.Timestamp;
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.port.out.ProcessedKafkaEventRepositoryPort;
+import com.nursena.payflow.eventprocessing.domain.model.ProcessedKafkaEvent;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JdbcProcessedKafkaEventRepositoryAdapter
+    implements ProcessedKafkaEventRepositoryPort {
+
+    private static final String INSERT_SQL = """
+        INSERT INTO processed_kafka_events (
+            consumer_name,
+            event_id,
+            event_type,
+            event_version,
+            topic,
+            partition_number,
+            record_offset,
+            processed_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (
+            consumer_name,
+            event_id
+        )
+        DO NOTHING
+        """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    JdbcProcessedKafkaEventRepositoryAdapter(
+        JdbcTemplate jdbcTemplate
+    ) {
+        this.jdbcTemplate =
+            Objects.requireNonNull(
+                jdbcTemplate,
+                "jdbcTemplate must not be null"
+            );
+    }
+
+    @Override
+    public boolean tryRecord(
+        ProcessedKafkaEvent event
+    ) {
+        Objects.requireNonNull(
+            event,
+            "event must not be null"
+        );
+
+        int affectedRows = jdbcTemplate.update(
+            INSERT_SQL,
+            event.consumerName(),
+            event.eventId(),
+            event.eventType(),
+            event.eventVersion(),
+            event.topic(),
+            event.partitionNumber(),
+            event.recordOffset(),
+            Timestamp.from(
+                event.processedAt()
+            )
+        );
+
+        if (affectedRows == 1) {
+            return true;
+        }
+
+        if (affectedRows == 0) {
+            return false;
+        }
+
+        throw new IllegalStateException(
+            "Processed Kafka event insert affected "
+                + affectedRows
+                + " rows."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcTransferCompletedEventAuditHandlerAdapter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcTransferCompletedEventAuditHandlerAdapter.java
@@ -12,7 +12,7 @@ import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-@Repository
+@Repository("transferCompletedAuditHandler")
 class JdbcTransferCompletedEventAuditHandlerAdapter
     implements TransferCompletedEventHandlerPort {
 

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcTransferCompletedEventAuditHandlerAdapter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcTransferCompletedEventAuditHandlerAdapter.java
@@ -1,0 +1,115 @@
+package com.nursena.payflow.eventprocessing.adapter.out.persistence;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.port.out.TransferCompletedEventHandlerPort;
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JdbcTransferCompletedEventAuditHandlerAdapter
+    implements TransferCompletedEventHandlerPort {
+
+    private static final String INSERT_SQL = """
+        INSERT INTO transfer_completed_event_audits (
+            event_id,
+            event_type,
+            event_version,
+            occurred_at,
+            transaction_id,
+            source_wallet_id,
+            target_wallet_id,
+            amount,
+            currency,
+            recorded_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private final Clock clock;
+
+    JdbcTransferCompletedEventAuditHandlerAdapter(
+        JdbcTemplate jdbcTemplate,
+        Clock clock
+    ) {
+        this.jdbcTemplate =
+            Objects.requireNonNull(
+                jdbcTemplate,
+                "jdbcTemplate must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+    }
+
+    @Override
+    public void handle(
+        TransferCompletedEvent event
+    ) {
+        Objects.requireNonNull(
+            event,
+            "event must not be null"
+        );
+
+        int affectedRows = jdbcTemplate.update(
+            INSERT_SQL,
+            event.eventId(),
+            event.eventType(),
+            event.eventVersion(),
+            Timestamp.from(
+                event.occurredAt()
+            ),
+            event.transactionId(),
+            event.sourceWalletId(),
+            event.targetWalletId(),
+            parseAmount(
+                event.amount()
+            ),
+            event.currency(),
+            Timestamp.from(
+                currentTime()
+            )
+        );
+
+        if (affectedRows != 1) {
+            throw new IllegalStateException(
+                "Transfer completed audit insert "
+                    + "affected "
+                    + affectedRows
+                    + " rows."
+            );
+        }
+    }
+
+    private Instant currentTime() {
+        return clock
+            .instant()
+            .truncatedTo(
+                ChronoUnit.MICROS
+            );
+    }
+
+    private static BigDecimal parseAmount(
+        String amount
+    ) {
+        try {
+            return new BigDecimal(amount);
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException(
+                "amount must be a valid decimal.",
+                exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/ProcessTransferCompletedEventCommand.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/ProcessTransferCompletedEventCommand.java
@@ -1,0 +1,48 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.util.Objects;
+
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+
+public record ProcessTransferCompletedEventCommand(
+    TransferCompletedEvent event,
+    String topic,
+    int partitionNumber,
+    long recordOffset
+) {
+
+    private static final int MAX_TOPIC_LENGTH = 200;
+
+    public ProcessTransferCompletedEventCommand {
+        Objects.requireNonNull(
+            event,
+            "event must not be null"
+        );
+
+        if (topic == null || topic.isBlank()) {
+            throw new IllegalArgumentException(
+                "topic must not be blank."
+            );
+        }
+
+        if (topic.length() > MAX_TOPIC_LENGTH) {
+            throw new IllegalArgumentException(
+                "topic must not exceed "
+                    + MAX_TOPIC_LENGTH
+                    + " characters."
+            );
+        }
+
+        if (partitionNumber < 0) {
+            throw new IllegalArgumentException(
+                "partitionNumber must not be negative."
+            );
+        }
+
+        if (recordOffset < 0) {
+            throw new IllegalArgumentException(
+                "recordOffset must not be negative."
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/ProcessTransferCompletedEventResult.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/ProcessTransferCompletedEventResult.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+public enum ProcessTransferCompletedEventResult {
+    PROCESSED,
+    DUPLICATE
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/ProcessTransferCompletedEventUseCase.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/ProcessTransferCompletedEventUseCase.java
@@ -1,0 +1,11 @@
+package com.nursena.payflow.eventprocessing.application.port.in;
+
+import com.nursena.payflow.eventprocessing.application.model.ProcessTransferCompletedEventCommand;
+import com.nursena.payflow.eventprocessing.application.model.ProcessTransferCompletedEventResult;
+
+public interface ProcessTransferCompletedEventUseCase {
+
+    ProcessTransferCompletedEventResult process(
+        ProcessTransferCompletedEventCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/ProcessedKafkaEventRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/ProcessedKafkaEventRepositoryPort.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.eventprocessing.application.port.out;
+
+import com.nursena.payflow.eventprocessing.domain.model.ProcessedKafkaEvent;
+
+public interface ProcessedKafkaEventRepositoryPort {
+
+    boolean tryRecord(
+        ProcessedKafkaEvent event
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/TransferCompletedEventHandlerPort.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/TransferCompletedEventHandlerPort.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.eventprocessing.application.port.out;
+
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+
+public interface TransferCompletedEventHandlerPort {
+
+    void handle(
+        TransferCompletedEvent event
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/ProcessTransferCompletedEventService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/ProcessTransferCompletedEventService.java
@@ -1,0 +1,135 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.model.ProcessTransferCompletedEventCommand;
+import com.nursena.payflow.eventprocessing.application.model.ProcessTransferCompletedEventResult;
+import com.nursena.payflow.eventprocessing.application.port.in.ProcessTransferCompletedEventUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.ProcessedKafkaEventRepositoryPort;
+import com.nursena.payflow.eventprocessing.application.port.out.TransferCompletedEventHandlerPort;
+import com.nursena.payflow.eventprocessing.domain.model.ProcessedKafkaEvent;
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import org.springframework.transaction.annotation.Transactional;
+
+public class ProcessTransferCompletedEventService
+    implements ProcessTransferCompletedEventUseCase {
+
+    private static final int MAX_CONSUMER_NAME_LENGTH =
+        200;
+
+    private final String consumerName;
+
+    private final ProcessedKafkaEventRepositoryPort
+        processedEventRepository;
+
+    private final TransferCompletedEventHandlerPort
+        eventHandler;
+
+    private final Clock clock;
+
+    public ProcessTransferCompletedEventService(
+        String consumerName,
+        ProcessedKafkaEventRepositoryPort
+            processedEventRepository,
+        TransferCompletedEventHandlerPort eventHandler,
+        Clock clock
+    ) {
+        this.consumerName =
+            validateConsumerName(consumerName);
+
+        this.processedEventRepository =
+            Objects.requireNonNull(
+                processedEventRepository,
+                "processedEventRepository "
+                    + "must not be null"
+            );
+
+        this.eventHandler =
+            Objects.requireNonNull(
+                eventHandler,
+                "eventHandler must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+    }
+
+    @Override
+    @Transactional
+    public ProcessTransferCompletedEventResult process(
+        ProcessTransferCompletedEventCommand command
+    ) {
+        Objects.requireNonNull(
+            command,
+            "command must not be null"
+        );
+
+        TransferCompletedEvent event =
+            command.event();
+
+        ProcessedKafkaEvent processedEvent =
+            new ProcessedKafkaEvent(
+                consumerName,
+                event.eventId(),
+                event.eventType(),
+                event.eventVersion(),
+                command.topic(),
+                command.partitionNumber(),
+                command.recordOffset(),
+                currentTime()
+            );
+
+        boolean recorded =
+            processedEventRepository.tryRecord(
+                processedEvent
+            );
+
+        if (!recorded) {
+            return ProcessTransferCompletedEventResult
+                .DUPLICATE;
+        }
+
+        eventHandler.handle(event);
+
+        return ProcessTransferCompletedEventResult
+            .PROCESSED;
+    }
+
+    private Instant currentTime() {
+        return clock
+            .instant()
+            .truncatedTo(
+                ChronoUnit.MICROS
+            );
+    }
+
+    private static String validateConsumerName(
+        String consumerName
+    ) {
+        if (consumerName == null
+            || consumerName.isBlank()) {
+
+            throw new IllegalArgumentException(
+                "consumerName must not be blank."
+            );
+        }
+
+        if (consumerName.length()
+            > MAX_CONSUMER_NAME_LENGTH) {
+
+            throw new IllegalArgumentException(
+                "consumerName must not exceed "
+                    + MAX_CONSUMER_NAME_LENGTH
+                    + " characters."
+            );
+        }
+
+        return consumerName;
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/domain/model/ProcessedKafkaEvent.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/domain/model/ProcessedKafkaEvent.java
@@ -1,0 +1,95 @@
+package com.nursena.payflow.eventprocessing.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+public record ProcessedKafkaEvent(
+    String consumerName,
+    UUID eventId,
+    String eventType,
+    int eventVersion,
+    String topic,
+    int partitionNumber,
+    long recordOffset,
+    Instant processedAt
+) {
+
+    private static final int MAX_CONSUMER_NAME_LENGTH =
+        200;
+
+    private static final int MAX_EVENT_TYPE_LENGTH =
+        200;
+
+    private static final int MAX_TOPIC_LENGTH =
+        200;
+
+    public ProcessedKafkaEvent {
+        requireText(
+            consumerName,
+            "consumerName",
+            MAX_CONSUMER_NAME_LENGTH
+        );
+
+        Objects.requireNonNull(
+            eventId,
+            "eventId must not be null"
+        );
+
+        requireText(
+            eventType,
+            "eventType",
+            MAX_EVENT_TYPE_LENGTH
+        );
+
+        if (eventVersion <= 0) {
+            throw new IllegalArgumentException(
+                "eventVersion must be positive."
+            );
+        }
+
+        requireText(
+            topic,
+            "topic",
+            MAX_TOPIC_LENGTH
+        );
+
+        if (partitionNumber < 0) {
+            throw new IllegalArgumentException(
+                "partitionNumber must not be negative."
+            );
+        }
+
+        if (recordOffset < 0) {
+            throw new IllegalArgumentException(
+                "recordOffset must not be negative."
+            );
+        }
+
+        Objects.requireNonNull(
+            processedAt,
+            "processedAt must not be null"
+        );
+    }
+
+    private static void requireText(
+        String value,
+        String fieldName,
+        int maximumLength
+    ) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(
+                fieldName + " must not be blank."
+            );
+        }
+
+        if (value.length() > maximumLength) {
+            throw new IllegalArgumentException(
+                fieldName
+                    + " must not exceed "
+                    + maximumLength
+                    + " characters."
+            );
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,12 @@ spring:
         "[enable.idempotence]": true
     consumer:
       group-id: ${KAFKA_CONSUMER_GROUP:payflow}
+      enable-auto-commit: false
       auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    listener:
+      ack-mode: record
 
 server:
   port: ${SERVER_PORT:8080}
@@ -82,3 +87,9 @@ payflow:
       lease-duration: ${OUTBOX_POLLING_LEASE_DURATION:30s}
       fixed-delay: ${OUTBOX_POLLING_FIXED_DELAY:1s}
       initial-delay: ${OUTBOX_POLLING_INITIAL_DELAY:5s}
+  event-processing:
+    transfer-completed:
+      enabled: ${TRANSFER_COMPLETED_CONSUMER_ENABLED:false}
+      topic: ${TRANSFER_COMPLETED_CONSUMER_TOPIC:wallet.transfer.completed}
+      group-id: ${TRANSFER_COMPLETED_CONSUMER_GROUP:payflow-transfer-completed-audit-v1}
+      consumer-name: ${TRANSFER_COMPLETED_CONSUMER_NAME:transfer-completed-audit}

--- a/src/main/resources/db/migration/V7__create_processed_kafka_events.sql
+++ b/src/main/resources/db/migration/V7__create_processed_kafka_events.sql
@@ -1,0 +1,51 @@
+CREATE TABLE processed_kafka_events (
+    consumer_name VARCHAR(200) NOT NULL,
+    event_id UUID NOT NULL,
+    event_type VARCHAR(200) NOT NULL,
+    event_version INTEGER NOT NULL,
+    topic VARCHAR(200) NOT NULL,
+    partition_number INTEGER NOT NULL,
+    record_offset BIGINT NOT NULL,
+    processed_at TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT pk_processed_kafka_events
+        PRIMARY KEY (
+            consumer_name,
+            event_id
+        ),
+
+    CONSTRAINT chk_processed_kafka_events_consumer_name
+        CHECK (
+            btrim(consumer_name) <> ''
+        ),
+
+    CONSTRAINT chk_processed_kafka_events_event_type
+        CHECK (
+            btrim(event_type) <> ''
+        ),
+
+    CONSTRAINT chk_processed_kafka_events_event_version
+        CHECK (
+            event_version > 0
+        ),
+
+    CONSTRAINT chk_processed_kafka_events_topic
+        CHECK (
+            btrim(topic) <> ''
+        ),
+
+    CONSTRAINT chk_processed_kafka_events_partition
+        CHECK (
+            partition_number >= 0
+        ),
+
+    CONSTRAINT chk_processed_kafka_events_offset
+        CHECK (
+            record_offset >= 0
+        )
+);
+
+CREATE INDEX idx_processed_kafka_events_processed_at
+    ON processed_kafka_events (
+        processed_at
+    );

--- a/src/main/resources/db/migration/V8__create_transfer_completed_event_audits.sql
+++ b/src/main/resources/db/migration/V8__create_transfer_completed_event_audits.sql
@@ -1,0 +1,45 @@
+CREATE TABLE transfer_completed_event_audits (
+    event_id UUID PRIMARY KEY,
+    event_type VARCHAR(200) NOT NULL,
+    event_version INTEGER NOT NULL,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    transaction_id UUID NOT NULL,
+    source_wallet_id UUID NOT NULL,
+    target_wallet_id UUID NOT NULL,
+    amount NUMERIC NOT NULL,
+    currency VARCHAR(3) NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT uq_transfer_completed_event_audits_transaction_id
+        UNIQUE (transaction_id),
+
+    CONSTRAINT chk_transfer_completed_event_audits_type
+        CHECK (
+            event_type = 'wallet.transfer.completed'
+        ),
+
+    CONSTRAINT chk_transfer_completed_event_audits_version
+        CHECK (
+            event_version = 1
+        ),
+
+    CONSTRAINT chk_transfer_completed_event_audits_wallets
+        CHECK (
+            source_wallet_id <> target_wallet_id
+        ),
+
+    CONSTRAINT chk_transfer_completed_event_audits_amount
+        CHECK (
+            amount > 0
+        ),
+
+    CONSTRAINT chk_transfer_completed_event_audits_currency
+        CHECK (
+            currency ~ '^[A-Z]{3}$'
+        )
+);
+
+CREATE INDEX idx_transfer_completed_event_audits_recorded_at
+    ON transfer_completed_event_audits (
+        recorded_at DESC
+    );

--- a/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaListenerTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaListenerTest.java
@@ -1,0 +1,205 @@
+package com.nursena.payflow.eventprocessing.adapter.in.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.nursena.payflow.eventprocessing.application.model.ProcessTransferCompletedEventCommand;
+import com.nursena.payflow.eventprocessing.application.port.in.ProcessTransferCompletedEventUseCase;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TransferCompletedKafkaListenerTest {
+
+    private static final String TOPIC =
+        "wallet.transfer.completed";
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000001101"
+        );
+
+    private static final String PAYLOAD = """
+        {
+          "eventId": "50000000-0000-0000-0000-000000001101",
+          "eventType": "wallet.transfer.completed",
+          "eventVersion": 1,
+          "occurredAt": "2026-07-20T20:00:00Z",
+          "transactionId": "60000000-0000-0000-0000-000000001101",
+          "sourceWalletId": "70000000-0000-0000-0000-000000001101",
+          "targetWalletId": "70000000-0000-0000-0000-000000001102",
+          "amount": "125.50",
+          "currency": "TRY"
+        }
+        """;
+
+    @Mock
+    private ProcessTransferCompletedEventUseCase
+        useCase;
+
+    private TransferCompletedKafkaListener listener;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper =
+            JsonMapper.builder()
+                .findAndAddModules()
+                .build();
+
+        listener =
+            new TransferCompletedKafkaListener(
+                useCase,
+                objectMapper
+            );
+    }
+
+    @Test
+    void shouldConvertKafkaRecordToProcessingCommand() {
+        listener.consume(
+            record(
+                TRANSACTION_ID.toString(),
+                PAYLOAD
+            )
+        );
+
+        ArgumentCaptor<ProcessTransferCompletedEventCommand>
+            captor =
+            ArgumentCaptor.forClass(
+                ProcessTransferCompletedEventCommand
+                    .class
+            );
+
+        verify(useCase)
+            .process(captor.capture());
+
+        ProcessTransferCompletedEventCommand command =
+            captor.getValue();
+
+        assertThat(command.event().transactionId())
+            .isEqualTo(TRANSACTION_ID);
+
+        assertThat(command.event().occurredAt())
+            .isEqualTo(
+                Instant.parse(
+                    "2026-07-20T20:00:00Z"
+                )
+            );
+
+        assertThat(command.topic())
+            .isEqualTo(TOPIC);
+
+        assertThat(command.partitionNumber())
+            .isZero();
+
+        assertThat(command.recordOffset())
+            .isEqualTo(25L);
+    }
+
+    @Test
+    void shouldRejectMalformedJson() {
+        assertThatThrownBy(
+            () -> listener.consume(
+                record(
+                    TRANSACTION_ID.toString(),
+                    "{invalid-json"
+                )
+            )
+        )
+            .isInstanceOf(
+                TransferCompletedEventDeserializationException
+                    .class
+            )
+            .hasMessageContaining(
+                "partition 0, offset 25"
+            );
+
+        verify(
+            useCase,
+            never()
+        )
+            .process(
+                org.mockito.ArgumentMatchers.any()
+            );
+    }
+
+    @Test
+    void shouldRejectPartitionKeyMismatch() {
+        assertThatThrownBy(
+            () -> listener.consume(
+                record(
+                    UUID.randomUUID().toString(),
+                    PAYLOAD
+                )
+            )
+        )
+            .isInstanceOf(
+                InvalidTransferCompletedKafkaRecordException
+                    .class
+            )
+            .hasMessage(
+                "Kafka record key must equal "
+                    + "transactionId."
+            );
+
+        verify(
+            useCase,
+            never()
+        )
+            .process(
+                org.mockito.ArgumentMatchers.any()
+            );
+    }
+
+    @Test
+    void shouldRejectBlankPayload() {
+        assertThatThrownBy(
+            () -> listener.consume(
+                record(
+                    TRANSACTION_ID.toString(),
+                    " "
+                )
+            )
+        )
+            .isInstanceOf(
+                InvalidTransferCompletedKafkaRecordException
+                    .class
+            )
+            .hasMessage(
+                "Kafka record value must not be blank."
+            );
+
+        verify(
+            useCase,
+            never()
+        )
+            .process(
+                org.mockito.ArgumentMatchers.any()
+            );
+    }
+
+    private static ConsumerRecord<String, String>
+    record(
+        String key,
+        String value
+    ) {
+        return new ConsumerRecord<>(
+            TOPIC,
+            0,
+            25L,
+            key,
+            value
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/ProcessTransferCompletedEventCommandTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/ProcessTransferCompletedEventCommandTest.java
@@ -1,0 +1,110 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import org.junit.jupiter.api.Test;
+
+class ProcessTransferCompletedEventCommandTest {
+
+    @Test
+    void shouldCreateValidCommand() {
+        ProcessTransferCompletedEventCommand command =
+            new ProcessTransferCompletedEventCommand(
+                event(),
+                TransferCompletedEvent.TYPE,
+                0,
+                25L
+            );
+
+        assertThat(command.event())
+            .isEqualTo(event());
+
+        assertThat(command.topic())
+            .isEqualTo(
+                TransferCompletedEvent.TYPE
+            );
+
+        assertThat(command.partitionNumber())
+            .isZero();
+
+        assertThat(command.recordOffset())
+            .isEqualTo(25L);
+    }
+
+    @Test
+    void shouldRejectInvalidKafkaMetadata() {
+        assertThatThrownBy(
+            () -> new ProcessTransferCompletedEventCommand(
+                event(),
+                " ",
+                0,
+                25L
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "topic must not be blank."
+            );
+
+        assertThatThrownBy(
+            () -> new ProcessTransferCompletedEventCommand(
+                event(),
+                TransferCompletedEvent.TYPE,
+                -1,
+                25L
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "partitionNumber must not be negative."
+            );
+
+        assertThatThrownBy(
+            () -> new ProcessTransferCompletedEventCommand(
+                event(),
+                TransferCompletedEvent.TYPE,
+                0,
+                -1L
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "recordOffset must not be negative."
+            );
+    }
+
+    private static TransferCompletedEvent event() {
+        return new TransferCompletedEvent(
+            UUID.fromString(
+                "50000000-0000-0000-0000-000000000501"
+            ),
+            TransferCompletedEvent.TYPE,
+            TransferCompletedEvent.VERSION,
+            Instant.parse(
+                "2026-07-20T20:00:00Z"
+            ),
+            UUID.fromString(
+                "60000000-0000-0000-0000-000000000501"
+            ),
+            UUID.fromString(
+                "70000000-0000-0000-0000-000000000501"
+            ),
+            UUID.fromString(
+                "70000000-0000-0000-0000-000000000502"
+            ),
+            "125.50",
+            "TRY"
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/ProcessTransferCompletedEventServiceTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/ProcessTransferCompletedEventServiceTest.java
@@ -1,0 +1,204 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.ProcessTransferCompletedEventCommand;
+import com.nursena.payflow.eventprocessing.application.model.ProcessTransferCompletedEventResult;
+import com.nursena.payflow.eventprocessing.application.port.out.ProcessedKafkaEventRepositoryPort;
+import com.nursena.payflow.eventprocessing.application.port.out.TransferCompletedEventHandlerPort;
+import com.nursena.payflow.eventprocessing.domain.model.ProcessedKafkaEvent;
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessTransferCompletedEventServiceTest {
+
+    private static final String CONSUMER_NAME =
+        "transfer-completed-notification";
+
+    private static final Instant PROCESSED_AT =
+        Instant.parse(
+            "2026-07-20T21:00:00.123456Z"
+        );
+
+    @Mock
+    private ProcessedKafkaEventRepositoryPort
+        processedEventRepository;
+
+    @Mock
+    private TransferCompletedEventHandlerPort
+        eventHandler;
+
+    private ProcessTransferCompletedEventService
+        service;
+
+    @BeforeEach
+    void setUp() {
+        service =
+            new ProcessTransferCompletedEventService(
+                CONSUMER_NAME,
+                processedEventRepository,
+                eventHandler,
+                Clock.fixed(
+                    PROCESSED_AT,
+                    ZoneOffset.UTC
+                )
+            );
+    }
+
+    @Test
+    void shouldProcessFirstDelivery() {
+        when(
+            processedEventRepository.tryRecord(
+                any(ProcessedKafkaEvent.class)
+            )
+        )
+            .thenReturn(true);
+
+        ProcessTransferCompletedEventResult result =
+            service.process(command());
+
+        assertThat(result)
+            .isEqualTo(
+                ProcessTransferCompletedEventResult
+                    .PROCESSED
+            );
+
+        ArgumentCaptor<ProcessedKafkaEvent> captor =
+            ArgumentCaptor.forClass(
+                ProcessedKafkaEvent.class
+            );
+
+        verify(processedEventRepository)
+            .tryRecord(captor.capture());
+
+        ProcessedKafkaEvent recordedEvent =
+            captor.getValue();
+
+        assertThat(recordedEvent.consumerName())
+            .isEqualTo(CONSUMER_NAME);
+
+        assertThat(recordedEvent.eventId())
+            .isEqualTo(event().eventId());
+
+        assertThat(recordedEvent.topic())
+            .isEqualTo(
+                TransferCompletedEvent.TYPE
+            );
+
+        assertThat(recordedEvent.partitionNumber())
+            .isZero();
+
+        assertThat(recordedEvent.recordOffset())
+            .isEqualTo(25L);
+
+        assertThat(recordedEvent.processedAt())
+            .isEqualTo(PROCESSED_AT);
+
+        verify(eventHandler)
+            .handle(event());
+    }
+
+    @Test
+    void shouldSkipHandlerForDuplicateDelivery() {
+        when(
+            processedEventRepository.tryRecord(
+                any(ProcessedKafkaEvent.class)
+            )
+        )
+            .thenReturn(false);
+
+        ProcessTransferCompletedEventResult result =
+            service.process(command());
+
+        assertThat(result)
+            .isEqualTo(
+                ProcessTransferCompletedEventResult
+                    .DUPLICATE
+            );
+
+        verify(
+            eventHandler,
+            never()
+        )
+            .handle(any());
+    }
+
+    @Test
+    void shouldPropagateHandlerFailure() {
+        when(
+            processedEventRepository.tryRecord(
+                any(ProcessedKafkaEvent.class)
+            )
+        )
+            .thenReturn(true);
+
+        org.mockito.Mockito
+            .doThrow(
+                new IllegalStateException(
+                    "handler failure"
+                )
+            )
+            .when(eventHandler)
+            .handle(event());
+
+        assertThatThrownBy(
+            () -> service.process(command())
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "handler failure"
+            );
+    }
+
+    private static
+    ProcessTransferCompletedEventCommand command() {
+        return new ProcessTransferCompletedEventCommand(
+            event(),
+            TransferCompletedEvent.TYPE,
+            0,
+            25L
+        );
+    }
+
+    private static TransferCompletedEvent event() {
+        return new TransferCompletedEvent(
+            UUID.fromString(
+                "50000000-0000-0000-0000-000000000601"
+            ),
+            TransferCompletedEvent.TYPE,
+            TransferCompletedEvent.VERSION,
+            Instant.parse(
+                "2026-07-20T20:00:00Z"
+            ),
+            UUID.fromString(
+                "60000000-0000-0000-0000-000000000601"
+            ),
+            UUID.fromString(
+                "70000000-0000-0000-0000-000000000601"
+            ),
+            UUID.fromString(
+                "70000000-0000-0000-0000-000000000602"
+            ),
+            "125.50",
+            "TRY"
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/domain/model/ProcessedKafkaEventTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/domain/model/ProcessedKafkaEventTest.java
@@ -1,0 +1,146 @@
+package com.nursena.payflow.eventprocessing.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class ProcessedKafkaEventTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000301"
+        );
+
+    private static final Instant PROCESSED_AT =
+        Instant.parse(
+            "2026-07-20T18:00:00Z"
+        );
+
+    @Test
+    void shouldCreateValidProcessedEvent() {
+        ProcessedKafkaEvent event =
+            validEvent();
+
+        assertThat(event.consumerName())
+            .isEqualTo(
+                "transfer-completed-notification"
+            );
+
+        assertThat(event.eventId())
+            .isEqualTo(EVENT_ID);
+
+        assertThat(event.eventVersion())
+            .isEqualTo(1);
+
+        assertThat(event.partitionNumber())
+            .isZero();
+
+        assertThat(event.recordOffset())
+            .isEqualTo(15L);
+
+        assertThat(event.processedAt())
+            .isEqualTo(PROCESSED_AT);
+    }
+
+    @Test
+    void shouldRejectBlankConsumerName() {
+        assertThatThrownBy(
+            () -> new ProcessedKafkaEvent(
+                " ",
+                EVENT_ID,
+                "wallet.transfer.completed",
+                1,
+                "wallet.transfer.completed",
+                0,
+                15L,
+                PROCESSED_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "consumerName must not be blank."
+            );
+    }
+
+    @Test
+    void shouldRejectNonPositiveEventVersion() {
+        assertThatThrownBy(
+            () -> new ProcessedKafkaEvent(
+                "transfer-completed-notification",
+                EVENT_ID,
+                "wallet.transfer.completed",
+                0,
+                "wallet.transfer.completed",
+                0,
+                15L,
+                PROCESSED_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "eventVersion must be positive."
+            );
+    }
+
+    @Test
+    void shouldRejectNegativeKafkaMetadata() {
+        assertThatThrownBy(
+            () -> new ProcessedKafkaEvent(
+                "transfer-completed-notification",
+                EVENT_ID,
+                "wallet.transfer.completed",
+                1,
+                "wallet.transfer.completed",
+                -1,
+                15L,
+                PROCESSED_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "partitionNumber must not be negative."
+            );
+
+        assertThatThrownBy(
+            () -> new ProcessedKafkaEvent(
+                "transfer-completed-notification",
+                EVENT_ID,
+                "wallet.transfer.completed",
+                1,
+                "wallet.transfer.completed",
+                0,
+                -1L,
+                PROCESSED_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "recordOffset must not be negative."
+            );
+    }
+
+    private static ProcessedKafkaEvent validEvent() {
+        return new ProcessedKafkaEvent(
+            "transfer-completed-notification",
+            EVENT_ID,
+            "wallet.transfer.completed",
+            1,
+            "wallet.transfer.completed",
+            0,
+            15L,
+            PROCESSED_AT
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/ProcessTransferCompletedEventAuditTransactionIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/ProcessTransferCompletedEventAuditTransactionIntegrationTest.java
@@ -15,6 +15,7 @@ import com.nursena.payflow.eventprocessing.application.port.out.ProcessedKafkaEv
 import com.nursena.payflow.eventprocessing.application.port.out.TransferCompletedEventHandlerPort;
 import com.nursena.payflow.eventprocessing.application.service.ProcessTransferCompletedEventService;
 import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 @SpringBootTest
 @Testcontainers
@@ -63,6 +65,7 @@ class ProcessTransferCompletedEventAuditTransactionIntegrationTest {
         );
 
     @Autowired
+    @Qualifier("processTransferCompletedEventUseCase")
     private ProcessTransferCompletedEventUseCase
         useCase;
 

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/ProcessTransferCompletedEventAuditTransactionIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/ProcessTransferCompletedEventAuditTransactionIntegrationTest.java
@@ -1,0 +1,281 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.ProcessTransferCompletedEventCommand;
+import com.nursena.payflow.eventprocessing.application.model.ProcessTransferCompletedEventResult;
+import com.nursena.payflow.eventprocessing.application.port.in.ProcessTransferCompletedEventUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.ProcessedKafkaEventRepositoryPort;
+import com.nursena.payflow.eventprocessing.application.port.out.TransferCompletedEventHandlerPort;
+import com.nursena.payflow.eventprocessing.application.service.ProcessTransferCompletedEventService;
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+@Import(
+    ProcessTransferCompletedEventAuditTransactionIntegrationTest
+        .ProcessingTestConfiguration.class
+)
+class ProcessTransferCompletedEventAuditTransactionIntegrationTest {
+
+    private static final String CONSUMER_NAME =
+        "transfer-completed-audit";
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000001001"
+        );
+
+    private static final UUID SECOND_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000001002"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000001001"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private ProcessTransferCompletedEventUseCase
+        useCase;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM transfer_completed_event_audits"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM processed_kafka_events"
+        );
+    }
+
+    @Test
+    void shouldPersistProcessedMarkerAndAuditOnce() {
+        ProcessTransferCompletedEventResult firstResult =
+            useCase.process(
+                command(
+                    EVENT_ID,
+                    25L
+                )
+            );
+
+        assertThat(firstResult)
+            .isEqualTo(
+                ProcessTransferCompletedEventResult
+                    .PROCESSED
+            );
+
+        assertThat(
+            processedEventCount(EVENT_ID)
+        )
+            .isEqualTo(1);
+
+        assertThat(
+            auditCount(EVENT_ID)
+        )
+            .isEqualTo(1);
+
+        ProcessTransferCompletedEventResult duplicateResult =
+            useCase.process(
+                command(
+                    EVENT_ID,
+                    25L
+                )
+            );
+
+        assertThat(duplicateResult)
+            .isEqualTo(
+                ProcessTransferCompletedEventResult
+                    .DUPLICATE
+            );
+
+        assertThat(
+            processedEventCount(EVENT_ID)
+        )
+            .isEqualTo(1);
+
+        assertThat(
+            auditCount(EVENT_ID)
+        )
+            .isEqualTo(1);
+    }
+
+    @Test
+    void shouldRollbackProcessedMarkerWhenAuditInsertFails() {
+        ProcessTransferCompletedEventResult firstResult =
+            useCase.process(
+                command(
+                    EVENT_ID,
+                    25L
+                )
+            );
+
+        assertThat(firstResult)
+            .isEqualTo(
+                ProcessTransferCompletedEventResult
+                    .PROCESSED
+            );
+
+        assertThatThrownBy(
+            () -> useCase.process(
+                command(
+                    SECOND_EVENT_ID,
+                    26L
+                )
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+
+        assertThat(
+            processedEventCount(EVENT_ID)
+        )
+            .isEqualTo(1);
+
+        assertThat(
+            processedEventCount(SECOND_EVENT_ID)
+        )
+            .isZero();
+
+        assertThat(
+            auditCountByTransactionId(
+                TRANSACTION_ID
+            )
+        )
+            .isEqualTo(1);
+    }
+
+    private Integer processedEventCount(
+        UUID eventId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM processed_kafka_events
+            WHERE consumer_name = ?
+              AND event_id = ?
+            """,
+            Integer.class,
+            CONSUMER_NAME,
+            eventId
+        );
+    }
+
+    private Integer auditCount(
+        UUID eventId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM transfer_completed_event_audits
+            WHERE event_id = ?
+            """,
+            Integer.class,
+            eventId
+        );
+    }
+
+    private Integer auditCountByTransactionId(
+        UUID transactionId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM transfer_completed_event_audits
+            WHERE transaction_id = ?
+            """,
+            Integer.class,
+            transactionId
+        );
+    }
+
+    private static
+    ProcessTransferCompletedEventCommand command(
+        UUID eventId,
+        long recordOffset
+    ) {
+        return new ProcessTransferCompletedEventCommand(
+            event(eventId),
+            TransferCompletedEvent.TYPE,
+            0,
+            recordOffset
+        );
+    }
+
+    private static TransferCompletedEvent event(
+        UUID eventId
+    ) {
+        return new TransferCompletedEvent(
+            eventId,
+            TransferCompletedEvent.TYPE,
+            TransferCompletedEvent.VERSION,
+            Instant.parse(
+                "2026-07-20T20:00:00Z"
+            ),
+            TRANSACTION_ID,
+            UUID.fromString(
+                "70000000-0000-0000-0000-000000001001"
+            ),
+            UUID.fromString(
+                "70000000-0000-0000-0000-000000001002"
+            ),
+            "125.50",
+            "TRY"
+        );
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class ProcessingTestConfiguration {
+
+        @Bean
+        ProcessTransferCompletedEventUseCase
+        processTransferCompletedEventUseCase(
+            ProcessedKafkaEventRepositoryPort repository,
+            TransferCompletedEventHandlerPort handler
+        ) {
+            return new ProcessTransferCompletedEventService(
+                CONSUMER_NAME,
+                repository,
+                handler,
+                Clock.fixed(
+                    Instant.parse(
+                        "2026-07-20T21:00:00Z"
+                    ),
+                    ZoneOffset.UTC
+                )
+            );
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/ProcessTransferCompletedEventTransactionIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/ProcessTransferCompletedEventTransactionIntegrationTest.java
@@ -15,6 +15,7 @@ import com.nursena.payflow.eventprocessing.application.port.out.ProcessedKafkaEv
 import com.nursena.payflow.eventprocessing.application.port.out.TransferCompletedEventHandlerPort;
 import com.nursena.payflow.eventprocessing.application.service.ProcessTransferCompletedEventService;
 import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +28,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 @SpringBootTest
 @Testcontainers
@@ -49,6 +51,7 @@ class ProcessTransferCompletedEventTransactionIntegrationTest {
         );
 
     @Autowired
+    @Qualifier("processTransferCompletedEventUseCase")
     private ProcessTransferCompletedEventUseCase
         useCase;
 

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/ProcessTransferCompletedEventTransactionIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/ProcessTransferCompletedEventTransactionIntegrationTest.java
@@ -1,0 +1,231 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.ProcessTransferCompletedEventCommand;
+import com.nursena.payflow.eventprocessing.application.model.ProcessTransferCompletedEventResult;
+import com.nursena.payflow.eventprocessing.application.port.in.ProcessTransferCompletedEventUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.ProcessedKafkaEventRepositoryPort;
+import com.nursena.payflow.eventprocessing.application.port.out.TransferCompletedEventHandlerPort;
+import com.nursena.payflow.eventprocessing.application.service.ProcessTransferCompletedEventService;
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+@Import(
+    ProcessTransferCompletedEventTransactionIntegrationTest
+        .ProcessingTestConfiguration.class
+)
+class ProcessTransferCompletedEventTransactionIntegrationTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000701"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private ProcessTransferCompletedEventUseCase
+        useCase;
+
+    @Autowired
+    private TestTransferCompletedEventHandler
+        eventHandler;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM processed_kafka_events"
+        );
+
+        eventHandler.reset();
+    }
+
+    @Test
+    void shouldRollbackProcessedEventWhenHandlerFails() {
+        eventHandler.fail();
+
+        assertThatThrownBy(
+            () -> useCase.process(command())
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "test handler failure"
+            );
+
+        assertThat(processedEventCount())
+            .isZero();
+
+        eventHandler.succeed();
+
+        ProcessTransferCompletedEventResult retryResult =
+            useCase.process(command());
+
+        assertThat(retryResult)
+            .isEqualTo(
+                ProcessTransferCompletedEventResult
+                    .PROCESSED
+            );
+
+        assertThat(processedEventCount())
+            .isEqualTo(1);
+
+        ProcessTransferCompletedEventResult duplicateResult =
+            useCase.process(command());
+
+        assertThat(duplicateResult)
+            .isEqualTo(
+                ProcessTransferCompletedEventResult
+                    .DUPLICATE
+            );
+
+        assertThat(processedEventCount())
+            .isEqualTo(1);
+
+        assertThat(eventHandler.invocationCount())
+            .isEqualTo(2);
+    }
+
+    private Integer processedEventCount() {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM processed_kafka_events
+            WHERE consumer_name = ?
+              AND event_id = ?
+            """,
+            Integer.class,
+            "transfer-completed-notification",
+            EVENT_ID
+        );
+    }
+
+    private static
+    ProcessTransferCompletedEventCommand command() {
+        return new ProcessTransferCompletedEventCommand(
+            event(),
+            TransferCompletedEvent.TYPE,
+            0,
+            25L
+        );
+    }
+
+    private static TransferCompletedEvent event() {
+        return new TransferCompletedEvent(
+            EVENT_ID,
+            TransferCompletedEvent.TYPE,
+            TransferCompletedEvent.VERSION,
+            Instant.parse(
+                "2026-07-20T20:00:00Z"
+            ),
+            UUID.fromString(
+                "60000000-0000-0000-0000-000000000701"
+            ),
+            UUID.fromString(
+                "70000000-0000-0000-0000-000000000701"
+            ),
+            UUID.fromString(
+                "70000000-0000-0000-0000-000000000702"
+            ),
+            "125.50",
+            "TRY"
+        );
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class ProcessingTestConfiguration {
+
+        @Bean
+        TestTransferCompletedEventHandler
+        testTransferCompletedEventHandler() {
+            return new TestTransferCompletedEventHandler();
+        }
+
+        @Bean
+        ProcessTransferCompletedEventUseCase
+        processTransferCompletedEventUseCase(
+            ProcessedKafkaEventRepositoryPort repository,
+            TestTransferCompletedEventHandler handler
+        ) {
+            return new ProcessTransferCompletedEventService(
+                "transfer-completed-notification",
+                repository,
+                handler,
+                Clock.fixed(
+                    Instant.parse(
+                        "2026-07-20T21:00:00Z"
+                    ),
+                    ZoneOffset.UTC
+                )
+            );
+        }
+    }
+
+    static final class
+    TestTransferCompletedEventHandler
+        implements TransferCompletedEventHandlerPort {
+
+        private boolean failing;
+
+        private int invocationCount;
+
+        @Override
+        public void handle(
+            TransferCompletedEvent event
+        ) {
+            invocationCount++;
+
+            if (failing) {
+                throw new IllegalStateException(
+                    "test handler failure"
+                );
+            }
+        }
+
+        void fail() {
+            failing = true;
+        }
+
+        void succeed() {
+            failing = false;
+        }
+
+        void reset() {
+            failing = false;
+            invocationCount = 0;
+        }
+
+        int invocationCount() {
+            return invocationCount;
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/ProcessedKafkaEventPersistenceIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/ProcessedKafkaEventPersistenceIntegrationTest.java
@@ -1,0 +1,269 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.nursena.payflow.eventprocessing.application.port.out.ProcessedKafkaEventRepositoryPort;
+import com.nursena.payflow.eventprocessing.domain.model.ProcessedKafkaEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class ProcessedKafkaEventPersistenceIntegrationTest {
+
+    private static final String NOTIFICATION_CONSUMER =
+        "transfer-completed-notification";
+
+    private static final String AUDIT_CONSUMER =
+        "transfer-completed-audit";
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000401"
+        );
+
+    private static final Instant PROCESSED_AT =
+        Instant.parse(
+            "2026-07-20T19:00:00Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private ProcessedKafkaEventRepositoryPort
+        repositoryPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM processed_kafka_events"
+        );
+    }
+
+    @Test
+    void shouldRecordEventForFirstDelivery() {
+        boolean recorded =
+            repositoryPort.tryRecord(
+                processedEvent(
+                    NOTIFICATION_CONSUMER
+                )
+            );
+
+        assertThat(recorded)
+            .isTrue();
+
+        Integer count = countByEventId(
+            EVENT_ID
+        );
+
+        assertThat(count)
+            .isEqualTo(1);
+    }
+
+    @Test
+    void shouldReturnFalseForDuplicateDelivery() {
+        boolean firstResult =
+            repositoryPort.tryRecord(
+                processedEvent(
+                    NOTIFICATION_CONSUMER
+                )
+            );
+
+        boolean duplicateResult =
+            repositoryPort.tryRecord(
+                processedEvent(
+                    NOTIFICATION_CONSUMER
+                )
+            );
+
+        assertThat(firstResult)
+            .isTrue();
+
+        assertThat(duplicateResult)
+            .isFalse();
+
+        assertThat(
+            countByEventId(EVENT_ID)
+        )
+            .isEqualTo(1);
+    }
+
+    @Test
+    void shouldAllowSameEventForDifferentConsumers() {
+        boolean notificationResult =
+            repositoryPort.tryRecord(
+                processedEvent(
+                    NOTIFICATION_CONSUMER
+                )
+            );
+
+        boolean auditResult =
+            repositoryPort.tryRecord(
+                processedEvent(
+                    AUDIT_CONSUMER
+                )
+            );
+
+        assertThat(notificationResult)
+            .isTrue();
+
+        assertThat(auditResult)
+            .isTrue();
+
+        assertThat(
+            countByEventId(EVENT_ID)
+        )
+            .isEqualTo(2);
+    }
+
+    @Test
+    void shouldRecordOnlyOnceUnderConcurrentDelivery()
+        throws Exception {
+
+        int workerCount = 8;
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(
+                workerCount
+            );
+
+        CountDownLatch ready =
+            new CountDownLatch(
+                workerCount
+            );
+
+        CountDownLatch start =
+            new CountDownLatch(1);
+
+        List<Future<Boolean>> results =
+            new ArrayList<>();
+
+        try {
+            for (int index = 0;
+                 index < workerCount;
+                 index++) {
+
+                results.add(
+                    executor.submit(
+                        () -> {
+                            ready.countDown();
+
+                            boolean started =
+                                start.await(
+                                    10,
+                                    TimeUnit.SECONDS
+                                );
+
+                            if (!started) {
+                                throw new IllegalStateException(
+                                    "Concurrent test start "
+                                        + "timed out."
+                                );
+                            }
+
+                            return repositoryPort.tryRecord(
+                                processedEvent(
+                                    NOTIFICATION_CONSUMER
+                                )
+                            );
+                        }
+                    )
+                );
+            }
+
+            assertThat(
+                ready.await(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            )
+                .isTrue();
+
+            start.countDown();
+
+            long successfulInsertCount = 0;
+
+            for (Future<Boolean> result : results) {
+                if (result.get(
+                    10,
+                    TimeUnit.SECONDS
+                )) {
+                    successfulInsertCount++;
+                }
+            }
+
+            assertThat(successfulInsertCount)
+                .isEqualTo(1);
+
+            assertThat(
+                countByEventId(EVENT_ID)
+            )
+                .isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            )
+                .isTrue();
+        }
+    }
+
+    private Integer countByEventId(
+        UUID eventId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM processed_kafka_events
+            WHERE event_id = ?
+            """,
+            Integer.class,
+            eventId
+        );
+    }
+
+    private static ProcessedKafkaEvent
+    processedEvent(
+        String consumerName
+    ) {
+        return new ProcessedKafkaEvent(
+            consumerName,
+            EVENT_ID,
+            "wallet.transfer.completed",
+            1,
+            "wallet.transfer.completed",
+            0,
+            15L,
+            PROCESSED_AT
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/ProcessedKafkaEventSchemaIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/ProcessedKafkaEventSchemaIntegrationTest.java
@@ -1,0 +1,325 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class ProcessedKafkaEventSchemaIntegrationTest {
+
+    private static final String NOTIFICATION_CONSUMER =
+        "transfer-completed-notification";
+
+    private static final String AUDIT_CONSUMER =
+        "transfer-completed-audit";
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000201"
+        );
+
+    private static final String EVENT_TYPE =
+        "wallet.transfer.completed";
+
+    private static final Instant PROCESSED_AT =
+        Instant.parse(
+            "2026-07-20T17:00:00Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM processed_kafka_events"
+        );
+    }
+
+    @Test
+    void shouldPersistValidProcessedEvent() {
+        insertProcessedEvent(
+            NOTIFICATION_CONSUMER,
+            EVENT_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            0,
+            15L
+        );
+
+        Integer count = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM processed_kafka_events
+            WHERE consumer_name = ?
+              AND event_id = ?
+            """,
+            Integer.class,
+            NOTIFICATION_CONSUMER,
+            EVENT_ID
+        );
+
+        Long recordOffset = jdbcTemplate.queryForObject(
+            """
+            SELECT record_offset
+            FROM processed_kafka_events
+            WHERE consumer_name = ?
+              AND event_id = ?
+            """,
+            Long.class,
+            NOTIFICATION_CONSUMER,
+            EVENT_ID
+        );
+
+        assertThat(count)
+            .isEqualTo(1);
+
+        assertThat(recordOffset)
+            .isEqualTo(15L);
+    }
+
+    @Test
+    void shouldRejectDuplicateEventForSameConsumer() {
+        insertProcessedEvent(
+            NOTIFICATION_CONSUMER,
+            EVENT_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            0,
+            15L
+        );
+
+        assertConstraintViolation(
+            () -> insertProcessedEvent(
+                NOTIFICATION_CONSUMER,
+                EVENT_ID,
+                EVENT_TYPE,
+                1,
+                EVENT_TYPE,
+                0,
+                16L
+            ),
+            "pk_processed_kafka_events"
+        );
+    }
+
+    @Test
+    void shouldAllowSameEventForDifferentConsumers() {
+        insertProcessedEvent(
+            NOTIFICATION_CONSUMER,
+            EVENT_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            0,
+            15L
+        );
+
+        insertProcessedEvent(
+            AUDIT_CONSUMER,
+            EVENT_ID,
+            EVENT_TYPE,
+            1,
+            EVENT_TYPE,
+            0,
+            15L
+        );
+
+        Integer count = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM processed_kafka_events
+            WHERE event_id = ?
+            """,
+            Integer.class,
+            EVENT_ID
+        );
+
+        assertThat(count)
+            .isEqualTo(2);
+    }
+
+    @Test
+    void shouldRejectBlankConsumerName() {
+        assertConstraintViolation(
+            () -> insertProcessedEvent(
+                " ",
+                EVENT_ID,
+                EVENT_TYPE,
+                1,
+                EVENT_TYPE,
+                0,
+                15L
+            ),
+            "chk_processed_kafka_events_consumer_name"
+        );
+    }
+
+    @Test
+    void shouldRejectBlankEventType() {
+        assertConstraintViolation(
+            () -> insertProcessedEvent(
+                NOTIFICATION_CONSUMER,
+                EVENT_ID,
+                " ",
+                1,
+                EVENT_TYPE,
+                0,
+                15L
+            ),
+            "chk_processed_kafka_events_event_type"
+        );
+    }
+
+    @Test
+    void shouldRejectNonPositiveEventVersion() {
+        assertConstraintViolation(
+            () -> insertProcessedEvent(
+                NOTIFICATION_CONSUMER,
+                EVENT_ID,
+                EVENT_TYPE,
+                0,
+                EVENT_TYPE,
+                0,
+                15L
+            ),
+            "chk_processed_kafka_events_event_version"
+        );
+    }
+
+    @Test
+    void shouldRejectBlankTopic() {
+        assertConstraintViolation(
+            () -> insertProcessedEvent(
+                NOTIFICATION_CONSUMER,
+                EVENT_ID,
+                EVENT_TYPE,
+                1,
+                " ",
+                0,
+                15L
+            ),
+            "chk_processed_kafka_events_topic"
+        );
+    }
+
+    @Test
+    void shouldRejectNegativePartition() {
+        assertConstraintViolation(
+            () -> insertProcessedEvent(
+                NOTIFICATION_CONSUMER,
+                EVENT_ID,
+                EVENT_TYPE,
+                1,
+                EVENT_TYPE,
+                -1,
+                15L
+            ),
+            "chk_processed_kafka_events_partition"
+        );
+    }
+
+    @Test
+    void shouldRejectNegativeOffset() {
+        assertConstraintViolation(
+            () -> insertProcessedEvent(
+                NOTIFICATION_CONSUMER,
+                EVENT_ID,
+                EVENT_TYPE,
+                1,
+                EVENT_TYPE,
+                0,
+                -1L
+            ),
+            "chk_processed_kafka_events_offset"
+        );
+    }
+
+    private void insertProcessedEvent(
+        String consumerName,
+        UUID eventId,
+        String eventType,
+        int eventVersion,
+        String topic,
+        int partitionNumber,
+        long recordOffset
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO processed_kafka_events (
+                consumer_name,
+                event_id,
+                event_type,
+                event_version,
+                topic,
+                partition_number,
+                record_offset,
+                processed_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            consumerName,
+            eventId,
+            eventType,
+            eventVersion,
+            topic,
+            partitionNumber,
+            recordOffset,
+            Timestamp.from(PROCESSED_AT)
+        );
+    }
+
+    private static void assertConstraintViolation(
+        ThrowingCallable operation,
+        String constraintName
+    ) {
+        Throwable thrown = catchThrowable(
+            operation
+        );
+
+        assertThat(thrown)
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+
+        assertThat(rootCauseOf(thrown).getMessage())
+            .contains(constraintName);
+    }
+
+    private static Throwable rootCauseOf(
+        Throwable throwable
+    ) {
+        Throwable current = throwable;
+
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+
+        return current;
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/TransferCompletedEventAuditPersistenceIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/TransferCompletedEventAuditPersistenceIntegrationTest.java
@@ -1,0 +1,173 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.port.out.TransferCompletedEventHandlerPort;
+import com.nursena.payflow.transaction.application.model.TransferCompletedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class TransferCompletedEventAuditPersistenceIntegrationTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000901"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000901"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private TransferCompletedEventHandlerPort
+        eventHandler;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM transfer_completed_event_audits"
+        );
+    }
+
+    @Test
+    void shouldPersistTransferCompletedAudit() {
+        eventHandler.handle(
+            event(
+                EVENT_ID,
+                TRANSACTION_ID
+            )
+        );
+
+        Map<String, Object> stored =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT
+                    event_type,
+                    event_version,
+                    occurred_at,
+                    transaction_id,
+                    source_wallet_id,
+                    target_wallet_id,
+                    amount,
+                    currency,
+                    recorded_at
+                FROM transfer_completed_event_audits
+                WHERE event_id = ?
+                """,
+                EVENT_ID
+            );
+
+        assertThat(
+            stored.get("event_type")
+        )
+            .isEqualTo(
+                TransferCompletedEvent.TYPE
+            );
+
+        assertThat(
+            stored.get("event_version")
+        )
+            .isEqualTo(
+                TransferCompletedEvent.VERSION
+            );
+
+        assertThat(
+            stored.get("transaction_id")
+        )
+            .isEqualTo(TRANSACTION_ID);
+
+        assertThat(
+            (BigDecimal) stored.get("amount")
+        )
+            .isEqualByComparingTo(
+                "125.50"
+            );
+
+        assertThat(
+            stored.get("currency")
+        )
+            .isEqualTo("TRY");
+
+        assertThat(
+            stored.get("recorded_at")
+        )
+            .isInstanceOf(
+                Timestamp.class
+            );
+    }
+
+    @Test
+    void shouldRejectSecondAuditForSameTransaction() {
+        eventHandler.handle(
+            event(
+                EVENT_ID,
+                TRANSACTION_ID
+            )
+        );
+
+        assertThatThrownBy(
+            () -> eventHandler.handle(
+                event(
+                    UUID.fromString(
+                        "50000000-0000-0000-0000-000000000902"
+                    ),
+                    TRANSACTION_ID
+                )
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    private static TransferCompletedEvent event(
+        UUID eventId,
+        UUID transactionId
+    ) {
+        return new TransferCompletedEvent(
+            eventId,
+            TransferCompletedEvent.TYPE,
+            TransferCompletedEvent.VERSION,
+            Instant.parse(
+                "2026-07-20T20:00:00Z"
+            ),
+            transactionId,
+            UUID.fromString(
+                "70000000-0000-0000-0000-000000000901"
+            ),
+            UUID.fromString(
+                "70000000-0000-0000-0000-000000000902"
+            ),
+            "125.50",
+            "TRY"
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/TransferCompletedEventAuditSchemaIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/TransferCompletedEventAuditSchemaIntegrationTest.java
@@ -1,0 +1,286 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class TransferCompletedEventAuditSchemaIntegrationTest {
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000801"
+        );
+
+    private static final UUID SECOND_EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000000802"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000000801"
+        );
+
+    private static final UUID SOURCE_WALLET_ID =
+        UUID.fromString(
+            "70000000-0000-0000-0000-000000000801"
+        );
+
+    private static final UUID TARGET_WALLET_ID =
+        UUID.fromString(
+            "70000000-0000-0000-0000-000000000802"
+        );
+
+    private static final Instant OCCURRED_AT =
+        Instant.parse(
+            "2026-07-20T20:00:00Z"
+        );
+
+    private static final Instant RECORDED_AT =
+        Instant.parse(
+            "2026-07-20T20:00:01Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM transfer_completed_event_audits"
+        );
+    }
+
+    @Test
+    void shouldPersistValidAuditRecord() {
+        insertAudit(
+            EVENT_ID,
+            TRANSACTION_ID,
+            "wallet.transfer.completed",
+            1,
+            SOURCE_WALLET_ID,
+            TARGET_WALLET_ID,
+            new BigDecimal("125.50"),
+            "TRY"
+        );
+
+        Integer count = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM transfer_completed_event_audits
+            WHERE event_id = ?
+            """,
+            Integer.class,
+            EVENT_ID
+        );
+
+        assertThat(count)
+            .isEqualTo(1);
+    }
+
+    @Test
+    void shouldRejectDuplicateTransactionId() {
+        insertAudit(
+            EVENT_ID,
+            TRANSACTION_ID,
+            "wallet.transfer.completed",
+            1,
+            SOURCE_WALLET_ID,
+            TARGET_WALLET_ID,
+            new BigDecimal("125.50"),
+            "TRY"
+        );
+
+        assertConstraintViolation(
+            () -> insertAudit(
+                SECOND_EVENT_ID,
+                TRANSACTION_ID,
+                "wallet.transfer.completed",
+                1,
+                SOURCE_WALLET_ID,
+                TARGET_WALLET_ID,
+                new BigDecimal("125.50"),
+                "TRY"
+            ),
+            "uq_transfer_completed_event_audits_transaction_id"
+        );
+    }
+
+    @Test
+    void shouldRejectUnsupportedEventType() {
+        assertConstraintViolation(
+            () -> insertAudit(
+                EVENT_ID,
+                TRANSACTION_ID,
+                "wallet.transfer.failed",
+                1,
+                SOURCE_WALLET_ID,
+                TARGET_WALLET_ID,
+                new BigDecimal("125.50"),
+                "TRY"
+            ),
+            "chk_transfer_completed_event_audits_type"
+        );
+    }
+
+    @Test
+    void shouldRejectUnsupportedEventVersion() {
+        assertConstraintViolation(
+            () -> insertAudit(
+                EVENT_ID,
+                TRANSACTION_ID,
+                "wallet.transfer.completed",
+                2,
+                SOURCE_WALLET_ID,
+                TARGET_WALLET_ID,
+                new BigDecimal("125.50"),
+                "TRY"
+            ),
+            "chk_transfer_completed_event_audits_version"
+        );
+    }
+
+    @Test
+    void shouldRejectSameSourceAndTargetWallet() {
+        assertConstraintViolation(
+            () -> insertAudit(
+                EVENT_ID,
+                TRANSACTION_ID,
+                "wallet.transfer.completed",
+                1,
+                SOURCE_WALLET_ID,
+                SOURCE_WALLET_ID,
+                new BigDecimal("125.50"),
+                "TRY"
+            ),
+            "chk_transfer_completed_event_audits_wallets"
+        );
+    }
+
+    @Test
+    void shouldRejectNonPositiveAmount() {
+        assertConstraintViolation(
+            () -> insertAudit(
+                EVENT_ID,
+                TRANSACTION_ID,
+                "wallet.transfer.completed",
+                1,
+                SOURCE_WALLET_ID,
+                TARGET_WALLET_ID,
+                BigDecimal.ZERO,
+                "TRY"
+            ),
+            "chk_transfer_completed_event_audits_amount"
+        );
+    }
+
+    @Test
+    void shouldRejectInvalidCurrency() {
+        assertConstraintViolation(
+            () -> insertAudit(
+                EVENT_ID,
+                TRANSACTION_ID,
+                "wallet.transfer.completed",
+                1,
+                SOURCE_WALLET_ID,
+                TARGET_WALLET_ID,
+                new BigDecimal("125.50"),
+                "tr"
+            ),
+            "chk_transfer_completed_event_audits_currency"
+        );
+    }
+
+    private void insertAudit(
+        UUID eventId,
+        UUID transactionId,
+        String eventType,
+        int eventVersion,
+        UUID sourceWalletId,
+        UUID targetWalletId,
+        BigDecimal amount,
+        String currency
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO transfer_completed_event_audits (
+                event_id,
+                event_type,
+                event_version,
+                occurred_at,
+                transaction_id,
+                source_wallet_id,
+                target_wallet_id,
+                amount,
+                currency,
+                recorded_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            eventId,
+            eventType,
+            eventVersion,
+            Timestamp.from(OCCURRED_AT),
+            transactionId,
+            sourceWalletId,
+            targetWalletId,
+            amount,
+            currency,
+            Timestamp.from(RECORDED_AT)
+        );
+    }
+
+    private static void assertConstraintViolation(
+        ThrowingCallable operation,
+        String constraintName
+    ) {
+        Throwable thrown = catchThrowable(
+            operation
+        );
+
+        assertThat(thrown)
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+
+        assertThat(rootCauseOf(thrown).getMessage())
+            .contains(constraintName);
+    }
+
+    private static Throwable rootCauseOf(
+        Throwable throwable
+    ) {
+        Throwable current = throwable;
+
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+
+        return current;
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/TransferCompletedKafkaConsumerIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/TransferCompletedKafkaConsumerIntegrationTest.java
@@ -1,0 +1,321 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+
+@SpringBootTest(
+    properties = {
+        "payflow.event-processing"
+            + ".transfer-completed.enabled=true",
+        "payflow.event-processing"
+            + ".transfer-completed.topic="
+            + "wallet.transfer.completed"
+            + ".consumer-integration",
+        "payflow.event-processing"
+            + ".transfer-completed.group-id="
+            + "transfer-completed-consumer"
+            + "-integration-test",
+        "payflow.event-processing"
+            + ".transfer-completed.consumer-name="
+            + "transfer-completed-audit"
+            + "-integration-test",
+        "spring.kafka.consumer"
+            + ".enable-auto-commit=false",
+        "spring.kafka.consumer"
+            + ".auto-offset-reset=earliest",
+        "spring.kafka.listener.ack-mode=record"
+    }
+)
+@Testcontainers
+@Import(
+    TransferCompletedKafkaConsumerIntegrationTest
+        .KafkaTopicTestConfiguration.class
+)
+class TransferCompletedKafkaConsumerIntegrationTest {
+
+    private static final String TOPIC =
+        "wallet.transfer.completed"
+            + ".consumer-integration";
+
+    private static final String CONSUMER_GROUP =
+        "transfer-completed-consumer"
+            + "-integration-test";
+
+    private static final String CONSUMER_NAME =
+        "transfer-completed-audit"
+            + "-integration-test";
+
+    private static final UUID EVENT_ID =
+        UUID.fromString(
+            "50000000-0000-0000-0000-000000001201"
+        );
+
+    private static final UUID TRANSACTION_ID =
+        UUID.fromString(
+            "60000000-0000-0000-0000-000000001201"
+        );
+
+    private static final String PAYLOAD = """
+        {
+          "eventId": "50000000-0000-0000-0000-000000001201",
+          "eventType": "wallet.transfer.completed",
+          "eventVersion": 1,
+          "occurredAt": "2026-07-21T12:00:00Z",
+          "transactionId": "60000000-0000-0000-0000-000000001201",
+          "sourceWalletId": "70000000-0000-0000-0000-000000001201",
+          "targetWalletId": "70000000-0000-0000-0000-000000001202",
+          "amount": "125.50",
+          "currency": "TRY"
+        }
+        """;
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final KafkaContainer KAFKA =
+        new KafkaContainer(
+            "apache/kafka:4.1.2"
+        );
+
+    @Autowired
+    private KafkaTemplate<String, String>
+        kafkaTemplate;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM transfer_completed_event_audits"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM processed_kafka_events"
+        );
+    }
+
+    @Test
+    void shouldConsumeDuplicateDeliveryOnlyOnce()
+        throws Exception {
+
+        publishEvent();
+
+        awaitCommittedOffset(1L);
+
+        assertStoredCounts();
+
+        publishEvent();
+
+        awaitCommittedOffset(2L);
+
+        assertStoredCounts();
+
+        Map<String, Object> processedEvent =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT
+                    event_type,
+                    event_version,
+                    topic,
+                    partition_number,
+                    record_offset
+                FROM processed_kafka_events
+                WHERE consumer_name = ?
+                  AND event_id = ?
+                """,
+                CONSUMER_NAME,
+                EVENT_ID
+            );
+
+        assertThat(
+            processedEvent.get("event_type")
+        )
+            .isEqualTo(
+                "wallet.transfer.completed"
+            );
+
+        assertThat(
+            processedEvent.get("event_version")
+        )
+            .isEqualTo(1);
+
+        assertThat(
+            processedEvent.get("topic")
+        )
+            .isEqualTo(TOPIC);
+
+        assertThat(
+            processedEvent.get("partition_number")
+        )
+            .isEqualTo(0);
+
+        assertThat(
+            ((Number) processedEvent.get(
+                "record_offset"
+            )).longValue()
+        )
+            .isZero();
+    }
+
+    private void publishEvent()
+        throws Exception {
+
+        kafkaTemplate.send(
+                TOPIC,
+                TRANSACTION_ID.toString(),
+                PAYLOAD
+            )
+            .get(
+                20,
+                TimeUnit.SECONDS
+            );
+    }
+
+    private void assertStoredCounts() {
+        Long processedEventCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM processed_kafka_events
+                WHERE consumer_name = ?
+                  AND event_id = ?
+                """,
+                Long.class,
+                CONSUMER_NAME,
+                EVENT_ID
+            );
+
+        Long auditCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM transfer_completed_event_audits
+                WHERE event_id = ?
+                  AND transaction_id = ?
+                """,
+                Long.class,
+                EVENT_ID,
+                TRANSACTION_ID
+            );
+
+        assertThat(processedEventCount)
+            .isEqualTo(1L);
+
+        assertThat(auditCount)
+            .isEqualTo(1L);
+    }
+
+    private static void awaitCommittedOffset(
+        long expectedOffset
+    ) throws Exception {
+
+        TopicPartition topicPartition =
+            new TopicPartition(
+                TOPIC,
+                0
+            );
+
+        long deadline =
+            System.nanoTime()
+                + TimeUnit.SECONDS.toNanos(20);
+
+        long latestCommittedOffset = -1L;
+
+        try (
+            Admin admin = Admin.create(
+                Map.of(
+                    AdminClientConfig
+                        .BOOTSTRAP_SERVERS_CONFIG,
+                    KAFKA.getBootstrapServers()
+                )
+            )
+        ) {
+            while (
+                System.nanoTime() < deadline
+            ) {
+                Map<TopicPartition, OffsetAndMetadata>
+                    committedOffsets =
+                    admin
+                        .listConsumerGroupOffsets(
+                            CONSUMER_GROUP
+                        )
+                        .partitionsToOffsetAndMetadata()
+                        .get(
+                            5,
+                            TimeUnit.SECONDS
+                        );
+
+                OffsetAndMetadata metadata =
+                    committedOffsets.get(
+                        topicPartition
+                    );
+
+                if (metadata != null) {
+                    latestCommittedOffset =
+                        metadata.offset();
+
+                    if (latestCommittedOffset
+                        >= expectedOffset) {
+
+                        return;
+                    }
+                }
+
+                Thread.sleep(100);
+            }
+        }
+
+        assertThat(latestCommittedOffset)
+            .as(
+                "committed offset for %s",
+                topicPartition
+            )
+            .isGreaterThanOrEqualTo(
+                expectedOffset
+            );
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class KafkaTopicTestConfiguration {
+
+        @Bean
+        NewTopic transferCompletedIntegrationTopic() {
+            return TopicBuilder
+                .name(TOPIC)
+                .partitions(1)
+                .replicas(1)
+                .build();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add durable processed Kafka event tracking with a composite
  `(consumer_name, event_id)` identity
- add transactional and idempotent transfer-completed event processing
- add transfer-completed audit persistence
- consume `wallet.transfer.completed` events with a dedicated consumer
  group and logical consumer identity
- validate Kafka payloads, metadata, and transaction partition keys
- enable the consumer explicitly in the Compose application profile

## Processing guarantees

- Kafka delivery remains at least once
- duplicate deliveries are treated as successful no-op processing
- the processed-event marker and audit side effect are stored in the
  same PostgreSQL transaction
- handler failures roll back the processed-event marker
- duplicate records can advance the consumer group offset safely

## Testing

- domain and application unit tests
- PostgreSQL schema and persistence integration tests
- transactional rollback integration tests
- Kafka and PostgreSQL Testcontainers integration test
- duplicate delivery verification using committed consumer offsets
- full Maven quality gate:

  `.\mvnw.cmd clean verify`