### PR TITLE
feat: add controlled Kafka dead-letter replay

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -76,6 +76,8 @@ services:
       TRANSFER_COMPLETED_RETRY_MULTIPLIER: "2.0"
       TRANSFER_COMPLETED_RETRY_MAXIMUM_DELAY: 5s
       TRANSFER_COMPLETED_DLT_SEND_TIMEOUT: 10s
+      TRANSFER_COMPLETED_DLT_INTAKE_ENABLED: "true"
+      TRANSFER_COMPLETED_DLT_INTAKE_GROUP: payflow-transfer-completed-dlt-intake-v1
     ports:
       - "8080:8080"
     depends_on:

--- a/docs/adr/0005-controlled-kafka-dead-letter-replay.md
+++ b/docs/adr/0005-controlled-kafka-dead-letter-replay.md
@@ -117,6 +117,8 @@ The initial dead-letter model stores:
 - replay lease owner
 - replay lease expiration
 - last replay error
+- replay origin identifier
+- replay-attempt base
 
 The original record key and payload may be null.
 
@@ -138,7 +140,9 @@ Supported statuses are:
 
 ### RECEIVED
 
-The record was durably ingested from the DLT and has not been replayed.
+The record was durably ingested from the DLT and has not been replayed directly from its current physical DLT location.
+
+A `RECEIVED` record may still be replay-derived when its lineage metadata indicates that replay attempts occurred before the current physical DLT record was created.
 
 ### REPLAYING
 
@@ -167,7 +171,7 @@ This is a terminal operational decision.
 A record is replayable only when:
 
 - its status is `RECEIVED` or `REPLAY_FAILED`
-- its replay count is below the configured maximum
+- `replay_attempt_base + replay_count` is lower than the configured maximum replay-attempt limit
 - it is not protected by an active replay lease
 - its original topic is present
 - its payload satisfies the replay command requirements
@@ -201,6 +205,8 @@ A replay count is incremented when a replay attempt is claimed, not after public
 
 This preserves an accurate upper bound even when a worker crashes during publication.
 
+`last_replayed_at` records the start time of the latest replay attempt, meaning the moment the record was claimed. It does not prove that Kafka publication completed successfully.
+
 ## Kafka publication
 
 A claimed record is published to its original topic.
@@ -210,14 +216,13 @@ The replay publication uses:
 - original topic
 - original key
 - original payload
+- PayFlow replay-lineage headers
 
 Spring Kafka DLT exception headers are not copied to the replayed source record.
 
 Delivery-attempt and prior DLT metadata headers are also not copied.
 
 This prevents dead-letter and exception headers from accumulating across replay cycles.
-
-The initial replay implementation republishes only the key and payload.
 
 Business-header replay may be introduced later through an explicit allowlist.
 
@@ -252,11 +257,53 @@ This existing idempotency boundary is required for safe at-least-once replay.
 
 Replay attempts are bounded by configuration.
 
-The default maximum replay count will be conservative.
+The limit applies to the complete logical replay chain rather than independently to each physical Kafka DLT record.
 
-A record that reaches the configured replay limit is no longer eligible for replay without an explicit future administrative intervention.
+A record that reaches the configured chain-wide replay-attempt limit is no longer eligible for replay without an explicit future administrative intervention.
 
 Replay limits prevent permanent failures from consuming resources indefinitely.
+
+### Replay lineage and chain-wide attempt limits
+
+A replay attempt limit must apply to the complete logical replay chain, not only to one physical Kafka DLT record.
+
+Each persisted dead-letter record therefore stores:
+
+- `replay_origin_id`: the identifier of the first persisted dead-letter record in the replay chain.
+- `replay_attempt_base`: the number of replay attempts that occurred before the current physical DLT record was created.
+- `replay_count`: the number of attempts claimed directly from the current physical DLT record.
+
+The total number of attempts for a record is:
+
+`replay_attempt_base + replay_count`
+
+A record may be claimed only while this total is lower than the configured maximum replay-attempt limit.
+
+An initial DLT record uses its own identifier as `replay_origin_id` and stores a zero `replay_attempt_base`.
+
+A replay-derived DLT record preserves the original `replay_origin_id` and receives the total attempt number from the replayed Kafka message.
+
+### Replay lineage headers
+
+A replay publication adds exactly these PayFlow-owned headers:
+
+- `payflow-replay-origin-id`
+- `payflow-replay-attempt`
+
+`payflow-replay-attempt` contains the total attempt count after the current record has been claimed:
+
+`replay_attempt_base + replay_count`
+
+The replay publisher must not copy Spring Kafka DLT exception, stack-trace, delivery-attempt, original-topic, original-offset, or original-consumer-group headers onto the replayed source message.
+
+The DLT intake listener applies the following rules:
+
+- Neither replay header present: initial DLT delivery.
+- Both replay headers present and valid: replay-derived delivery.
+- Only one header present: reject the record.
+- Invalid UUID, non-integer attempt, or non-positive attempt: reject the record.
+
+Rejected lineage metadata is handled fail-closed: the intake transaction is not committed and the DLT consumer offset must not advance.
 
 ## Offset behavior
 
@@ -265,6 +312,10 @@ The DLT intake listener acknowledges a Kafka record only after its PostgreSQL re
 When database persistence fails, the listener must not silently advance the DLT consumer offset.
 
 Duplicate intake caused by Kafka redelivery is expected and is handled through the unique DLT-location constraint.
+
+Invalid or incomplete replay-lineage metadata must also prevent successful acknowledgement.
+
+The DLT intake listener must not advance its consumer offset after rejecting lineage metadata.
 
 ## Security
 
@@ -292,6 +343,8 @@ The replay lifecycle will expose low-cardinality metrics for:
 
 Identifiers, payloads, offsets, exception messages, and record keys will not be metric tags.
 
+Replay-chain identifiers and total replay-attempt values must also not be exposed as metric tags because they would introduce high-cardinality dimensions.
+
 ## Database constraints
 
 PostgreSQL will enforce:
@@ -301,9 +354,12 @@ PostgreSQL will enforce:
 - non-negative partitions
 - non-negative offsets
 - non-negative replay count
+- non-negative replay-attempt base
 - valid lifecycle statuses
 - replay lease consistency
 - replay timestamp consistency
+- valid initial and replay-derived lineage relationships
+- non-overflowing total replay-attempt count
 
 Database constraints complement domain validation and protect the operational state from invalid writes outside the application service.
 
@@ -314,9 +370,11 @@ Database constraints complement domain validation and protect the operational st
 - DLT records remain inspectable beyond Kafka retention.
 - DLT intake is idempotent.
 - Replay is explicit rather than automatic.
-- Replay attempts are bounded.
+- Replay attempts are bounded across the complete logical replay chain.
+- Replay-derived DLT records preserve their original lineage.
 - Concurrent replay claims can be controlled.
 - Kafka exception headers do not accumulate.
+- Invalid lineage metadata is rejected without advancing the DLT consumer offset.
 - Existing consumer idempotency makes replay duplicates safe.
 - Persistence and Kafka concerns remain behind hexagonal ports.
 
@@ -325,6 +383,7 @@ Database constraints complement domain validation and protect the operational st
 - PostgreSQL becomes part of the DLT operational workflow.
 - Replay cannot provide exactly-once publication across PostgreSQL and Kafka.
 - Additional lifecycle recovery logic is required for expired replay leases.
+- Replay lineage must be propagated correctly across Kafka publication and DLT intake.
 - Operational authorization must be designed before exposing replay over HTTP.
 - Stored payloads may contain business data and require normal database access controls.
 
@@ -334,9 +393,15 @@ Database constraints complement domain validation and protect the operational st
 
 Rejected because permanent failures would create unbounded source-to-DLT loops.
 
+### Apply the replay limit independently to each physical DLT record
+
+Rejected because every source-to-DLT cycle would create a new physical record whose local replay count started from zero.
+
+A per-record limit would therefore fail to bound the complete logical replay chain.
+
 ### Use Kafka offsets as the only replay state
 
-Rejected because Kafka retention removes historical records and offsets do not provide operational lifecycle, replay limits, or discard decisions.
+Rejected because Kafka retention removes historical records and offsets do not provide operational lifecycle, replay limits, lineage, or discard decisions.
 
 ### Publish and update PostgreSQL atomically
 
@@ -357,10 +422,19 @@ The implementation must demonstrate:
 - duplicate delivery of one DLT offset creates one database record
 - malformed payloads can still be persisted
 - missing required original-record headers are rejected
+- initial DLT records use their own identifier as `replay_origin_id`
+- initial DLT records use a zero `replay_attempt_base`
+- replay-derived records preserve the original replay-chain identifier
+- replay-derived records persist the attempt base received from Kafka
+- partial replay-lineage headers are rejected
+- invalid replay-origin UUID values are rejected
+- non-integer or non-positive replay-attempt values are rejected
+- rejected lineage metadata prevents DLT offset advancement
 - persistence failure prevents successful DLT consumption
 - concurrent replay claims cannot own the same record
 - expired replay leases can be reclaimed
-- replay count limits are enforced
+- chain-wide replay limits are enforced using `replay_attempt_base + replay_count`
+- total replay-attempt arithmetic cannot overflow
 - successful publication transitions the record to `REPLAYED`
 - failed publication transitions the record to `REPLAY_FAILED`
 - replayed valid events remain safe under duplicate publication

