### PR TITLE
feat: add operations authorization

### DIFF
--- a/docs/adr/0006-operations-authorization-boundary.md
+++ b/docs/adr/0006-operations-authorization-boundary.md
@@ -1,0 +1,169 @@
+# ADR 0006: Operations Authorization Boundary
+
+- Status: Accepted
+- Date: 2026-07-22
+
+## Context
+
+PayFlow now supports durable and controlled Kafka dead-letter
+replay. The replay application use case is intentionally not exposed
+through an HTTP endpoint because operational capabilities require a
+dedicated authorization boundary.
+
+The current authentication model issues RSA-signed JWT access tokens.
+Each token contains:
+
+- `sub`: the authenticated user identifier
+- `email`: the authenticated user's email address
+- `role`: the user's PayFlow domain role
+
+The supported domain roles are `USER` and `ADMIN`. Public registration
+always creates a `USER`.
+
+Spring Security currently authenticates JWTs but does not map the
+PayFlow `role` claim to application authorities. Customer-facing
+endpoints require authentication only.
+
+Operational capabilities are more sensitive than customer operations.
+They must not rely on request-controlled values or on broad implicit
+role conventions.
+
+## Decision
+
+PayFlow will introduce an explicit operations authority:
+
+```text
+PAYFLOW_OPERATIONS
+```
+
+A dedicated JWT authentication converter will inspect the trusted
+`role` claim after token signature, expiry, and issuer validation.
+
+The authority mapping will be:
+
+- `ADMIN` maps to `PAYFLOW_OPERATIONS`
+- `USER` receives no operations authority
+- a missing role receives no operations authority
+- a blank role receives no operations authority
+- a non-string role receives no operations authority
+- an unknown role receives no operations authority
+
+The mapping is exact and fail-closed. The converter will not infer
+operational authority from:
+
+- HTTP headers
+- query parameters
+- path variables
+- request bodies
+- email addresses
+- request-provided user identifiers
+- OAuth scopes not issued and defined by PayFlow
+
+Operational HTTP endpoints will use the namespace
+`/api/v1/operations/**`.
+
+The Spring Security filter chain will require
+`PAYFLOW_OPERATIONS` for that namespace.
+
+Customer-facing endpoints will retain their current authenticated-user
+behavior.
+
+All unmatched endpoints will continue to be denied by default.
+
+## Authentication and authorization behavior
+
+Requests without a valid access token will receive HTTP 401.
+
+Requests with a valid access token but without
+`PAYFLOW_OPERATIONS` will receive HTTP 403.
+
+Requests with the required authority may proceed to a protected
+operations controller.
+
+Authorization must occur before the controller or application use case
+is invoked.
+
+## User provisioning
+
+Public registration will continue to create only `USER` accounts.
+
+This decision does not introduce a public role-assignment or
+privilege-elevation endpoint.
+
+Operational users must be provisioned through a trusted administrative
+process outside the public registration flow.
+
+## Rationale
+
+Using the existing `ADMIN` domain role avoids introducing an additional
+database role solely for operational HTTP delivery.
+
+Mapping `ADMIN` to the narrower `PAYFLOW_OPERATIONS` authority keeps the
+HTTP authorization boundary independent from Spring Security's
+`ROLE_` prefix convention and from direct domain-role checks.
+
+An explicit converter is preferred over Spring Security's default
+scope mapping because PayFlow issues a single `role` claim rather than
+OAuth scopes, and fail-closed claim handling is required.
+
+A dedicated operations namespace makes the sensitive API surface easy
+to identify, secure, test, document, observe, and audit.
+
+## Consequences
+
+### Positive
+
+- operational endpoints are denied by default
+- public users cannot self-assign operational access
+- authorization depends only on trusted token claims
+- customer endpoint behavior remains backward compatible
+- future operational authorities can be introduced independently
+- controllers and application services remain independent from
+  Spring Security types
+
+### Negative
+
+- a custom JWT authentication converter must be maintained
+- trusted administrative provisioning is required for `ADMIN` users
+- role changes take effect only after a new access token is issued
+- an `ADMIN` token grants the complete operations authority until more
+  granular authorities are introduced
+
+## Alternatives considered
+
+### Use `hasRole("ADMIN")` directly
+
+Rejected because it couples the operations API to Spring Security's
+`ROLE_` naming convention and directly to the domain role name.
+
+### Introduce an `OPERATIONS` user role
+
+Rejected for the current scope because the existing `ADMIN` role and
+database constraint support trusted operator provisioning.
+
+A separate operator role may be introduced later if administrator and
+operator identities require independent permissions.
+
+### Accept an operations flag from the request
+
+Rejected because request-controlled authorization data is not trusted.
+
+### Expose replay without an authorization boundary
+
+Rejected because dead-letter replay can cause externally visible and
+duplicate Kafka message delivery.
+
+## Verification
+
+The implementation must prove:
+
+- `ADMIN` maps to `PAYFLOW_OPERATIONS`
+- `USER` does not receive the operations authority
+- missing, blank, non-string, and unknown role claims fail closed
+- anonymous operations requests return HTTP 401
+- authenticated non-operator requests return HTTP 403
+- authorized operator requests reach the protected controller
+- authorization failures do not invoke controller collaborators
+- customer endpoints retain their existing authenticated behavior
+- unknown endpoints remain denied
+- the full Maven verification build succeeds

--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -3,13 +3,16 @@ package com.nursena.payflow.configuration;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 
+import com.nursena.payflow.configuration.security.OperationsAuthorities;
+import com.nursena.payflow.configuration.security.PayFlowJwtGrantedAuthoritiesConverter;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -29,7 +32,8 @@ public class SecurityConfiguration {
 
     @Bean
     SecurityFilterChain securityFilterChain(
-        HttpSecurity http
+        HttpSecurity http,
+        JwtAuthenticationConverter jwtAuthenticationConverter
     ) throws Exception {
         return http
             .csrf(csrf -> csrf.disable())
@@ -41,6 +45,12 @@ public class SecurityConfiguration {
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(PUBLIC_ENDPOINTS)
                 .permitAll()
+                .requestMatchers(
+                    "/api/v1/operations/**"
+                )
+                .hasAuthority(
+                    OperationsAuthorities.OPERATIONS
+                )
                 .requestMatchers(
                     GET,
                     "/api/v1/users/me",
@@ -59,8 +69,10 @@ public class SecurityConfiguration {
                 .denyAll()
             )
             .oauth2ResourceServer(resourceServer ->
-                resourceServer.jwt(
-                    Customizer.withDefaults()
+                resourceServer.jwt(jwt ->
+                    jwt.jwtAuthenticationConverter(
+                        jwtAuthenticationConverter
+                    )
                 )
             )
             .httpBasic(httpBasic ->
@@ -70,6 +82,18 @@ public class SecurityConfiguration {
                 formLogin.disable()
             )
             .build();
+    }
+
+    @Bean
+    JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter =
+            new JwtAuthenticationConverter();
+
+        converter.setJwtGrantedAuthoritiesConverter(
+            new PayFlowJwtGrantedAuthoritiesConverter()
+        );
+
+        return converter;
     }
 
     @Bean

--- a/src/main/java/com/nursena/payflow/configuration/security/OperationsAuthorities.java
+++ b/src/main/java/com/nursena/payflow/configuration/security/OperationsAuthorities.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.configuration.security;
+
+public final class OperationsAuthorities {
+
+    public static final String OPERATIONS =
+        "PAYFLOW_OPERATIONS";
+
+    private OperationsAuthorities() {
+    }
+}

--- a/src/main/java/com/nursena/payflow/configuration/security/PayFlowJwtGrantedAuthoritiesConverter.java
+++ b/src/main/java/com/nursena/payflow/configuration/security/PayFlowJwtGrantedAuthoritiesConverter.java
@@ -1,0 +1,44 @@
+package com.nursena.payflow.configuration.security;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public final class PayFlowJwtGrantedAuthoritiesConverter
+    implements Converter<
+    Jwt,
+    Collection<GrantedAuthority>
+    > {
+
+    private static final String ROLE_CLAIM = "role";
+    private static final String ADMIN_ROLE = "ADMIN";
+
+    @Override
+    public Collection<GrantedAuthority> convert(
+        Jwt jwt
+    ) {
+        Objects.requireNonNull(
+            jwt,
+            "jwt must not be null"
+        );
+
+        Object role = jwt
+            .getClaims()
+            .get(ROLE_CLAIM);
+
+        if (!ADMIN_ROLE.equals(role)) {
+            return List.of();
+        }
+
+        return List.of(
+            new SimpleGrantedAuthority(
+                OperationsAuthorities.OPERATIONS
+            )
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/SecurityConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/SecurityConfigurationTest.java
@@ -1,33 +1,58 @@
 package com.nursena.payflow.configuration;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request
+    .MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.status;
 
+import java.time.Instant;
+
+import com.nursena.payflowtest.configuration.SecurityProbeController;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.autoconfigure.web.servlet
+    .WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito
+    .MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.bind.annotation.RestController;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
-@WebMvcTest(
-    controllers =
-        SecurityConfigurationTest.TestController.class
+@WebMvcTest
+@ContextConfiguration(
+    classes = {
+        SecurityConfiguration.class,
+        SecurityProbeController.class
+    }
 )
-@Import(SecurityConfiguration.class)
 class SecurityConfigurationTest {
+
+    private static final Instant ISSUED_AT =
+        Instant.parse("2026-07-22T12:00:00Z");
+
+    private static final Instant EXPIRES_AT =
+        Instant.parse("2026-07-22T12:15:00Z");
+
+    private static final String SUBJECT =
+        "10000000-0000-0000-0000-000000000001";
 
     @Autowired
     private MockMvc mockMvc;
 
     @MockitoBean
     private JwtDecoder jwtDecoder;
-
+    @MockitoBean
+    private SecurityProbeController.ProbeService probeService;
     @Test
     void shouldPermitAnonymousRequestToPrometheusEndpoint()
         throws Exception {
+
         mockMvc.perform(
                 get("/actuator/prometheus")
             )
@@ -37,6 +62,7 @@ class SecurityConfigurationTest {
     @Test
     void shouldPermitAnonymousRequestToHealthSubEndpoints()
         throws Exception {
+
         mockMvc.perform(
                 get("/actuator/health/liveness")
             )
@@ -46,13 +72,201 @@ class SecurityConfigurationTest {
     @Test
     void shouldRejectAnonymousRequestToSensitiveActuatorEndpoints()
         throws Exception {
+
         mockMvc.perform(
                 get("/actuator/env")
             )
             .andExpect(status().isUnauthorized());
     }
 
-    @RestController
-    static class TestController {
+    @Test
+    void shouldRejectAnonymousOperationsRequest()
+        throws Exception {
+
+        mockMvc.perform(
+                get("/api/v1/operations/probe")
+            )
+            .andExpect(status().isUnauthorized());
+        verifyNoInteractions(probeService);
     }
+
+    @Test
+    void shouldRejectUserWithoutOperationsAuthority()
+        throws Exception {
+
+        mockDecodedJwt(
+            "user-token",
+            "USER"
+        );
+
+        mockMvc.perform(
+                get("/api/v1/operations/probe")
+                    .header(
+                        AUTHORIZATION,
+                        bearer("user-token")
+                    )
+            )
+            .andExpect(status().isForbidden());
+        verifyNoInteractions(probeService);
+    }
+
+    @Test
+    void shouldRejectTokenWithoutRoleClaim()
+        throws Exception {
+
+        when(
+            jwtDecoder.decode("missing-role-token")
+        ).thenReturn(
+            jwtWithoutRole("missing-role-token")
+        );
+
+        mockMvc.perform(
+                get("/api/v1/operations/probe")
+                    .header(
+                        AUTHORIZATION,
+                        bearer("missing-role-token")
+                    )
+            )
+            .andExpect(status().isForbidden());
+        verifyNoInteractions(probeService);
+    }
+
+    @Test
+    void shouldPermitAdminOperationsRequest()
+        throws Exception {
+
+        mockDecodedJwt(
+            "admin-token",
+            "ADMIN"
+        );
+
+        mockMvc.perform(
+                get("/api/v1/operations/probe")
+                    .header(
+                        AUTHORIZATION,
+                        bearer("admin-token")
+                    )
+            )
+            .andExpect(status().isOk());
+
+        verify(
+            probeService
+        ).operationsAccessed();
+    }
+
+    @Test
+    void shouldIgnoreRequestControlledRoleHeader()
+        throws Exception {
+
+        mockDecodedJwt(
+            "user-token",
+            "USER"
+        );
+
+        mockMvc.perform(
+                get("/api/v1/operations/probe")
+                    .header(
+                        AUTHORIZATION,
+                        bearer("user-token")
+                    )
+                    .header(
+                        "X-PayFlow-Role",
+                        "ADMIN"
+                    )
+            )
+            .andExpect(status().isForbidden());
+        verifyNoInteractions(probeService);
+    }
+
+    @Test
+    void shouldPreserveAuthenticatedCustomerAccess()
+        throws Exception {
+
+        mockDecodedJwt(
+            "user-token",
+            "USER"
+        );
+
+        mockMvc.perform(
+                get("/api/v1/users/me")
+                    .header(
+                        AUTHORIZATION,
+                        bearer("user-token")
+                    )
+            )
+            .andExpect(status().isOk());
+
+        verify(
+            probeService
+        ).customerAccessed();
+    }
+
+    @Test
+    void shouldDenyUnknownEndpointForAuthenticatedAdmin()
+        throws Exception {
+
+        mockDecodedJwt(
+            "admin-token",
+            "ADMIN"
+        );
+
+        mockMvc.perform(
+                get("/api/v1/internal/probe")
+                    .header(
+                        AUTHORIZATION,
+                        bearer("admin-token")
+                    )
+            )
+            .andExpect(status().isForbidden());
+        verifyNoInteractions(probeService);
+    }
+
+
+    private void mockDecodedJwt(
+        String tokenValue,
+        String role
+    ) {
+        when(
+            jwtDecoder.decode(tokenValue)
+        ).thenReturn(
+            jwtWithRole(
+                tokenValue,
+                role
+            )
+        );
+    }
+
+    private static Jwt jwtWithRole(
+        String tokenValue,
+        String role
+    ) {
+        return baseJwt(tokenValue)
+            .claim("role", role)
+            .build();
+    }
+
+    private static Jwt jwtWithoutRole(
+        String tokenValue
+    ) {
+        return baseJwt(tokenValue)
+            .build();
+    }
+
+    private static Jwt.Builder baseJwt(
+        String tokenValue
+    ) {
+        return Jwt
+            .withTokenValue(tokenValue)
+            .header("alg", "RS256")
+            .subject(SUBJECT)
+            .issuedAt(ISSUED_AT)
+            .expiresAt(EXPIRES_AT);
+    }
+
+    private static String bearer(
+        String tokenValue
+    ) {
+        return "Bearer " + tokenValue;
+    }
+
 }

--- a/src/test/java/com/nursena/payflow/configuration/security/PayFlowJwtGrantedAuthoritiesConverterTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/security/PayFlowJwtGrantedAuthoritiesConverterTest.java
@@ -1,0 +1,104 @@
+package com.nursena.payflow.configuration.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+class PayFlowJwtGrantedAuthoritiesConverterTest {
+
+    private static final Instant ISSUED_AT =
+        Instant.parse("2026-07-22T12:00:00Z");
+
+    private static final Instant EXPIRES_AT =
+        Instant.parse("2026-07-22T12:15:00Z");
+
+    private final PayFlowJwtGrantedAuthoritiesConverter
+        converter =
+        new PayFlowJwtGrantedAuthoritiesConverter();
+
+    @Test
+    void shouldMapAdminRoleToOperationsAuthority() {
+        assertThat(
+            converter.convert(
+                jwtWithRole("ADMIN")
+            )
+        )
+            .extracting(
+                GrantedAuthority::getAuthority
+            )
+            .containsExactly(
+                OperationsAuthorities.OPERATIONS
+            );
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "USER",
+            "",
+            " ",
+            "admin",
+            "OPERATIONS",
+            "UNKNOWN"
+        }
+    )
+    void shouldNotGrantOperationsAuthorityForOtherRoles(
+        String role
+    ) {
+        assertThat(
+            converter.convert(
+                jwtWithRole(role)
+            )
+        ).isEmpty();
+    }
+
+    @Test
+    void shouldNotGrantOperationsAuthorityWhenRoleIsMissing() {
+        assertThat(
+            converter.convert(
+                jwtWithoutRole()
+            )
+        ).isEmpty();
+    }
+
+    @Test
+    void shouldNotGrantOperationsAuthorityForNonStringRole() {
+        assertThat(
+            converter.convert(
+                jwtWithRole(
+                    List.of("ADMIN")
+                )
+            )
+        ).isEmpty();
+    }
+
+    private static Jwt jwtWithRole(
+        Object role
+    ) {
+        return baseJwt()
+            .claim("role", role)
+            .build();
+    }
+
+    private static Jwt jwtWithoutRole() {
+        return baseJwt().build();
+    }
+
+    private static Jwt.Builder baseJwt() {
+        return Jwt
+            .withTokenValue("access-token")
+            .header("alg", "RS256")
+            .subject(
+                "10000000-0000-0000-0000-000000000001"
+            )
+            .issuedAt(ISSUED_AT)
+            .expiresAt(EXPIRES_AT);
+    }
+}

--- a/src/test/java/com/nursena/payflowtest/configuration/SecurityProbeController.java
+++ b/src/test/java/com/nursena/payflowtest/configuration/SecurityProbeController.java
@@ -1,0 +1,43 @@
+package com.nursena.payflowtest.configuration;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SecurityProbeController {
+
+    private final ProbeService probeService;
+
+    public SecurityProbeController(
+        ProbeService probeService
+    ) {
+        this.probeService = probeService;
+    }
+
+    @GetMapping("/api/v1/operations/probe")
+    public String operationsProbe() {
+        probeService.operationsAccessed();
+        return "operations";
+    }
+
+    @GetMapping("/api/v1/users/me")
+    public String customerProbe() {
+        probeService.customerAccessed();
+        return "customer";
+    }
+
+    @GetMapping("/api/v1/internal/probe")
+    public String unknownProbe() {
+        probeService.unknownAccessed();
+        return "unknown";
+    }
+
+    public interface ProbeService {
+
+        void operationsAccessed();
+
+        void customerAccessed();
+
+        void unknownAccessed();
+    }
+}


### PR DESCRIPTION
## Summary

- introduce the explicit `PAYFLOW_OPERATIONS` authority
- map the trusted JWT `role=ADMIN` claim through a fail-closed converter
- protect the `/api/v1/operations/**` namespace
- preserve existing authenticated customer endpoint behavior
- retain deny-by-default handling for unmatched endpoints
- document the authorization model in ADR 0006
- add converter unit tests and full security filter-chain tests

## Security behavior

- unauthenticated operations requests return HTTP 401
- authenticated users without operations authority receive HTTP 403
- administrators with `PAYFLOW_OPERATIONS` can access operations handlers
- missing, blank, malformed, and unknown role claims fail closed
- request-controlled headers cannot elevate privileges
- rejected requests do not invoke controller collaborators
- existing customer endpoint authorization remains unchanged

## Architecture

- reuse the trusted `ADMIN` role without introducing a database migration
- map `ADMIN` to the application-specific `PAYFLOW_OPERATIONS` authority
- keep authorization independent from Spring's `ROLE_` convention
- isolate security probe fixtures from the production component scan

## Verification

- JWT granted-authority converter unit tests
- MockMvc tests using real Bearer tokens and the configured `JwtDecoder`
- full Maven verification:

  `.\mvnw.cmd clean verify`

- result: `BUILD SUCCESS`
- duration: `03:55 min`

Closes #47