--- a/docs/adr/0005-controlled-kafka-dead-letter-replay.md
+++ b/docs/adr/0005-controlled-kafka-dead-letter-replay.md
@@ -1,0 +1,366 @@
+# ADR 0005: Control Kafka dead-letter replay through durable PostgreSQL state
+
+- Status: Accepted
+- Date: 2026-07-21
+
+## Context
+
+The transfer-completed Kafka consumer uses bounded retries and publishes permanent or exhausted failures to:
+
+`wallet.transfer.completed.dlt`
+
+Dead-letter publication prevents an unrecoverable record from blocking the source consumer partition indefinitely.
+
+However, routing a record to a dead-letter topic does not complete the operational lifecycle.
+
+Operators still need to:
+
+- inspect failed records
+- understand their original Kafka location
+- distinguish malformed records from transient processing failures
+- decide whether a record is safe to replay
+- limit repeated replay attempts
+- prevent uncontrolled source-to-DLT replay loops
+- preserve an auditable history of replay decisions
+
+Automatically forwarding every DLT record back to the source topic is unsafe.
+
+Permanent failures such as malformed JSON or an invalid partition key would repeatedly travel through:
+
+`source topic -> consumer -> DLT -> source topic`
+
+Kafka offsets alone are also insufficient as the operational source of truth because retention policies may eventually remove DLT records.
+
+A durable PostgreSQL representation is required before controlled replay is introduced.
+
+## Decision
+
+PayFlow persists transfer-completed dead-letter records in PostgreSQL before they become eligible for replay.
+
+A dedicated Kafka listener consumes the configured DLT topic and records each DLT message through the event-processing application boundary.
+
+The DLT listener does not automatically republish records.
+
+Replay requires an explicit application command.
+
+The initial replay workflow remains internal until PayFlow has an authenticated operations or administrator authorization model.
+
+No unauthenticated HTTP replay endpoint will be exposed.
+
+## Architecture boundary
+
+The Kafka input adapter is responsible for:
+
+- reading the DLT `ConsumerRecord`
+- extracting required Spring Kafka dead-letter headers
+- validating Kafka metadata
+- creating an application command
+
+The application service is responsible for:
+
+- creating the dead-letter domain model
+- assigning initial lifecycle state
+- recording the reception timestamp
+- enforcing application-level replay rules
+
+The persistence output port is responsible for durable storage.
+
+The application layer does not depend directly on:
+
+- `KafkaTemplate`
+- Kafka consumer APIs
+- JDBC
+- Spring Kafka header constants
+
+Kafka-specific header extraction stays inside the Kafka input adapter.
+
+JDBC-specific persistence stays inside the persistence output adapter.
+
+## Dead-letter identity
+
+A dead-letter record is uniquely identified by its physical location in the DLT:
+
+- DLT topic
+- DLT partition
+- DLT offset
+
+PostgreSQL enforces uniqueness for:
+
+`(dlt_topic, dlt_partition, dlt_offset)`
+
+This identity makes DLT intake idempotent.
+
+When the DLT listener receives the same Kafka record more than once, the existing database row remains authoritative and no duplicate dead-letter record is created.
+
+The event identifier inside the payload is not used as the intake identity because malformed payloads may not contain a readable event identifier.
+
+## Persisted information
+
+The initial dead-letter model stores:
+
+- generated record identifier
+- DLT topic
+- DLT partition
+- DLT offset
+- original topic
+- original partition
+- original offset
+- original consumer group
+- original record key
+- original payload
+- original exception type
+- original exception message
+- lifecycle status
+- replay count
+- reception timestamp
+- last replay timestamp
+- replay lease owner
+- replay lease expiration
+- last replay error
+
+The original record key and payload may be null.
+
+Malformed or incomplete records must still remain inspectable even when they are not replayable.
+
+Full exception stack traces are not stored.
+
+Stack traces may contain excessive or sensitive implementation details and are not required to decide whether a record can be replayed.
+
+## Lifecycle
+
+Supported statuses are:
+
+- `RECEIVED`
+- `REPLAYING`
+- `REPLAYED`
+- `REPLAY_FAILED`
+- `DISCARDED`
+
+### RECEIVED
+
+The record was durably ingested from the DLT and has not been replayed.
+
+### REPLAYING
+
+A replay worker has atomically claimed the record.
+
+The claim uses a bounded lease so that a crashed replay worker does not leave the record permanently locked.
+
+### REPLAYED
+
+The record was published successfully to its original topic and the successful result was persisted.
+
+### REPLAY_FAILED
+
+The latest replay publication or state transition failed.
+
+The record may become eligible for another explicit replay attempt when the configured replay limit has not been reached.
+
+### DISCARDED
+
+An operator determined that the record must not be replayed.
+
+This is a terminal operational decision.
+
+## Replay eligibility
+
+A record is replayable only when:
+
+- its status is `RECEIVED` or `REPLAY_FAILED`
+- its replay count is below the configured maximum
+- it is not protected by an active replay lease
+- its original topic is present
+- its payload satisfies the replay command requirements
+- its original topic is not the configured DLT topic
+
+The application must reject replay when the original topic equals the DLT topic.
+
+This prevents direct DLT-to-DLT loops.
+
+A malformed payload may be stored successfully while remaining ineligible for replay until an operator corrects the underlying issue through a future remediation workflow.
+
+The initial implementation does not mutate stored payloads.
+
+## Replay claim
+
+Replay uses an atomic PostgreSQL claim operation.
+
+A successful claim:
+
+- changes the status to `REPLAYING`
+- increments the replay count
+- records the lease owner
+- records the lease expiration
+- clears the previous replay error
+
+Concurrent workers cannot claim the same record simultaneously.
+
+Expired `REPLAYING` leases may be reclaimed.
+
+A replay count is incremented when a replay attempt is claimed, not after publication succeeds.
+
+This preserves an accurate upper bound even when a worker crashes during publication.
+
+## Kafka publication
+
+A claimed record is published to its original topic.
+
+The replay publication uses:
+
+- original topic
+- original key
+- original payload
+
+Spring Kafka DLT exception headers are not copied to the replayed source record.
+
+Delivery-attempt and prior DLT metadata headers are also not copied.
+
+This prevents dead-letter and exception headers from accumulating across replay cycles.
+
+The initial replay implementation republishes only the key and payload.
+
+Business-header replay may be introduced later through an explicit allowlist.
+
+## Delivery semantics
+
+PostgreSQL and Kafka do not participate in one local transaction.
+
+Replay therefore provides at-least-once publication.
+
+The workflow is:
+
+1. claim the dead-letter record in PostgreSQL
+2. publish the original key and payload to Kafka
+3. mark the dead-letter record as `REPLAYED`
+
+If publication fails, the record is marked `REPLAY_FAILED` when possible.
+
+If Kafka publication succeeds but the database success update fails, the replay lease eventually expires and the record may be published again.
+
+Duplicate replay publication is therefore possible.
+
+The existing transfer-completed consumer protects its database side effects using:
+
+- stable logical consumer name
+- event identifier
+
+A duplicate valid event is processed as a successful no-op.
+
+This existing idempotency boundary is required for safe at-least-once replay.
+
+## Replay limits
+
+Replay attempts are bounded by configuration.
+
+The default maximum replay count will be conservative.
+
+A record that reaches the configured replay limit is no longer eligible for replay without an explicit future administrative intervention.
+
+Replay limits prevent permanent failures from consuming resources indefinitely.
+
+## Offset behavior
+
+The DLT intake listener acknowledges a Kafka record only after its PostgreSQL representation is durably committed.
+
+When database persistence fails, the listener must not silently advance the DLT consumer offset.
+
+Duplicate intake caused by Kafka redelivery is expected and is handled through the unique DLT-location constraint.
+
+## Security
+
+Replay is an operationally privileged action.
+
+The initial persistence and intake implementation exposes no replay HTTP endpoint.
+
+A future HTTP or administrative adapter must require an explicit operations authority.
+
+Authenticated end-user permissions are not sufficient for replay access.
+
+Replay actions must be attributable to an operational actor when an authenticated operations boundary is introduced.
+
+## Observability
+
+The replay lifecycle will expose low-cardinality metrics for:
+
+- DLT records received
+- duplicate DLT deliveries
+- replay claims
+- successful replay publications
+- failed replay publications
+- discarded records
+- records blocked by the replay limit
+
+Identifiers, payloads, offsets, exception messages, and record keys will not be metric tags.
+
+## Database constraints
+
+PostgreSQL will enforce:
+
+- unique DLT topic, partition, and offset
+- nonblank topic names
+- non-negative partitions
+- non-negative offsets
+- non-negative replay count
+- valid lifecycle statuses
+- replay lease consistency
+- replay timestamp consistency
+
+Database constraints complement domain validation and protect the operational state from invalid writes outside the application service.
+
+## Consequences
+
+### Positive
+
+- DLT records remain inspectable beyond Kafka retention.
+- DLT intake is idempotent.
+- Replay is explicit rather than automatic.
+- Replay attempts are bounded.
+- Concurrent replay claims can be controlled.
+- Kafka exception headers do not accumulate.
+- Existing consumer idempotency makes replay duplicates safe.
+- Persistence and Kafka concerns remain behind hexagonal ports.
+
+### Negative
+
+- PostgreSQL becomes part of the DLT operational workflow.
+- Replay cannot provide exactly-once publication across PostgreSQL and Kafka.
+- Additional lifecycle recovery logic is required for expired replay leases.
+- Operational authorization must be designed before exposing replay over HTTP.
+- Stored payloads may contain business data and require normal database access controls.
+
+## Alternatives considered
+
+### Automatically republish every DLT record
+
+Rejected because permanent failures would create unbounded source-to-DLT loops.
+
+### Use Kafka offsets as the only replay state
+
+Rejected because Kafka retention removes historical records and offsets do not provide operational lifecycle, replay limits, or discard decisions.
+
+### Publish and update PostgreSQL atomically
+
+Rejected because PostgreSQL and Kafka do not share a local transaction and introducing distributed transactions would add disproportionate complexity.
+
+### Use the event identifier as the DLT intake key
+
+Rejected because malformed records may not contain a readable event identifier.
+
+### Copy every DLT header during replay
+
+Rejected because exception, stack-trace, delivery-attempt, and prior DLT headers would accumulate and leak infrastructure metadata back into the source flow.
+
+## Verification
+
+The implementation must demonstrate:
+
+- duplicate delivery of one DLT offset creates one database record
+- malformed payloads can still be persisted
+- missing required original-record headers are rejected
+- persistence failure prevents successful DLT consumption
+- concurrent replay claims cannot own the same record
+- expired replay leases can be reclaimed
+- replay count limits are enforced
+- successful publication transitions the record to `REPLAYED`
+- failed publication transitions the record to `REPLAY_FAILED`
+- replayed valid events remain safe under duplicate publication

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/InvalidKafkaDeadLetterRecordException.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/InvalidKafkaDeadLetterRecordException.java
@@ -1,0 +1,11 @@
+package com.nursena.payflow.eventprocessing.adapter.in.kafka;
+
+class InvalidKafkaDeadLetterRecordException
+    extends RuntimeException {
+
+    InvalidKafkaDeadLetterRecordException(
+        String message
+    ) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterConfiguration.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterConfiguration.java
@@ -1,0 +1,83 @@
+package com.nursena.payflow.eventprocessing.adapter.in.kafka;
+
+import java.time.Clock;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.port.in.RecordKafkaDeadLetterUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterRecordRepositoryPort;
+import com.nursena.payflow.eventprocessing.application.service.RecordKafkaDeadLetterService;
+import org.springframework.boot.autoconfigure.kafka.ConcurrentKafkaListenerContainerFactoryConfigurer;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.CommonContainerStoppingErrorHandler;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(
+    TransferCompletedKafkaDeadLetterIntakeProperties
+        .class
+)
+class TransferCompletedKafkaDeadLetterConfiguration {
+
+    @Bean(
+        "transferCompletedKafkaDeadLetterRecorder"
+    )
+    RecordKafkaDeadLetterUseCase
+    transferCompletedKafkaDeadLetterRecorder(
+        KafkaDeadLetterRecordRepositoryPort repository,
+        Clock clock
+    ) {
+        return new RecordKafkaDeadLetterService(
+            repository,
+            clock,
+            UUID::randomUUID
+        );
+    }
+
+    @Bean(
+        "transferCompletedKafkaDeadLetter"
+            + "ListenerContainerFactory"
+    )
+    ConcurrentKafkaListenerContainerFactory<
+        Object,
+        Object
+        >
+    transferCompletedKafkaDeadLetterListenerContainerFactory(
+        ConcurrentKafkaListenerContainerFactoryConfigurer
+            configurer,
+        ConsumerFactory<Object, Object>
+            consumerFactory
+    ) {
+        ConcurrentKafkaListenerContainerFactory<
+            Object,
+            Object
+            > factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+
+        configurer.configure(
+            factory,
+            consumerFactory
+        );
+
+        CommonContainerStoppingErrorHandler
+            errorHandler =
+            new CommonContainerStoppingErrorHandler();
+
+        /*
+         * Invalid DLT metadata or PostgreSQL
+         * persistence failures must not be
+         * recovered by skipping the record.
+         */
+        errorHandler.setStopContainerAbnormally(
+            true
+        );
+
+        factory.setCommonErrorHandler(
+            errorHandler
+        );
+
+        return factory;
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterIntakeProperties.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterIntakeProperties.java
@@ -1,0 +1,36 @@
+package com.nursena.payflow.eventprocessing.adapter.in.kafka;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(
+    prefix =
+        "payflow.event-processing"
+            + ".transfer-completed"
+            + ".dead-letter-intake"
+)
+record TransferCompletedKafkaDeadLetterIntakeProperties(
+    boolean enabled,
+    String groupId
+) {
+
+    private static final int MAX_GROUP_ID_LENGTH =
+        255;
+
+    TransferCompletedKafkaDeadLetterIntakeProperties {
+        if (groupId == null || groupId.isBlank()) {
+            throw new IllegalArgumentException(
+                "groupId must not be blank."
+            );
+        }
+
+        if (groupId.length()
+            > MAX_GROUP_ID_LENGTH) {
+
+            throw new IllegalArgumentException(
+                "groupId must not exceed "
+                    + MAX_GROUP_ID_LENGTH
+                    + " characters."
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterListener.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterListener.java
@@ -1,0 +1,261 @@
+package com.nursena.payflow.eventprocessing.adapter.in.kafka;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.model.RecordKafkaDeadLetterCommand;
+import com.nursena.payflow.eventprocessing.application.port.in.RecordKafkaDeadLetterUseCase;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.stereotype.Component;
+
+@Component
+class TransferCompletedKafkaDeadLetterListener {
+
+    private final RecordKafkaDeadLetterUseCase
+        useCase;
+
+    TransferCompletedKafkaDeadLetterListener(
+        @Qualifier(
+            "transferCompletedKafkaDeadLetterRecorder"
+        )
+        RecordKafkaDeadLetterUseCase useCase
+    ) {
+        this.useCase =
+            Objects.requireNonNull(
+                useCase,
+                "useCase must not be null"
+            );
+    }
+
+    @KafkaListener(
+        id =
+            "transferCompletedKafkaDeadLetterIntakeListener",
+        idIsGroup = false,
+        topics =
+            "${payflow.event-processing"
+                + ".transfer-completed.failure"
+                + ".dead-letter-topic}",
+        groupId =
+            "${payflow.event-processing"
+                + ".transfer-completed"
+                + ".dead-letter-intake.group-id}",
+        containerFactory =
+            "transferCompletedKafkaDeadLetter"
+                + "ListenerContainerFactory",
+        autoStartup =
+            "${payflow.event-processing"
+                + ".transfer-completed"
+                + ".dead-letter-intake.enabled}"
+    )
+    void consume(
+        ConsumerRecord<String, String> record
+    ) {
+        Objects.requireNonNull(
+            record,
+            "record must not be null"
+        );
+
+        validateRecordMetadata(record);
+
+        useCase.record(
+            new RecordKafkaDeadLetterCommand(
+                record.topic(),
+                record.partition(),
+                record.offset(),
+                requiredStringHeader(
+                    record,
+                    KafkaHeaders.DLT_ORIGINAL_TOPIC
+                ),
+                requiredIntegerHeader(
+                    record,
+                    KafkaHeaders
+                        .DLT_ORIGINAL_PARTITION
+                ),
+                requiredLongHeader(
+                    record,
+                    KafkaHeaders.DLT_ORIGINAL_OFFSET
+                ),
+                requiredStringHeader(
+                    record,
+                    KafkaHeaders
+                        .DLT_ORIGINAL_CONSUMER_GROUP
+                ),
+                record.key(),
+                record.value(),
+                requiredStringHeader(
+                    record,
+                    KafkaHeaders.DLT_EXCEPTION_FQCN
+                ),
+                optionalStringHeader(
+                    record,
+                    KafkaHeaders
+                        .DLT_EXCEPTION_MESSAGE
+                )
+            )
+        );
+    }
+
+    private static void validateRecordMetadata(
+        ConsumerRecord<?, ?> record
+    ) {
+        if (
+            record.topic() == null
+                || record.topic().isBlank()
+        ) {
+            throw invalid(
+                "DLT record topic must not be blank."
+            );
+        }
+
+        if (record.partition() < 0) {
+            throw invalid(
+                "DLT record partition "
+                    + "must not be negative."
+            );
+        }
+
+        if (record.offset() < 0) {
+            throw invalid(
+                "DLT record offset "
+                    + "must not be negative."
+            );
+        }
+    }
+
+    private static String requiredStringHeader(
+        ConsumerRecord<?, ?> record,
+        String headerName
+    ) {
+        String value =
+            new String(
+                requiredHeaderValue(
+                    record,
+                    headerName
+                ),
+                StandardCharsets.UTF_8
+            );
+
+        if (value.isBlank()) {
+            throw invalid(
+                "Required Kafka header "
+                    + headerName
+                    + " must not be blank."
+            );
+        }
+
+        return value;
+    }
+
+    private static String optionalStringHeader(
+        ConsumerRecord<?, ?> record,
+        String headerName
+    ) {
+        Header header =
+            record.headers()
+                .lastHeader(headerName);
+
+        if (header == null
+            || header.value() == null) {
+
+            return null;
+        }
+
+        return new String(
+            header.value(),
+            StandardCharsets.UTF_8
+        );
+    }
+
+    private static int requiredIntegerHeader(
+        ConsumerRecord<?, ?> record,
+        String headerName
+    ) {
+        byte[] value =
+            requiredHeaderValue(
+                record,
+                headerName
+            );
+
+        if (value.length
+            != Integer.BYTES) {
+
+            throw invalid(
+                "Kafka header "
+                    + headerName
+                    + " must contain "
+                    + Integer.BYTES
+                    + " bytes."
+            );
+        }
+
+        return ByteBuffer
+            .wrap(value)
+            .getInt();
+    }
+
+    private static long requiredLongHeader(
+        ConsumerRecord<?, ?> record,
+        String headerName
+    ) {
+        byte[] value =
+            requiredHeaderValue(
+                record,
+                headerName
+            );
+
+        if (value.length
+            != Long.BYTES) {
+
+            throw invalid(
+                "Kafka header "
+                    + headerName
+                    + " must contain "
+                    + Long.BYTES
+                    + " bytes."
+            );
+        }
+
+        return ByteBuffer
+            .wrap(value)
+            .getLong();
+    }
+
+    private static byte[] requiredHeaderValue(
+        ConsumerRecord<?, ?> record,
+        String headerName
+    ) {
+        Header header =
+            record.headers()
+                .lastHeader(headerName);
+
+        if (
+            header == null
+                || header.value() == null
+                || header.value().length == 0
+        ) {
+            throw invalid(
+                "Required Kafka header "
+                    + headerName
+                    + " is missing."
+            );
+        }
+
+        return header.value();
+    }
+
+    private static
+    InvalidKafkaDeadLetterRecordException
+    invalid(
+        String message
+    ) {
+        return new
+            InvalidKafkaDeadLetterRecordException(
+            message
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterListener.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterListener.java
@@ -3,7 +3,9 @@ package com.nursena.payflow.eventprocessing.adapter.in.kafka;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import java.util.UUID;
 
+import com.nursena.payflow.eventprocessing.adapter.kafka.KafkaDeadLetterReplayHeaders;
 import com.nursena.payflow.eventprocessing.application.model.RecordKafkaDeadLetterCommand;
 import com.nursena.payflow.eventprocessing.application.port.in.RecordKafkaDeadLetterUseCase;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -62,6 +64,9 @@ class TransferCompletedKafkaDeadLetterListener {
 
         validateRecordMetadata(record);
 
+        ReplayMetadata replayMetadata =
+            replayMetadata(record);
+
         useCase.record(
             new RecordKafkaDeadLetterCommand(
                 record.topic(),
@@ -95,8 +100,99 @@ class TransferCompletedKafkaDeadLetterListener {
                     record,
                     KafkaHeaders
                         .DLT_EXCEPTION_MESSAGE
-                )
+                ),
+                replayMetadata.originId(),
+                replayMetadata.attemptBase()
             )
+        );
+    }
+
+    private static ReplayMetadata replayMetadata(
+        ConsumerRecord<?, ?> record
+    ) {
+        Header originHeader =
+            record.headers()
+                .lastHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ORIGIN_ID
+                );
+
+        Header attemptHeader =
+            record.headers()
+                .lastHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ATTEMPT
+                );
+
+        if (
+            originHeader == null
+                && attemptHeader == null
+        ) {
+            return new ReplayMetadata(
+                null,
+                null
+            );
+        }
+
+        if (
+            originHeader == null
+                || attemptHeader == null
+        ) {
+            throw invalid(
+                "Replay origin id and attempt "
+                    + "headers must either both "
+                    + "be present or both be absent."
+            );
+        }
+
+        String originValue =
+            requiredStringHeader(
+                record,
+                KafkaDeadLetterReplayHeaders
+                    .REPLAY_ORIGIN_ID
+            );
+
+        String attemptValue =
+            requiredStringHeader(
+                record,
+                KafkaDeadLetterReplayHeaders
+                    .REPLAY_ATTEMPT
+            );
+
+        UUID originId;
+
+        try {
+            originId =
+                UUID.fromString(originValue);
+        } catch (IllegalArgumentException exception) {
+            throw invalid(
+                "Kafka replay origin id header "
+                    + "must contain a valid UUID."
+            );
+        }
+
+        int attempt;
+
+        try {
+            attempt =
+                Integer.parseInt(attemptValue);
+        } catch (NumberFormatException exception) {
+            throw invalid(
+                "Kafka replay attempt header "
+                    + "must contain an integer."
+            );
+        }
+
+        if (attempt <= 0) {
+            throw invalid(
+                "Kafka replay attempt header "
+                    + "must be positive."
+            );
+        }
+
+        return new ReplayMetadata(
+            originId,
+            attempt
         );
     }
 
@@ -159,9 +255,10 @@ class TransferCompletedKafkaDeadLetterListener {
             record.headers()
                 .lastHeader(headerName);
 
-        if (header == null
-            || header.value() == null) {
-
+        if (
+            header == null
+                || header.value() == null
+        ) {
             return null;
         }
 
@@ -181,9 +278,10 @@ class TransferCompletedKafkaDeadLetterListener {
                 headerName
             );
 
-        if (value.length
-            != Integer.BYTES) {
-
+        if (
+            value.length
+                != Integer.BYTES
+        ) {
             throw invalid(
                 "Kafka header "
                     + headerName
@@ -208,9 +306,10 @@ class TransferCompletedKafkaDeadLetterListener {
                 headerName
             );
 
-        if (value.length
-            != Long.BYTES) {
-
+        if (
+            value.length
+                != Long.BYTES
+        ) {
             throw invalid(
                 "Kafka header "
                     + headerName
@@ -257,5 +356,11 @@ class TransferCompletedKafkaDeadLetterListener {
             InvalidKafkaDeadLetterRecordException(
             message
         );
+    }
+
+    private record ReplayMetadata(
+        UUID originId,
+        Integer attemptBase
+    ) {
     }
 }

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/kafka/KafkaDeadLetterReplayHeaders.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/kafka/KafkaDeadLetterReplayHeaders.java
@@ -1,0 +1,13 @@
+package com.nursena.payflow.eventprocessing.adapter.kafka;
+
+public final class KafkaDeadLetterReplayHeaders {
+
+    public static final String REPLAY_ORIGIN_ID =
+        "payflow-replay-origin-id";
+
+    public static final String REPLAY_ATTEMPT =
+        "payflow-replay-attempt";
+
+    private KafkaDeadLetterReplayHeaders() {
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/kafka/KafkaDeadLetterReplayPublisherAdapter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/kafka/KafkaDeadLetterReplayPublisherAdapter.java
@@ -1,0 +1,262 @@
+package com.nursena.payflow.eventprocessing.adapter.out.kafka;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.nursena.payflow.eventprocessing.adapter.kafka.KafkaDeadLetterReplayHeaders;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayPublisherPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.springframework.kafka.core.KafkaOperations;
+
+public final class
+KafkaDeadLetterReplayPublisherAdapter
+    implements KafkaDeadLetterReplayPublisherPort {
+
+    private final KafkaOperations<String, String>
+        kafkaOperations;
+
+    private final Duration sendTimeout;
+
+    public KafkaDeadLetterReplayPublisherAdapter(
+        KafkaOperations<String, String>
+            kafkaOperations,
+        Duration sendTimeout
+    ) {
+        this.kafkaOperations =
+            Objects.requireNonNull(
+                kafkaOperations,
+                "kafkaOperations must not be null"
+            );
+
+        this.sendTimeout =
+            validateSendTimeout(
+                sendTimeout
+            );
+    }
+
+    @Override
+    public void publish(
+        KafkaDeadLetterRecord record
+    ) {
+        KafkaDeadLetterRecord validatedRecord =
+            validateRecord(record);
+
+        ProducerRecord<String, String>
+            producerRecord =
+            producerRecord(validatedRecord);
+
+        try {
+            kafkaOperations
+                .send(producerRecord)
+                .get(
+                    sendTimeout.toMillis(),
+                    TimeUnit.MILLISECONDS
+                );
+        } catch (InterruptedException exception) {
+            Thread.currentThread()
+                .interrupt();
+
+            throw publishingFailure(
+                validatedRecord,
+                "Kafka send was interrupted.",
+                exception
+            );
+        } catch (TimeoutException exception) {
+            throw publishingFailure(
+                validatedRecord,
+                "Kafka broker acknowledgement "
+                    + "timed out.",
+                exception
+            );
+        } catch (ExecutionException exception) {
+            Throwable cause =
+                exception.getCause() == null
+                    ? exception
+                    : exception.getCause();
+
+            throw publishingFailure(
+                validatedRecord,
+                "Kafka broker rejected or failed "
+                    + "the send operation.",
+                cause
+            );
+        } catch (RuntimeException exception) {
+            throw publishingFailure(
+                validatedRecord,
+                "Kafka send could not be started.",
+                exception
+            );
+        }
+    }
+
+    private static ProducerRecord<String, String>
+    producerRecord(
+        KafkaDeadLetterRecord record
+    ) {
+        ProducerRecord<String, String>
+            producerRecord =
+            new ProducerRecord<>(
+                record.originalTopic(),
+                record.recordKey(),
+                record.payload()
+            );
+
+        producerRecord.headers()
+            .add(
+                new RecordHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ORIGIN_ID,
+                    record.replayOriginId()
+                        .toString()
+                        .getBytes(UTF_8)
+                )
+            );
+
+        producerRecord.headers()
+            .add(
+                new RecordHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ATTEMPT,
+                    Integer.toString(
+                        totalReplayAttempts(
+                            record
+                        )
+                    ).getBytes(UTF_8)
+                )
+            );
+
+        return producerRecord;
+    }
+
+    private static KafkaDeadLetterRecord
+    validateRecord(
+        KafkaDeadLetterRecord record
+    ) {
+        KafkaDeadLetterRecord validatedRecord =
+            Objects.requireNonNull(
+                record,
+                "record must not be null"
+            );
+
+        if (
+            validatedRecord.status()
+                != KafkaDeadLetterRecordStatus
+                .REPLAYING
+        ) {
+            throw new IllegalArgumentException(
+                "Only REPLAYING dead-letter "
+                    + "records may be published."
+            );
+        }
+
+        if (
+            validatedRecord.payload() == null
+                || validatedRecord.payload()
+                .isBlank()
+        ) {
+            throw new IllegalArgumentException(
+                "Replay payload must not be blank."
+            );
+        }
+
+        if (
+            validatedRecord.originalTopic()
+                .equals(
+                    validatedRecord
+                        .deadLetterTopic()
+                )
+        ) {
+            throw new IllegalArgumentException(
+                "Replay source topic must differ "
+                    + "from the dead-letter topic."
+            );
+        }
+
+        totalReplayAttempts(
+            validatedRecord
+        );
+
+        return validatedRecord;
+    }
+
+    private static int totalReplayAttempts(
+        KafkaDeadLetterRecord record
+    ) {
+        int total;
+
+        try {
+            total =
+                Math.addExact(
+                    record.replayAttemptBase(),
+                    record.replayCount()
+                );
+        } catch (ArithmeticException exception) {
+            throw new IllegalArgumentException(
+                "Total replay attempt count "
+                    + "must not overflow.",
+                exception
+            );
+        }
+
+        if (total <= 0) {
+            throw new IllegalArgumentException(
+                "Total replay attempt count "
+                    + "must be positive."
+            );
+        }
+
+        return total;
+    }
+
+    private static Duration validateSendTimeout(
+        Duration value
+    ) {
+        Duration validated =
+            Objects.requireNonNull(
+                value,
+                "sendTimeout must not be null"
+            );
+
+        if (
+            validated.isZero()
+                || validated.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                "sendTimeout must be positive."
+            );
+        }
+
+        if (validated.toMillis() == 0) {
+            throw new IllegalArgumentException(
+                "sendTimeout must be at least "
+                    + "one millisecond."
+            );
+        }
+
+        return validated;
+    }
+
+    private static
+    KafkaDeadLetterReplayPublishingException
+    publishingFailure(
+        KafkaDeadLetterRecord record,
+        String reason,
+        Throwable cause
+    ) {
+        return new
+            KafkaDeadLetterReplayPublishingException(
+            record.id(),
+            record.originalTopic(),
+            reason,
+            cause
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/kafka/KafkaDeadLetterReplayPublishingException.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/kafka/KafkaDeadLetterReplayPublishingException.java
@@ -1,0 +1,91 @@
+package com.nursena.payflow.eventprocessing.adapter.out.kafka;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public final class
+KafkaDeadLetterReplayPublishingException
+    extends RuntimeException {
+
+    private final UUID recordId;
+    private final String topic;
+
+    public KafkaDeadLetterReplayPublishingException(
+        UUID recordId,
+        String topic,
+        String reason,
+        Throwable cause
+    ) {
+        super(
+            message(
+                recordId,
+                topic,
+                reason
+            ),
+            cause
+        );
+
+        this.recordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+
+        this.topic =
+            requireText(
+                topic,
+                "topic"
+            );
+    }
+
+    public UUID recordId() {
+        return recordId;
+    }
+
+    public String topic() {
+        return topic;
+    }
+
+    private static String message(
+        UUID recordId,
+        String topic,
+        String reason
+    ) {
+        Objects.requireNonNull(
+            recordId,
+            "recordId must not be null"
+        );
+
+        return "Kafka dead-letter replay "
+            + "publication failed. "
+            + "recordId="
+            + recordId
+            + ", topic="
+            + requireText(
+            topic,
+            "topic"
+        )
+            + ", reason="
+            + requireText(
+            reason,
+            "reason"
+        );
+    }
+
+    private static String requireText(
+        String value,
+        String fieldName
+    ) {
+        if (
+            value == null
+                || value.isBlank()
+        ) {
+            throw new IllegalArgumentException(
+                fieldName
+                    + " must not be blank."
+            );
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterRecordRepositoryAdapter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterRecordRepositoryAdapter.java
@@ -33,11 +33,14 @@ class JdbcKafkaDeadLetterRecordRepositoryAdapter
             last_replayed_at,
             replay_lease_owner,
             replay_lease_until,
-            last_replay_error
+            last_replay_error,
+            replay_origin_id,
+            replay_attempt_base
         )
         VALUES (
             ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-            ?, ?, ?, ?, ?, ?, ?, ?, ?
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+            ?
         )
         ON CONFLICT (
             dlt_topic,
@@ -95,7 +98,9 @@ class JdbcKafkaDeadLetterRecordRepositoryAdapter
                 timestamp(
                     record.replayLeaseUntil()
                 ),
-                record.lastReplayError()
+                record.lastReplayError(),
+                record.replayOriginId(),
+                record.replayAttemptBase()
             );
 
         if (affectedRows == 1) {

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterRecordRepositoryAdapter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterRecordRepositoryAdapter.java
@@ -1,0 +1,126 @@
+package com.nursena.payflow.eventprocessing.adapter.out.persistence;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterRecordRepositoryPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JdbcKafkaDeadLetterRecordRepositoryAdapter
+    implements KafkaDeadLetterRecordRepositoryPort {
+
+    private static final String INSERT_SQL = """
+        INSERT INTO kafka_dead_letter_records (
+            id,
+            dlt_topic,
+            dlt_partition,
+            dlt_offset,
+            original_topic,
+            original_partition,
+            original_offset,
+            original_consumer_group,
+            record_key,
+            payload,
+            exception_type,
+            exception_message,
+            status,
+            replay_count,
+            received_at,
+            last_replayed_at,
+            replay_lease_owner,
+            replay_lease_until,
+            last_replay_error
+        )
+        VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+            ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
+        ON CONFLICT (
+            dlt_topic,
+            dlt_partition,
+            dlt_offset
+        )
+        DO NOTHING
+        """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    JdbcKafkaDeadLetterRecordRepositoryAdapter(
+        JdbcTemplate jdbcTemplate
+    ) {
+        this.jdbcTemplate =
+            Objects.requireNonNull(
+                jdbcTemplate,
+                "jdbcTemplate must not be null"
+            );
+    }
+
+    @Override
+    public boolean tryRecord(
+        KafkaDeadLetterRecord record
+    ) {
+        Objects.requireNonNull(
+            record,
+            "record must not be null"
+        );
+
+        int affectedRows =
+            jdbcTemplate.update(
+                INSERT_SQL,
+                record.id(),
+                record.deadLetterTopic(),
+                record.deadLetterPartition(),
+                record.deadLetterOffset(),
+                record.originalTopic(),
+                record.originalPartition(),
+                record.originalOffset(),
+                record.originalConsumerGroup(),
+                record.recordKey(),
+                record.payload(),
+                record.exceptionType(),
+                record.exceptionMessage(),
+                record.status().name(),
+                record.replayCount(),
+                timestamp(
+                    record.receivedAt()
+                ),
+                timestamp(
+                    record.lastReplayedAt()
+                ),
+                record.replayLeaseOwner(),
+                timestamp(
+                    record.replayLeaseUntil()
+                ),
+                record.lastReplayError()
+            );
+
+        if (affectedRows == 1) {
+            return true;
+        }
+
+        if (affectedRows == 0) {
+            return false;
+        }
+
+        throw new IllegalStateException(
+            "Kafka dead-letter record insert "
+                + "affected "
+                + affectedRows
+                + " rows."
+        );
+    }
+
+    private static Timestamp timestamp(
+        Instant value
+    ) {
+        if (value == null) {
+            return null;
+        }
+
+        return Timestamp.from(value);
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterReplayRepositoryAdapter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterReplayRepositoryAdapter.java
@@ -1,0 +1,322 @@
+package com.nursena.payflow.eventprocessing.adapter.out.persistence;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayRepositoryPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JdbcKafkaDeadLetterReplayRepositoryAdapter
+    implements KafkaDeadLetterReplayRepositoryPort {
+
+    private static final int
+        MAX_WORKER_ID_LENGTH = 200;
+
+    private static final String CLAIM_SQL = """
+        UPDATE kafka_dead_letter_records
+        SET
+            status = 'REPLAYING',
+            replay_count = replay_count + 1,
+            last_replayed_at = ?,
+            replay_lease_owner = ?,
+            replay_lease_until = ?,
+            last_replay_error = NULL
+        WHERE id = ?
+          AND (
+                replay_attempt_base::BIGINT
+                + replay_count::BIGINT
+              ) < ?
+          AND payload IS NOT NULL
+          AND btrim(payload) <> ''
+          AND original_topic <> dlt_topic
+          AND (
+                status IN (
+                    'RECEIVED',
+                    'REPLAY_FAILED'
+                )
+                OR (
+                    status = 'REPLAYING'
+                    AND replay_lease_until <= ?
+                )
+          )
+        RETURNING
+            id,
+            dlt_topic,
+            dlt_partition,
+            dlt_offset,
+            original_topic,
+            original_partition,
+            original_offset,
+            original_consumer_group,
+            record_key,
+            payload,
+            exception_type,
+            exception_message,
+            status,
+            replay_count,
+            received_at,
+            last_replayed_at,
+            replay_lease_owner,
+            replay_lease_until,
+            last_replay_error,
+            replay_origin_id,
+            replay_attempt_base
+        """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    JdbcKafkaDeadLetterReplayRepositoryAdapter(
+        JdbcTemplate jdbcTemplate
+    ) {
+        this.jdbcTemplate =
+            Objects.requireNonNull(
+                jdbcTemplate,
+                "jdbcTemplate must not be null"
+            );
+    }
+
+    @Override
+    public Optional<KafkaDeadLetterRecord>
+    tryClaim(
+        UUID recordId,
+        String workerId,
+        Instant claimedAt,
+        Duration leaseDuration,
+        int maxReplayAttempts
+    ) {
+        UUID validatedRecordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+
+        String validatedWorkerId =
+            validateWorkerId(workerId);
+
+        Instant validatedClaimedAt =
+            Objects.requireNonNull(
+                claimedAt,
+                "claimedAt must not be null"
+            );
+
+        Duration validatedLeaseDuration =
+            validateLeaseDuration(
+                leaseDuration
+            );
+
+        if (maxReplayAttempts <= 0) {
+            throw new IllegalArgumentException(
+                "maxReplayAttempts must be "
+                    + "positive."
+            );
+        }
+
+        Instant leaseUntil =
+            calculateLeaseUntil(
+                validatedClaimedAt,
+                validatedLeaseDuration
+            );
+
+        List<KafkaDeadLetterRecord> claimed =
+            jdbcTemplate.query(
+                CLAIM_SQL,
+                JdbcKafkaDeadLetterReplayRepositoryAdapter
+                    ::mapRecord,
+                Timestamp.from(
+                    validatedClaimedAt
+                ),
+                validatedWorkerId,
+                Timestamp.from(leaseUntil),
+                validatedRecordId,
+                maxReplayAttempts,
+                Timestamp.from(
+                    validatedClaimedAt
+                )
+            );
+
+        if (claimed.size() > 1) {
+            throw new IllegalStateException(
+                "Kafka dead-letter claim returned "
+                    + claimed.size()
+                    + " records."
+            );
+        }
+
+        return claimed.stream()
+            .findFirst();
+    }
+
+    private static KafkaDeadLetterRecord
+    mapRecord(
+        ResultSet resultSet,
+        int rowNumber
+    ) throws SQLException {
+
+        return new KafkaDeadLetterRecord(
+            resultSet.getObject(
+                "id",
+                UUID.class
+            ),
+            resultSet.getString(
+                "dlt_topic"
+            ),
+            resultSet.getInt(
+                "dlt_partition"
+            ),
+            resultSet.getLong(
+                "dlt_offset"
+            ),
+            resultSet.getString(
+                "original_topic"
+            ),
+            resultSet.getInt(
+                "original_partition"
+            ),
+            resultSet.getLong(
+                "original_offset"
+            ),
+            resultSet.getString(
+                "original_consumer_group"
+            ),
+            resultSet.getString(
+                "record_key"
+            ),
+            resultSet.getString(
+                "payload"
+            ),
+            resultSet.getString(
+                "exception_type"
+            ),
+            resultSet.getString(
+                "exception_message"
+            ),
+            KafkaDeadLetterRecordStatus.valueOf(
+                resultSet.getString(
+                    "status"
+                )
+            ),
+            resultSet.getInt(
+                "replay_count"
+            ),
+            instant(
+                resultSet,
+                "received_at"
+            ),
+            instant(
+                resultSet,
+                "last_replayed_at"
+            ),
+            resultSet.getString(
+                "replay_lease_owner"
+            ),
+            instant(
+                resultSet,
+                "replay_lease_until"
+            ),
+            resultSet.getString(
+                "last_replay_error"
+            ),
+            resultSet.getObject(
+                "replay_origin_id",
+                UUID.class
+            ),
+            resultSet.getInt(
+                "replay_attempt_base"
+            )
+        );
+    }
+
+    private static Instant instant(
+        ResultSet resultSet,
+        String columnName
+    ) throws SQLException {
+
+        Timestamp timestamp =
+            resultSet.getTimestamp(
+                columnName
+            );
+
+        return timestamp == null
+            ? null
+            : timestamp.toInstant();
+    }
+
+    private static String validateWorkerId(
+        String value
+    ) {
+        if (
+            value == null
+                || value.isBlank()
+        ) {
+            throw new IllegalArgumentException(
+                "workerId must not be blank."
+            );
+        }
+
+        if (
+            value.length()
+                > MAX_WORKER_ID_LENGTH
+        ) {
+            throw new IllegalArgumentException(
+                "workerId must not exceed "
+                    + MAX_WORKER_ID_LENGTH
+                    + " characters."
+            );
+        }
+
+        return value;
+    }
+
+    private static Duration
+    validateLeaseDuration(
+        Duration value
+    ) {
+        Objects.requireNonNull(
+            value,
+            "leaseDuration must not be null"
+        );
+
+        if (
+            value.isZero()
+                || value.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                "leaseDuration must be positive."
+            );
+        }
+
+        return value;
+    }
+
+    private static Instant calculateLeaseUntil(
+        Instant claimedAt,
+        Duration leaseDuration
+    ) {
+        try {
+            return claimedAt.plus(
+                leaseDuration
+            );
+        } catch (
+            DateTimeException
+            | ArithmeticException exception
+        ) {
+            throw new IllegalArgumentException(
+                "leaseDuration produces "
+                    + "an invalid lease end.",
+                exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterReplayRepositoryAdapter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterReplayRepositoryAdapter.java
@@ -11,15 +11,18 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayLifecyclePort;
 import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayRepositoryPort;
 import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
 import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Component;
 
-@Repository
+@Component
 class JdbcKafkaDeadLetterReplayRepositoryAdapter
-    implements KafkaDeadLetterReplayRepositoryPort {
+    implements
+    KafkaDeadLetterReplayRepositoryPort,
+    KafkaDeadLetterReplayLifecyclePort {
 
     private static final int
         MAX_WORKER_ID_LENGTH = 200;
@@ -73,6 +76,35 @@ class JdbcKafkaDeadLetterReplayRepositoryAdapter
             last_replay_error,
             replay_origin_id,
             replay_attempt_base
+        """;
+    private static final String
+        MARK_REPLAYED_SQL = """
+        UPDATE kafka_dead_letter_records
+        SET
+            status = 'REPLAYED',
+            replay_lease_owner = NULL,
+            replay_lease_until = NULL,
+            last_replay_error = NULL
+        WHERE id = ?
+          AND status = 'REPLAYING'
+          AND replay_lease_owner = ?
+          AND last_replayed_at <= ?
+          AND replay_lease_until > ?
+        """;
+
+    private static final String
+        MARK_REPLAY_FAILED_SQL = """
+        UPDATE kafka_dead_letter_records
+        SET
+            status = 'REPLAY_FAILED',
+            replay_lease_owner = NULL,
+            replay_lease_until = NULL,
+            last_replay_error = ?
+        WHERE id = ?
+          AND status = 'REPLAYING'
+          AND replay_lease_owner = ?
+          AND last_replayed_at <= ?
+          AND replay_lease_until > ?
         """;
 
     private final JdbcTemplate jdbcTemplate;
@@ -157,7 +189,90 @@ class JdbcKafkaDeadLetterReplayRepositoryAdapter
         return claimed.stream()
             .findFirst();
     }
+    @Override
+    public boolean tryMarkReplayed(
+        UUID recordId,
+        String workerId,
+        Instant completedAt
+    ) {
+        UUID validatedRecordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
 
+        String validatedWorkerId =
+            validateWorkerId(workerId);
+
+        Instant validatedCompletedAt =
+            Objects.requireNonNull(
+                completedAt,
+                "completedAt must not be null"
+            );
+
+        int affectedRows =
+            jdbcTemplate.update(
+                MARK_REPLAYED_SQL,
+                validatedRecordId,
+                validatedWorkerId,
+                Timestamp.from(
+                    validatedCompletedAt
+                ),
+                Timestamp.from(
+                    validatedCompletedAt
+                )
+            );
+
+        return transitionResult(
+            affectedRows,
+            "mark replayed"
+        );
+    }
+
+    @Override
+    public boolean tryMarkReplayFailed(
+        UUID recordId,
+        String workerId,
+        Instant failedAt,
+        String error
+    ) {
+        UUID validatedRecordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+
+        String validatedWorkerId =
+            validateWorkerId(workerId);
+
+        Instant validatedFailedAt =
+            Objects.requireNonNull(
+                failedAt,
+                "failedAt must not be null"
+            );
+
+        String validatedError =
+            validateReplayError(error);
+
+        int affectedRows =
+            jdbcTemplate.update(
+                MARK_REPLAY_FAILED_SQL,
+                validatedError,
+                validatedRecordId,
+                validatedWorkerId,
+                Timestamp.from(
+                    validatedFailedAt
+                ),
+                Timestamp.from(
+                    validatedFailedAt
+                )
+            );
+
+        return transitionResult(
+            affectedRows,
+            "mark replay failed"
+        );
+    }
     private static KafkaDeadLetterRecord
     mapRecord(
         ResultSet resultSet,
@@ -298,6 +413,42 @@ class JdbcKafkaDeadLetterReplayRepositoryAdapter
         }
 
         return value;
+    }
+
+    private static String validateReplayError(
+        String value
+    ) {
+        if (
+            value == null
+                || value.isBlank()
+        ) {
+            throw new IllegalArgumentException(
+                "error must not be blank."
+            );
+        }
+
+        return value;
+    }
+
+    private static boolean transitionResult(
+        int affectedRows,
+        String operation
+    ) {
+        if (affectedRows == 1) {
+            return true;
+        }
+
+        if (affectedRows == 0) {
+            return false;
+        }
+
+        throw new IllegalStateException(
+            "Kafka dead-letter replay "
+                + operation
+                + " operation affected "
+                + affectedRows
+                + " rows."
+        );
     }
 
     private static Instant calculateLeaseUntil(

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/ClaimKafkaDeadLetterRecordCommand.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/ClaimKafkaDeadLetterRecordCommand.java
@@ -1,0 +1,17 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record ClaimKafkaDeadLetterRecordCommand(
+    UUID recordId
+) {
+
+    public ClaimKafkaDeadLetterRecordCommand {
+        recordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/ClaimKafkaDeadLetterRecordResult.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/ClaimKafkaDeadLetterRecordResult.java
@@ -1,0 +1,70 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+
+public record ClaimKafkaDeadLetterRecordResult(
+    Outcome outcome,
+    KafkaDeadLetterRecord record
+) {
+
+    public ClaimKafkaDeadLetterRecordResult {
+        outcome =
+            Objects.requireNonNull(
+                outcome,
+                "outcome must not be null"
+            );
+
+        if (
+            outcome == Outcome.CLAIMED
+                && record == null
+        ) {
+            throw new IllegalArgumentException(
+                "CLAIMED result must contain "
+                    + "a record."
+            );
+        }
+
+        if (
+            outcome == Outcome.NOT_CLAIMABLE
+                && record != null
+        ) {
+            throw new IllegalArgumentException(
+                "NOT_CLAIMABLE result must not "
+                    + "contain a record."
+            );
+        }
+    }
+
+    public static ClaimKafkaDeadLetterRecordResult
+    claimed(
+        KafkaDeadLetterRecord record
+    ) {
+        return new ClaimKafkaDeadLetterRecordResult(
+            Outcome.CLAIMED,
+            Objects.requireNonNull(
+                record,
+                "record must not be null"
+            )
+        );
+    }
+
+    public static ClaimKafkaDeadLetterRecordResult
+    notClaimable() {
+        return new ClaimKafkaDeadLetterRecordResult(
+            Outcome.NOT_CLAIMABLE,
+            null
+        );
+    }
+
+    public boolean isClaimed() {
+        return outcome == Outcome.CLAIMED;
+    }
+
+    public enum Outcome {
+
+        CLAIMED,
+        NOT_CLAIMABLE
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/RecordKafkaDeadLetterCommand.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/RecordKafkaDeadLetterCommand.java
@@ -1,5 +1,7 @@
 package com.nursena.payflow.eventprocessing.application.model;
 
+import java.util.UUID;
+
 public record RecordKafkaDeadLetterCommand(
     String deadLetterTopic,
     int deadLetterPartition,
@@ -11,7 +13,9 @@ public record RecordKafkaDeadLetterCommand(
     String recordKey,
     String payload,
     String exceptionType,
-    String exceptionMessage
+    String exceptionMessage,
+    UUID replayOriginId,
+    Integer replayAttemptBase
 ) {
 
     private static final int MAX_TOPIC_LENGTH = 200;
@@ -70,6 +74,58 @@ public record RecordKafkaDeadLetterCommand(
                 "exceptionType",
                 MAX_EXCEPTION_TYPE_LENGTH
             );
+        boolean hasOrigin =
+            replayOriginId != null;
+
+        boolean hasAttempt =
+            replayAttemptBase != null;
+
+        if (hasOrigin != hasAttempt) {
+            throw new IllegalArgumentException(
+                "Replay origin id and attempt must "
+                    + "either both be present "
+                    + "or both be absent."
+            );
+        }
+
+        if (
+            replayAttemptBase != null
+                && replayAttemptBase <= 0
+        ) {
+            throw new IllegalArgumentException(
+                "replayAttemptBase must be positive "
+                    + "when replay metadata is present."
+            );
+        }
+    }
+    public RecordKafkaDeadLetterCommand(
+        String deadLetterTopic,
+        int deadLetterPartition,
+        long deadLetterOffset,
+        String originalTopic,
+        int originalPartition,
+        long originalOffset,
+        String originalConsumerGroup,
+        String recordKey,
+        String payload,
+        String exceptionType,
+        String exceptionMessage
+    ) {
+        this(
+            deadLetterTopic,
+            deadLetterPartition,
+            deadLetterOffset,
+            originalTopic,
+            originalPartition,
+            originalOffset,
+            originalConsumerGroup,
+            recordKey,
+            payload,
+            exceptionType,
+            exceptionMessage,
+            null,
+            null
+        );
     }
 
     private static String validateText(

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/RecordKafkaDeadLetterCommand.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/RecordKafkaDeadLetterCommand.java
@@ -1,0 +1,109 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+public record RecordKafkaDeadLetterCommand(
+    String deadLetterTopic,
+    int deadLetterPartition,
+    long deadLetterOffset,
+    String originalTopic,
+    int originalPartition,
+    long originalOffset,
+    String originalConsumerGroup,
+    String recordKey,
+    String payload,
+    String exceptionType,
+    String exceptionMessage
+) {
+
+    private static final int MAX_TOPIC_LENGTH = 200;
+
+    private static final int
+        MAX_CONSUMER_GROUP_LENGTH = 255;
+
+    private static final int
+        MAX_EXCEPTION_TYPE_LENGTH = 500;
+
+    public RecordKafkaDeadLetterCommand {
+        deadLetterTopic =
+            validateText(
+                deadLetterTopic,
+                "deadLetterTopic",
+                MAX_TOPIC_LENGTH
+            );
+
+        validateNonNegative(
+            deadLetterPartition,
+            "deadLetterPartition"
+        );
+
+        validateNonNegative(
+            deadLetterOffset,
+            "deadLetterOffset"
+        );
+
+        originalTopic =
+            validateText(
+                originalTopic,
+                "originalTopic",
+                MAX_TOPIC_LENGTH
+            );
+
+        validateNonNegative(
+            originalPartition,
+            "originalPartition"
+        );
+
+        validateNonNegative(
+            originalOffset,
+            "originalOffset"
+        );
+
+        originalConsumerGroup =
+            validateText(
+                originalConsumerGroup,
+                "originalConsumerGroup",
+                MAX_CONSUMER_GROUP_LENGTH
+            );
+
+        exceptionType =
+            validateText(
+                exceptionType,
+                "exceptionType",
+                MAX_EXCEPTION_TYPE_LENGTH
+            );
+    }
+
+    private static String validateText(
+        String value,
+        String fieldName,
+        int maximumLength
+    ) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(
+                fieldName + " must not be blank."
+            );
+        }
+
+        if (value.length() > maximumLength) {
+            throw new IllegalArgumentException(
+                fieldName
+                    + " must not exceed "
+                    + maximumLength
+                    + " characters."
+            );
+        }
+
+        return value;
+    }
+
+    private static void validateNonNegative(
+        long value,
+        String fieldName
+    ) {
+        if (value < 0) {
+            throw new IllegalArgumentException(
+                fieldName
+                    + " must not be negative."
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/RecordKafkaDeadLetterResult.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/RecordKafkaDeadLetterResult.java
@@ -1,0 +1,7 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+public enum RecordKafkaDeadLetterResult {
+
+    RECORDED,
+    DUPLICATE
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/ReplayKafkaDeadLetterRecordCommand.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/ReplayKafkaDeadLetterRecordCommand.java
@@ -1,0 +1,17 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record ReplayKafkaDeadLetterRecordCommand(
+    UUID recordId
+) {
+
+    public ReplayKafkaDeadLetterRecordCommand {
+        recordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/ReplayKafkaDeadLetterRecordResult.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/ReplayKafkaDeadLetterRecordResult.java
@@ -1,0 +1,68 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.util.Objects;
+
+public record ReplayKafkaDeadLetterRecordResult(
+    Outcome outcome
+) {
+
+    public ReplayKafkaDeadLetterRecordResult {
+        outcome =
+            Objects.requireNonNull(
+                outcome,
+                "outcome must not be null"
+            );
+    }
+
+    public static ReplayKafkaDeadLetterRecordResult
+    notClaimable() {
+        return new ReplayKafkaDeadLetterRecordResult(
+            Outcome.NOT_CLAIMABLE
+        );
+    }
+
+    public static ReplayKafkaDeadLetterRecordResult
+    replayed() {
+        return new ReplayKafkaDeadLetterRecordResult(
+            Outcome.REPLAYED
+        );
+    }
+
+    public static ReplayKafkaDeadLetterRecordResult
+    replayFailed() {
+        return new ReplayKafkaDeadLetterRecordResult(
+            Outcome.REPLAY_FAILED
+        );
+    }
+
+    public static ReplayKafkaDeadLetterRecordResult
+    unresolved() {
+        return new ReplayKafkaDeadLetterRecordResult(
+            Outcome.UNRESOLVED
+        );
+    }
+
+    public boolean isNotClaimable() {
+        return outcome == Outcome.NOT_CLAIMABLE;
+    }
+
+    public boolean isReplayed() {
+        return outcome == Outcome.REPLAYED;
+    }
+
+    public boolean isReplayFailed() {
+        return outcome == Outcome.REPLAY_FAILED;
+    }
+
+    public boolean isUnresolved() {
+        return outcome == Outcome.UNRESOLVED;
+    }
+
+    public enum Outcome {
+
+        NOT_CLAIMABLE,
+        REPLAYED,
+        REPLAY_FAILED,
+        UNRESOLVED
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/ClaimKafkaDeadLetterRecordUseCase.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/ClaimKafkaDeadLetterRecordUseCase.java
@@ -1,0 +1,11 @@
+package com.nursena.payflow.eventprocessing.application.port.in;
+
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordResult;
+
+public interface ClaimKafkaDeadLetterRecordUseCase {
+
+    ClaimKafkaDeadLetterRecordResult claim(
+        ClaimKafkaDeadLetterRecordCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/RecordKafkaDeadLetterUseCase.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/RecordKafkaDeadLetterUseCase.java
@@ -1,0 +1,11 @@
+package com.nursena.payflow.eventprocessing.application.port.in;
+
+import com.nursena.payflow.eventprocessing.application.model.RecordKafkaDeadLetterCommand;
+import com.nursena.payflow.eventprocessing.application.model.RecordKafkaDeadLetterResult;
+
+public interface RecordKafkaDeadLetterUseCase {
+
+    RecordKafkaDeadLetterResult record(
+        RecordKafkaDeadLetterCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/ReplayKafkaDeadLetterRecordUseCase.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/ReplayKafkaDeadLetterRecordUseCase.java
@@ -1,0 +1,11 @@
+package com.nursena.payflow.eventprocessing.application.port.in;
+
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordResult;
+
+public interface ReplayKafkaDeadLetterRecordUseCase {
+
+    ReplayKafkaDeadLetterRecordResult replay(
+        ReplayKafkaDeadLetterRecordCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterRecordRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterRecordRepositoryPort.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.eventprocessing.application.port.out;
+
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+
+public interface KafkaDeadLetterRecordRepositoryPort {
+
+    boolean tryRecord(
+        KafkaDeadLetterRecord record
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterReplayLifecyclePort.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterReplayLifecyclePort.java
@@ -1,0 +1,20 @@
+package com.nursena.payflow.eventprocessing.application.port.out;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public interface KafkaDeadLetterReplayLifecyclePort {
+
+    boolean tryMarkReplayed(
+        UUID recordId,
+        String workerId,
+        Instant completedAt
+    );
+
+    boolean tryMarkReplayFailed(
+        UUID recordId,
+        String workerId,
+        Instant failedAt,
+        String error
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterReplayPublisherPort.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterReplayPublisherPort.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.eventprocessing.application.port.out;
+
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+
+public interface KafkaDeadLetterReplayPublisherPort {
+
+    void publish(
+        KafkaDeadLetterRecord record
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterReplayRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterReplayRepositoryPort.java
@@ -1,0 +1,19 @@
+package com.nursena.payflow.eventprocessing.application.port.out;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+
+public interface KafkaDeadLetterReplayRepositoryPort {
+
+    Optional<KafkaDeadLetterRecord> tryClaim(
+        UUID recordId,
+        String workerId,
+        Instant claimedAt,
+        Duration leaseDuration,
+        int maxReplayAttempts
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/ClaimKafkaDeadLetterRecordService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/ClaimKafkaDeadLetterRecordService.java
@@ -1,0 +1,165 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.in.ClaimKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayRepositoryPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import org.springframework.transaction.annotation.Transactional;
+
+public class ClaimKafkaDeadLetterRecordService
+    implements ClaimKafkaDeadLetterRecordUseCase {
+
+    private static final int
+        MAX_WORKER_ID_LENGTH = 200;
+
+    private final KafkaDeadLetterReplayRepositoryPort
+        repository;
+
+    private final String workerId;
+
+    private final Duration leaseDuration;
+
+    private final int maxReplayAttempts;
+
+    private final Clock clock;
+
+    public ClaimKafkaDeadLetterRecordService(
+        KafkaDeadLetterReplayRepositoryPort
+            repository,
+        String workerId,
+        Duration leaseDuration,
+        int maxReplayAttempts,
+        Clock clock
+    ) {
+        this.repository =
+            Objects.requireNonNull(
+                repository,
+                "repository must not be null"
+            );
+
+        this.workerId =
+            validateWorkerId(workerId);
+
+        this.leaseDuration =
+            validateLeaseDuration(
+                leaseDuration
+            );
+
+        this.maxReplayAttempts =
+            validateMaximumAttempts(
+                maxReplayAttempts
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+    }
+
+    @Override
+    @Transactional
+    public ClaimKafkaDeadLetterRecordResult claim(
+        ClaimKafkaDeadLetterRecordCommand command
+    ) {
+        Objects.requireNonNull(
+            command,
+            "command must not be null"
+        );
+
+        Instant claimedAt =
+            currentTime();
+
+        return repository
+            .tryClaim(
+                command.recordId(),
+                workerId,
+                claimedAt,
+                leaseDuration,
+                maxReplayAttempts
+            )
+            .map(
+                ClaimKafkaDeadLetterRecordResult
+                    ::claimed
+            )
+            .orElseGet(
+                ClaimKafkaDeadLetterRecordResult
+                    ::notClaimable
+            );
+    }
+
+    private Instant currentTime() {
+        return clock
+            .instant()
+            .truncatedTo(
+                ChronoUnit.MICROS
+            );
+    }
+
+    private static String validateWorkerId(
+        String value
+    ) {
+        if (
+            value == null
+                || value.isBlank()
+        ) {
+            throw new IllegalArgumentException(
+                "workerId must not be blank."
+            );
+        }
+
+        if (
+            value.length()
+                > MAX_WORKER_ID_LENGTH
+        ) {
+            throw new IllegalArgumentException(
+                "workerId must not exceed "
+                    + MAX_WORKER_ID_LENGTH
+                    + " characters."
+            );
+        }
+
+        return value;
+    }
+
+    private static Duration
+    validateLeaseDuration(
+        Duration value
+    ) {
+        Objects.requireNonNull(
+            value,
+            "leaseDuration must not be null"
+        );
+
+        if (
+            value.isZero()
+                || value.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                "leaseDuration must be positive."
+            );
+        }
+
+        return value;
+    }
+
+    private static int validateMaximumAttempts(
+        int value
+    ) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(
+                "maxReplayAttempts must be "
+                    + "positive."
+            );
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/RecordKafkaDeadLetterService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/RecordKafkaDeadLetterService.java
@@ -1,0 +1,111 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import com.nursena.payflow.eventprocessing.application.model.RecordKafkaDeadLetterCommand;
+import com.nursena.payflow.eventprocessing.application.model.RecordKafkaDeadLetterResult;
+import com.nursena.payflow.eventprocessing.application.port.in.RecordKafkaDeadLetterUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterRecordRepositoryPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.springframework.transaction.annotation.Transactional;
+
+public class RecordKafkaDeadLetterService
+    implements RecordKafkaDeadLetterUseCase {
+
+    private final KafkaDeadLetterRecordRepositoryPort
+        repository;
+
+    private final Clock clock;
+
+    private final Supplier<UUID> idSupplier;
+
+    public RecordKafkaDeadLetterService(
+        KafkaDeadLetterRecordRepositoryPort
+            repository,
+        Clock clock,
+        Supplier<UUID> idSupplier
+    ) {
+        this.repository =
+            Objects.requireNonNull(
+                repository,
+                "repository must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+
+        this.idSupplier =
+            Objects.requireNonNull(
+                idSupplier,
+                "idSupplier must not be null"
+            );
+    }
+
+    @Override
+    @Transactional
+    public RecordKafkaDeadLetterResult record(
+        RecordKafkaDeadLetterCommand command
+    ) {
+        Objects.requireNonNull(
+            command,
+            "command must not be null"
+        );
+
+        UUID recordId =
+            Objects.requireNonNull(
+                idSupplier.get(),
+                "idSupplier must not return null"
+            );
+
+        KafkaDeadLetterRecord record =
+            new KafkaDeadLetterRecord(
+                recordId,
+                command.deadLetterTopic(),
+                command.deadLetterPartition(),
+                command.deadLetterOffset(),
+                command.originalTopic(),
+                command.originalPartition(),
+                command.originalOffset(),
+                command.originalConsumerGroup(),
+                command.recordKey(),
+                command.payload(),
+                command.exceptionType(),
+                command.exceptionMessage(),
+                KafkaDeadLetterRecordStatus.RECEIVED,
+                0,
+                currentTime(),
+                null,
+                null,
+                null,
+                null
+            );
+
+        boolean recorded =
+            repository.tryRecord(record);
+
+        if (!recorded) {
+            return RecordKafkaDeadLetterResult
+                .DUPLICATE;
+        }
+
+        return RecordKafkaDeadLetterResult
+            .RECORDED;
+    }
+
+    private Instant currentTime() {
+        return clock
+            .instant()
+            .truncatedTo(
+                ChronoUnit.MICROS
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/RecordKafkaDeadLetterService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/RecordKafkaDeadLetterService.java
@@ -66,6 +66,16 @@ public class RecordKafkaDeadLetterService
                 "idSupplier must not return null"
             );
 
+        UUID replayOriginId =
+            command.replayOriginId() == null
+                ? recordId
+                : command.replayOriginId();
+
+        int replayAttemptBase =
+            command.replayAttemptBase() == null
+                ? 0
+                : command.replayAttemptBase();
+
         KafkaDeadLetterRecord record =
             new KafkaDeadLetterRecord(
                 recordId,
@@ -86,7 +96,9 @@ public class RecordKafkaDeadLetterService
                 null,
                 null,
                 null,
-                null
+                null,
+                replayOriginId,
+                replayAttemptBase
             );
 
         boolean recorded =

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/ReplayKafkaDeadLetterRecordService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/ReplayKafkaDeadLetterRecordService.java
@@ -1,0 +1,321 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.in.ClaimKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.in.ReplayKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayLifecyclePort;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayPublisherPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReplayKafkaDeadLetterRecordService
+    implements ReplayKafkaDeadLetterRecordUseCase {
+
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(
+            ReplayKafkaDeadLetterRecordService.class
+        );
+
+    private static final int
+        MAX_ERROR_LENGTH = 1000;
+
+    private final ClaimKafkaDeadLetterRecordUseCase
+        claimUseCase;
+
+    private final KafkaDeadLetterReplayPublisherPort
+        publisherPort;
+
+    private final KafkaDeadLetterReplayLifecyclePort
+        lifecyclePort;
+
+    private final Clock clock;
+
+    public ReplayKafkaDeadLetterRecordService(
+        ClaimKafkaDeadLetterRecordUseCase
+            claimUseCase,
+        KafkaDeadLetterReplayPublisherPort
+            publisherPort,
+        KafkaDeadLetterReplayLifecyclePort
+            lifecyclePort,
+        Clock clock
+    ) {
+        this.claimUseCase =
+            Objects.requireNonNull(
+                claimUseCase,
+                "claimUseCase must not be null"
+            );
+
+        this.publisherPort =
+            Objects.requireNonNull(
+                publisherPort,
+                "publisherPort must not be null"
+            );
+
+        this.lifecyclePort =
+            Objects.requireNonNull(
+                lifecyclePort,
+                "lifecyclePort must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+    }
+
+    @Override
+    public ReplayKafkaDeadLetterRecordResult replay(
+        ReplayKafkaDeadLetterRecordCommand command
+    ) {
+        ReplayKafkaDeadLetterRecordCommand
+            validatedCommand =
+            Objects.requireNonNull(
+                command,
+                "command must not be null"
+            );
+
+        ClaimKafkaDeadLetterRecordResult
+            claimResult =
+            claimUseCase.claim(
+                new ClaimKafkaDeadLetterRecordCommand(
+                    validatedCommand.recordId()
+                )
+            );
+
+        if (!claimResult.isClaimed()) {
+            return ReplayKafkaDeadLetterRecordResult
+                .notClaimable();
+        }
+
+        KafkaDeadLetterRecord record =
+            validateClaimedRecord(
+                validatedCommand,
+                claimResult
+            );
+
+        try {
+            publisherPort.publish(record);
+        } catch (RuntimeException exception) {
+            return persistReplayFailure(
+                record,
+                exception
+            );
+        }
+
+        return persistReplaySuccess(record);
+    }
+
+    private ReplayKafkaDeadLetterRecordResult
+    persistReplaySuccess(
+        KafkaDeadLetterRecord record
+    ) {
+        try {
+            boolean transitioned =
+                lifecyclePort.tryMarkReplayed(
+                    record.id(),
+                    record.replayLeaseOwner(),
+                    currentTime()
+                );
+
+            if (transitioned) {
+                return ReplayKafkaDeadLetterRecordResult
+                    .replayed();
+            }
+
+            logRejectedLifecycleTransition(
+                record,
+                "REPLAYED"
+            );
+
+            return ReplayKafkaDeadLetterRecordResult
+                .unresolved();
+        } catch (RuntimeException exception) {
+            logLifecyclePersistenceFailure(
+                record,
+                "REPLAYED",
+                exception
+            );
+
+            return ReplayKafkaDeadLetterRecordResult
+                .unresolved();
+        }
+    }
+
+    private ReplayKafkaDeadLetterRecordResult
+    persistReplayFailure(
+        KafkaDeadLetterRecord record,
+        RuntimeException publishingFailure
+    ) {
+        try {
+            boolean transitioned =
+                lifecyclePort
+                    .tryMarkReplayFailed(
+                        record.id(),
+                        record.replayLeaseOwner(),
+                        currentTime(),
+                        failureMessage(
+                            publishingFailure
+                        )
+                    );
+
+            if (transitioned) {
+                return ReplayKafkaDeadLetterRecordResult
+                    .replayFailed();
+            }
+
+            logRejectedLifecycleTransition(
+                record,
+                "REPLAY_FAILED"
+            );
+
+            return ReplayKafkaDeadLetterRecordResult
+                .unresolved();
+        } catch (RuntimeException exception) {
+            logLifecyclePersistenceFailure(
+                record,
+                "REPLAY_FAILED",
+                exception
+            );
+
+            return ReplayKafkaDeadLetterRecordResult
+                .unresolved();
+        }
+    }
+
+    private static KafkaDeadLetterRecord
+    validateClaimedRecord(
+        ReplayKafkaDeadLetterRecordCommand command,
+        ClaimKafkaDeadLetterRecordResult result
+    ) {
+        KafkaDeadLetterRecord record =
+            Objects.requireNonNull(
+                result.record(),
+                "CLAIMED result record "
+                    + "must not be null"
+            );
+
+        if (!record.id().equals(
+            command.recordId()
+        )) {
+            throw new IllegalStateException(
+                "Claimed Kafka dead-letter "
+                    + "record identifier does not "
+                    + "match the replay command."
+            );
+        }
+
+        if (
+            record.status()
+                != KafkaDeadLetterRecordStatus
+                .REPLAYING
+        ) {
+            throw new IllegalStateException(
+                "Claimed Kafka dead-letter "
+                    + "record must be REPLAYING."
+            );
+        }
+
+        if (
+            record.replayLeaseOwner() == null
+                || record.replayLeaseOwner()
+                .isBlank()
+        ) {
+            throw new IllegalStateException(
+                "Claimed Kafka dead-letter "
+                    + "record must have a replay "
+                    + "lease owner."
+            );
+        }
+
+        return record;
+    }
+
+    private static String failureMessage(
+        RuntimeException exception
+    ) {
+        String exceptionType =
+            exception.getClass()
+                .getSimpleName();
+
+        if (exceptionType.isBlank()) {
+            exceptionType =
+                exception.getClass()
+                    .getName();
+        }
+
+        String detail =
+            exception.getMessage();
+
+        String error =
+            detail == null
+                || detail.isBlank()
+                ? exceptionType
+                : exceptionType
+                + ": "
+                + detail;
+
+        if (
+            error.length()
+                <= MAX_ERROR_LENGTH
+        ) {
+            return error;
+        }
+
+        return error.substring(
+            0,
+            MAX_ERROR_LENGTH
+        );
+    }
+
+    private static void
+    logRejectedLifecycleTransition(
+        KafkaDeadLetterRecord record,
+        String intendedOutcome
+    ) {
+        LOGGER.error(
+            "Kafka dead-letter replay lifecycle "
+                + "transition was rejected. "
+                + "recordId={}, workerId={}, "
+                + "intendedOutcome={}",
+            record.id(),
+            record.replayLeaseOwner(),
+            intendedOutcome
+        );
+    }
+
+    private static void
+    logLifecyclePersistenceFailure(
+        KafkaDeadLetterRecord record,
+        String intendedOutcome,
+        RuntimeException exception
+    ) {
+        LOGGER.error(
+            "Kafka dead-letter replay outcome "
+                + "could not be persisted. "
+                + "recordId={}, workerId={}, "
+                + "intendedOutcome={}",
+            record.id(),
+            record.replayLeaseOwner(),
+            intendedOutcome,
+            exception
+        );
+    }
+
+    private Instant currentTime() {
+        return clock.instant()
+            .truncatedTo(
+                ChronoUnit.MICROS
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterReplayConfiguration.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterReplayConfiguration.java
@@ -2,12 +2,19 @@ package com.nursena.payflow.eventprocessing.configuration;
 
 import java.time.Clock;
 
+import com.nursena.payflow.eventprocessing.adapter.out.kafka.KafkaDeadLetterReplayPublisherAdapter;
 import com.nursena.payflow.eventprocessing.application.port.in.ClaimKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.in.ReplayKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayLifecyclePort;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayPublisherPort;
 import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayRepositoryPort;
 import com.nursena.payflow.eventprocessing.application.service.ClaimKafkaDeadLetterRecordService;
+import com.nursena.payflow.eventprocessing.application.service.ReplayKafkaDeadLetterRecordService;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(
@@ -30,6 +37,39 @@ public class KafkaDeadLetterReplayConfiguration {
             properties.workerId(),
             properties.leaseDuration(),
             properties.maxAttempts(),
+            clock
+        );
+    }
+    @Bean
+    KafkaDeadLetterReplayPublisherPort
+    kafkaDeadLetterReplayPublisherPort(
+        KafkaTemplate<String, String>
+            kafkaTemplate,
+        KafkaDeadLetterReplayProperties
+            properties
+    ) {
+        return new
+            KafkaDeadLetterReplayPublisherAdapter(
+            kafkaTemplate,
+            properties.sendTimeout()
+        );
+    }
+    @Bean
+    ReplayKafkaDeadLetterRecordUseCase
+    replayKafkaDeadLetterRecordUseCase(
+        ClaimKafkaDeadLetterRecordUseCase
+            claimUseCase,
+        KafkaDeadLetterReplayPublisherPort
+            publisherPort,
+        KafkaDeadLetterReplayLifecyclePort
+            lifecyclePort,
+        Clock clock
+    ) {
+        return new
+            ReplayKafkaDeadLetterRecordService(
+            claimUseCase,
+            publisherPort,
+            lifecyclePort,
             clock
         );
     }

--- a/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterReplayConfiguration.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterReplayConfiguration.java
@@ -1,0 +1,36 @@
+package com.nursena.payflow.eventprocessing.configuration;
+
+import java.time.Clock;
+
+import com.nursena.payflow.eventprocessing.application.port.in.ClaimKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayRepositoryPort;
+import com.nursena.payflow.eventprocessing.application.service.ClaimKafkaDeadLetterRecordService;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(
+    KafkaDeadLetterReplayProperties.class
+)
+public class KafkaDeadLetterReplayConfiguration {
+
+    @Bean
+    ClaimKafkaDeadLetterRecordUseCase
+    claimKafkaDeadLetterRecordUseCase(
+        KafkaDeadLetterReplayRepositoryPort
+            repository,
+        KafkaDeadLetterReplayProperties
+            properties,
+        Clock clock
+    ) {
+        return new
+            ClaimKafkaDeadLetterRecordService(
+            repository,
+            properties.workerId(),
+            properties.leaseDuration(),
+            properties.maxAttempts(),
+            clock
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterReplayProperties.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterReplayProperties.java
@@ -14,7 +14,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record KafkaDeadLetterReplayProperties(
     String workerId,
     Duration leaseDuration,
-    int maxAttempts
+    int maxAttempts,
+    Duration sendTimeout
 ) {
 
     private static final int
@@ -58,6 +59,26 @@ public record KafkaDeadLetterReplayProperties(
         if (maxAttempts <= 0) {
             throw new IllegalArgumentException(
                 "maxAttempts must be positive."
+            );
+        }
+        Objects.requireNonNull(
+            sendTimeout,
+            "sendTimeout must not be null"
+        );
+
+        if (
+            sendTimeout.isZero()
+                || sendTimeout.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                "sendTimeout must be positive."
+            );
+        }
+
+        if (sendTimeout.toMillis() == 0) {
+            throw new IllegalArgumentException(
+                "sendTimeout must be at least "
+                    + "one millisecond."
             );
         }
     }

--- a/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterReplayProperties.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterReplayProperties.java
@@ -1,0 +1,64 @@
+package com.nursena.payflow.eventprocessing.configuration;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(
+    prefix =
+        "payflow.event-processing"
+            + ".transfer-completed"
+            + ".dead-letter-replay"
+)
+public record KafkaDeadLetterReplayProperties(
+    String workerId,
+    Duration leaseDuration,
+    int maxAttempts
+) {
+
+    private static final int
+        MAX_WORKER_ID_LENGTH = 200;
+
+    public KafkaDeadLetterReplayProperties {
+        if (
+            workerId == null
+                || workerId.isBlank()
+        ) {
+            throw new IllegalArgumentException(
+                "workerId must not be blank."
+            );
+        }
+
+        if (
+            workerId.length()
+                > MAX_WORKER_ID_LENGTH
+        ) {
+            throw new IllegalArgumentException(
+                "workerId must not exceed "
+                    + MAX_WORKER_ID_LENGTH
+                    + " characters."
+            );
+        }
+
+        Objects.requireNonNull(
+            leaseDuration,
+            "leaseDuration must not be null"
+        );
+
+        if (
+            leaseDuration.isZero()
+                || leaseDuration.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                "leaseDuration must be positive."
+            );
+        }
+
+        if (maxAttempts <= 0) {
+            throw new IllegalArgumentException(
+                "maxAttempts must be positive."
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/domain/model/KafkaDeadLetterRecord.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/domain/model/KafkaDeadLetterRecord.java
@@ -1,0 +1,266 @@
+package com.nursena.payflow.eventprocessing.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+public record KafkaDeadLetterRecord(
+    UUID id,
+    String deadLetterTopic,
+    int deadLetterPartition,
+    long deadLetterOffset,
+    String originalTopic,
+    int originalPartition,
+    long originalOffset,
+    String originalConsumerGroup,
+    String recordKey,
+    String payload,
+    String exceptionType,
+    String exceptionMessage,
+    KafkaDeadLetterRecordStatus status,
+    int replayCount,
+    Instant receivedAt,
+    Instant lastReplayedAt,
+    String replayLeaseOwner,
+    Instant replayLeaseUntil,
+    String lastReplayError
+) {
+
+    private static final int MAX_TOPIC_LENGTH = 200;
+
+    private static final int
+        MAX_CONSUMER_GROUP_LENGTH = 255;
+
+    private static final int
+        MAX_EXCEPTION_TYPE_LENGTH = 500;
+
+    private static final int
+        MAX_REPLAY_LEASE_OWNER_LENGTH = 200;
+
+    public KafkaDeadLetterRecord {
+        id =
+            Objects.requireNonNull(
+                id,
+                "id must not be null"
+            );
+
+        deadLetterTopic =
+            validateText(
+                deadLetterTopic,
+                "deadLetterTopic",
+                MAX_TOPIC_LENGTH
+            );
+
+        validateNonNegative(
+            deadLetterPartition,
+            "deadLetterPartition"
+        );
+
+        validateNonNegative(
+            deadLetterOffset,
+            "deadLetterOffset"
+        );
+
+        originalTopic =
+            validateText(
+                originalTopic,
+                "originalTopic",
+                MAX_TOPIC_LENGTH
+            );
+
+        validateNonNegative(
+            originalPartition,
+            "originalPartition"
+        );
+
+        validateNonNegative(
+            originalOffset,
+            "originalOffset"
+        );
+
+        originalConsumerGroup =
+            validateText(
+                originalConsumerGroup,
+                "originalConsumerGroup",
+                MAX_CONSUMER_GROUP_LENGTH
+            );
+
+        exceptionType =
+            validateText(
+                exceptionType,
+                "exceptionType",
+                MAX_EXCEPTION_TYPE_LENGTH
+            );
+
+        status =
+            Objects.requireNonNull(
+                status,
+                "status must not be null"
+            );
+
+        receivedAt =
+            Objects.requireNonNull(
+                receivedAt,
+                "receivedAt must not be null"
+            );
+
+        validateReplayState(
+            status,
+            replayCount,
+            lastReplayedAt,
+            replayLeaseOwner,
+            replayLeaseUntil
+        );
+    }
+
+    private static void validateReplayState(
+        KafkaDeadLetterRecordStatus status,
+        int replayCount,
+        Instant lastReplayedAt,
+        String replayLeaseOwner,
+        Instant replayLeaseUntil
+    ) {
+        validateNonNegative(
+            replayCount,
+            "replayCount"
+        );
+
+        if (
+            replayCount == 0
+                && lastReplayedAt != null
+        ) {
+            throw new IllegalArgumentException(
+                "lastReplayedAt must be null "
+                    + "when replayCount is zero."
+            );
+        }
+
+        if (
+            replayCount > 0
+                && lastReplayedAt == null
+        ) {
+            throw new IllegalArgumentException(
+                "lastReplayedAt must not be null "
+                    + "when replayCount is positive."
+            );
+        }
+
+        if (
+            status
+                == KafkaDeadLetterRecordStatus
+                .RECEIVED
+                && replayCount != 0
+        ) {
+            throw new IllegalArgumentException(
+                "RECEIVED records must have "
+                    + "a zero replayCount."
+            );
+        }
+
+        boolean requiresReplayAttempt =
+            status
+                == KafkaDeadLetterRecordStatus
+                .REPLAYING
+                || status
+                == KafkaDeadLetterRecordStatus
+                .REPLAYED
+                || status
+                == KafkaDeadLetterRecordStatus
+                .REPLAY_FAILED;
+
+        if (
+            requiresReplayAttempt
+                && replayCount == 0
+        ) {
+            throw new IllegalArgumentException(
+                status
+                    + " records must have "
+                    + "a positive replayCount."
+            );
+        }
+
+        validateReplayLease(
+            status,
+            replayLeaseOwner,
+            replayLeaseUntil
+        );
+    }
+
+    private static void validateReplayLease(
+        KafkaDeadLetterRecordStatus status,
+        String replayLeaseOwner,
+        Instant replayLeaseUntil
+    ) {
+        if (
+            status
+                == KafkaDeadLetterRecordStatus
+                .REPLAYING
+        ) {
+            validateText(
+                replayLeaseOwner,
+                "replayLeaseOwner",
+                MAX_REPLAY_LEASE_OWNER_LENGTH
+            );
+
+            Objects.requireNonNull(
+                replayLeaseUntil,
+                "replayLeaseUntil must not be null "
+                    + "for REPLAYING records"
+            );
+
+            return;
+        }
+
+        if (
+            replayLeaseOwner != null
+                || replayLeaseUntil != null
+        ) {
+            throw new IllegalArgumentException(
+                "Replay lease fields must be null "
+                    + "unless status is REPLAYING."
+            );
+        }
+    }
+
+    private static String validateText(
+        String value,
+        String fieldName,
+        int maximumLength
+    ) {
+        if (
+            value == null
+                || value.isBlank()
+        ) {
+            throw new IllegalArgumentException(
+                fieldName
+                    + " must not be blank."
+            );
+        }
+
+        if (
+            value.length()
+                > maximumLength
+        ) {
+            throw new IllegalArgumentException(
+                fieldName
+                    + " must not exceed "
+                    + maximumLength
+                    + " characters."
+            );
+        }
+
+        return value;
+    }
+
+    private static void validateNonNegative(
+        long value,
+        String fieldName
+    ) {
+        if (value < 0) {
+            throw new IllegalArgumentException(
+                fieldName
+                    + " must not be negative."
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/domain/model/KafkaDeadLetterRecord.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/domain/model/KafkaDeadLetterRecord.java
@@ -23,7 +23,9 @@ public record KafkaDeadLetterRecord(
     Instant lastReplayedAt,
     String replayLeaseOwner,
     Instant replayLeaseUntil,
-    String lastReplayError
+    String lastReplayError,
+    UUID replayOriginId,
+    int replayAttemptBase
 ) {
 
     private static final int MAX_TOPIC_LENGTH = 200;
@@ -104,12 +106,75 @@ public record KafkaDeadLetterRecord(
                 "receivedAt must not be null"
             );
 
+        if (
+            lastReplayedAt != null
+                && lastReplayedAt.isBefore(receivedAt)
+        ) {
+            throw new IllegalArgumentException(
+                "lastReplayedAt must not be "
+                    + "before receivedAt."
+            );
+        }
+
         validateReplayState(
             status,
             replayCount,
             lastReplayedAt,
             replayLeaseOwner,
             replayLeaseUntil
+        );
+
+        validateReplayLineage(
+            id,
+            replayOriginId,
+            replayAttemptBase,
+            replayCount
+        );
+    }
+
+    public KafkaDeadLetterRecord(
+        UUID id,
+        String deadLetterTopic,
+        int deadLetterPartition,
+        long deadLetterOffset,
+        String originalTopic,
+        int originalPartition,
+        long originalOffset,
+        String originalConsumerGroup,
+        String recordKey,
+        String payload,
+        String exceptionType,
+        String exceptionMessage,
+        KafkaDeadLetterRecordStatus status,
+        int replayCount,
+        Instant receivedAt,
+        Instant lastReplayedAt,
+        String replayLeaseOwner,
+        Instant replayLeaseUntil,
+        String lastReplayError
+    ) {
+        this(
+            id,
+            deadLetterTopic,
+            deadLetterPartition,
+            deadLetterOffset,
+            originalTopic,
+            originalPartition,
+            originalOffset,
+            originalConsumerGroup,
+            recordKey,
+            payload,
+            exceptionType,
+            exceptionMessage,
+            status,
+            replayCount,
+            receivedAt,
+            lastReplayedAt,
+            replayLeaseOwner,
+            replayLeaseUntil,
+            lastReplayError,
+            id,
+            0
         );
     }
 
@@ -181,6 +246,7 @@ public record KafkaDeadLetterRecord(
 
         validateReplayLease(
             status,
+            lastReplayedAt,
             replayLeaseOwner,
             replayLeaseUntil
         );
@@ -188,6 +254,7 @@ public record KafkaDeadLetterRecord(
 
     private static void validateReplayLease(
         KafkaDeadLetterRecordStatus status,
+        Instant lastReplayedAt,
         String replayLeaseOwner,
         Instant replayLeaseUntil
     ) {
@@ -208,6 +275,18 @@ public record KafkaDeadLetterRecord(
                     + "for REPLAYING records"
             );
 
+            if (
+                lastReplayedAt != null
+                    && !replayLeaseUntil.isAfter(
+                    lastReplayedAt
+                )
+            ) {
+                throw new IllegalArgumentException(
+                    "replayLeaseUntil must be after "
+                        + "lastReplayedAt."
+                );
+            }
+
             return;
         }
 
@@ -218,6 +297,59 @@ public record KafkaDeadLetterRecord(
             throw new IllegalArgumentException(
                 "Replay lease fields must be null "
                     + "unless status is REPLAYING."
+            );
+        }
+    }
+
+    private static void validateReplayLineage(
+        UUID id,
+        UUID replayOriginId,
+        int replayAttemptBase,
+        int replayCount
+    ) {
+        UUID validatedOriginId =
+            Objects.requireNonNull(
+                replayOriginId,
+                "replayOriginId must not be null"
+            );
+
+        validateNonNegative(
+            replayAttemptBase,
+            "replayAttemptBase"
+        );
+
+        if (
+            replayAttemptBase == 0
+                && !validatedOriginId.equals(id)
+        ) {
+            throw new IllegalArgumentException(
+                "Initial dead-letter records must "
+                    + "use their own id as "
+                    + "replayOriginId."
+            );
+        }
+
+        if (
+            replayAttemptBase > 0
+                && validatedOriginId.equals(id)
+        ) {
+            throw new IllegalArgumentException(
+                "Replay-derived dead-letter records "
+                    + "must use a different "
+                    + "replayOriginId."
+            );
+        }
+
+        try {
+            Math.addExact(
+                replayAttemptBase,
+                replayCount
+            );
+        } catch (ArithmeticException exception) {
+            throw new IllegalArgumentException(
+                "Total replay attempt count "
+                    + "must not overflow.",
+                exception
             );
         }
     }

--- a/src/main/java/com/nursena/payflow/eventprocessing/domain/model/KafkaDeadLetterRecordStatus.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/domain/model/KafkaDeadLetterRecordStatus.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.eventprocessing.domain.model;
+
+public enum KafkaDeadLetterRecordStatus {
+
+    RECEIVED,
+    REPLAYING,
+    REPLAYED,
+    REPLAY_FAILED,
+    DISCARDED
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,3 +103,7 @@ payflow:
       dead-letter-intake:
         enabled: ${TRANSFER_COMPLETED_DLT_INTAKE_ENABLED:false}
         group-id: ${TRANSFER_COMPLETED_DLT_INTAKE_GROUP:payflow-transfer-completed-dlt-intake-v1}
+      dead-letter-replay:
+        worker-id: ${TRANSFER_COMPLETED_DLT_REPLAY_WORKER_ID:payflow-dlt-replay}
+        lease-duration: ${TRANSFER_COMPLETED_DLT_REPLAY_LEASE_DURATION:30s}
+        max-attempts: ${TRANSFER_COMPLETED_DLT_REPLAY_MAX_ATTEMPTS:3}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -100,3 +100,6 @@ payflow:
         multiplier: ${TRANSFER_COMPLETED_RETRY_MULTIPLIER:2.0}
         maximum-delay: ${TRANSFER_COMPLETED_RETRY_MAXIMUM_DELAY:5s}
         send-timeout: ${TRANSFER_COMPLETED_DLT_SEND_TIMEOUT:10s}
+      dead-letter-intake:
+        enabled: ${TRANSFER_COMPLETED_DLT_INTAKE_ENABLED:false}
+        group-id: ${TRANSFER_COMPLETED_DLT_INTAKE_GROUP:payflow-transfer-completed-dlt-intake-v1}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,3 +107,4 @@ payflow:
         worker-id: ${TRANSFER_COMPLETED_DLT_REPLAY_WORKER_ID:payflow-dlt-replay}
         lease-duration: ${TRANSFER_COMPLETED_DLT_REPLAY_LEASE_DURATION:30s}
         max-attempts: ${TRANSFER_COMPLETED_DLT_REPLAY_MAX_ATTEMPTS:3}
+        send-timeout: ${TRANSFER_COMPLETED_DLT_REPLAY_SEND_TIMEOUT:10s}

--- a/src/main/resources/db/migration/V10__strengthen_kafka_dead_letter_replay_constraints.sql
+++ b/src/main/resources/db/migration/V10__strengthen_kafka_dead_letter_replay_constraints.sql
@@ -1,0 +1,72 @@
+ALTER TABLE kafka_dead_letter_records
+    ADD COLUMN replay_origin_id UUID;
+
+ALTER TABLE kafka_dead_letter_records
+    ADD COLUMN replay_attempt_base INTEGER
+        NOT NULL
+        DEFAULT 0;
+
+UPDATE kafka_dead_letter_records
+SET replay_origin_id = id
+WHERE replay_origin_id IS NULL;
+
+ALTER TABLE kafka_dead_letter_records
+    ALTER COLUMN replay_origin_id
+    SET NOT NULL;
+
+ALTER TABLE kafka_dead_letter_records
+    ALTER COLUMN replay_attempt_base
+    DROP DEFAULT;
+
+ALTER TABLE kafka_dead_letter_records
+    ADD CONSTRAINT
+        chk_kafka_dead_letter_records_replay_attempt_base
+    CHECK (
+        replay_attempt_base >= 0
+    );
+
+ALTER TABLE kafka_dead_letter_records
+    ADD CONSTRAINT
+        chk_kafka_dead_letter_records_replay_lineage
+    CHECK (
+        (
+            replay_attempt_base = 0
+            AND replay_origin_id = id
+        )
+        OR
+        (
+            replay_attempt_base > 0
+            AND replay_origin_id <> id
+        )
+    );
+
+ALTER TABLE kafka_dead_letter_records
+    ADD CONSTRAINT
+        chk_kafka_dead_letter_records_total_replay_count
+    CHECK (
+        replay_attempt_base
+            <= 2147483647 - replay_count
+    );
+
+ALTER TABLE kafka_dead_letter_records
+    ADD CONSTRAINT
+        chk_kafka_dead_letter_records_replay_timestamp
+    CHECK (
+        last_replayed_at IS NULL
+        OR last_replayed_at >= received_at
+    );
+
+ALTER TABLE kafka_dead_letter_records
+    ADD CONSTRAINT
+        chk_kafka_dead_letter_records_replay_lease_period
+    CHECK (
+        status <> 'REPLAYING'
+        OR replay_lease_until > last_replayed_at
+    );
+
+CREATE INDEX
+    idx_kafka_dead_letter_records_replay_origin
+ON kafka_dead_letter_records (
+    replay_origin_id,
+    received_at
+);

--- a/src/main/resources/db/migration/V9__create_kafka_dead_letter_records.sql
+++ b/src/main/resources/db/migration/V9__create_kafka_dead_letter_records.sql
@@ -1,0 +1,149 @@
+CREATE TABLE kafka_dead_letter_records (
+    id UUID PRIMARY KEY,
+
+    dlt_topic VARCHAR(200) NOT NULL,
+    dlt_partition INTEGER NOT NULL,
+    dlt_offset BIGINT NOT NULL,
+
+    original_topic VARCHAR(200) NOT NULL,
+    original_partition INTEGER NOT NULL,
+    original_offset BIGINT NOT NULL,
+    original_consumer_group VARCHAR(255) NOT NULL,
+
+    record_key TEXT,
+    payload TEXT,
+
+    exception_type VARCHAR(500) NOT NULL,
+    exception_message TEXT,
+
+    status VARCHAR(30) NOT NULL,
+    replay_count INTEGER NOT NULL,
+
+    received_at TIMESTAMPTZ NOT NULL,
+    last_replayed_at TIMESTAMPTZ,
+
+    replay_lease_owner VARCHAR(200),
+    replay_lease_until TIMESTAMPTZ,
+
+    last_replay_error TEXT,
+
+    CONSTRAINT uq_kafka_dead_letter_records_location
+        UNIQUE (
+            dlt_topic,
+            dlt_partition,
+            dlt_offset
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_dlt_topic
+        CHECK (
+            btrim(dlt_topic) <> ''
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_dlt_partition
+        CHECK (
+            dlt_partition >= 0
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_dlt_offset
+        CHECK (
+            dlt_offset >= 0
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_original_topic
+        CHECK (
+            btrim(original_topic) <> ''
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_original_partition
+        CHECK (
+            original_partition >= 0
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_original_offset
+        CHECK (
+            original_offset >= 0
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_consumer_group
+        CHECK (
+            btrim(original_consumer_group) <> ''
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_exception_type
+        CHECK (
+            btrim(exception_type) <> ''
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_status
+        CHECK (
+            status IN (
+                'RECEIVED',
+                'REPLAYING',
+                'REPLAYED',
+                'REPLAY_FAILED',
+                'DISCARDED'
+            )
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_replay_count
+        CHECK (
+            replay_count >= 0
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_replay_time
+        CHECK (
+            (
+                replay_count = 0
+                AND last_replayed_at IS NULL
+            )
+            OR
+            (
+                replay_count > 0
+                AND last_replayed_at IS NOT NULL
+            )
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_received_state
+        CHECK (
+            status <> 'RECEIVED'
+            OR replay_count = 0
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_attempt_state
+        CHECK (
+            status NOT IN (
+                'REPLAYING',
+                'REPLAYED',
+                'REPLAY_FAILED'
+            )
+            OR replay_count > 0
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_records_replay_lease
+        CHECK (
+            (
+                status = 'REPLAYING'
+                AND replay_lease_owner IS NOT NULL
+                AND btrim(replay_lease_owner) <> ''
+                AND replay_lease_until IS NOT NULL
+            )
+            OR
+            (
+                status <> 'REPLAYING'
+                AND replay_lease_owner IS NULL
+                AND replay_lease_until IS NULL
+            )
+        )
+);
+
+CREATE INDEX idx_kafka_dead_letter_records_status_received
+    ON kafka_dead_letter_records (
+        status,
+        received_at DESC
+    );
+
+CREATE INDEX idx_kafka_dead_letter_records_replay_lease
+    ON kafka_dead_letter_records (
+        replay_lease_until
+    )
+    WHERE status = 'REPLAYING';

--- a/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterIntakePropertiesTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterIntakePropertiesTest.java
@@ -1,0 +1,65 @@
+package com.nursena.payflow.eventprocessing.adapter.in.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class TransferCompletedKafkaDeadLetterIntakePropertiesTest {
+
+    @Test
+    void shouldCreateValidIntakeProperties() {
+        TransferCompletedKafkaDeadLetterIntakeProperties
+            properties =
+            new
+                TransferCompletedKafkaDeadLetterIntakeProperties(
+                true,
+                "payflow-transfer-completed"
+                    + "-dlt-intake-v1"
+            );
+
+        assertThat(properties.enabled())
+            .isTrue();
+
+        assertThat(properties.groupId())
+            .isEqualTo(
+                "payflow-transfer-completed"
+                    + "-dlt-intake-v1"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankGroupId() {
+        assertThatThrownBy(
+            () -> new
+                TransferCompletedKafkaDeadLetterIntakeProperties(
+                true,
+                " "
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "groupId must not be blank."
+            );
+    }
+
+    @Test
+    void shouldRejectGroupIdAboveMaximumLength() {
+        assertThatThrownBy(
+            () -> new
+                TransferCompletedKafkaDeadLetterIntakeProperties(
+                true,
+                "g".repeat(256)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "groupId must not exceed "
+                    + "255 characters."
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterListenerTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterListenerTest.java
@@ -1,0 +1,377 @@
+package com.nursena.payflow.eventprocessing.adapter.in.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import com.nursena.payflow.eventprocessing.application.model.RecordKafkaDeadLetterCommand;
+import com.nursena.payflow.eventprocessing.application.port.in.RecordKafkaDeadLetterUseCase;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.KafkaHeaders;
+
+@ExtendWith(MockitoExtension.class)
+class TransferCompletedKafkaDeadLetterListenerTest {
+
+    private static final String DEAD_LETTER_TOPIC =
+        "wallet.transfer.completed.dlt";
+
+    private static final String ORIGINAL_TOPIC =
+        "wallet.transfer.completed";
+
+    private static final String ORIGINAL_GROUP =
+        "payflow-transfer-completed-audit-v1";
+
+    @Mock
+    private RecordKafkaDeadLetterUseCase useCase;
+
+    private TransferCompletedKafkaDeadLetterListener
+        listener;
+
+    @BeforeEach
+    void setUp() {
+        listener =
+            new TransferCompletedKafkaDeadLetterListener(
+                useCase
+            );
+    }
+
+    @Test
+    void shouldConvertDeadLetterRecordToCommand() {
+        ConsumerRecord<String, String> record =
+            validRecord(
+                "transaction-id",
+                "{invalid-json"
+            );
+
+        /*
+         * Verify that accumulated headers resolve
+         * to the latest value.
+         */
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders.DLT_ORIGINAL_TOPIC,
+                    bytes(ORIGINAL_TOPIC)
+                )
+            );
+
+        listener.consume(record);
+
+        ArgumentCaptor<RecordKafkaDeadLetterCommand>
+            captor =
+            ArgumentCaptor.forClass(
+                RecordKafkaDeadLetterCommand.class
+            );
+
+        verify(useCase)
+            .record(captor.capture());
+
+        RecordKafkaDeadLetterCommand command =
+            captor.getValue();
+
+        assertThat(command.deadLetterTopic())
+            .isEqualTo(DEAD_LETTER_TOPIC);
+
+        assertThat(command.deadLetterPartition())
+            .isEqualTo(2);
+
+        assertThat(command.deadLetterOffset())
+            .isEqualTo(25L);
+
+        assertThat(command.originalTopic())
+            .isEqualTo(ORIGINAL_TOPIC);
+
+        assertThat(command.originalPartition())
+            .isEqualTo(1);
+
+        assertThat(command.originalOffset())
+            .isEqualTo(42L);
+
+        assertThat(command.originalConsumerGroup())
+            .isEqualTo(ORIGINAL_GROUP);
+
+        assertThat(command.recordKey())
+            .isEqualTo("transaction-id");
+
+        assertThat(command.payload())
+            .isEqualTo("{invalid-json");
+
+        assertThat(command.exceptionType())
+            .isEqualTo(
+                "java.lang.IllegalStateException"
+            );
+
+        assertThat(command.exceptionMessage())
+            .isEqualTo(
+                "Temporary processing failure."
+            );
+    }
+
+    @Test
+    void shouldPreserveNullableKeyPayloadAndMessage() {
+        ConsumerRecord<String, String> record =
+            validRecord(
+                null,
+                null
+            );
+
+        record.headers()
+            .remove(
+                KafkaHeaders.DLT_EXCEPTION_MESSAGE
+            );
+
+        listener.consume(record);
+
+        ArgumentCaptor<RecordKafkaDeadLetterCommand>
+            captor =
+            ArgumentCaptor.forClass(
+                RecordKafkaDeadLetterCommand.class
+            );
+
+        verify(useCase)
+            .record(captor.capture());
+
+        RecordKafkaDeadLetterCommand command =
+            captor.getValue();
+
+        assertThat(command.recordKey())
+            .isNull();
+
+        assertThat(command.payload())
+            .isNull();
+
+        assertThat(command.exceptionMessage())
+            .isNull();
+    }
+
+    @Test
+    void shouldRejectMissingRequiredHeader() {
+        ConsumerRecord<String, String> record =
+            validRecord(
+                "transaction-id",
+                "payload"
+            );
+
+        record.headers()
+            .remove(
+                KafkaHeaders.DLT_ORIGINAL_OFFSET
+            );
+
+        assertThatThrownBy(
+            () -> listener.consume(record)
+        )
+            .isInstanceOf(
+                InvalidKafkaDeadLetterRecordException
+                    .class
+            )
+            .hasMessage(
+                "Required Kafka header "
+                    + KafkaHeaders.DLT_ORIGINAL_OFFSET
+                    + " is missing."
+            );
+
+        verify(
+            useCase,
+            never()
+        )
+            .record(any());
+    }
+
+    @Test
+    void shouldRejectMalformedIntegerHeader() {
+        ConsumerRecord<String, String> record =
+            validRecord(
+                "transaction-id",
+                "payload"
+            );
+
+        record.headers()
+            .remove(
+                KafkaHeaders.DLT_ORIGINAL_PARTITION
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders
+                        .DLT_ORIGINAL_PARTITION,
+                    new byte[] {1}
+                )
+            );
+
+        assertThatThrownBy(
+            () -> listener.consume(record)
+        )
+            .isInstanceOf(
+                InvalidKafkaDeadLetterRecordException
+                    .class
+            )
+            .hasMessage(
+                "Kafka header "
+                    + KafkaHeaders
+                    .DLT_ORIGINAL_PARTITION
+                    + " must contain "
+                    + Integer.BYTES
+                    + " bytes."
+            );
+
+        verify(
+            useCase,
+            never()
+        )
+            .record(any());
+    }
+
+    @Test
+    void shouldRejectBlankRequiredStringHeader() {
+        ConsumerRecord<String, String> record =
+            validRecord(
+                "transaction-id",
+                "payload"
+            );
+
+        record.headers()
+            .remove(
+                KafkaHeaders
+                    .DLT_ORIGINAL_CONSUMER_GROUP
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders
+                        .DLT_ORIGINAL_CONSUMER_GROUP,
+                    bytes(" ")
+                )
+            );
+
+        assertThatThrownBy(
+            () -> listener.consume(record)
+        )
+            .isInstanceOf(
+                InvalidKafkaDeadLetterRecordException
+                    .class
+            )
+            .hasMessage(
+                "Required Kafka header "
+                    + KafkaHeaders
+                    .DLT_ORIGINAL_CONSUMER_GROUP
+                    + " must not be blank."
+            );
+
+        verify(
+            useCase,
+            never()
+        )
+            .record(any());
+    }
+
+    private static ConsumerRecord<String, String>
+    validRecord(
+        String key,
+        String payload
+    ) {
+        ConsumerRecord<String, String> record =
+            new ConsumerRecord<>(
+                DEAD_LETTER_TOPIC,
+                2,
+                25L,
+                key,
+                payload
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders.DLT_ORIGINAL_TOPIC,
+                    bytes("obsolete-topic")
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders
+                        .DLT_ORIGINAL_PARTITION,
+                    integerBytes(1)
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders.DLT_ORIGINAL_OFFSET,
+                    longBytes(42L)
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders
+                        .DLT_ORIGINAL_CONSUMER_GROUP,
+                    bytes(ORIGINAL_GROUP)
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders.DLT_EXCEPTION_FQCN,
+                    bytes(
+                        "java.lang.IllegalStateException"
+                    )
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders.DLT_EXCEPTION_MESSAGE,
+                    bytes(
+                        "Temporary processing failure."
+                    )
+                )
+            );
+
+        return record;
+    }
+
+    private static byte[] bytes(
+        String value
+    ) {
+        return value.getBytes(
+            StandardCharsets.UTF_8
+        );
+    }
+
+    private static byte[] integerBytes(
+        int value
+    ) {
+        return ByteBuffer
+            .allocate(Integer.BYTES)
+            .putInt(value)
+            .array();
+    }
+
+    private static byte[] longBytes(
+        long value
+    ) {
+        return ByteBuffer
+            .allocate(Long.BYTES)
+            .putLong(value)
+            .array();
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterListenerTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/kafka/TransferCompletedKafkaDeadLetterListenerTest.java
@@ -8,7 +8,9 @@ import static org.mockito.Mockito.verify;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
+import com.nursena.payflow.eventprocessing.adapter.kafka.KafkaDeadLetterReplayHeaders;
 import com.nursena.payflow.eventprocessing.application.model.RecordKafkaDeadLetterCommand;
 import com.nursena.payflow.eventprocessing.application.port.in.RecordKafkaDeadLetterUseCase;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -117,6 +119,107 @@ class TransferCompletedKafkaDeadLetterListenerTest {
             .isEqualTo(
                 "Temporary processing failure."
             );
+
+        assertThat(command.replayOriginId())
+            .isNull();
+
+        assertThat(command.replayAttemptBase())
+            .isNull();
+    }
+
+    @Test
+    void shouldExtractReplayLineageHeaders() {
+        UUID replayOriginId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001307"
+            );
+
+        ConsumerRecord<String, String> record =
+            validRecord(
+                "transaction-id",
+                "{}"
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ORIGIN_ID,
+                    bytes(
+                        replayOriginId.toString()
+                    )
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ATTEMPT,
+                    bytes("2")
+                )
+            );
+
+        listener.consume(record);
+
+        ArgumentCaptor<RecordKafkaDeadLetterCommand>
+            captor =
+            ArgumentCaptor.forClass(
+                RecordKafkaDeadLetterCommand.class
+            );
+
+        verify(useCase)
+            .record(captor.capture());
+
+        assertThat(
+            captor.getValue().replayOriginId()
+        )
+            .isEqualTo(replayOriginId);
+
+        assertThat(
+            captor.getValue().replayAttemptBase()
+        )
+            .isEqualTo(2);
+    }
+
+    @Test
+    void shouldRejectPartialReplayLineageHeaders() {
+        ConsumerRecord<String, String> record =
+            validRecord(
+                "transaction-id",
+                "{}"
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ORIGIN_ID,
+                    bytes(
+                        UUID.randomUUID()
+                            .toString()
+                    )
+                )
+            );
+
+        assertThatThrownBy(
+            () -> listener.consume(record)
+        )
+            .isInstanceOf(
+                InvalidKafkaDeadLetterRecordException
+                    .class
+            )
+            .hasMessage(
+                "Replay origin id and attempt "
+                    + "headers must either both "
+                    + "be present or both be absent."
+            );
+
+        verify(
+            useCase,
+            never()
+        )
+            .record(any());
     }
 
     @Test
@@ -347,6 +450,99 @@ class TransferCompletedKafkaDeadLetterListenerTest {
             );
 
         return record;
+    }
+
+    @Test
+    void shouldRejectMalformedReplayOriginHeader() {
+        ConsumerRecord<String, String> record =
+            validRecord(
+                "transaction-id",
+                "{}"
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ORIGIN_ID,
+                    bytes("not-a-uuid")
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ATTEMPT,
+                    bytes("2")
+                )
+            );
+
+        assertThatThrownBy(
+            () -> listener.consume(record)
+        )
+            .isInstanceOf(
+                InvalidKafkaDeadLetterRecordException
+                    .class
+            )
+            .hasMessage(
+                "Kafka replay origin id header "
+                    + "must contain a valid UUID."
+            );
+
+        verify(
+            useCase,
+            never()
+        )
+            .record(any());
+    }
+
+    @Test
+    void shouldRejectMalformedReplayAttemptHeader() {
+        ConsumerRecord<String, String> record =
+            validRecord(
+                "transaction-id",
+                "{}"
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ORIGIN_ID,
+                    bytes(
+                        UUID.randomUUID()
+                            .toString()
+                    )
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ATTEMPT,
+                    bytes("not-an-integer")
+                )
+            );
+
+        assertThatThrownBy(
+            () -> listener.consume(record)
+        )
+            .isInstanceOf(
+                InvalidKafkaDeadLetterRecordException
+                    .class
+            )
+            .hasMessage(
+                "Kafka replay attempt header "
+                    + "must contain an integer."
+            );
+
+        verify(
+            useCase,
+            never()
+        )
+            .record(any());
     }
 
     private static byte[] bytes(

--- a/src/test/java/com/nursena/payflow/eventprocessing/adapter/out/kafka/KafkaDeadLetterReplayPublisherAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/adapter/out/kafka/KafkaDeadLetterReplayPublisherAdapterTest.java
@@ -1,0 +1,574 @@
+package com.nursena.payflow.eventprocessing.adapter.out.kafka;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+
+import com.nursena.payflow.eventprocessing.adapter.kafka.KafkaDeadLetterReplayHeaders;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.header.Header;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaOperations;
+import org.springframework.kafka.support.SendResult;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaDeadLetterReplayPublisherAdapterTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001701"
+        );
+
+    private static final UUID REPLAY_ORIGIN_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001700"
+        );
+
+    private static final String ORIGINAL_TOPIC =
+        "wallet.transfer.completed";
+
+    private static final String DEAD_LETTER_TOPIC =
+        "wallet.transfer.completed.dlt";
+
+    private static final String RECORD_KEY =
+        "transaction-id";
+
+    private static final String PAYLOAD = """
+        {
+          "eventId":
+            "80000000-0000-0000-0000-000000001702"
+        }
+        """;
+
+    private static final Duration SEND_TIMEOUT =
+        Duration.ofSeconds(5);
+
+    private static final Instant RECEIVED_AT =
+        Instant.parse(
+            "2026-07-21T20:00:00Z"
+        );
+
+    private static final Instant CLAIMED_AT =
+        Instant.parse(
+            "2026-07-21T20:05:00Z"
+        );
+
+    @Mock
+    private KafkaOperations<String, String>
+        kafkaOperations;
+
+    private KafkaDeadLetterReplayPublisherAdapter
+        adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter =
+            new KafkaDeadLetterReplayPublisherAdapter(
+                kafkaOperations,
+                SEND_TIMEOUT
+            );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldPublishOriginalMessageWithReplayLineage()
+        throws Exception {
+
+        CompletableFuture<
+            SendResult<String, String>
+            > sendFuture =
+            mock(CompletableFuture.class);
+
+        SendResult<String, String> sendResult =
+            mock(SendResult.class);
+
+        when(kafkaOperations.send(
+            any(ProducerRecord.class)
+        )).thenReturn(sendFuture);
+
+        when(sendFuture.get(
+            5_000,
+            MILLISECONDS
+        )).thenReturn(sendResult);
+
+        KafkaDeadLetterRecord record =
+            replayingRecord(
+                RECORD_KEY,
+                PAYLOAD,
+                ORIGINAL_TOPIC,
+                DEAD_LETTER_TOPIC,
+                3,
+                2
+            );
+
+        adapter.publish(record);
+
+        ArgumentCaptor<
+            ProducerRecord<String, String>
+            > captor =
+            ArgumentCaptor.forClass(
+                ProducerRecord.class
+            );
+
+        verify(kafkaOperations)
+            .send(captor.capture());
+
+        verify(sendFuture)
+            .get(
+                5_000,
+                MILLISECONDS
+            );
+
+        ProducerRecord<String, String> published =
+            captor.getValue();
+
+        assertThat(published.topic())
+            .isEqualTo(ORIGINAL_TOPIC);
+
+        assertThat(published.partition())
+            .isNull();
+
+        assertThat(published.key())
+            .isEqualTo(RECORD_KEY);
+
+        assertThat(published.value())
+            .isEqualTo(PAYLOAD);
+
+        Header[] headers =
+            published.headers()
+                .toArray();
+
+        assertThat(headers)
+            .extracting(Header::key)
+            .containsExactly(
+                KafkaDeadLetterReplayHeaders
+                    .REPLAY_ORIGIN_ID,
+                KafkaDeadLetterReplayHeaders
+                    .REPLAY_ATTEMPT
+            );
+
+        assertThat(
+            headerValue(
+                published,
+                KafkaDeadLetterReplayHeaders
+                    .REPLAY_ORIGIN_ID
+            )
+        )
+            .isEqualTo(
+                REPLAY_ORIGIN_ID.toString()
+            );
+
+        /*
+         * replayAttemptBase 2 + replayCount 3
+         * gives a chain-wide attempt value of 5.
+         */
+        assertThat(
+            headerValue(
+                published,
+                KafkaDeadLetterReplayHeaders
+                    .REPLAY_ATTEMPT
+            )
+        )
+            .isEqualTo("5");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldPreserveNullableOriginalKey() {
+        SendResult<String, String> sendResult =
+            mock(SendResult.class);
+
+        when(kafkaOperations.send(
+            any(ProducerRecord.class)
+        )).thenReturn(
+            CompletableFuture.completedFuture(
+                sendResult
+            )
+        );
+
+        adapter.publish(
+            replayingRecord(
+                null,
+                PAYLOAD,
+                ORIGINAL_TOPIC,
+                DEAD_LETTER_TOPIC,
+                1,
+                0
+            )
+        );
+
+        ArgumentCaptor<
+            ProducerRecord<String, String>
+            > captor =
+            ArgumentCaptor.forClass(
+                ProducerRecord.class
+            );
+
+        verify(kafkaOperations)
+            .send(captor.capture());
+
+        assertThat(
+            captor.getValue().key()
+        )
+            .isNull();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldTranslateAsynchronousBrokerFailure() {
+        CompletableFuture<
+            SendResult<String, String>
+            > failedFuture =
+            CompletableFuture.failedFuture(
+                new KafkaException(
+                    "Broker is unavailable."
+                )
+            );
+
+        when(kafkaOperations.send(
+            any(ProducerRecord.class)
+        )).thenReturn(failedFuture);
+
+        assertThatThrownBy(() ->
+            adapter.publish(
+                replayingRecord()
+            )
+        )
+            .isInstanceOf(
+                KafkaDeadLetterReplayPublishingException
+                    .class
+            )
+            .hasMessageContaining(
+                RECORD_ID.toString()
+            )
+            .hasMessageContaining(
+                ORIGINAL_TOPIC
+            )
+            .hasMessageContaining(
+                "rejected or failed"
+            )
+            .hasRootCauseMessage(
+                "Broker is unavailable."
+            );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldTranslateBrokerAcknowledgementTimeout()
+        throws Exception {
+
+        CompletableFuture<
+            SendResult<String, String>
+            > sendFuture =
+            mock(CompletableFuture.class);
+
+        when(kafkaOperations.send(
+            any(ProducerRecord.class)
+        )).thenReturn(sendFuture);
+
+        when(sendFuture.get(
+            5_000,
+            MILLISECONDS
+        )).thenThrow(
+            new TimeoutException(
+                "Kafka acknowledgement timed out."
+            )
+        );
+
+        assertThatThrownBy(() ->
+            adapter.publish(
+                replayingRecord()
+            )
+        )
+            .isInstanceOf(
+                KafkaDeadLetterReplayPublishingException
+                    .class
+            )
+            .hasMessageContaining(
+                "acknowledgement timed out"
+            )
+            .hasRootCauseMessage(
+                "Kafka acknowledgement timed out."
+            );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRestoreInterruptStatus()
+        throws Exception {
+
+        CompletableFuture<
+            SendResult<String, String>
+            > sendFuture =
+            mock(CompletableFuture.class);
+
+        when(kafkaOperations.send(
+            any(ProducerRecord.class)
+        )).thenReturn(sendFuture);
+
+        when(sendFuture.get(
+            5_000,
+            MILLISECONDS
+        )).thenThrow(
+            new InterruptedException(
+                "Publisher thread interrupted."
+            )
+        );
+
+        try {
+            assertThatThrownBy(() ->
+                adapter.publish(
+                    replayingRecord()
+                )
+            )
+                .isInstanceOf(
+                    KafkaDeadLetterReplayPublishingException
+                        .class
+                )
+                .hasMessageContaining(
+                    "Kafka send was interrupted"
+                );
+
+            assertThat(
+                Thread.currentThread()
+                    .isInterrupted()
+            )
+                .isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldTranslateSynchronousSendFailure() {
+        when(kafkaOperations.send(
+            any(ProducerRecord.class)
+        )).thenThrow(
+            new KafkaException(
+                "Producer is closed."
+            )
+        );
+
+        assertThatThrownBy(() ->
+            adapter.publish(
+                replayingRecord()
+            )
+        )
+            .isInstanceOf(
+                KafkaDeadLetterReplayPublishingException
+                    .class
+            )
+            .hasMessageContaining(
+                "could not be started"
+            )
+            .hasRootCauseMessage(
+                "Producer is closed."
+            );
+    }
+
+    @Test
+    void shouldRejectRecordThatIsNotReplaying() {
+        assertThatThrownBy(() ->
+            adapter.publish(
+                receivedRecord()
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "Only REPLAYING dead-letter "
+                    + "records may be published."
+            );
+    }
+
+    @Test
+    void shouldRejectBlankReplayPayload() {
+        assertThatThrownBy(() ->
+            adapter.publish(
+                replayingRecord(
+                    RECORD_KEY,
+                    " ",
+                    ORIGINAL_TOPIC,
+                    DEAD_LETTER_TOPIC,
+                    1,
+                    0
+                )
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "Replay payload must not be blank."
+            );
+    }
+
+    @Test
+    void shouldRejectDeadLetterTopicAsReplaySource() {
+        assertThatThrownBy(() ->
+            adapter.publish(
+                replayingRecord(
+                    RECORD_KEY,
+                    PAYLOAD,
+                    DEAD_LETTER_TOPIC,
+                    DEAD_LETTER_TOPIC,
+                    1,
+                    0
+                )
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "Replay source topic must differ "
+                    + "from the dead-letter topic."
+            );
+    }
+
+    @Test
+    void shouldValidateSendTimeout() {
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterReplayPublisherAdapter(
+                kafkaOperations,
+                Duration.ZERO
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "sendTimeout must be positive."
+            );
+
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterReplayPublisherAdapter(
+                kafkaOperations,
+                Duration.ofNanos(999_999)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "sendTimeout must be at least "
+                    + "one millisecond."
+            );
+    }
+
+    private static String headerValue(
+        ProducerRecord<String, String> record,
+        String headerName
+    ) {
+        Header header =
+            record.headers()
+                .lastHeader(headerName);
+
+        assertThat(header)
+            .isNotNull();
+
+        return new String(
+            header.value(),
+            UTF_8
+        );
+    }
+
+    private static KafkaDeadLetterRecord
+    replayingRecord() {
+        return replayingRecord(
+            RECORD_KEY,
+            PAYLOAD,
+            ORIGINAL_TOPIC,
+            DEAD_LETTER_TOPIC,
+            3,
+            2
+        );
+    }
+
+    private static KafkaDeadLetterRecord
+    replayingRecord(
+        String recordKey,
+        String payload,
+        String originalTopic,
+        String deadLetterTopic,
+        int replayCount,
+        int replayAttemptBase
+    ) {
+        UUID originId =
+            replayAttemptBase == 0
+                ? RECORD_ID
+                : REPLAY_ORIGIN_ID;
+
+        return new KafkaDeadLetterRecord(
+            RECORD_ID,
+            deadLetterTopic,
+            0,
+            25L,
+            originalTopic,
+            0,
+            10L,
+            "payflow-transfer-completed-audit-v1",
+            recordKey,
+            payload,
+            "java.lang.IllegalStateException",
+            "Temporary processing failure.",
+            KafkaDeadLetterRecordStatus.REPLAYING,
+            replayCount,
+            RECEIVED_AT,
+            CLAIMED_AT,
+            "replay-worker-1",
+            CLAIMED_AT.plusSeconds(30),
+            null,
+            originId,
+            replayAttemptBase
+        );
+    }
+
+    private static KafkaDeadLetterRecord
+    receivedRecord() {
+        return new KafkaDeadLetterRecord(
+            RECORD_ID,
+            DEAD_LETTER_TOPIC,
+            0,
+            25L,
+            ORIGINAL_TOPIC,
+            0,
+            10L,
+            "payflow-transfer-completed-audit-v1",
+            RECORD_KEY,
+            PAYLOAD,
+            "java.lang.IllegalStateException",
+            "Temporary processing failure.",
+            KafkaDeadLetterRecordStatus.RECEIVED,
+            0,
+            RECEIVED_AT,
+            null,
+            null,
+            null,
+            null,
+            RECORD_ID,
+            0
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/adapter/out/kafka/KafkaDeadLetterReplayPublishingExceptionTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/adapter/out/kafka/KafkaDeadLetterReplayPublishingExceptionTest.java
@@ -1,0 +1,101 @@
+package com.nursena.payflow.eventprocessing.adapter.out.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class KafkaDeadLetterReplayPublishingExceptionTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001801"
+        );
+
+    @Test
+    void shouldExposeSafePublicationContext() {
+        IllegalStateException cause =
+            new IllegalStateException(
+                "Broker failure."
+            );
+
+        KafkaDeadLetterReplayPublishingException
+            exception =
+            new KafkaDeadLetterReplayPublishingException(
+                RECORD_ID,
+                "wallet.transfer.completed",
+                "Kafka broker rejected the send.",
+                cause
+            );
+
+        assertThat(exception.recordId())
+            .isEqualTo(RECORD_ID);
+
+        assertThat(exception.topic())
+            .isEqualTo(
+                "wallet.transfer.completed"
+            );
+
+        assertThat(exception)
+            .hasMessageContaining(
+                RECORD_ID.toString()
+            )
+            .hasMessageContaining(
+                "wallet.transfer.completed"
+            )
+            .hasMessageContaining(
+                "Kafka broker rejected the send."
+            )
+            .hasCause(cause);
+    }
+
+    @Test
+    void shouldValidateExceptionContext() {
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterReplayPublishingException(
+                null,
+                "wallet.transfer.completed",
+                "Failure.",
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "recordId must not be null"
+            );
+
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterReplayPublishingException(
+                RECORD_ID,
+                " ",
+                "Failure.",
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "topic must not be blank."
+            );
+
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterReplayPublishingException(
+                RECORD_ID,
+                "wallet.transfer.completed",
+                " ",
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "reason must not be blank."
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/ClaimKafkaDeadLetterRecordCommandTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/ClaimKafkaDeadLetterRecordCommandTest.java
@@ -1,0 +1,43 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class ClaimKafkaDeadLetterRecordCommandTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001301"
+        );
+
+    @Test
+    void shouldCreateCommand() {
+        ClaimKafkaDeadLetterRecordCommand command =
+            new ClaimKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            );
+
+        assertThat(command.recordId())
+            .isEqualTo(RECORD_ID);
+    }
+
+    @Test
+    void shouldRejectNullRecordId() {
+        assertThatThrownBy(
+            () ->
+                new ClaimKafkaDeadLetterRecordCommand(
+                    null
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "recordId must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/ClaimKafkaDeadLetterRecordResultTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/ClaimKafkaDeadLetterRecordResultTest.java
@@ -1,0 +1,135 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.Test;
+
+class ClaimKafkaDeadLetterRecordResultTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001302"
+        );
+
+    @Test
+    void shouldCreateClaimedResult() {
+        KafkaDeadLetterRecord record =
+            claimedRecord();
+
+        ClaimKafkaDeadLetterRecordResult result =
+            ClaimKafkaDeadLetterRecordResult
+                .claimed(record);
+
+        assertThat(result.isClaimed())
+            .isTrue();
+
+        assertThat(result.outcome())
+            .isEqualTo(
+                ClaimKafkaDeadLetterRecordResult
+                    .Outcome.CLAIMED
+            );
+
+        assertThat(result.record())
+            .isSameAs(record);
+    }
+
+    @Test
+    void shouldCreateNotClaimableResult() {
+        ClaimKafkaDeadLetterRecordResult result =
+            ClaimKafkaDeadLetterRecordResult
+                .notClaimable();
+
+        assertThat(result.isClaimed())
+            .isFalse();
+
+        assertThat(result.outcome())
+            .isEqualTo(
+                ClaimKafkaDeadLetterRecordResult
+                    .Outcome.NOT_CLAIMABLE
+            );
+
+        assertThat(result.record())
+            .isNull();
+    }
+
+    @Test
+    void shouldRejectClaimedResultWithoutRecord() {
+        assertThatThrownBy(
+            () ->
+                new ClaimKafkaDeadLetterRecordResult(
+                    ClaimKafkaDeadLetterRecordResult
+                        .Outcome.CLAIMED,
+                    null
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "CLAIMED result must contain "
+                    + "a record."
+            );
+    }
+
+    @Test
+    void shouldRejectNotClaimableResultWithRecord() {
+        assertThatThrownBy(
+            () ->
+                new ClaimKafkaDeadLetterRecordResult(
+                    ClaimKafkaDeadLetterRecordResult
+                        .Outcome.NOT_CLAIMABLE,
+                    claimedRecord()
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "NOT_CLAIMABLE result must not "
+                    + "contain a record."
+            );
+    }
+
+    private static KafkaDeadLetterRecord
+    claimedRecord() {
+        Instant receivedAt =
+            Instant.parse(
+                "2026-07-21T19:00:00Z"
+            );
+
+        Instant claimedAt =
+            Instant.parse(
+                "2026-07-21T19:05:00Z"
+            );
+
+        return new KafkaDeadLetterRecord(
+            RECORD_ID,
+            "wallet.transfer.completed.dlt",
+            0,
+            25L,
+            "wallet.transfer.completed",
+            0,
+            10L,
+            "payflow-transfer-completed-audit-v1",
+            "transaction-id",
+            "{}",
+            "IllegalStateException",
+            "Temporary failure.",
+            KafkaDeadLetterRecordStatus.REPLAYING,
+            1,
+            receivedAt,
+            claimedAt,
+            "replay-worker-1",
+            claimedAt.plusSeconds(30),
+            null,
+            RECORD_ID,
+            0
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/RecordKafkaDeadLetterCommandTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/RecordKafkaDeadLetterCommandTest.java
@@ -1,0 +1,159 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class RecordKafkaDeadLetterCommandTest {
+
+    @Test
+    void shouldCreateValidCommandWithNullableContent() {
+        RecordKafkaDeadLetterCommand command =
+            validCommand();
+
+        assertThat(command.deadLetterTopic())
+            .isEqualTo(
+                "wallet.transfer.completed.dlt"
+            );
+
+        assertThat(command.deadLetterPartition())
+            .isEqualTo(2);
+
+        assertThat(command.deadLetterOffset())
+            .isEqualTo(25L);
+
+        assertThat(command.originalTopic())
+            .isEqualTo(
+                "wallet.transfer.completed"
+            );
+
+        assertThat(command.originalPartition())
+            .isEqualTo(1);
+
+        assertThat(command.originalOffset())
+            .isEqualTo(42L);
+
+        assertThat(command.recordKey())
+            .isNull();
+
+        assertThat(command.payload())
+            .isNull();
+    }
+
+    @Test
+    void shouldRejectBlankRequiredMetadata() {
+        assertThatThrownBy(
+            () -> new RecordKafkaDeadLetterCommand(
+                "wallet.transfer.completed.dlt",
+                2,
+                25L,
+                " ",
+                1,
+                42L,
+                "payflow-transfer-completed-audit-v1",
+                null,
+                null,
+                "java.lang.IllegalStateException",
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "originalTopic must not be blank."
+            );
+    }
+
+    @Test
+    void shouldRejectNegativeDeadLetterMetadata() {
+        assertThatThrownBy(
+            () -> new RecordKafkaDeadLetterCommand(
+                "wallet.transfer.completed.dlt",
+                -1,
+                25L,
+                "wallet.transfer.completed",
+                1,
+                42L,
+                "payflow-transfer-completed-audit-v1",
+                null,
+                null,
+                "java.lang.IllegalStateException",
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "deadLetterPartition "
+                    + "must not be negative."
+            );
+
+        assertThatThrownBy(
+            () -> new RecordKafkaDeadLetterCommand(
+                "wallet.transfer.completed.dlt",
+                2,
+                -1L,
+                "wallet.transfer.completed",
+                1,
+                42L,
+                "payflow-transfer-completed-audit-v1",
+                null,
+                null,
+                "java.lang.IllegalStateException",
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "deadLetterOffset "
+                    + "must not be negative."
+            );
+    }
+
+    @Test
+    void shouldRejectNegativeOriginalMetadata() {
+        assertThatThrownBy(
+            () -> new RecordKafkaDeadLetterCommand(
+                "wallet.transfer.completed.dlt",
+                2,
+                25L,
+                "wallet.transfer.completed",
+                1,
+                -1L,
+                "payflow-transfer-completed-audit-v1",
+                null,
+                null,
+                "java.lang.IllegalStateException",
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "originalOffset must not be negative."
+            );
+    }
+
+    private static RecordKafkaDeadLetterCommand
+    validCommand() {
+        return new RecordKafkaDeadLetterCommand(
+            "wallet.transfer.completed.dlt",
+            2,
+            25L,
+            "wallet.transfer.completed",
+            1,
+            42L,
+            "payflow-transfer-completed-audit-v1",
+            null,
+            null,
+            "java.lang.IllegalStateException",
+            "Temporary processing failure."
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/RecordKafkaDeadLetterCommandTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/RecordKafkaDeadLetterCommandTest.java
@@ -2,7 +2,7 @@ package com.nursena.payflow.eventprocessing.application.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class RecordKafkaDeadLetterCommandTest {
@@ -39,6 +39,105 @@ class RecordKafkaDeadLetterCommandTest {
 
         assertThat(command.payload())
             .isNull();
+
+        assertThat(command.replayOriginId())
+            .isNull();
+
+        assertThat(command.replayAttemptBase())
+            .isNull();
+    }
+
+
+    @Test
+    void shouldAcceptCompleteReplayMetadata() {
+        UUID replayOriginId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001305"
+            );
+
+        RecordKafkaDeadLetterCommand command =
+            new RecordKafkaDeadLetterCommand(
+                "wallet.transfer.completed.dlt",
+                2,
+                25L,
+                "wallet.transfer.completed",
+                1,
+                42L,
+                "payflow-transfer-completed-audit-v1",
+                "transaction-id",
+                "{}",
+                "java.lang.IllegalStateException",
+                "Temporary processing failure.",
+                replayOriginId,
+                2
+            );
+
+        assertThat(command.replayOriginId())
+            .isEqualTo(replayOriginId);
+
+        assertThat(command.replayAttemptBase())
+            .isEqualTo(2);
+    }
+
+    @Test
+    void shouldRejectPartialOrInvalidReplayMetadata() {
+        UUID replayOriginId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001305"
+            );
+
+        assertThatThrownBy(
+            () ->
+                new RecordKafkaDeadLetterCommand(
+                    "wallet.transfer.completed.dlt",
+                    2,
+                    25L,
+                    "wallet.transfer.completed",
+                    1,
+                    42L,
+                    "payflow-transfer-completed-audit-v1",
+                    "transaction-id",
+                    "{}",
+                    "java.lang.IllegalStateException",
+                    null,
+                    replayOriginId,
+                    null
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "Replay origin id and attempt must "
+                    + "either both be present "
+                    + "or both be absent."
+            );
+
+        assertThatThrownBy(
+            () ->
+                new RecordKafkaDeadLetterCommand(
+                    "wallet.transfer.completed.dlt",
+                    2,
+                    25L,
+                    "wallet.transfer.completed",
+                    1,
+                    42L,
+                    "payflow-transfer-completed-audit-v1",
+                    "transaction-id",
+                    "{}",
+                    "java.lang.IllegalStateException",
+                    null,
+                    replayOriginId,
+                    0
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "replayAttemptBase must be positive "
+                    + "when replay metadata is present."
+            );
     }
 
     @Test

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/ReplayKafkaDeadLetterRecordCommandTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/ReplayKafkaDeadLetterRecordCommandTest.java
@@ -1,0 +1,42 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class ReplayKafkaDeadLetterRecordCommandTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001901"
+        );
+
+    @Test
+    void shouldCreateCommand() {
+        ReplayKafkaDeadLetterRecordCommand command =
+            new ReplayKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            );
+
+        assertThat(command.recordId())
+            .isEqualTo(RECORD_ID);
+    }
+
+    @Test
+    void shouldRequireRecordIdentifier() {
+        assertThatThrownBy(() ->
+            new ReplayKafkaDeadLetterRecordCommand(
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "recordId must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/ReplayKafkaDeadLetterRecordResultTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/ReplayKafkaDeadLetterRecordResultTest.java
@@ -1,0 +1,124 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class ReplayKafkaDeadLetterRecordResultTest {
+
+    @Test
+    void shouldCreateNotClaimableResult() {
+        ReplayKafkaDeadLetterRecordResult result =
+            ReplayKafkaDeadLetterRecordResult
+                .notClaimable();
+
+        assertThat(result.outcome())
+            .isEqualTo(
+                ReplayKafkaDeadLetterRecordResult
+                    .Outcome.NOT_CLAIMABLE
+            );
+
+        assertThat(result.isNotClaimable())
+            .isTrue();
+
+        assertThat(result.isReplayed())
+            .isFalse();
+
+        assertThat(result.isReplayFailed())
+            .isFalse();
+
+        assertThat(result.isUnresolved())
+            .isFalse();
+    }
+
+    @Test
+    void shouldCreateReplayedResult() {
+        ReplayKafkaDeadLetterRecordResult result =
+            ReplayKafkaDeadLetterRecordResult
+                .replayed();
+
+        assertThat(result.outcome())
+            .isEqualTo(
+                ReplayKafkaDeadLetterRecordResult
+                    .Outcome.REPLAYED
+            );
+
+        assertThat(result.isReplayed())
+            .isTrue();
+
+        assertThat(result.isNotClaimable())
+            .isFalse();
+
+        assertThat(result.isReplayFailed())
+            .isFalse();
+
+        assertThat(result.isUnresolved())
+            .isFalse();
+    }
+
+    @Test
+    void shouldCreateReplayFailedResult() {
+        ReplayKafkaDeadLetterRecordResult result =
+            ReplayKafkaDeadLetterRecordResult
+                .replayFailed();
+
+        assertThat(result.outcome())
+            .isEqualTo(
+                ReplayKafkaDeadLetterRecordResult
+                    .Outcome.REPLAY_FAILED
+            );
+
+        assertThat(result.isReplayFailed())
+            .isTrue();
+
+        assertThat(result.isNotClaimable())
+            .isFalse();
+
+        assertThat(result.isReplayed())
+            .isFalse();
+
+        assertThat(result.isUnresolved())
+            .isFalse();
+    }
+
+    @Test
+    void shouldCreateUnresolvedResult() {
+        ReplayKafkaDeadLetterRecordResult result =
+            ReplayKafkaDeadLetterRecordResult
+                .unresolved();
+
+        assertThat(result.outcome())
+            .isEqualTo(
+                ReplayKafkaDeadLetterRecordResult
+                    .Outcome.UNRESOLVED
+            );
+
+        assertThat(result.isUnresolved())
+            .isTrue();
+
+        assertThat(result.isNotClaimable())
+            .isFalse();
+
+        assertThat(result.isReplayed())
+            .isFalse();
+
+        assertThat(result.isReplayFailed())
+            .isFalse();
+    }
+
+    @Test
+    void shouldRequireOutcome() {
+        assertThatThrownBy(() ->
+            new ReplayKafkaDeadLetterRecordResult(
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "outcome must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/ClaimKafkaDeadLetterRecordServiceTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/ClaimKafkaDeadLetterRecordServiceTest.java
@@ -1,0 +1,246 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayRepositoryPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClaimKafkaDeadLetterRecordServiceTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001303"
+        );
+
+    private static final String WORKER_ID =
+        "replay-worker-1";
+
+    private static final Duration LEASE_DURATION =
+        Duration.ofSeconds(30);
+
+    private static final int MAX_ATTEMPTS = 3;
+
+    private static final Instant CLAIMED_AT =
+        Instant.parse(
+            "2026-07-21T19:05:00.123456Z"
+        );
+
+    @Mock
+    private KafkaDeadLetterReplayRepositoryPort
+        repository;
+
+    private ClaimKafkaDeadLetterRecordService
+        service;
+
+    @BeforeEach
+    void setUp() {
+        service =
+            new ClaimKafkaDeadLetterRecordService(
+                repository,
+                WORKER_ID,
+                LEASE_DURATION,
+                MAX_ATTEMPTS,
+                Clock.fixed(
+                    CLAIMED_AT,
+                    ZoneOffset.UTC
+                )
+            );
+    }
+
+    @Test
+    void shouldReturnClaimedRecord() {
+        KafkaDeadLetterRecord record =
+            claimedRecord();
+
+        when(
+            repository.tryClaim(
+                RECORD_ID,
+                WORKER_ID,
+                CLAIMED_AT,
+                LEASE_DURATION,
+                MAX_ATTEMPTS
+            )
+        )
+            .thenReturn(
+                Optional.of(record)
+            );
+
+        ClaimKafkaDeadLetterRecordResult result =
+            service.claim(
+                new ClaimKafkaDeadLetterRecordCommand(
+                    RECORD_ID
+                )
+            );
+
+        assertThat(result.isClaimed())
+            .isTrue();
+
+        assertThat(result.record())
+            .isSameAs(record);
+
+        verify(repository)
+            .tryClaim(
+                RECORD_ID,
+                WORKER_ID,
+                CLAIMED_AT,
+                LEASE_DURATION,
+                MAX_ATTEMPTS
+            );
+    }
+
+    @Test
+    void shouldReturnNotClaimableWhenRepositoryCannotClaim() {
+        when(
+            repository.tryClaim(
+                RECORD_ID,
+                WORKER_ID,
+                CLAIMED_AT,
+                LEASE_DURATION,
+                MAX_ATTEMPTS
+            )
+        )
+            .thenReturn(
+                Optional.empty()
+            );
+
+        ClaimKafkaDeadLetterRecordResult result =
+            service.claim(
+                new ClaimKafkaDeadLetterRecordCommand(
+                    RECORD_ID
+                )
+            );
+
+        assertThat(result.isClaimed())
+            .isFalse();
+
+        assertThat(result.record())
+            .isNull();
+    }
+
+    @Test
+    void shouldRejectNullCommand() {
+        assertThatThrownBy(
+            () -> service.claim(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "command must not be null"
+            );
+    }
+
+    @Test
+    void shouldRejectInvalidConfiguration() {
+        Clock clock =
+            Clock.fixed(
+                CLAIMED_AT,
+                ZoneOffset.UTC
+            );
+
+        assertThatThrownBy(
+            () ->
+                new ClaimKafkaDeadLetterRecordService(
+                    repository,
+                    " ",
+                    LEASE_DURATION,
+                    MAX_ATTEMPTS,
+                    clock
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "workerId must not be blank."
+            );
+
+        assertThatThrownBy(
+            () ->
+                new ClaimKafkaDeadLetterRecordService(
+                    repository,
+                    WORKER_ID,
+                    Duration.ZERO,
+                    MAX_ATTEMPTS,
+                    clock
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "leaseDuration must be positive."
+            );
+
+        assertThatThrownBy(
+            () ->
+                new ClaimKafkaDeadLetterRecordService(
+                    repository,
+                    WORKER_ID,
+                    LEASE_DURATION,
+                    0,
+                    clock
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "maxReplayAttempts must be "
+                    + "positive."
+            );
+    }
+
+    private static KafkaDeadLetterRecord
+    claimedRecord() {
+        Instant receivedAt =
+            Instant.parse(
+                "2026-07-21T19:00:00Z"
+            );
+
+        return new KafkaDeadLetterRecord(
+            RECORD_ID,
+            "wallet.transfer.completed.dlt",
+            0,
+            25L,
+            "wallet.transfer.completed",
+            0,
+            10L,
+            "payflow-transfer-completed-audit-v1",
+            "transaction-id",
+            "{}",
+            "IllegalStateException",
+            "Temporary failure.",
+            KafkaDeadLetterRecordStatus.REPLAYING,
+            1,
+            receivedAt,
+            CLAIMED_AT,
+            WORKER_ID,
+            CLAIMED_AT.plus(
+                LEASE_DURATION
+            ),
+            null,
+            RECORD_ID,
+            0
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/RecordKafkaDeadLetterServiceTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/RecordKafkaDeadLetterServiceTest.java
@@ -1,0 +1,198 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.RecordKafkaDeadLetterCommand;
+import com.nursena.payflow.eventprocessing.application.model.RecordKafkaDeadLetterResult;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterRecordRepositoryPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RecordKafkaDeadLetterServiceTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001201"
+        );
+
+    private static final Instant RECEIVED_AT =
+        Instant.parse(
+            "2026-07-21T18:00:00.123456Z"
+        );
+
+    @Mock
+    private KafkaDeadLetterRecordRepositoryPort
+        repository;
+
+    private RecordKafkaDeadLetterService service;
+
+    @BeforeEach
+    void setUp() {
+        service =
+            new RecordKafkaDeadLetterService(
+                repository,
+                Clock.fixed(
+                    RECEIVED_AT,
+                    ZoneOffset.UTC
+                ),
+                () -> RECORD_ID
+            );
+    }
+
+    @Test
+    void shouldRecordFirstDeadLetterDelivery() {
+        when(
+            repository.tryRecord(
+                any(KafkaDeadLetterRecord.class)
+            )
+        )
+            .thenReturn(true);
+
+        RecordKafkaDeadLetterResult result =
+            service.record(command());
+
+        assertThat(result)
+            .isEqualTo(
+                RecordKafkaDeadLetterResult.RECORDED
+            );
+
+        ArgumentCaptor<KafkaDeadLetterRecord>
+            captor =
+            ArgumentCaptor.forClass(
+                KafkaDeadLetterRecord.class
+            );
+
+        verify(repository)
+            .tryRecord(captor.capture());
+
+        KafkaDeadLetterRecord record =
+            captor.getValue();
+
+        assertThat(record.id())
+            .isEqualTo(RECORD_ID);
+
+        assertThat(record.deadLetterTopic())
+            .isEqualTo(
+                "wallet.transfer.completed.dlt"
+            );
+
+        assertThat(record.deadLetterPartition())
+            .isEqualTo(2);
+
+        assertThat(record.deadLetterOffset())
+            .isEqualTo(25L);
+
+        assertThat(record.originalTopic())
+            .isEqualTo(
+                "wallet.transfer.completed"
+            );
+
+        assertThat(record.originalOffset())
+            .isEqualTo(42L);
+
+        assertThat(record.recordKey())
+            .isNull();
+
+        assertThat(record.payload())
+            .isNull();
+
+        assertThat(record.status())
+            .isEqualTo(
+                KafkaDeadLetterRecordStatus.RECEIVED
+            );
+
+        assertThat(record.replayCount())
+            .isZero();
+
+        assertThat(record.receivedAt())
+            .isEqualTo(RECEIVED_AT);
+    }
+
+    @Test
+    void shouldReturnDuplicateForExistingLocation() {
+        when(
+            repository.tryRecord(
+                any(KafkaDeadLetterRecord.class)
+            )
+        )
+            .thenReturn(false);
+
+        RecordKafkaDeadLetterResult result =
+            service.record(command());
+
+        assertThat(result)
+            .isEqualTo(
+                RecordKafkaDeadLetterResult.DUPLICATE
+            );
+    }
+
+    @Test
+    void shouldRejectNullCommand() {
+        assertThatThrownBy(
+            () -> service.record(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "command must not be null"
+            );
+    }
+
+    @Test
+    void shouldRejectNullGeneratedIdentifier() {
+        RecordKafkaDeadLetterService
+            invalidService =
+            new RecordKafkaDeadLetterService(
+                repository,
+                Clock.fixed(
+                    RECEIVED_AT,
+                    ZoneOffset.UTC
+                ),
+                () -> null
+            );
+
+        assertThatThrownBy(
+            () -> invalidService.record(command())
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "idSupplier must not return null"
+            );
+    }
+
+    private static RecordKafkaDeadLetterCommand
+    command() {
+        return new RecordKafkaDeadLetterCommand(
+            "wallet.transfer.completed.dlt",
+            2,
+            25L,
+            "wallet.transfer.completed",
+            1,
+            42L,
+            "payflow-transfer-completed-audit-v1",
+            null,
+            null,
+            "java.lang.IllegalStateException",
+            "Temporary processing failure."
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/RecordKafkaDeadLetterServiceTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/RecordKafkaDeadLetterServiceTest.java
@@ -122,6 +122,64 @@ class RecordKafkaDeadLetterServiceTest {
 
         assertThat(record.receivedAt())
             .isEqualTo(RECEIVED_AT);
+
+        assertThat(record.replayOriginId())
+            .isEqualTo(RECORD_ID);
+
+        assertThat(record.replayAttemptBase())
+            .isZero();
+    }
+
+    @Test
+    void shouldPreserveReplayLineage() {
+        UUID replayOriginId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001306"
+            );
+
+        when(
+            repository.tryRecord(
+                any(KafkaDeadLetterRecord.class)
+            )
+        )
+            .thenReturn(true);
+
+        service.record(
+            new RecordKafkaDeadLetterCommand(
+                "wallet.transfer.completed.dlt",
+                2,
+                25L,
+                "wallet.transfer.completed",
+                1,
+                42L,
+                "payflow-transfer-completed-audit-v1",
+                "transaction-id",
+                "{}",
+                "java.lang.IllegalStateException",
+                "Temporary processing failure.",
+                replayOriginId,
+                2
+            )
+        );
+
+        ArgumentCaptor<KafkaDeadLetterRecord>
+            captor =
+            ArgumentCaptor.forClass(
+                KafkaDeadLetterRecord.class
+            );
+
+        verify(repository)
+            .tryRecord(captor.capture());
+
+        assertThat(
+            captor.getValue().replayOriginId()
+        )
+            .isEqualTo(replayOriginId);
+
+        assertThat(
+            captor.getValue().replayAttemptBase()
+        )
+            .isEqualTo(2);
     }
 
     @Test

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/ReplayKafkaDeadLetterRecordServiceTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/ReplayKafkaDeadLetterRecordServiceTest.java
@@ -1,0 +1,550 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.in.ClaimKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayLifecyclePort;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayPublisherPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReplayKafkaDeadLetterRecordServiceTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002001"
+        );
+
+    private static final UUID OTHER_RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002002"
+        );
+
+    private static final UUID REPLAY_ORIGIN_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002000"
+        );
+
+    private static final String WORKER_ID =
+        "replay-worker-1";
+
+    private static final Instant RECEIVED_AT =
+        Instant.parse(
+            "2026-07-21T20:00:00Z"
+        );
+
+    private static final Instant CLAIMED_AT =
+        Instant.parse(
+            "2026-07-21T20:05:00Z"
+        );
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-21T20:06:00Z"
+        );
+
+    private static final ReplayKafkaDeadLetterRecordCommand
+        COMMAND =
+        new ReplayKafkaDeadLetterRecordCommand(
+            RECORD_ID
+        );
+
+    @Mock
+    private ClaimKafkaDeadLetterRecordUseCase
+        claimUseCase;
+
+    @Mock
+    private KafkaDeadLetterReplayPublisherPort
+        publisherPort;
+
+    @Mock
+    private KafkaDeadLetterReplayLifecyclePort
+        lifecyclePort;
+
+    private ReplayKafkaDeadLetterRecordService
+        service;
+
+    @BeforeEach
+    void setUp() {
+        service =
+            new ReplayKafkaDeadLetterRecordService(
+                claimUseCase,
+                publisherPort,
+                lifecyclePort,
+                Clock.fixed(
+                    NOW,
+                    ZoneOffset.UTC
+                )
+            );
+    }
+
+    @Test
+    void shouldReturnNotClaimableWithoutPublishing() {
+        when(claimUseCase.claim(
+            new ClaimKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            )
+        )).thenReturn(
+            ClaimKafkaDeadLetterRecordResult
+                .notClaimable()
+        );
+
+        ReplayKafkaDeadLetterRecordResult result =
+            service.replay(COMMAND);
+
+        assertThat(result.isNotClaimable())
+            .isTrue();
+
+        verifyNoInteractions(
+            publisherPort,
+            lifecyclePort
+        );
+    }
+
+    @Test
+    void shouldPublishAndPersistReplayedOutcome() {
+        KafkaDeadLetterRecord record =
+            replayingRecord(RECORD_ID);
+
+        when(claimUseCase.claim(
+            new ClaimKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            )
+        )).thenReturn(
+            ClaimKafkaDeadLetterRecordResult
+                .claimed(record)
+        );
+
+        when(lifecyclePort.tryMarkReplayed(
+            RECORD_ID,
+            WORKER_ID,
+            NOW
+        )).thenReturn(true);
+
+        ReplayKafkaDeadLetterRecordResult result =
+            service.replay(COMMAND);
+
+        assertThat(result.isReplayed())
+            .isTrue();
+
+        InOrder ordered =
+            inOrder(
+                claimUseCase,
+                publisherPort,
+                lifecyclePort
+            );
+
+        ordered.verify(claimUseCase)
+            .claim(
+                new ClaimKafkaDeadLetterRecordCommand(
+                    RECORD_ID
+                )
+            );
+
+        ordered.verify(publisherPort)
+            .publish(record);
+
+        ordered.verify(lifecyclePort)
+            .tryMarkReplayed(
+                RECORD_ID,
+                WORKER_ID,
+                NOW
+            );
+
+        verify(lifecyclePort, never())
+            .tryMarkReplayFailed(
+                eq(RECORD_ID),
+                eq(WORKER_ID),
+                eq(NOW),
+                anyString()
+            );
+    }
+
+    @Test
+    void shouldPersistReplayFailureWhenPublishingFails() {
+        KafkaDeadLetterRecord record =
+            replayingRecord(RECORD_ID);
+
+        when(claimUseCase.claim(
+            new ClaimKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            )
+        )).thenReturn(
+            ClaimKafkaDeadLetterRecordResult
+                .claimed(record)
+        );
+
+        doThrow(
+            new IllegalStateException(
+                "Broker is unavailable."
+            )
+        )
+            .when(publisherPort)
+            .publish(record);
+
+        when(lifecyclePort.tryMarkReplayFailed(
+            RECORD_ID,
+            WORKER_ID,
+            NOW,
+            "IllegalStateException: "
+                + "Broker is unavailable."
+        )).thenReturn(true);
+
+        ReplayKafkaDeadLetterRecordResult result =
+            service.replay(COMMAND);
+
+        assertThat(result.isReplayFailed())
+            .isTrue();
+
+        verify(lifecyclePort)
+            .tryMarkReplayFailed(
+                RECORD_ID,
+                WORKER_ID,
+                NOW,
+                "IllegalStateException: "
+                    + "Broker is unavailable."
+            );
+
+        verify(lifecyclePort, never())
+            .tryMarkReplayed(
+                RECORD_ID,
+                WORKER_ID,
+                NOW
+            );
+    }
+
+    @Test
+    void shouldReturnUnresolvedWhenReplayedTransitionIsRejected() {
+        KafkaDeadLetterRecord record =
+            replayingRecord(RECORD_ID);
+
+        when(claimUseCase.claim(
+            new ClaimKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            )
+        )).thenReturn(
+            ClaimKafkaDeadLetterRecordResult
+                .claimed(record)
+        );
+
+        when(lifecyclePort.tryMarkReplayed(
+            RECORD_ID,
+            WORKER_ID,
+            NOW
+        )).thenReturn(false);
+
+        ReplayKafkaDeadLetterRecordResult result =
+            service.replay(COMMAND);
+
+        assertThat(result.isUnresolved())
+            .isTrue();
+
+        verify(publisherPort)
+            .publish(record);
+    }
+
+    @Test
+    void shouldReturnUnresolvedWhenFailureTransitionIsRejected() {
+        KafkaDeadLetterRecord record =
+            replayingRecord(RECORD_ID);
+
+        when(claimUseCase.claim(
+            new ClaimKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            )
+        )).thenReturn(
+            ClaimKafkaDeadLetterRecordResult
+                .claimed(record)
+        );
+
+        doThrow(
+            new IllegalStateException(
+                "Broker is unavailable."
+            )
+        )
+            .when(publisherPort)
+            .publish(record);
+
+        when(lifecyclePort.tryMarkReplayFailed(
+            RECORD_ID,
+            WORKER_ID,
+            NOW,
+            "IllegalStateException: "
+                + "Broker is unavailable."
+        )).thenReturn(false);
+
+        ReplayKafkaDeadLetterRecordResult result =
+            service.replay(COMMAND);
+
+        assertThat(result.isUnresolved())
+            .isTrue();
+    }
+
+    @Test
+    void shouldReturnUnresolvedWhenLifecyclePersistenceFails() {
+        KafkaDeadLetterRecord record =
+            replayingRecord(RECORD_ID);
+
+        when(claimUseCase.claim(
+            new ClaimKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            )
+        )).thenReturn(
+            ClaimKafkaDeadLetterRecordResult
+                .claimed(record)
+        );
+
+        when(lifecyclePort.tryMarkReplayed(
+            RECORD_ID,
+            WORKER_ID,
+            NOW
+        )).thenThrow(
+            new IllegalStateException(
+                "Database is unavailable."
+            )
+        );
+
+        ReplayKafkaDeadLetterRecordResult result =
+            service.replay(COMMAND);
+
+        assertThat(result.isUnresolved())
+            .isTrue();
+
+        verify(publisherPort)
+            .publish(record);
+    }
+
+    @Test
+    void shouldTruncatePersistedPublishingFailure() {
+        KafkaDeadLetterRecord record =
+            replayingRecord(RECORD_ID);
+
+        String longMessage =
+            "x".repeat(2_000);
+
+        when(claimUseCase.claim(
+            new ClaimKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            )
+        )).thenReturn(
+            ClaimKafkaDeadLetterRecordResult
+                .claimed(record)
+        );
+
+        doThrow(
+            new IllegalStateException(
+                longMessage
+            )
+        )
+            .when(publisherPort)
+            .publish(record);
+
+        when(lifecyclePort.tryMarkReplayFailed(
+            eq(RECORD_ID),
+            eq(WORKER_ID),
+            eq(NOW),
+            anyString()
+        )).thenReturn(true);
+
+        ReplayKafkaDeadLetterRecordResult result =
+            service.replay(COMMAND);
+
+        assertThat(result.isReplayFailed())
+            .isTrue();
+
+        ArgumentCaptor<String> errorCaptor =
+            ArgumentCaptor.forClass(
+                String.class
+            );
+
+        verify(lifecyclePort)
+            .tryMarkReplayFailed(
+                eq(RECORD_ID),
+                eq(WORKER_ID),
+                eq(NOW),
+                errorCaptor.capture()
+            );
+
+        assertThat(errorCaptor.getValue())
+            .hasSize(1_000)
+            .startsWith(
+                "IllegalStateException: "
+            );
+    }
+
+    @Test
+    void shouldRejectClaimedRecordWithDifferentIdentifier() {
+        KafkaDeadLetterRecord record =
+            replayingRecord(
+                OTHER_RECORD_ID
+            );
+
+        when(claimUseCase.claim(
+            new ClaimKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            )
+        )).thenReturn(
+            ClaimKafkaDeadLetterRecordResult
+                .claimed(record)
+        );
+
+        assertThatThrownBy(() ->
+            service.replay(COMMAND)
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "Claimed Kafka dead-letter "
+                    + "record identifier does not "
+                    + "match the replay command."
+            );
+
+        verifyNoInteractions(
+            publisherPort,
+            lifecyclePort
+        );
+    }
+
+    @Test
+    void shouldRejectClaimedRecordThatIsNotReplaying() {
+        KafkaDeadLetterRecord record =
+            receivedRecord();
+
+        when(claimUseCase.claim(
+            new ClaimKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            )
+        )).thenReturn(
+            ClaimKafkaDeadLetterRecordResult
+                .claimed(record)
+        );
+
+        assertThatThrownBy(() ->
+            service.replay(COMMAND)
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "Claimed Kafka dead-letter "
+                    + "record must be REPLAYING."
+            );
+
+        verifyNoInteractions(
+            publisherPort,
+            lifecyclePort
+        );
+    }
+
+    @Test
+    void shouldRequireCommand() {
+        assertThatThrownBy(() ->
+            service.replay(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "command must not be null"
+            );
+
+        verifyNoInteractions(
+            claimUseCase,
+            publisherPort,
+            lifecyclePort
+        );
+    }
+
+    private static KafkaDeadLetterRecord
+    replayingRecord(
+        UUID recordId
+    ) {
+        return new KafkaDeadLetterRecord(
+            recordId,
+            "wallet.transfer.completed.dlt",
+            0,
+            25L,
+            "wallet.transfer.completed",
+            0,
+            10L,
+            "payflow-transfer-completed-audit-v1",
+            "transaction-id",
+            """
+            {
+              "eventId":
+                "80000000-0000-0000-0000-000000002003"
+            }
+            """,
+            "java.lang.IllegalStateException",
+            "Temporary processing failure.",
+            KafkaDeadLetterRecordStatus.REPLAYING,
+            3,
+            RECEIVED_AT,
+            CLAIMED_AT,
+            WORKER_ID,
+            CLAIMED_AT.plusSeconds(30),
+            null,
+            REPLAY_ORIGIN_ID,
+            2
+        );
+    }
+
+    private static KafkaDeadLetterRecord
+    receivedRecord() {
+        return new KafkaDeadLetterRecord(
+            RECORD_ID,
+            "wallet.transfer.completed.dlt",
+            0,
+            25L,
+            "wallet.transfer.completed",
+            0,
+            10L,
+            "payflow-transfer-completed-audit-v1",
+            "transaction-id",
+            """
+            {
+              "eventId":
+                "80000000-0000-0000-0000-000000002003"
+            }
+            """,
+            "java.lang.IllegalStateException",
+            "Temporary processing failure.",
+            KafkaDeadLetterRecordStatus.RECEIVED,
+            0,
+            RECEIVED_AT,
+            null,
+            null,
+            null,
+            null,
+            RECORD_ID,
+            0
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterReplayPropertiesTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterReplayPropertiesTest.java
@@ -1,0 +1,80 @@
+package com.nursena.payflow.eventprocessing.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class KafkaDeadLetterReplayPropertiesTest {
+
+    @Test
+    void shouldCreateValidProperties() {
+        KafkaDeadLetterReplayProperties properties =
+            new KafkaDeadLetterReplayProperties(
+                "replay-worker-1",
+                Duration.ofSeconds(30),
+                3
+            );
+
+        assertThat(properties.workerId())
+            .isEqualTo("replay-worker-1");
+
+        assertThat(properties.leaseDuration())
+            .isEqualTo(
+                Duration.ofSeconds(30)
+            );
+
+        assertThat(properties.maxAttempts())
+            .isEqualTo(3);
+    }
+
+    @Test
+    void shouldRejectInvalidProperties() {
+        assertThatThrownBy(
+            () ->
+                new KafkaDeadLetterReplayProperties(
+                    " ",
+                    Duration.ofSeconds(30),
+                    3
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "workerId must not be blank."
+            );
+
+        assertThatThrownBy(
+            () ->
+                new KafkaDeadLetterReplayProperties(
+                    "replay-worker-1",
+                    Duration.ZERO,
+                    3
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "leaseDuration must be positive."
+            );
+
+        assertThatThrownBy(
+            () ->
+                new KafkaDeadLetterReplayProperties(
+                    "replay-worker-1",
+                    Duration.ofSeconds(30),
+                    0
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "maxAttempts must be positive."
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterReplayPropertiesTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterReplayPropertiesTest.java
@@ -9,36 +9,49 @@ import org.junit.jupiter.api.Test;
 
 class KafkaDeadLetterReplayPropertiesTest {
 
+    private static final String WORKER_ID =
+        "replay-worker-1";
+
+    private static final Duration LEASE_DURATION =
+        Duration.ofSeconds(30);
+
+    private static final int MAX_ATTEMPTS = 3;
+
+    private static final Duration SEND_TIMEOUT =
+        Duration.ofSeconds(10);
+
     @Test
     void shouldCreateValidProperties() {
         KafkaDeadLetterReplayProperties properties =
             new KafkaDeadLetterReplayProperties(
-                "replay-worker-1",
-                Duration.ofSeconds(30),
-                3
+                WORKER_ID,
+                LEASE_DURATION,
+                MAX_ATTEMPTS,
+                SEND_TIMEOUT
             );
 
         assertThat(properties.workerId())
-            .isEqualTo("replay-worker-1");
+            .isEqualTo(WORKER_ID);
 
         assertThat(properties.leaseDuration())
-            .isEqualTo(
-                Duration.ofSeconds(30)
-            );
+            .isEqualTo(LEASE_DURATION);
 
         assertThat(properties.maxAttempts())
-            .isEqualTo(3);
+            .isEqualTo(MAX_ATTEMPTS);
+
+        assertThat(properties.sendTimeout())
+            .isEqualTo(SEND_TIMEOUT);
     }
 
     @Test
-    void shouldRejectInvalidProperties() {
-        assertThatThrownBy(
-            () ->
-                new KafkaDeadLetterReplayProperties(
-                    " ",
-                    Duration.ofSeconds(30),
-                    3
-                )
+    void shouldRejectInvalidWorkerId() {
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterReplayProperties(
+                " ",
+                LEASE_DURATION,
+                MAX_ATTEMPTS,
+                SEND_TIMEOUT
+            )
         )
             .isInstanceOf(
                 IllegalArgumentException.class
@@ -46,14 +59,17 @@ class KafkaDeadLetterReplayPropertiesTest {
             .hasMessage(
                 "workerId must not be blank."
             );
+    }
 
-        assertThatThrownBy(
-            () ->
-                new KafkaDeadLetterReplayProperties(
-                    "replay-worker-1",
-                    Duration.ZERO,
-                    3
-                )
+    @Test
+    void shouldRejectInvalidLeaseDuration() {
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterReplayProperties(
+                WORKER_ID,
+                Duration.ZERO,
+                MAX_ATTEMPTS,
+                SEND_TIMEOUT
+            )
         )
             .isInstanceOf(
                 IllegalArgumentException.class
@@ -61,20 +77,72 @@ class KafkaDeadLetterReplayPropertiesTest {
             .hasMessage(
                 "leaseDuration must be positive."
             );
+    }
 
-        assertThatThrownBy(
-            () ->
-                new KafkaDeadLetterReplayProperties(
-                    "replay-worker-1",
-                    Duration.ofSeconds(30),
-                    0
-                )
+    @Test
+    void shouldRejectInvalidMaximumAttempts() {
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterReplayProperties(
+                WORKER_ID,
+                LEASE_DURATION,
+                0,
+                SEND_TIMEOUT
+            )
         )
             .isInstanceOf(
                 IllegalArgumentException.class
             )
             .hasMessage(
                 "maxAttempts must be positive."
+            );
+    }
+
+    @Test
+    void shouldValidateSendTimeout() {
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterReplayProperties(
+                WORKER_ID,
+                LEASE_DURATION,
+                MAX_ATTEMPTS,
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "sendTimeout must not be null"
+            );
+
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterReplayProperties(
+                WORKER_ID,
+                LEASE_DURATION,
+                MAX_ATTEMPTS,
+                Duration.ZERO
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "sendTimeout must be positive."
+            );
+
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterReplayProperties(
+                WORKER_ID,
+                LEASE_DURATION,
+                MAX_ATTEMPTS,
+                Duration.ofNanos(999_999)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "sendTimeout must be at least "
+                    + "one millisecond."
             );
     }
 }

--- a/src/test/java/com/nursena/payflow/eventprocessing/domain/model/KafkaDeadLetterRecordTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/domain/model/KafkaDeadLetterRecordTest.java
@@ -1,0 +1,308 @@
+package com.nursena.payflow.eventprocessing.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class KafkaDeadLetterRecordTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000000901"
+        );
+
+    private static final Instant RECEIVED_AT =
+        Instant.parse(
+            "2026-07-21T15:00:00Z"
+        );
+
+    private static final Instant REPLAYED_AT =
+        Instant.parse(
+            "2026-07-21T15:05:00Z"
+        );
+
+    private static final Instant LEASE_UNTIL =
+        Instant.parse(
+            "2026-07-21T15:10:00Z"
+        );
+
+    @Test
+    void shouldCreateReceivedRecordWithNullableKeyAndPayload() {
+        KafkaDeadLetterRecord record =
+            receivedRecord(
+                RECORD_ID
+            );
+
+        assertThat(record.id())
+            .isEqualTo(RECORD_ID);
+
+        assertThat(record.deadLetterTopic())
+            .isEqualTo(
+                "wallet.transfer.completed.dlt"
+            );
+
+        assertThat(record.deadLetterPartition())
+            .isZero();
+
+        assertThat(record.deadLetterOffset())
+            .isEqualTo(25L);
+
+        assertThat(record.recordKey())
+            .isNull();
+
+        assertThat(record.payload())
+            .isNull();
+
+        assertThat(record.status())
+            .isEqualTo(
+                KafkaDeadLetterRecordStatus
+                    .RECEIVED
+            );
+
+        assertThat(record.replayCount())
+            .isZero();
+
+        assertThat(record.receivedAt())
+            .isEqualTo(RECEIVED_AT);
+    }
+
+    @Test
+    void shouldCreateValidReplayingRecord() {
+        KafkaDeadLetterRecord record =
+            new KafkaDeadLetterRecord(
+                RECORD_ID,
+                "wallet.transfer.completed.dlt",
+                0,
+                25L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "payflow-transfer-completed-audit-v1",
+                "transaction-id",
+                "{}",
+                "IllegalStateException",
+                "Temporary failure.",
+                KafkaDeadLetterRecordStatus.REPLAYING,
+                1,
+                RECEIVED_AT,
+                REPLAYED_AT,
+                "replay-worker-1",
+                LEASE_UNTIL,
+                null
+            );
+
+        assertThat(record.status())
+            .isEqualTo(
+                KafkaDeadLetterRecordStatus
+                    .REPLAYING
+            );
+
+        assertThat(record.replayCount())
+            .isEqualTo(1);
+
+        assertThat(record.replayLeaseOwner())
+            .isEqualTo(
+                "replay-worker-1"
+            );
+
+        assertThat(record.replayLeaseUntil())
+            .isEqualTo(LEASE_UNTIL);
+    }
+
+    @Test
+    void shouldRejectNegativeKafkaMetadata() {
+        assertThatThrownBy(
+            () -> new KafkaDeadLetterRecord(
+                RECORD_ID,
+                "wallet.transfer.completed.dlt",
+                -1,
+                25L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "payflow-transfer-completed-audit-v1",
+                null,
+                null,
+                "IllegalStateException",
+                null,
+                KafkaDeadLetterRecordStatus.RECEIVED,
+                0,
+                RECEIVED_AT,
+                null,
+                null,
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "deadLetterPartition "
+                    + "must not be negative."
+            );
+
+        assertThatThrownBy(
+            () -> new KafkaDeadLetterRecord(
+                RECORD_ID,
+                "wallet.transfer.completed.dlt",
+                0,
+                -1L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "payflow-transfer-completed-audit-v1",
+                null,
+                null,
+                "IllegalStateException",
+                null,
+                KafkaDeadLetterRecordStatus.RECEIVED,
+                0,
+                RECEIVED_AT,
+                null,
+                null,
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "deadLetterOffset "
+                    + "must not be negative."
+            );
+    }
+
+    @Test
+    void shouldRejectReplayTimestampWithoutAttempt() {
+        assertThatThrownBy(
+            () -> new KafkaDeadLetterRecord(
+                RECORD_ID,
+                "wallet.transfer.completed.dlt",
+                0,
+                25L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "payflow-transfer-completed-audit-v1",
+                null,
+                null,
+                "IllegalStateException",
+                null,
+                KafkaDeadLetterRecordStatus.RECEIVED,
+                0,
+                RECEIVED_AT,
+                REPLAYED_AT,
+                null,
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "lastReplayedAt must be null "
+                    + "when replayCount is zero."
+            );
+    }
+
+    @Test
+    void shouldRejectReceivedRecordWithReplayAttempt() {
+        assertThatThrownBy(
+            () -> new KafkaDeadLetterRecord(
+                RECORD_ID,
+                "wallet.transfer.completed.dlt",
+                0,
+                25L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "payflow-transfer-completed-audit-v1",
+                null,
+                null,
+                "IllegalStateException",
+                null,
+                KafkaDeadLetterRecordStatus.RECEIVED,
+                1,
+                RECEIVED_AT,
+                REPLAYED_AT,
+                null,
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "RECEIVED records must have "
+                    + "a zero replayCount."
+            );
+    }
+
+    @Test
+    void shouldRejectReplayingRecordWithoutLease() {
+        assertThatThrownBy(
+            () -> new KafkaDeadLetterRecord(
+                RECORD_ID,
+                "wallet.transfer.completed.dlt",
+                0,
+                25L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "payflow-transfer-completed-audit-v1",
+                null,
+                null,
+                "IllegalStateException",
+                null,
+                KafkaDeadLetterRecordStatus.REPLAYING,
+                1,
+                RECEIVED_AT,
+                REPLAYED_AT,
+                null,
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "replayLeaseOwner must not be blank."
+            );
+    }
+
+    private static KafkaDeadLetterRecord
+    receivedRecord(
+        UUID id
+    ) {
+        return new KafkaDeadLetterRecord(
+            id,
+            "wallet.transfer.completed.dlt",
+            0,
+            25L,
+            "wallet.transfer.completed",
+            0,
+            10L,
+            "payflow-transfer-completed-audit-v1",
+            null,
+            null,
+            "IllegalStateException",
+            "Temporary failure.",
+            KafkaDeadLetterRecordStatus.RECEIVED,
+            0,
+            RECEIVED_AT,
+            null,
+            null,
+            null,
+            null
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/domain/model/KafkaDeadLetterRecordTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/domain/model/KafkaDeadLetterRecordTest.java
@@ -68,6 +68,171 @@ class KafkaDeadLetterRecordTest {
 
         assertThat(record.receivedAt())
             .isEqualTo(RECEIVED_AT);
+
+        assertThat(record.replayOriginId())
+            .isEqualTo(RECORD_ID);
+
+        assertThat(record.replayAttemptBase())
+            .isZero();
+    }
+
+    @Test
+    void shouldCreateReplayDerivedReceivedRecord() {
+        UUID derivedRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000000902"
+            );
+
+        KafkaDeadLetterRecord record =
+            new KafkaDeadLetterRecord(
+                derivedRecordId,
+                "wallet.transfer.completed.dlt",
+                0,
+                30L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "payflow-transfer-completed-audit-v1",
+                "transaction-id",
+                "{}",
+                "IllegalStateException",
+                "Temporary failure.",
+                KafkaDeadLetterRecordStatus.RECEIVED,
+                0,
+                RECEIVED_AT,
+                null,
+                null,
+                null,
+                null,
+                RECORD_ID,
+                2
+            );
+
+        assertThat(record.replayOriginId())
+            .isEqualTo(RECORD_ID);
+
+        assertThat(record.replayAttemptBase())
+            .isEqualTo(2);
+    }
+
+    @Test
+    void shouldRejectIncompleteReplayLineage() {
+        UUID derivedRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000000903"
+            );
+
+        assertThatThrownBy(
+            () ->
+                new KafkaDeadLetterRecord(
+                    derivedRecordId,
+                    "wallet.transfer.completed.dlt",
+                    0,
+                    30L,
+                    "wallet.transfer.completed",
+                    0,
+                    10L,
+                    "payflow-transfer-completed-audit-v1",
+                    "transaction-id",
+                    "{}",
+                    "IllegalStateException",
+                    null,
+                    KafkaDeadLetterRecordStatus.RECEIVED,
+                    0,
+                    RECEIVED_AT,
+                    null,
+                    null,
+                    null,
+                    null,
+                    RECORD_ID,
+                    0
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "Initial dead-letter records must "
+                    + "use their own id as "
+                    + "replayOriginId."
+            );
+
+        assertThatThrownBy(
+            () ->
+                new KafkaDeadLetterRecord(
+                    RECORD_ID,
+                    "wallet.transfer.completed.dlt",
+                    0,
+                    30L,
+                    "wallet.transfer.completed",
+                    0,
+                    10L,
+                    "payflow-transfer-completed-audit-v1",
+                    "transaction-id",
+                    "{}",
+                    "IllegalStateException",
+                    null,
+                    KafkaDeadLetterRecordStatus.RECEIVED,
+                    0,
+                    RECEIVED_AT,
+                    null,
+                    null,
+                    null,
+                    null,
+                    RECORD_ID,
+                    1
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "Replay-derived dead-letter records "
+                    + "must use a different "
+                    + "replayOriginId."
+            );
+    }
+
+    @Test
+    void shouldRejectReplayAttemptOverflow() {
+        UUID derivedRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000000904"
+            );
+
+        assertThatThrownBy(
+            () ->
+                new KafkaDeadLetterRecord(
+                    derivedRecordId,
+                    "wallet.transfer.completed.dlt",
+                    0,
+                    30L,
+                    "wallet.transfer.completed",
+                    0,
+                    10L,
+                    "payflow-transfer-completed-audit-v1",
+                    "transaction-id",
+                    "{}",
+                    "IllegalStateException",
+                    null,
+                    KafkaDeadLetterRecordStatus.REPLAYING,
+                    1,
+                    RECEIVED_AT,
+                    REPLAYED_AT,
+                    "replay-worker-1",
+                    LEASE_UNTIL,
+                    null,
+                    RECORD_ID,
+                    Integer.MAX_VALUE
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "Total replay attempt count "
+                    + "must not overflow."
+            );
     }
 
     @Test

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterRecordPersistenceIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterRecordPersistenceIntegrationTest.java
@@ -82,7 +82,9 @@ class KafkaDeadLetterRecordPersistenceIntegrationTest {
                     status,
                     replay_count,
                     record_key,
-                    payload
+                    payload,
+                    replay_origin_id,
+                    replay_attempt_base
                 FROM kafka_dead_letter_records
                 WHERE id = ?
                 """,
@@ -134,6 +136,16 @@ class KafkaDeadLetterRecordPersistenceIntegrationTest {
             stored.get("payload")
         )
             .isNull();
+
+        assertThat(
+            stored.get("replay_origin_id")
+        )
+            .isEqualTo(RECORD_ID);
+
+        assertThat(
+            stored.get("replay_attempt_base")
+        )
+            .isEqualTo(0);
     }
 
     @Test
@@ -262,6 +274,66 @@ class KafkaDeadLetterRecordPersistenceIntegrationTest {
             )
                 .isTrue();
         }
+    }
+
+    @Test
+    void shouldPreserveReplayLineage() {
+        UUID derivedRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001103"
+            );
+
+        KafkaDeadLetterRecord record =
+            new KafkaDeadLetterRecord(
+                derivedRecordId,
+                "wallet.transfer.completed.dlt",
+                0,
+                30L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "payflow-transfer-completed-audit-v1",
+                "transaction-id",
+                "{}",
+                "IllegalStateException",
+                "Temporary failure.",
+                KafkaDeadLetterRecordStatus.RECEIVED,
+                0,
+                RECEIVED_AT,
+                null,
+                null,
+                null,
+                null,
+                RECORD_ID,
+                2
+            );
+
+        assertThat(
+            repositoryPort.tryRecord(record)
+        )
+            .isTrue();
+
+        Map<String, Object> stored =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT
+                    replay_origin_id,
+                    replay_attempt_base
+                FROM kafka_dead_letter_records
+                WHERE id = ?
+                """,
+                derivedRecordId
+            );
+
+        assertThat(
+            stored.get("replay_origin_id")
+        )
+            .isEqualTo(RECORD_ID);
+
+        assertThat(
+            stored.get("replay_attempt_base")
+        )
+            .isEqualTo(2);
     }
 
     private Integer countRecords() {

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterRecordPersistenceIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterRecordPersistenceIntegrationTest.java
@@ -1,0 +1,303 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterRecordRepositoryPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class KafkaDeadLetterRecordPersistenceIntegrationTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001101"
+        );
+
+    private static final Instant RECEIVED_AT =
+        Instant.parse(
+            "2026-07-21T17:00:00.123456Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private KafkaDeadLetterRecordRepositoryPort
+        repositoryPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM kafka_dead_letter_records"
+        );
+    }
+
+    @Test
+    void shouldRecordFirstDeadLetterDelivery() {
+        boolean recorded =
+            repositoryPort.tryRecord(
+                deadLetterRecord(RECORD_ID)
+            );
+
+        assertThat(recorded)
+            .isTrue();
+
+        Map<String, Object> stored =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT
+                    dlt_topic,
+                    dlt_partition,
+                    dlt_offset,
+                    original_topic,
+                    status,
+                    replay_count,
+                    record_key,
+                    payload
+                FROM kafka_dead_letter_records
+                WHERE id = ?
+                """,
+                RECORD_ID
+            );
+
+        assertThat(
+            stored.get("dlt_topic")
+        )
+            .isEqualTo(
+                "wallet.transfer.completed.dlt"
+            );
+
+        assertThat(
+            stored.get("dlt_partition")
+        )
+            .isEqualTo(0);
+
+        assertThat(
+            ((Number) stored.get(
+                "dlt_offset"
+            )).longValue()
+        )
+            .isEqualTo(25L);
+
+        assertThat(
+            stored.get("original_topic")
+        )
+            .isEqualTo(
+                "wallet.transfer.completed"
+            );
+
+        assertThat(
+            stored.get("status")
+        )
+            .isEqualTo("RECEIVED");
+
+        assertThat(
+            stored.get("replay_count")
+        )
+            .isEqualTo(0);
+
+        assertThat(
+            stored.get("record_key")
+        )
+            .isNull();
+
+        assertThat(
+            stored.get("payload")
+        )
+            .isNull();
+    }
+
+    @Test
+    void shouldReturnFalseForDuplicateDeadLetterLocation() {
+        boolean firstResult =
+            repositoryPort.tryRecord(
+                deadLetterRecord(RECORD_ID)
+            );
+
+        boolean duplicateResult =
+            repositoryPort.tryRecord(
+                deadLetterRecord(
+                    UUID.fromString(
+                        "80000000-0000-0000-0000-000000001102"
+                    )
+                )
+            );
+
+        assertThat(firstResult)
+            .isTrue();
+
+        assertThat(duplicateResult)
+            .isFalse();
+
+        assertThat(countRecords())
+            .isEqualTo(1);
+    }
+
+    @Test
+    void shouldRecordOnlyOnceUnderConcurrentDelivery()
+        throws Exception {
+
+        int workerCount = 8;
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(
+                workerCount
+            );
+
+        CountDownLatch ready =
+            new CountDownLatch(
+                workerCount
+            );
+
+        CountDownLatch start =
+            new CountDownLatch(1);
+
+        List<Future<Boolean>> results =
+            new ArrayList<>();
+
+        try {
+            for (
+                int index = 0;
+                index < workerCount;
+                index++
+            ) {
+                results.add(
+                    executor.submit(
+                        () -> {
+                            ready.countDown();
+
+                            boolean started =
+                                start.await(
+                                    10,
+                                    TimeUnit.SECONDS
+                                );
+
+                            if (!started) {
+                                throw new
+                                    IllegalStateException(
+                                    "Concurrent test "
+                                        + "start timed out."
+                                );
+                            }
+
+                            return repositoryPort
+                                .tryRecord(
+                                    deadLetterRecord(
+                                        UUID.randomUUID()
+                                    )
+                                );
+                        }
+                    )
+                );
+            }
+
+            assertThat(
+                ready.await(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            )
+                .isTrue();
+
+            start.countDown();
+
+            long successfulInsertCount = 0;
+
+            for (
+                Future<Boolean> result
+                : results
+            ) {
+                if (
+                    result.get(
+                        10,
+                        TimeUnit.SECONDS
+                    )
+                ) {
+                    successfulInsertCount++;
+                }
+            }
+
+            assertThat(successfulInsertCount)
+                .isEqualTo(1);
+
+            assertThat(countRecords())
+                .isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            )
+                .isTrue();
+        }
+    }
+
+    private Integer countRecords() {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM kafka_dead_letter_records
+            """,
+            Integer.class
+        );
+    }
+
+    private static KafkaDeadLetterRecord
+    deadLetterRecord(
+        UUID id
+    ) {
+        return new KafkaDeadLetterRecord(
+            id,
+            "wallet.transfer.completed.dlt",
+            0,
+            25L,
+            "wallet.transfer.completed",
+            0,
+            10L,
+            "payflow-transfer-completed-audit-v1",
+            null,
+            null,
+            "IllegalStateException",
+            "Temporary failure.",
+            KafkaDeadLetterRecordStatus.RECEIVED,
+            0,
+            RECEIVED_AT,
+            null,
+            null,
+            null,
+            null
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterRecordSchemaIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterRecordSchemaIntegrationTest.java
@@ -1,0 +1,369 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class KafkaDeadLetterRecordSchemaIntegrationTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001001"
+        );
+
+    private static final Instant RECEIVED_AT =
+        Instant.parse(
+            "2026-07-21T16:00:00Z"
+        );
+
+    private static final Instant REPLAYED_AT =
+        Instant.parse(
+            "2026-07-21T16:05:00Z"
+        );
+
+    private static final Instant LEASE_UNTIL =
+        Instant.parse(
+            "2026-07-21T16:10:00Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM kafka_dead_letter_records"
+        );
+    }
+
+    @Test
+    void shouldPersistReceivedRecordWithNullableContent() {
+        insertRecord(
+            RECORD_ID,
+            "wallet.transfer.completed.dlt",
+            0,
+            25L,
+            "wallet.transfer.completed",
+            0,
+            10L,
+            "RECEIVED",
+            0,
+            null,
+            null,
+            null
+        );
+
+        var stored =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT
+                    record_key,
+                    payload,
+                    status,
+                    replay_count
+                FROM kafka_dead_letter_records
+                WHERE id = ?
+                """,
+                RECORD_ID
+            );
+
+        assertThat(
+            stored.get("record_key")
+        )
+            .isNull();
+
+        assertThat(
+            stored.get("payload")
+        )
+            .isNull();
+
+        assertThat(
+            stored.get("status")
+        )
+            .isEqualTo("RECEIVED");
+
+        assertThat(
+            stored.get("replay_count")
+        )
+            .isEqualTo(0);
+    }
+
+    @Test
+    void shouldRejectDuplicateDeadLetterLocation() {
+        insertReceivedRecord(
+            RECORD_ID
+        );
+
+        assertConstraintViolation(
+            () -> insertReceivedRecord(
+                UUID.fromString(
+                    "80000000-0000-0000-0000-000000001002"
+                )
+            ),
+            "uq_kafka_dead_letter_records_location"
+        );
+    }
+
+    @Test
+    void shouldRejectNegativeDeadLetterPartition() {
+        assertConstraintViolation(
+            () -> insertRecord(
+                RECORD_ID,
+                "wallet.transfer.completed.dlt",
+                -1,
+                25L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "RECEIVED",
+                0,
+                null,
+                null,
+                null
+            ),
+            "chk_kafka_dead_letter_records_dlt_partition"
+        );
+    }
+
+    @Test
+    void shouldRejectInvalidStatus() {
+        assertConstraintViolation(
+            () -> insertRecord(
+                RECORD_ID,
+                "wallet.transfer.completed.dlt",
+                0,
+                25L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "UNKNOWN",
+                0,
+                null,
+                null,
+                null
+            ),
+            "chk_kafka_dead_letter_records_status"
+        );
+    }
+
+    @Test
+    void shouldRejectReplayCountWithoutTimestamp() {
+        assertConstraintViolation(
+            () -> insertRecord(
+                RECORD_ID,
+                "wallet.transfer.completed.dlt",
+                0,
+                25L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "REPLAY_FAILED",
+                1,
+                null,
+                null,
+                null
+            ),
+            "chk_kafka_dead_letter_records_replay_time"
+        );
+    }
+
+    @Test
+    void shouldRejectReplayingRecordWithoutLease() {
+        assertConstraintViolation(
+            () -> insertRecord(
+                RECORD_ID,
+                "wallet.transfer.completed.dlt",
+                0,
+                25L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "REPLAYING",
+                1,
+                REPLAYED_AT,
+                null,
+                null
+            ),
+            "chk_kafka_dead_letter_records_replay_lease"
+        );
+    }
+
+    @Test
+    void shouldPersistValidReplayingRecord() {
+        insertRecord(
+            RECORD_ID,
+            "wallet.transfer.completed.dlt",
+            0,
+            25L,
+            "wallet.transfer.completed",
+            0,
+            10L,
+            "REPLAYING",
+            1,
+            REPLAYED_AT,
+            "replay-worker-1",
+            LEASE_UNTIL
+        );
+
+        String status =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT status
+                FROM kafka_dead_letter_records
+                WHERE id = ?
+                """,
+                String.class,
+                RECORD_ID
+            );
+
+        assertThat(status)
+            .isEqualTo("REPLAYING");
+    }
+
+    private void insertReceivedRecord(
+        UUID id
+    ) {
+        insertRecord(
+            id,
+            "wallet.transfer.completed.dlt",
+            0,
+            25L,
+            "wallet.transfer.completed",
+            0,
+            10L,
+            "RECEIVED",
+            0,
+            null,
+            null,
+            null
+        );
+    }
+
+    private void insertRecord(
+        UUID id,
+        String deadLetterTopic,
+        int deadLetterPartition,
+        long deadLetterOffset,
+        String originalTopic,
+        int originalPartition,
+        long originalOffset,
+        String status,
+        int replayCount,
+        Instant lastReplayedAt,
+        String replayLeaseOwner,
+        Instant replayLeaseUntil
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO kafka_dead_letter_records (
+                id,
+                dlt_topic,
+                dlt_partition,
+                dlt_offset,
+                original_topic,
+                original_partition,
+                original_offset,
+                original_consumer_group,
+                record_key,
+                payload,
+                exception_type,
+                exception_message,
+                status,
+                replay_count,
+                received_at,
+                last_replayed_at,
+                replay_lease_owner,
+                replay_lease_until,
+                last_replay_error
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            id,
+            deadLetterTopic,
+            deadLetterPartition,
+            deadLetterOffset,
+            originalTopic,
+            originalPartition,
+            originalOffset,
+            "payflow-transfer-completed-audit-v1",
+            null,
+            null,
+            "IllegalStateException",
+            "Temporary failure.",
+            status,
+            replayCount,
+            Timestamp.from(RECEIVED_AT),
+            timestamp(lastReplayedAt),
+            replayLeaseOwner,
+            timestamp(replayLeaseUntil),
+            null
+        );
+    }
+
+    private static Timestamp timestamp(
+        Instant value
+    ) {
+        if (value == null) {
+            return null;
+        }
+
+        return Timestamp.from(value);
+    }
+
+    private static void assertConstraintViolation(
+        ThrowingCallable operation,
+        String constraintName
+    ) {
+        Throwable thrown =
+            catchThrowable(operation);
+
+        assertThat(thrown)
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+
+        assertThat(
+            rootCauseOf(thrown).getMessage()
+        )
+            .contains(constraintName);
+    }
+
+    private static Throwable rootCauseOf(
+        Throwable throwable
+    ) {
+        Throwable current = throwable;
+
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+
+        return current;
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterRecordSchemaIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterRecordSchemaIntegrationTest.java
@@ -244,6 +244,171 @@ class KafkaDeadLetterRecordSchemaIntegrationTest {
             .isEqualTo("REPLAYING");
     }
 
+    @Test
+    void shouldPersistValidReplayDerivedRecord() {
+        UUID derivedRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001003"
+            );
+
+        insertRecord(
+            derivedRecordId,
+            "wallet.transfer.completed.dlt",
+            0,
+            30L,
+            "wallet.transfer.completed",
+            0,
+            10L,
+            "RECEIVED",
+            0,
+            null,
+            null,
+            null,
+            RECORD_ID,
+            2
+        );
+
+        var stored =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT
+                    replay_origin_id,
+                    replay_attempt_base
+                FROM kafka_dead_letter_records
+                WHERE id = ?
+                """,
+                derivedRecordId
+            );
+
+        assertThat(
+            stored.get("replay_origin_id")
+        )
+            .isEqualTo(RECORD_ID);
+
+        assertThat(
+            stored.get("replay_attempt_base")
+        )
+            .isEqualTo(2);
+    }
+
+    @Test
+    void shouldRejectInvalidReplayLineage() {
+        UUID derivedRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001004"
+            );
+
+        assertConstraintViolation(
+            () -> insertRecord(
+                derivedRecordId,
+                "wallet.transfer.completed.dlt",
+                0,
+                30L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "RECEIVED",
+                0,
+                null,
+                null,
+                null,
+                RECORD_ID,
+                0
+            ),
+            "chk_kafka_dead_letter_records_replay_lineage"
+        );
+
+        assertConstraintViolation(
+            () -> insertRecord(
+                derivedRecordId,
+                "wallet.transfer.completed.dlt",
+                0,
+                30L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "RECEIVED",
+                0,
+                null,
+                null,
+                null,
+                derivedRecordId,
+                1
+            ),
+            "chk_kafka_dead_letter_records_replay_lineage"
+        );
+    }
+
+    @Test
+    void shouldRejectReplayAttemptOverflow() {
+        UUID derivedRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001005"
+            );
+
+        assertConstraintViolation(
+            () -> insertRecord(
+                derivedRecordId,
+                "wallet.transfer.completed.dlt",
+                0,
+                30L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "REPLAY_FAILED",
+                1,
+                REPLAYED_AT,
+                null,
+                null,
+                RECORD_ID,
+                Integer.MAX_VALUE
+            ),
+            "chk_kafka_dead_letter_records_total_replay_count"
+        );
+    }
+
+    @Test
+    void shouldRejectReplayTimestampBeforeReceivedAt() {
+        assertConstraintViolation(
+            () -> insertRecord(
+                RECORD_ID,
+                "wallet.transfer.completed.dlt",
+                0,
+                25L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "REPLAY_FAILED",
+                1,
+                RECEIVED_AT.minusSeconds(1),
+                null,
+                null
+            ),
+            "chk_kafka_dead_letter_records_replay_timestamp"
+        );
+    }
+
+    @Test
+    void shouldRejectInvalidReplayLeasePeriod() {
+        assertConstraintViolation(
+            () -> insertRecord(
+                RECORD_ID,
+                "wallet.transfer.completed.dlt",
+                0,
+                25L,
+                "wallet.transfer.completed",
+                0,
+                10L,
+                "REPLAYING",
+                1,
+                REPLAYED_AT,
+                "replay-worker-1",
+                REPLAYED_AT
+            ),
+            "chk_kafka_dead_letter_records_replay_lease_period"
+        );
+    }
+
     private void insertReceivedRecord(
         UUID id
     ) {
@@ -277,6 +442,40 @@ class KafkaDeadLetterRecordSchemaIntegrationTest {
         String replayLeaseOwner,
         Instant replayLeaseUntil
     ) {
+        insertRecord(
+            id,
+            deadLetterTopic,
+            deadLetterPartition,
+            deadLetterOffset,
+            originalTopic,
+            originalPartition,
+            originalOffset,
+            status,
+            replayCount,
+            lastReplayedAt,
+            replayLeaseOwner,
+            replayLeaseUntil,
+            id,
+            0
+        );
+    }
+
+    private void insertRecord(
+        UUID id,
+        String deadLetterTopic,
+        int deadLetterPartition,
+        long deadLetterOffset,
+        String originalTopic,
+        int originalPartition,
+        long originalOffset,
+        String status,
+        int replayCount,
+        Instant lastReplayedAt,
+        String replayLeaseOwner,
+        Instant replayLeaseUntil,
+        UUID replayOriginId,
+        int replayAttemptBase
+    ) {
         jdbcTemplate.update(
             """
             INSERT INTO kafka_dead_letter_records (
@@ -298,11 +497,14 @@ class KafkaDeadLetterRecordSchemaIntegrationTest {
                 last_replayed_at,
                 replay_lease_owner,
                 replay_lease_until,
-                last_replay_error
+                last_replay_error,
+                replay_origin_id,
+                replay_attempt_base
             )
             VALUES (
                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                ?, ?, ?, ?, ?, ?, ?, ?, ?
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?
             )
             """,
             id,
@@ -323,7 +525,9 @@ class KafkaDeadLetterRecordSchemaIntegrationTest {
             timestamp(lastReplayedAt),
             replayLeaseOwner,
             timestamp(replayLeaseUntil),
-            null
+            null,
+            replayOriginId,
+            replayAttemptBase
         );
     }
 

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterReplayClaimIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterReplayClaimIntegrationTest.java
@@ -1,0 +1,667 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayRepositoryPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class KafkaDeadLetterReplayClaimIntegrationTest {
+
+    private static final String DLT_TOPIC =
+        "wallet.transfer.completed.dlt";
+
+    private static final String ORIGINAL_TOPIC =
+        "wallet.transfer.completed";
+
+    private static final UUID ORIGIN_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001400"
+        );
+
+    private static final Instant RECEIVED_AT =
+        Instant.parse(
+            "2026-07-21T20:00:00Z"
+        );
+
+    private static final Instant CLAIMED_AT =
+        Instant.parse(
+            "2026-07-21T20:10:00Z"
+        );
+
+    private static final Duration LEASE_DURATION =
+        Duration.ofSeconds(30);
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private KafkaDeadLetterReplayRepositoryPort
+        repositoryPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM kafka_dead_letter_records"
+        );
+    }
+
+    @Test
+    void shouldClaimReceivedRecord() {
+        UUID recordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001401"
+            );
+
+        insertRecord(
+            recordId,
+            41L,
+            ORIGINAL_TOPIC,
+            "{}",
+            "RECEIVED",
+            0,
+            null,
+            null,
+            null,
+            "Previous failure.",
+            recordId,
+            0
+        );
+
+        Optional<KafkaDeadLetterRecord> result =
+            repositoryPort.tryClaim(
+                recordId,
+                "replay-worker-1",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                3
+            );
+
+        assertThat(result)
+            .isPresent();
+
+        KafkaDeadLetterRecord claimed =
+            result.orElseThrow();
+
+        assertThat(claimed.status())
+            .isEqualTo(
+                KafkaDeadLetterRecordStatus.REPLAYING
+            );
+
+        assertThat(claimed.replayCount())
+            .isEqualTo(1);
+
+        assertThat(claimed.lastReplayedAt())
+            .isEqualTo(CLAIMED_AT);
+
+        assertThat(claimed.replayLeaseOwner())
+            .isEqualTo("replay-worker-1");
+
+        assertThat(claimed.replayLeaseUntil())
+            .isEqualTo(
+                CLAIMED_AT.plus(
+                    LEASE_DURATION
+                )
+            );
+
+        assertThat(claimed.lastReplayError())
+            .isNull();
+
+        assertThat(claimed.replayOriginId())
+            .isEqualTo(recordId);
+
+        assertThat(claimed.replayAttemptBase())
+            .isZero();
+
+        assertClaimedState(
+            recordId,
+            "replay-worker-1",
+            1
+        );
+    }
+
+    @Test
+    void shouldRejectActiveLeaseAndReclaimExpiredLease() {
+        UUID activeRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001402"
+            );
+
+        UUID expiredRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001403"
+            );
+
+        insertRecord(
+            activeRecordId,
+            42L,
+            ORIGINAL_TOPIC,
+            "{}",
+            "REPLAYING",
+            1,
+            CLAIMED_AT.minusSeconds(10),
+            "active-worker",
+            CLAIMED_AT.plusSeconds(10),
+            null,
+            activeRecordId,
+            0
+        );
+
+        insertRecord(
+            expiredRecordId,
+            43L,
+            ORIGINAL_TOPIC,
+            "{}",
+            "REPLAYING",
+            1,
+            CLAIMED_AT.minusSeconds(60),
+            "expired-worker",
+            CLAIMED_AT.minusSeconds(1),
+            "Previous replay failure.",
+            expiredRecordId,
+            0
+        );
+
+        assertThat(
+            repositoryPort.tryClaim(
+                activeRecordId,
+                "new-worker",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                3
+            )
+        )
+            .isEmpty();
+
+        Optional<KafkaDeadLetterRecord> reclaimed =
+            repositoryPort.tryClaim(
+                expiredRecordId,
+                "new-worker",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                3
+            );
+
+        assertThat(reclaimed)
+            .isPresent();
+
+        assertThat(
+            reclaimed.orElseThrow().replayCount()
+        )
+            .isEqualTo(2);
+
+        assertClaimedState(
+            expiredRecordId,
+            "new-worker",
+            2
+        );
+
+        ReplayState activeState =
+            stateOf(activeRecordId);
+
+        assertThat(activeState.replayLeaseOwner())
+            .isEqualTo("active-worker");
+
+        assertThat(activeState.replayCount())
+            .isEqualTo(1);
+    }
+
+    @Test
+    void shouldEnforceMaximumAttemptsAcrossReplayLineage() {
+        UUID derivedRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001404"
+            );
+
+        insertRecord(
+            derivedRecordId,
+            44L,
+            ORIGINAL_TOPIC,
+            "{}",
+            "RECEIVED",
+            0,
+            null,
+            null,
+            null,
+            null,
+            ORIGIN_ID,
+            2
+        );
+
+        Optional<KafkaDeadLetterRecord> firstClaim =
+            repositoryPort.tryClaim(
+                derivedRecordId,
+                "replay-worker-1",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                3
+            );
+
+        assertThat(firstClaim)
+            .isPresent();
+
+        assertThat(
+            firstClaim.orElseThrow()
+                .replayAttemptBase()
+        )
+            .isEqualTo(2);
+
+        assertThat(
+            firstClaim.orElseThrow()
+                .replayCount()
+        )
+            .isEqualTo(1);
+
+        Optional<KafkaDeadLetterRecord> secondClaim =
+            repositoryPort.tryClaim(
+                derivedRecordId,
+                "replay-worker-2",
+                CLAIMED_AT.plus(
+                    LEASE_DURATION
+                ),
+                LEASE_DURATION,
+                3
+            );
+
+        assertThat(secondClaim)
+            .isEmpty();
+
+        assertThat(
+            stateOf(derivedRecordId)
+                .replayCount()
+        )
+            .isEqualTo(1);
+    }
+
+    @Test
+    void shouldRejectRecordsWithoutReplayablePayloadOrSource() {
+        UUID nullPayloadId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001405"
+            );
+
+        UUID deadLetterSourceId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001406"
+            );
+
+        insertRecord(
+            nullPayloadId,
+            45L,
+            ORIGINAL_TOPIC,
+            null,
+            "RECEIVED",
+            0,
+            null,
+            null,
+            null,
+            null,
+            nullPayloadId,
+            0
+        );
+
+        insertRecord(
+            deadLetterSourceId,
+            46L,
+            DLT_TOPIC,
+            "{}",
+            "RECEIVED",
+            0,
+            null,
+            null,
+            null,
+            null,
+            deadLetterSourceId,
+            0
+        );
+
+        assertThat(
+            repositoryPort.tryClaim(
+                nullPayloadId,
+                "replay-worker-1",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                3
+            )
+        )
+            .isEmpty();
+
+        assertThat(
+            repositoryPort.tryClaim(
+                deadLetterSourceId,
+                "replay-worker-1",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                3
+            )
+        )
+            .isEmpty();
+    }
+
+    @Test
+    void shouldAllowOnlyOneConcurrentClaim()
+        throws Exception {
+
+        UUID recordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001407"
+            );
+
+        insertRecord(
+            recordId,
+            47L,
+            ORIGINAL_TOPIC,
+            "{}",
+            "RECEIVED",
+            0,
+            null,
+            null,
+            null,
+            null,
+            recordId,
+            0
+        );
+
+        int workerCount = 8;
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(
+                workerCount
+            );
+
+        CountDownLatch ready =
+            new CountDownLatch(
+                workerCount
+            );
+
+        CountDownLatch start =
+            new CountDownLatch(1);
+
+        List<Future<Optional<KafkaDeadLetterRecord>>>
+            futures =
+            new ArrayList<>();
+
+        try {
+            for (
+                int index = 0;
+                index < workerCount;
+                index++
+            ) {
+                String workerId =
+                    "replay-worker-" + index;
+
+                futures.add(
+                    executor.submit(
+                        () -> {
+                            ready.countDown();
+
+                            if (
+                                !start.await(
+                                    10,
+                                    TimeUnit.SECONDS
+                                )
+                            ) {
+                                throw new
+                                    IllegalStateException(
+                                    "Concurrent claim "
+                                        + "start timed out."
+                                );
+                            }
+
+                            return repositoryPort
+                                .tryClaim(
+                                    recordId,
+                                    workerId,
+                                    CLAIMED_AT,
+                                    LEASE_DURATION,
+                                    3
+                                );
+                        }
+                    )
+                );
+            }
+
+            assertThat(
+                ready.await(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            )
+                .isTrue();
+
+            start.countDown();
+
+            long successfulClaims = 0;
+
+            for (
+                Future<Optional<KafkaDeadLetterRecord>>
+                    future
+                : futures
+            ) {
+                if (
+                    future.get(
+                        10,
+                        TimeUnit.SECONDS
+                    ).isPresent()
+                ) {
+                    successfulClaims++;
+                }
+            }
+
+            assertThat(successfulClaims)
+                .isEqualTo(1);
+
+            assertThat(
+                stateOf(recordId).replayCount()
+            )
+                .isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            )
+                .isTrue();
+        }
+    }
+
+    private void assertClaimedState(
+        UUID recordId,
+        String workerId,
+        int replayCount
+    ) {
+        ReplayState state =
+            stateOf(recordId);
+
+        assertThat(state.status())
+            .isEqualTo("REPLAYING");
+
+        assertThat(state.replayCount())
+            .isEqualTo(replayCount);
+
+        assertThat(state.lastReplayedAt())
+            .isEqualTo(CLAIMED_AT);
+
+        assertThat(state.replayLeaseOwner())
+            .isEqualTo(workerId);
+
+        assertThat(state.replayLeaseUntil())
+            .isEqualTo(
+                CLAIMED_AT.plus(
+                    LEASE_DURATION
+                )
+            );
+
+        assertThat(state.lastReplayError())
+            .isNull();
+    }
+
+    private ReplayState stateOf(
+        UUID recordId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT
+                status,
+                replay_count,
+                last_replayed_at,
+                replay_lease_owner,
+                replay_lease_until,
+                last_replay_error
+            FROM kafka_dead_letter_records
+            WHERE id = ?
+            """,
+            (resultSet, rowNumber) ->
+                new ReplayState(
+                    resultSet.getString(
+                        "status"
+                    ),
+                    resultSet.getInt(
+                        "replay_count"
+                    ),
+                    resultSet.getTimestamp(
+                        "last_replayed_at"
+                    ) == null
+                        ? null
+                        : resultSet.getTimestamp(
+                        "last_replayed_at"
+                    ).toInstant(),
+                    resultSet.getString(
+                        "replay_lease_owner"
+                    ),
+                    resultSet.getTimestamp(
+                        "replay_lease_until"
+                    ) == null
+                        ? null
+                        : resultSet.getTimestamp(
+                        "replay_lease_until"
+                    ).toInstant(),
+                    resultSet.getString(
+                        "last_replay_error"
+                    )
+                ),
+            recordId
+        );
+    }
+
+    private void insertRecord(
+        UUID id,
+        long deadLetterOffset,
+        String originalTopic,
+        String payload,
+        String status,
+        int replayCount,
+        Instant lastReplayedAt,
+        String replayLeaseOwner,
+        Instant replayLeaseUntil,
+        String lastReplayError,
+        UUID replayOriginId,
+        int replayAttemptBase
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO kafka_dead_letter_records (
+                id,
+                dlt_topic,
+                dlt_partition,
+                dlt_offset,
+                original_topic,
+                original_partition,
+                original_offset,
+                original_consumer_group,
+                record_key,
+                payload,
+                exception_type,
+                exception_message,
+                status,
+                replay_count,
+                received_at,
+                last_replayed_at,
+                replay_lease_owner,
+                replay_lease_until,
+                last_replay_error,
+                replay_origin_id,
+                replay_attempt_base
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?
+            )
+            """,
+            id,
+            DLT_TOPIC,
+            0,
+            deadLetterOffset,
+            originalTopic,
+            0,
+            10L,
+            "payflow-transfer-completed-audit-v1",
+            "transaction-id",
+            payload,
+            "IllegalStateException",
+            "Temporary failure.",
+            status,
+            replayCount,
+            Timestamp.from(RECEIVED_AT),
+            timestamp(lastReplayedAt),
+            replayLeaseOwner,
+            timestamp(replayLeaseUntil),
+            lastReplayError,
+            replayOriginId,
+            replayAttemptBase
+        );
+    }
+
+    private static Timestamp timestamp(
+        Instant value
+    ) {
+        return value == null
+            ? null
+            : Timestamp.from(value);
+    }
+
+    private record ReplayState(
+        String status,
+        int replayCount,
+        Instant lastReplayedAt,
+        String replayLeaseOwner,
+        Instant replayLeaseUntil,
+        String lastReplayError
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterReplayLifecycleIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterReplayLifecycleIntegrationTest.java
@@ -1,0 +1,633 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayLifecyclePort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class KafkaDeadLetterReplayLifecycleIntegrationTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001601"
+        );
+
+    private static final String WORKER_ID =
+        "replay-worker-1";
+
+    private static final Instant RECEIVED_AT =
+        Instant.parse(
+            "2026-07-21T20:00:00Z"
+        );
+
+    private static final Instant CLAIMED_AT =
+        Instant.parse(
+            "2026-07-21T20:05:00Z"
+        );
+
+    private static final Instant TRANSITION_AT =
+        Instant.parse(
+            "2026-07-21T20:06:00Z"
+        );
+
+    private static final Instant LEASE_UNTIL =
+        Instant.parse(
+            "2026-07-21T20:10:00Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private KafkaDeadLetterReplayLifecyclePort
+        lifecyclePort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM kafka_dead_letter_records"
+        );
+    }
+
+    @Test
+    void shouldMarkReplayAsReplayed() {
+        insertReplayingRecord(
+            RECORD_ID,
+            WORKER_ID,
+            CLAIMED_AT,
+            LEASE_UNTIL,
+            "Previous replay failure."
+        );
+
+        boolean transitioned =
+            lifecyclePort.tryMarkReplayed(
+                RECORD_ID,
+                WORKER_ID,
+                TRANSITION_AT
+            );
+
+        assertThat(transitioned)
+            .isTrue();
+
+        ReplayState state =
+            stateOf(RECORD_ID);
+
+        assertThat(state.status())
+            .isEqualTo("REPLAYED");
+
+        assertThat(state.replayCount())
+            .isEqualTo(1);
+
+        assertThat(state.lastReplayedAt())
+            .isEqualTo(CLAIMED_AT);
+
+        assertThat(state.replayLeaseOwner())
+            .isNull();
+
+        assertThat(state.replayLeaseUntil())
+            .isNull();
+
+        assertThat(state.lastReplayError())
+            .isNull();
+
+        /*
+         * A terminal record cannot be transitioned
+         * a second time.
+         */
+        assertThat(
+            lifecyclePort.tryMarkReplayFailed(
+                RECORD_ID,
+                WORKER_ID,
+                TRANSITION_AT.plusSeconds(1),
+                "Late failure."
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            stateOf(RECORD_ID).status()
+        )
+            .isEqualTo("REPLAYED");
+    }
+
+    @Test
+    void shouldMarkReplayAsFailed() {
+        insertReplayingRecord(
+            RECORD_ID,
+            WORKER_ID,
+            CLAIMED_AT,
+            LEASE_UNTIL,
+            null
+        );
+
+        boolean transitioned =
+            lifecyclePort.tryMarkReplayFailed(
+                RECORD_ID,
+                WORKER_ID,
+                TRANSITION_AT,
+                "Kafka broker rejected publication."
+            );
+
+        assertThat(transitioned)
+            .isTrue();
+
+        ReplayState state =
+            stateOf(RECORD_ID);
+
+        assertThat(state.status())
+            .isEqualTo("REPLAY_FAILED");
+
+        assertThat(state.replayCount())
+            .isEqualTo(1);
+
+        assertThat(state.lastReplayedAt())
+            .isEqualTo(CLAIMED_AT);
+
+        assertThat(state.replayLeaseOwner())
+            .isNull();
+
+        assertThat(state.replayLeaseUntil())
+            .isNull();
+
+        assertThat(state.lastReplayError())
+            .isEqualTo(
+                "Kafka broker rejected publication."
+            );
+    }
+
+    @Test
+    void shouldRejectTransitionByAnotherWorker() {
+        insertReplayingRecord(
+            RECORD_ID,
+            WORKER_ID,
+            CLAIMED_AT,
+            LEASE_UNTIL,
+            null
+        );
+
+        boolean replayed =
+            lifecyclePort.tryMarkReplayed(
+                RECORD_ID,
+                "replay-worker-2",
+                TRANSITION_AT
+            );
+
+        boolean failed =
+            lifecyclePort.tryMarkReplayFailed(
+                RECORD_ID,
+                "replay-worker-2",
+                TRANSITION_AT,
+                "Publication failed."
+            );
+
+        assertThat(replayed)
+            .isFalse();
+
+        assertThat(failed)
+            .isFalse();
+
+        ReplayState state =
+            stateOf(RECORD_ID);
+
+        assertThat(state.status())
+            .isEqualTo("REPLAYING");
+
+        assertThat(state.replayLeaseOwner())
+            .isEqualTo(WORKER_ID);
+
+        assertThat(state.replayLeaseUntil())
+            .isEqualTo(LEASE_UNTIL);
+    }
+
+    @Test
+    void shouldRejectTransitionOutsideActiveLeaseWindow() {
+        insertReplayingRecord(
+            RECORD_ID,
+            WORKER_ID,
+            CLAIMED_AT,
+            LEASE_UNTIL,
+            null
+        );
+
+        /*
+         * A lifecycle result cannot occur before
+         * the replay attempt was claimed.
+         */
+        assertThat(
+            lifecyclePort.tryMarkReplayed(
+                RECORD_ID,
+                WORKER_ID,
+                CLAIMED_AT.minusSeconds(1)
+            )
+        )
+            .isFalse();
+
+        /*
+         * The lease is no longer active at the
+         * exact lease-expiration instant.
+         */
+        assertThat(
+            lifecyclePort.tryMarkReplayFailed(
+                RECORD_ID,
+                WORKER_ID,
+                LEASE_UNTIL,
+                "Late publication failure."
+            )
+        )
+            .isFalse();
+
+        ReplayState state =
+            stateOf(RECORD_ID);
+
+        assertThat(state.status())
+            .isEqualTo("REPLAYING");
+
+        assertThat(state.replayCount())
+            .isEqualTo(1);
+
+        assertThat(state.replayLeaseOwner())
+            .isEqualTo(WORKER_ID);
+    }
+
+    @Test
+    void shouldAllowOnlyOneConcurrentTerminalTransition()
+        throws Exception {
+
+        insertReplayingRecord(
+            RECORD_ID,
+            WORKER_ID,
+            CLAIMED_AT,
+            LEASE_UNTIL,
+            null
+        );
+
+        int operationCount = 8;
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(
+                operationCount
+            );
+
+        CountDownLatch ready =
+            new CountDownLatch(
+                operationCount
+            );
+
+        CountDownLatch start =
+            new CountDownLatch(1);
+
+        List<Future<Boolean>> futures =
+            new ArrayList<>();
+
+        try {
+            for (
+                int index = 0;
+                index < operationCount;
+                index++
+            ) {
+                int operationIndex = index;
+
+                futures.add(
+                    executor.submit(
+                        () -> {
+                            ready.countDown();
+
+                            boolean started =
+                                start.await(
+                                    10,
+                                    TimeUnit.SECONDS
+                                );
+
+                            if (!started) {
+                                throw new
+                                    IllegalStateException(
+                                    "Concurrent lifecycle "
+                                        + "test start "
+                                        + "timed out."
+                                );
+                            }
+
+                            if (
+                                operationIndex % 2 == 0
+                            ) {
+                                return lifecyclePort
+                                    .tryMarkReplayed(
+                                        RECORD_ID,
+                                        WORKER_ID,
+                                        TRANSITION_AT
+                                    );
+                            }
+
+                            return lifecyclePort
+                                .tryMarkReplayFailed(
+                                    RECORD_ID,
+                                    WORKER_ID,
+                                    TRANSITION_AT,
+                                    "Concurrent publication "
+                                        + "failure "
+                                        + operationIndex
+                                );
+                        }
+                    )
+                );
+            }
+
+            assertThat(
+                ready.await(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            )
+                .isTrue();
+
+            start.countDown();
+
+            long successfulTransitions = 0;
+
+            for (
+                Future<Boolean> future
+                : futures
+            ) {
+                if (
+                    future.get(
+                        10,
+                        TimeUnit.SECONDS
+                    )
+                ) {
+                    successfulTransitions++;
+                }
+            }
+
+            assertThat(successfulTransitions)
+                .isEqualTo(1);
+
+            ReplayState state =
+                stateOf(RECORD_ID);
+
+            assertThat(state.status())
+                .isIn(
+                    "REPLAYED",
+                    "REPLAY_FAILED"
+                );
+
+            assertThat(state.replayCount())
+                .isEqualTo(1);
+
+            assertThat(state.replayLeaseOwner())
+                .isNull();
+
+            assertThat(state.replayLeaseUntil())
+                .isNull();
+
+            if (
+                state.status()
+                    .equals("REPLAYED")
+            ) {
+                assertThat(
+                    state.lastReplayError()
+                )
+                    .isNull();
+            } else {
+                assertThat(
+                    state.lastReplayError()
+                )
+                    .startsWith(
+                        "Concurrent publication "
+                            + "failure "
+                    );
+            }
+        } finally {
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            )
+                .isTrue();
+        }
+    }
+
+    @Test
+    void shouldValidateLifecycleArguments() {
+        assertThatThrownBy(
+            () ->
+                lifecyclePort.tryMarkReplayed(
+                    null,
+                    WORKER_ID,
+                    TRANSITION_AT
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "recordId must not be null"
+            );
+
+        assertThatThrownBy(
+            () ->
+                lifecyclePort.tryMarkReplayed(
+                    RECORD_ID,
+                    " ",
+                    TRANSITION_AT
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "workerId must not be blank."
+            );
+
+        assertThatThrownBy(
+            () ->
+                lifecyclePort.tryMarkReplayed(
+                    RECORD_ID,
+                    WORKER_ID,
+                    null
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "completedAt must not be null"
+            );
+
+        assertThatThrownBy(
+            () ->
+                lifecyclePort.tryMarkReplayFailed(
+                    RECORD_ID,
+                    WORKER_ID,
+                    TRANSITION_AT,
+                    " "
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "error must not be blank."
+            );
+    }
+
+    private void insertReplayingRecord(
+        UUID id,
+        String workerId,
+        Instant claimedAt,
+        Instant leaseUntil,
+        String lastReplayError
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO kafka_dead_letter_records (
+                id,
+                dlt_topic,
+                dlt_partition,
+                dlt_offset,
+                original_topic,
+                original_partition,
+                original_offset,
+                original_consumer_group,
+                record_key,
+                payload,
+                exception_type,
+                exception_message,
+                status,
+                replay_count,
+                received_at,
+                last_replayed_at,
+                replay_lease_owner,
+                replay_lease_until,
+                last_replay_error,
+                replay_origin_id,
+                replay_attempt_base
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?
+            )
+            """,
+            id,
+            "wallet.transfer.completed.dlt",
+            0,
+            25L,
+            "wallet.transfer.completed",
+            0,
+            10L,
+            "payflow-transfer-completed-audit-v1",
+            "transaction-id",
+            """
+            {
+              "eventId":
+                "80000000-0000-0000-0000-000000001602"
+            }
+            """,
+            "java.lang.IllegalStateException",
+            "Temporary processing failure.",
+            "REPLAYING",
+            1,
+            Timestamp.from(RECEIVED_AT),
+            Timestamp.from(claimedAt),
+            workerId,
+            Timestamp.from(leaseUntil),
+            lastReplayError,
+            id,
+            0
+        );
+    }
+
+    private ReplayState stateOf(
+        UUID recordId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT
+                status,
+                replay_count,
+                last_replayed_at,
+                replay_lease_owner,
+                replay_lease_until,
+                last_replay_error
+            FROM kafka_dead_letter_records
+            WHERE id = ?
+            """,
+            (resultSet, rowNumber) ->
+                new ReplayState(
+                    resultSet.getString(
+                        "status"
+                    ),
+                    resultSet.getInt(
+                        "replay_count"
+                    ),
+                    instant(
+                        resultSet.getTimestamp(
+                            "last_replayed_at"
+                        )
+                    ),
+                    resultSet.getString(
+                        "replay_lease_owner"
+                    ),
+                    instant(
+                        resultSet.getTimestamp(
+                            "replay_lease_until"
+                        )
+                    ),
+                    resultSet.getString(
+                        "last_replay_error"
+                    )
+                ),
+            recordId
+        );
+    }
+
+    private static Instant instant(
+        Timestamp timestamp
+    ) {
+        return timestamp == null
+            ? null
+            : timestamp.toInstant();
+    }
+
+    private record ReplayState(
+        String status,
+        int replayCount,
+        Instant lastReplayedAt,
+        String replayLeaseOwner,
+        Instant replayLeaseUntil,
+        String lastReplayError
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterReplayPublicationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterReplayPublicationIntegrationTest.java
@@ -1,0 +1,474 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.adapter.kafka.KafkaDeadLetterReplayHeaders;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.in.ReplayKafkaDeadLetterRecordUseCase;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.kafka.config.TopicBuilder;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+
+@SpringBootTest(
+    properties = {
+        "payflow.event-processing"
+            + ".transfer-completed.enabled=false",
+        "payflow.event-processing"
+            + ".transfer-completed"
+            + ".dead-letter-intake.enabled=false",
+        "payflow.event-processing"
+            + ".transfer-completed"
+            + ".dead-letter-replay.worker-id="
+            + "replay-publication-integration-worker",
+        "payflow.event-processing"
+            + ".transfer-completed"
+            + ".dead-letter-replay.lease-duration=1m",
+        "payflow.event-processing"
+            + ".transfer-completed"
+            + ".dead-letter-replay.max-attempts=3",
+        "payflow.event-processing"
+            + ".transfer-completed"
+            + ".dead-letter-replay.send-timeout=10s"
+    }
+)
+@Testcontainers
+@Import(
+    KafkaDeadLetterReplayPublicationIntegrationTest
+        .KafkaTopicTestConfiguration.class
+)
+class KafkaDeadLetterReplayPublicationIntegrationTest {
+
+    private static final String ORIGINAL_TOPIC =
+        "wallet.transfer.completed"
+            + ".replay-publication-integration";
+
+    private static final String DEAD_LETTER_TOPIC =
+        ORIGINAL_TOPIC + ".dlt";
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002101"
+        );
+
+    private static final UUID REPLAY_ORIGIN_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002100"
+        );
+
+    private static final String RECORD_KEY =
+        "replayed-transaction-id";
+
+    private static final String PAYLOAD = """
+        {
+          "eventId":
+            "80000000-0000-0000-0000-000000002102",
+          "eventType":
+            "wallet.transfer.completed",
+          "eventVersion": 1
+        }
+        """;
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final KafkaContainer KAFKA =
+        new KafkaContainer(
+            "apache/kafka:4.1.2"
+        );
+
+    @Autowired
+    private ReplayKafkaDeadLetterRecordUseCase
+        replayUseCase;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM kafka_dead_letter_records"
+        );
+    }
+
+    @Test
+    void shouldClaimPublishAndMarkRecordAsReplayed() {
+        insertReplayDerivedRecord();
+
+        try (
+            KafkaConsumer<String, String> consumer =
+                replayConsumer()
+        ) {
+            consumer.subscribe(
+                List.of(ORIGINAL_TOPIC)
+            );
+
+            ReplayKafkaDeadLetterRecordResult result =
+                replayUseCase.replay(
+                    new ReplayKafkaDeadLetterRecordCommand(
+                        RECORD_ID
+                    )
+                );
+
+            assertThat(result.isReplayed())
+                .isTrue();
+
+            ConsumerRecord<String, String> published =
+                awaitPublishedRecord(consumer);
+
+            assertThat(published.topic())
+                .isEqualTo(ORIGINAL_TOPIC);
+
+            assertThat(published.key())
+                .isEqualTo(RECORD_KEY);
+
+            assertThat(published.value())
+                .isEqualTo(PAYLOAD);
+
+            Header[] headers =
+                published.headers()
+                    .toArray();
+
+            /*
+             * A new ProducerRecord is used for replay,
+             * so no Spring Kafka DLT headers are copied.
+             */
+            assertThat(headers)
+                .extracting(Header::key)
+                .containsExactly(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ORIGIN_ID,
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ATTEMPT
+                );
+
+            assertThat(
+                headerValue(
+                    published,
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ORIGIN_ID
+                )
+            )
+                .isEqualTo(
+                    REPLAY_ORIGIN_ID.toString()
+                );
+
+            /*
+             * The stored attempt base is 2. Claiming
+             * increments replay_count from 0 to 1,
+             * producing a chain-wide attempt value of 3.
+             */
+            assertThat(
+                headerValue(
+                    published,
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ATTEMPT
+                )
+            )
+                .isEqualTo("3");
+
+            assertNoAdditionalPublishedRecord(
+                consumer
+            );
+        }
+
+        ReplayState state =
+            stateOfRecord();
+
+        assertThat(state.status())
+            .isEqualTo("REPLAYED");
+
+        assertThat(state.replayCount())
+            .isEqualTo(1);
+
+        assertThat(state.lastReplayedAt())
+            .isNotNull();
+
+        assertThat(state.replayLeaseOwner())
+            .isNull();
+
+        assertThat(state.replayLeaseUntil())
+            .isNull();
+
+        assertThat(state.lastReplayError())
+            .isNull();
+
+        assertThat(state.replayOriginId())
+            .isEqualTo(REPLAY_ORIGIN_ID);
+
+        assertThat(state.replayAttemptBase())
+            .isEqualTo(2);
+    }
+
+    private void insertReplayDerivedRecord() {
+        jdbcTemplate.update(
+            """
+            INSERT INTO kafka_dead_letter_records (
+                id,
+                dlt_topic,
+                dlt_partition,
+                dlt_offset,
+                original_topic,
+                original_partition,
+                original_offset,
+                original_consumer_group,
+                record_key,
+                payload,
+                exception_type,
+                exception_message,
+                status,
+                replay_count,
+                received_at,
+                last_replayed_at,
+                replay_lease_owner,
+                replay_lease_until,
+                last_replay_error,
+                replay_origin_id,
+                replay_attempt_base
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?
+            )
+            """,
+            RECORD_ID,
+            DEAD_LETTER_TOPIC,
+            0,
+            25L,
+            ORIGINAL_TOPIC,
+            0,
+            10L,
+            "payflow-transfer-completed-audit-v1",
+            RECORD_KEY,
+            PAYLOAD,
+            "java.lang.IllegalStateException",
+            "Temporary processing failure.",
+            "RECEIVED",
+            0,
+            Timestamp.from(
+                Instant.now()
+                    .minusSeconds(60)
+            ),
+            null,
+            null,
+            null,
+            null,
+            REPLAY_ORIGIN_ID,
+            2
+        );
+    }
+
+    private static KafkaConsumer<String, String>
+    replayConsumer() {
+        Map<String, Object> properties =
+            new HashMap<>();
+
+        properties.put(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            KAFKA.getBootstrapServers()
+        );
+
+        properties.put(
+            ConsumerConfig.GROUP_ID_CONFIG,
+            "replay-publication-integration-"
+                + UUID.randomUUID()
+        );
+
+        properties.put(
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+            "earliest"
+        );
+
+        properties.put(
+            ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
+            false
+        );
+
+        return new KafkaConsumer<>(
+            properties,
+            new StringDeserializer(),
+            new StringDeserializer()
+        );
+    }
+
+    private static ConsumerRecord<String, String>
+    awaitPublishedRecord(
+        KafkaConsumer<String, String> consumer
+    ) {
+        long deadline =
+            System.nanoTime()
+                + Duration.ofSeconds(20)
+                .toNanos();
+
+        while (
+            System.nanoTime()
+                < deadline
+        ) {
+            ConsumerRecords<String, String> records =
+                consumer.poll(
+                    Duration.ofMillis(250)
+                );
+
+            if (!records.isEmpty()) {
+                assertThat(records.count())
+                    .isEqualTo(1);
+
+                return records.iterator()
+                    .next();
+            }
+        }
+
+        throw new AssertionError(
+            "Timed out waiting for replayed "
+                + "Kafka record."
+        );
+    }
+
+    private static void
+    assertNoAdditionalPublishedRecord(
+        KafkaConsumer<String, String> consumer
+    ) {
+        ConsumerRecords<String, String> additional =
+            consumer.poll(
+                Duration.ofMillis(500)
+            );
+
+        assertThat(additional)
+            .isEmpty();
+    }
+
+    private static String headerValue(
+        ConsumerRecord<String, String> record,
+        String headerName
+    ) {
+        Header header =
+            record.headers()
+                .lastHeader(headerName);
+
+        assertThat(header)
+            .isNotNull();
+
+        return new String(
+            header.value(),
+            UTF_8
+        );
+    }
+
+    private ReplayState stateOfRecord() {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT
+                status,
+                replay_count,
+                last_replayed_at,
+                replay_lease_owner,
+                replay_lease_until,
+                last_replay_error,
+                replay_origin_id,
+                replay_attempt_base
+            FROM kafka_dead_letter_records
+            WHERE id = ?
+            """,
+            (resultSet, rowNumber) ->
+                new ReplayState(
+                    resultSet.getString(
+                        "status"
+                    ),
+                    resultSet.getInt(
+                        "replay_count"
+                    ),
+                    instant(
+                        resultSet.getTimestamp(
+                            "last_replayed_at"
+                        )
+                    ),
+                    resultSet.getString(
+                        "replay_lease_owner"
+                    ),
+                    instant(
+                        resultSet.getTimestamp(
+                            "replay_lease_until"
+                        )
+                    ),
+                    resultSet.getString(
+                        "last_replay_error"
+                    ),
+                    resultSet.getObject(
+                        "replay_origin_id",
+                        UUID.class
+                    ),
+                    resultSet.getInt(
+                        "replay_attempt_base"
+                    )
+                ),
+            RECORD_ID
+        );
+    }
+
+    private static Instant instant(
+        Timestamp timestamp
+    ) {
+        return timestamp == null
+            ? null
+            : timestamp.toInstant();
+    }
+
+    private record ReplayState(
+        String status,
+        int replayCount,
+        Instant lastReplayedAt,
+        String replayLeaseOwner,
+        Instant replayLeaseUntil,
+        String lastReplayError,
+        UUID replayOriginId,
+        int replayAttemptBase
+    ) {
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class KafkaTopicTestConfiguration {
+
+        @Bean
+        NewTopic replayPublicationTopic() {
+            return TopicBuilder
+                .name(ORIGINAL_TOPIC)
+                .partitions(1)
+                .replicas(1)
+                .build();
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/TransferCompletedKafkaDeadLetterIntakeIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/TransferCompletedKafkaDeadLetterIntakeIntegrationTest.java
@@ -6,8 +6,10 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import com.nursena.payflow.eventprocessing.adapter.kafka.KafkaDeadLetterReplayHeaders;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -185,6 +187,34 @@ class TransferCompletedKafkaDeadLetterIntakeIntegrationTest {
         assertThat(countRecords())
             .isEqualTo(1);
 
+        UUID replayOriginId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001501"
+            );
+
+        long replayDerivedOffset =
+            publish(
+                replayDerivedRecord(
+                    replayOriginId,
+                    2
+                )
+            );
+
+        await(
+            () -> countRecords() == 2,
+            "replay-derived DLT record persistence"
+        );
+
+        awaitCommittedOffset(
+            replayDerivedOffset + 1
+        );
+
+        assertStoredReplayLineage(
+            replayDerivedOffset,
+            replayOriginId,
+            2
+        );
+
         /*
          * The next record lacks a required header.
          * The dedicated stopping error handler must
@@ -215,7 +245,7 @@ class TransferCompletedKafkaDeadLetterIntakeIntegrationTest {
             );
 
         assertThat(countRecords())
-            .isEqualTo(1);
+            .isEqualTo(2);
     }
 
     private ProducerRecord<String, String>
@@ -236,6 +266,53 @@ class TransferCompletedKafkaDeadLetterIntakeIntegrationTest {
                     KafkaHeaders.DLT_EXCEPTION_MESSAGE,
                     bytes(
                         "Temporary processing failure."
+                    )
+                )
+            );
+
+        return record;
+    }
+
+    private ProducerRecord<String, String>
+    replayDerivedRecord(
+        UUID replayOriginId,
+        int replayAttemptBase
+    ) {
+        ProducerRecord<String, String> record =
+            new ProducerRecord<>(
+                DEAD_LETTER_TOPIC,
+                0,
+                "replayed-transaction-id",
+                """
+                {
+                  "eventId":
+                    "80000000-0000-0000-0000-000000001502"
+                }
+                """
+            );
+
+        addRequiredHeaders(record);
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ORIGIN_ID,
+                    bytes(
+                        replayOriginId.toString()
+                    )
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ATTEMPT,
+                    bytes(
+                        Integer.toString(
+                            replayAttemptBase
+                        )
                     )
                 )
             );
@@ -332,6 +409,7 @@ class TransferCompletedKafkaDeadLetterIntakeIntegrationTest {
             jdbcTemplate.queryForMap(
                 """
                 SELECT
+                    id,
                     dlt_topic,
                     dlt_partition,
                     dlt_offset,
@@ -344,7 +422,9 @@ class TransferCompletedKafkaDeadLetterIntakeIntegrationTest {
                     exception_type,
                     exception_message,
                     status,
-                    replay_count
+                    replay_count,
+                    replay_origin_id,
+                    replay_attempt_base
                 FROM kafka_dead_letter_records
                 WHERE dlt_topic = ?
                   AND dlt_partition = ?
@@ -419,6 +499,62 @@ class TransferCompletedKafkaDeadLetterIntakeIntegrationTest {
             .isEqualTo(
                 "Temporary processing failure."
             );
+
+        assertThat(
+            stored.get("status")
+        )
+            .isEqualTo("RECEIVED");
+
+        assertThat(
+            stored.get("replay_count")
+        )
+            .isEqualTo(0);
+
+        assertThat(
+            stored.get("replay_origin_id")
+        )
+            .isEqualTo(
+                stored.get("id")
+            );
+
+        assertThat(
+            stored.get("replay_attempt_base")
+        )
+            .isEqualTo(0);
+    }
+
+    private void assertStoredReplayLineage(
+        long deadLetterOffset,
+        UUID expectedOriginId,
+        int expectedAttemptBase
+    ) {
+        Map<String, Object> stored =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT
+                    replay_origin_id,
+                    replay_attempt_base,
+                    status,
+                    replay_count
+                FROM kafka_dead_letter_records
+                WHERE dlt_topic = ?
+                  AND dlt_partition = ?
+                  AND dlt_offset = ?
+                """,
+                DEAD_LETTER_TOPIC,
+                0,
+                deadLetterOffset
+            );
+
+        assertThat(
+            stored.get("replay_origin_id")
+        )
+            .isEqualTo(expectedOriginId);
+
+        assertThat(
+            stored.get("replay_attempt_base")
+        )
+            .isEqualTo(expectedAttemptBase);
 
         assertThat(
             stored.get("status")

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/TransferCompletedKafkaDeadLetterIntakeIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/TransferCompletedKafkaDeadLetterIntakeIntegrationTest.java
@@ -1,0 +1,621 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+
+@SpringBootTest(
+    properties = {
+        "payflow.event-processing"
+            + ".transfer-completed.enabled=false",
+        "payflow.event-processing"
+            + ".transfer-completed.failure"
+            + ".dead-letter-topic="
+            + "wallet.transfer.completed"
+            + ".dlt-intake-integration",
+        "payflow.event-processing"
+            + ".transfer-completed"
+            + ".dead-letter-intake.enabled=true",
+        "payflow.event-processing"
+            + ".transfer-completed"
+            + ".dead-letter-intake.group-id="
+            + "transfer-completed-dlt-intake"
+            + "-integration-test",
+        "spring.kafka.consumer"
+            + ".enable-auto-commit=false",
+        "spring.kafka.consumer"
+            + ".auto-offset-reset=earliest",
+        "spring.kafka.listener.ack-mode=record"
+    }
+)
+@Testcontainers
+@Import(
+    TransferCompletedKafkaDeadLetterIntakeIntegrationTest
+        .KafkaTopicTestConfiguration.class
+)
+class TransferCompletedKafkaDeadLetterIntakeIntegrationTest {
+
+    private static final String DEAD_LETTER_TOPIC =
+        "wallet.transfer.completed"
+            + ".dlt-intake-integration";
+
+    private static final String ORIGINAL_TOPIC =
+        "wallet.transfer.completed"
+            + ".integration-source";
+
+    private static final String ORIGINAL_GROUP =
+        "transfer-completed-source"
+            + "-integration-test";
+
+    private static final String INTAKE_GROUP =
+        "transfer-completed-dlt-intake"
+            + "-integration-test";
+
+    private static final String LISTENER_ID =
+        "transferCompletedKafkaDeadLetter"
+            + "IntakeListener";
+
+    private static final TopicPartition
+        DEAD_LETTER_PARTITION =
+        new TopicPartition(
+            DEAD_LETTER_TOPIC,
+            0
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final KafkaContainer KAFKA =
+        new KafkaContainer(
+            "apache/kafka:4.1.2"
+        );
+
+    @Autowired
+    private KafkaTemplate<String, String>
+        kafkaTemplate;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private KafkaListenerEndpointRegistry
+        listenerRegistry;
+
+    @Test
+    void shouldPersistRedeliveryAndStopWithoutSkippingInvalidRecord()
+        throws Exception {
+
+        cleanDatabase();
+
+        MessageListenerContainer container =
+            listenerRegistry.getListenerContainer(
+                LISTENER_ID
+            );
+
+        assertThat(container)
+            .isNotNull();
+
+        await(
+            container::isRunning,
+            "DLT intake container to start"
+        );
+
+        long validOffset =
+            publish(
+                validRecord()
+            );
+
+        await(
+            () -> countRecords() == 1,
+            "valid DLT record persistence"
+        );
+
+        awaitCommittedOffset(
+            validOffset + 1
+        );
+
+        assertStoredRecord(
+            validOffset
+        );
+
+        /*
+         * Rewind the consumer group so that Kafka
+         * redelivers the same physical DLT record.
+         */
+        container.stop();
+
+        await(
+            () -> !container.isRunning(),
+            "DLT intake container to stop"
+        );
+
+        alterCommittedOffset(
+            validOffset
+        );
+
+        assertThat(committedOffset())
+            .isEqualTo(validOffset);
+
+        container.start();
+
+        await(
+            container::isRunning,
+            "DLT intake container to restart"
+        );
+
+        awaitCommittedOffset(
+            validOffset + 1
+        );
+
+        assertThat(countRecords())
+            .isEqualTo(1);
+
+        /*
+         * The next record lacks a required header.
+         * The dedicated stopping error handler must
+         * stop the container without committing it.
+         */
+        long committedBeforeInvalid =
+            committedOffset();
+
+        long invalidOffset =
+            publish(
+                recordWithoutOriginalOffset()
+            );
+
+        assertThat(invalidOffset)
+            .isEqualTo(
+                committedBeforeInvalid
+            );
+
+        await(
+            () -> !container.isRunning(),
+            "DLT intake container to stop "
+                + "after invalid metadata"
+        );
+
+        assertThat(committedOffset())
+            .isEqualTo(
+                committedBeforeInvalid
+            );
+
+        assertThat(countRecords())
+            .isEqualTo(1);
+    }
+
+    private ProducerRecord<String, String>
+    validRecord() {
+        ProducerRecord<String, String> record =
+            new ProducerRecord<>(
+                DEAD_LETTER_TOPIC,
+                0,
+                "transaction-id",
+                "{invalid-json"
+            );
+
+        addRequiredHeaders(record);
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders.DLT_EXCEPTION_MESSAGE,
+                    bytes(
+                        "Temporary processing failure."
+                    )
+                )
+            );
+
+        return record;
+    }
+
+    private ProducerRecord<String, String>
+    recordWithoutOriginalOffset() {
+        ProducerRecord<String, String> record =
+            new ProducerRecord<>(
+                DEAD_LETTER_TOPIC,
+                0,
+                "invalid-transaction-id",
+                "invalid-payload"
+            );
+
+        addRequiredHeaders(record);
+
+        record.headers()
+            .remove(
+                KafkaHeaders.DLT_ORIGINAL_OFFSET
+            );
+
+        return record;
+    }
+
+    private static void addRequiredHeaders(
+        ProducerRecord<String, String> record
+    ) {
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders.DLT_ORIGINAL_TOPIC,
+                    bytes(ORIGINAL_TOPIC)
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders
+                        .DLT_ORIGINAL_PARTITION,
+                    integerBytes(1)
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders.DLT_ORIGINAL_OFFSET,
+                    longBytes(42L)
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders
+                        .DLT_ORIGINAL_CONSUMER_GROUP,
+                    bytes(ORIGINAL_GROUP)
+                )
+            );
+
+        record.headers()
+            .add(
+                new RecordHeader(
+                    KafkaHeaders.DLT_EXCEPTION_FQCN,
+                    bytes(
+                        "java.lang.IllegalStateException"
+                    )
+                )
+            );
+    }
+
+    private long publish(
+        ProducerRecord<String, String> record
+    ) throws Exception {
+
+        return kafkaTemplate
+            .send(record)
+            .get(
+                10,
+                TimeUnit.SECONDS
+            )
+            .getRecordMetadata()
+            .offset();
+    }
+
+    private void assertStoredRecord(
+        long deadLetterOffset
+    ) {
+        Map<String, Object> stored =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT
+                    dlt_topic,
+                    dlt_partition,
+                    dlt_offset,
+                    original_topic,
+                    original_partition,
+                    original_offset,
+                    original_consumer_group,
+                    record_key,
+                    payload,
+                    exception_type,
+                    exception_message,
+                    status,
+                    replay_count
+                FROM kafka_dead_letter_records
+                WHERE dlt_topic = ?
+                  AND dlt_partition = ?
+                  AND dlt_offset = ?
+                """,
+                DEAD_LETTER_TOPIC,
+                0,
+                deadLetterOffset
+            );
+
+        assertThat(
+            stored.get("dlt_topic")
+        )
+            .isEqualTo(
+                DEAD_LETTER_TOPIC
+            );
+
+        assertThat(
+            stored.get("dlt_partition")
+        )
+            .isEqualTo(0);
+
+        assertThat(
+            ((Number) stored.get(
+                "dlt_offset"
+            )).longValue()
+        )
+            .isEqualTo(deadLetterOffset);
+
+        assertThat(
+            stored.get("original_topic")
+        )
+            .isEqualTo(ORIGINAL_TOPIC);
+
+        assertThat(
+            stored.get("original_partition")
+        )
+            .isEqualTo(1);
+
+        assertThat(
+            ((Number) stored.get(
+                "original_offset"
+            )).longValue()
+        )
+            .isEqualTo(42L);
+
+        assertThat(
+            stored.get("original_consumer_group")
+        )
+            .isEqualTo(ORIGINAL_GROUP);
+
+        assertThat(
+            stored.get("record_key")
+        )
+            .isEqualTo("transaction-id");
+
+        assertThat(
+            stored.get("payload")
+        )
+            .isEqualTo("{invalid-json");
+
+        assertThat(
+            stored.get("exception_type")
+        )
+            .isEqualTo(
+                "java.lang.IllegalStateException"
+            );
+
+        assertThat(
+            stored.get("exception_message")
+        )
+            .isEqualTo(
+                "Temporary processing failure."
+            );
+
+        assertThat(
+            stored.get("status")
+        )
+            .isEqualTo("RECEIVED");
+
+        assertThat(
+            stored.get("replay_count")
+        )
+            .isEqualTo(0);
+    }
+
+    private void alterCommittedOffset(
+        long offset
+    ) throws Exception {
+
+        try (
+            Admin admin =
+                Admin.create(
+                    Map.of(
+                        AdminClientConfig
+                            .BOOTSTRAP_SERVERS_CONFIG,
+                        KAFKA.getBootstrapServers()
+                    )
+                )
+        ) {
+            admin.alterConsumerGroupOffsets(
+                    INTAKE_GROUP,
+                    Map.of(
+                        DEAD_LETTER_PARTITION,
+                        new OffsetAndMetadata(offset)
+                    )
+                )
+                .all()
+                .get(
+                    10,
+                    TimeUnit.SECONDS
+                );
+        }
+    }
+
+    private long committedOffset()
+        throws Exception {
+
+        try (
+            Admin admin =
+                Admin.create(
+                    Map.of(
+                        AdminClientConfig
+                            .BOOTSTRAP_SERVERS_CONFIG,
+                        KAFKA.getBootstrapServers()
+                    )
+                )
+        ) {
+            OffsetAndMetadata metadata =
+                admin.listConsumerGroupOffsets(
+                        INTAKE_GROUP
+                    )
+                    .partitionsToOffsetAndMetadata()
+                    .get(
+                        10,
+                        TimeUnit.SECONDS
+                    )
+                    .get(
+                        DEAD_LETTER_PARTITION
+                    );
+
+            if (metadata == null) {
+                return -1L;
+            }
+
+            return metadata.offset();
+        }
+    }
+
+    private void awaitCommittedOffset(
+        long expectedOffset
+    ) throws Exception {
+
+        await(
+            () ->
+                committedOffset()
+                    == expectedOffset,
+            "committed DLT offset "
+                + expectedOffset
+        );
+    }
+
+    private int countRecords() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM kafka_dead_letter_records
+                """,
+                Integer.class
+            );
+
+        return count == null
+            ? 0
+            : count;
+    }
+
+    private void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM kafka_dead_letter_records"
+        );
+    }
+
+    private static byte[] bytes(
+        String value
+    ) {
+        return value.getBytes(
+            StandardCharsets.UTF_8
+        );
+    }
+
+    private static byte[] integerBytes(
+        int value
+    ) {
+        return ByteBuffer
+            .allocate(Integer.BYTES)
+            .putInt(value)
+            .array();
+    }
+
+    private static byte[] longBytes(
+        long value
+    ) {
+        return ByteBuffer
+            .allocate(Long.BYTES)
+            .putLong(value)
+            .array();
+    }
+
+    private static void await(
+        CheckedCondition condition,
+        String description
+    ) throws Exception {
+
+        long deadline =
+            System.nanoTime()
+                + Duration.ofSeconds(20)
+                .toNanos();
+
+        Throwable lastFailure = null;
+
+        while (
+            System.nanoTime()
+                < deadline
+        ) {
+            try {
+                if (condition.isSatisfied()) {
+                    return;
+                }
+            } catch (Throwable failure) {
+                lastFailure = failure;
+            }
+
+            Thread.sleep(100);
+        }
+
+        AssertionError timeout =
+            new AssertionError(
+                "Timed out waiting for "
+                    + description
+                    + "."
+            );
+
+        if (lastFailure != null) {
+            timeout.initCause(
+                lastFailure
+            );
+        }
+
+        throw timeout;
+    }
+
+    @FunctionalInterface
+    private interface CheckedCondition {
+
+        boolean isSatisfied()
+            throws Exception;
+    }
+
+    @TestConfiguration(
+        proxyBeanMethods = false
+    )
+    static class KafkaTopicTestConfiguration {
+
+        @Bean
+        NewTopic deadLetterIntakeTopic() {
+            return TopicBuilder
+                .name(DEAD_LETTER_TOPIC)
+                .partitions(1)
+                .replicas(1)
+                .build();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- define the controlled Kafka dead-letter replay architecture in ADR 0005
- persist Kafka DLT records durably and idempotently in PostgreSQL
- ingest DLT records with fail-closed offset handling
- preserve replay lineage across physical DLT records
- enforce chain-wide replay-attempt limits
- atomically claim replay records with worker leases
- support expired lease recovery
- transition replay records to REPLAYED or REPLAY_FAILED
- republish original topic, key, and payload with safe PayFlow lineage headers
- wait for Kafka broker acknowledgement before marking replay success
- expose unresolved outcomes when Kafka and PostgreSQL results cannot be safely reconciled

## Safety guarantees

- duplicate DLT intake is deduplicated by topic, partition, and offset
- concurrent workers cannot claim the same record
- active leases protect replay ownership
- replay limits apply across the full logical replay chain
- replay never uses the DLT topic as its publication source
- Spring Kafka exception and delivery headers are not copied
- duplicate replay publication remains safe through consumer idempotency
- failed persistence does not silently advance the DLT consumer offset

## Verification

- unit tests for commands, results, properties, services, and Kafka publisher behavior
- PostgreSQL schema and persistence integration tests
- concurrent claim and lifecycle transition tests
- Kafka DLT intake integration tests
- Kafka replay publication integration test with real Kafka and PostgreSQL containers
- full Maven clean verify