### PR TITLE
feat: add secured Kafka dead-letter query endpoints

### DIFF
--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterQueryController.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterQueryController.java
@@ -1,0 +1,267 @@
+package com.nursena.payflow.eventprocessing.adapter.in.web;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordDetails;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordFilter;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordPage;
+import com.nursena.payflow.eventprocessing.application.port.in.GetKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.in.ListKafkaDeadLetterRecordsQuery;
+import com.nursena.payflow.eventprocessing.application.port.in.ListKafkaDeadLetterRecordsUseCase;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+    name = "Kafka Dead Letters",
+    description =
+        "Authorized operations for querying "
+            + "Kafka dead-letter records."
+)
+@RestController
+@RequestMapping(
+    "/api/v1/operations/kafka/dead-letters"
+)
+public class KafkaDeadLetterQueryController {
+
+    private final ListKafkaDeadLetterRecordsUseCase
+        listUseCase;
+
+    private final GetKafkaDeadLetterRecordUseCase
+        getUseCase;
+
+    public KafkaDeadLetterQueryController(
+        ListKafkaDeadLetterRecordsUseCase listUseCase,
+        GetKafkaDeadLetterRecordUseCase getUseCase
+    ) {
+        this.listUseCase =
+            Objects.requireNonNull(
+                listUseCase,
+                "listUseCase must not be null"
+            );
+
+        this.getUseCase =
+            Objects.requireNonNull(
+                getUseCase,
+                "getUseCase must not be null"
+            );
+    }
+
+    @Operation(
+        operationId = "listKafkaDeadLetterRecords",
+        summary = "List Kafka dead-letter records",
+        description =
+            "Returns safe operational metadata ordered "
+                + "by receive time descending and "
+                + "record identifier descending."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description =
+                "Dead-letter records returned.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        KafkaDeadLetterRecordPageResponse
+                            .class
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description =
+                "A pagination or status value is invalid.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description =
+                "The authenticated principal does not "
+                    + "have operations authority."
+        )
+    })
+    @GetMapping
+    public ResponseEntity<KafkaDeadLetterRecordPageResponse>
+    listKafkaDeadLetterRecords(
+        @Parameter(
+            description = "Zero-based page index.",
+            example = "0"
+        )
+        @RequestParam(
+            name = "page",
+            defaultValue = "0"
+        )
+        @Min(
+            value = 0,
+            message = "page must not be negative"
+        )
+        int page,
+
+        @Parameter(
+            description =
+                "Number of records returned per page.",
+            example = "20"
+        )
+        @RequestParam(
+            name = "size",
+            defaultValue = "20"
+        )
+        @Min(
+            value = 1,
+            message = "size must be greater than zero"
+        )
+        @Max(
+            value =
+                ListKafkaDeadLetterRecordsQuery.MAX_SIZE,
+            message = "size must not exceed 100"
+        )
+        int size,
+
+        @Parameter(
+            description =
+                "Optional dead-letter administration "
+                    + "status filter.",
+            example = "REPLAY_FAILED"
+        )
+        @RequestParam(
+            name = "status",
+            required = false
+        )
+        KafkaDeadLetterRecordStatus status
+    ) {
+        KafkaDeadLetterRecordPage result =
+            listUseCase.listKafkaDeadLetterRecords(
+                new ListKafkaDeadLetterRecordsQuery(
+                    page,
+                    size,
+                    new KafkaDeadLetterRecordFilter(
+                        status
+                    )
+                )
+            );
+
+        return ResponseEntity.ok(
+            KafkaDeadLetterRecordPageResponse.from(
+                result
+            )
+        );
+    }
+
+    @Operation(
+        operationId = "getKafkaDeadLetterRecord",
+        summary = "Get a Kafka dead-letter record",
+        description =
+            "Returns safe operational details for "
+                + "one dead-letter record."
+    )
+    @SecurityRequirement(
+        name = OpenApiConfiguration.BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description =
+                "Dead-letter record returned.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        KafkaDeadLetterRecordDetailsResponse
+                            .class
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description =
+                "The record identifier is invalid.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description =
+                "The authenticated principal does not "
+                    + "have operations authority."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The dead-letter record was not found.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                )
+            )
+        )
+    })
+    @GetMapping("/{recordId}")
+    public ResponseEntity<KafkaDeadLetterRecordDetailsResponse>
+    getKafkaDeadLetterRecord(
+        @Parameter(
+            description =
+                "Dead-letter record identifier.",
+            schema = @Schema(
+                type = "string",
+                format = "uuid"
+            )
+        )
+        @PathVariable("recordId")
+        UUID recordId
+    ) {
+        KafkaDeadLetterRecordDetails result =
+            getUseCase.getKafkaDeadLetterRecord(
+                recordId
+            );
+
+        return ResponseEntity.ok(
+            KafkaDeadLetterRecordDetailsResponse.from(
+                result
+            )
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterQueryExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterQueryExceptionHandler.java
@@ -1,0 +1,76 @@
+package com.nursena.payflow.eventprocessing.adapter.in.web;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.eventprocessing.domain.exception.KafkaDeadLetterRecordNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(
+    assignableTypes =
+        KafkaDeadLetterQueryController.class
+)
+public class KafkaDeadLetterQueryExceptionHandler {
+
+    @ExceptionHandler(
+        KafkaDeadLetterRecordNotFoundException.class
+    )
+    ResponseEntity<ApiError> handleNotFound(
+        KafkaDeadLetterRecordNotFoundException exception,
+        HttpServletRequest request
+    ) {
+        return response(
+            HttpStatus.NOT_FOUND,
+            exception.getCode(),
+            exception.getMessage(),
+            request
+        );
+    }
+
+    @ExceptionHandler({
+        HandlerMethodValidationException.class,
+        MethodArgumentTypeMismatchException.class
+    })
+    ResponseEntity<ApiError> handleValidationFailure(
+        Exception exception,
+        HttpServletRequest request
+    ) {
+        return response(
+            HttpStatus.BAD_REQUEST,
+            "VALIDATION_FAILED",
+            "Request validation failed.",
+            request
+        );
+    }
+
+    private static ResponseEntity<ApiError> response(
+        HttpStatus status,
+        String code,
+        String message,
+        HttpServletRequest request
+    ) {
+        ApiError body =
+            new ApiError(
+                Instant.now(),
+                status.value(),
+                code,
+                message,
+                request.getRequestURI(),
+                List.of()
+            );
+
+        return ResponseEntity
+            .status(status)
+            .body(body);
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterRecordDetailsResponse.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterRecordDetailsResponse.java
@@ -1,0 +1,93 @@
+package com.nursena.payflow.eventprocessing.adapter.in.web;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordDetails;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordSummary;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "KafkaDeadLetterRecordDetailsResponse",
+    description =
+        "Safe operational details of a Kafka "
+            + "dead-letter record."
+)
+public record KafkaDeadLetterRecordDetailsResponse(
+    UUID id,
+    KafkaDeadLetterRecordStatus status,
+    String deadLetterTopic,
+    int deadLetterPartition,
+    long deadLetterOffset,
+    String originalTopic,
+    int originalPartition,
+    long originalOffset,
+    String originalConsumerGroup,
+    String exceptionType,
+    int replayCount,
+    int replayAttemptBase,
+    int totalReplayAttempts,
+    Instant receivedAt,
+    Instant lastReplayedAt,
+    UUID replayOriginId,
+    boolean payloadAvailable,
+
+    @Schema(
+        description =
+            "Exception message recorded during "
+                + "dead-letter intake."
+    )
+    String exceptionMessage,
+
+    @Schema(
+        description =
+            "Most recent controlled replay error."
+    )
+    String lastReplayError,
+
+    @Schema(
+        description =
+            "Expiration time of an active replay lease.",
+        format = "date-time"
+    )
+    Instant replayLeaseUntil
+) {
+
+    static KafkaDeadLetterRecordDetailsResponse from(
+        KafkaDeadLetterRecordDetails details
+    ) {
+        KafkaDeadLetterRecordDetails validatedDetails =
+            Objects.requireNonNull(
+                details,
+                "details must not be null"
+            );
+
+        KafkaDeadLetterRecordSummary summary =
+            validatedDetails.summary();
+
+        return new KafkaDeadLetterRecordDetailsResponse(
+            summary.id(),
+            summary.status(),
+            summary.deadLetterTopic(),
+            summary.deadLetterPartition(),
+            summary.deadLetterOffset(),
+            summary.originalTopic(),
+            summary.originalPartition(),
+            summary.originalOffset(),
+            summary.originalConsumerGroup(),
+            summary.exceptionType(),
+            summary.replayCount(),
+            summary.replayAttemptBase(),
+            summary.totalReplayAttempts(),
+            summary.receivedAt(),
+            summary.lastReplayedAt(),
+            summary.replayOriginId(),
+            summary.payloadAvailable(),
+            validatedDetails.exceptionMessage(),
+            validatedDetails.lastReplayError(),
+            validatedDetails.replayLeaseUntil()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterRecordPageResponse.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterRecordPageResponse.java
@@ -1,0 +1,109 @@
+package com.nursena.payflow.eventprocessing.adapter.in.web;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordPage;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "KafkaDeadLetterRecordPageResponse",
+    description =
+        "Paginated Kafka dead-letter administration records."
+)
+public record KafkaDeadLetterRecordPageResponse(
+
+    @Schema(
+        description =
+            "Dead-letter records contained in "
+                + "the current page."
+    )
+    List<KafkaDeadLetterRecordSummaryResponse> items,
+
+    @Schema(
+        description = "Zero-based page index.",
+        example = "0",
+        minimum = "0"
+    )
+    int page,
+
+    @Schema(
+        description = "Requested page size.",
+        example = "20",
+        minimum = "1",
+        maximum = "100"
+    )
+    int size,
+
+    @Schema(
+        description =
+            "Total number of matching records.",
+        example = "42",
+        minimum = "0"
+    )
+    long totalElements,
+
+    @Schema(
+        description = "Total number of result pages.",
+        example = "3",
+        minimum = "0"
+    )
+    int totalPages,
+
+    @Schema(
+        description = "Whether this is the first page.",
+        example = "true"
+    )
+    boolean first,
+
+    @Schema(
+        description = "Whether this is the last page.",
+        example = "false"
+    )
+    boolean last,
+
+    @Schema(
+        description = "Whether another page exists.",
+        example = "true"
+    )
+    boolean hasNext,
+
+    @Schema(
+        description = "Whether a previous page exists.",
+        example = "false"
+    )
+    boolean hasPrevious
+) {
+
+    static KafkaDeadLetterRecordPageResponse from(
+        KafkaDeadLetterRecordPage page
+    ) {
+        KafkaDeadLetterRecordPage validatedPage =
+            Objects.requireNonNull(
+                page,
+                "page must not be null"
+            );
+
+        List<KafkaDeadLetterRecordSummaryResponse>
+            items =
+            validatedPage.items()
+                .stream()
+                .map(
+                    KafkaDeadLetterRecordSummaryResponse
+                        ::from
+                )
+                .toList();
+
+        return new KafkaDeadLetterRecordPageResponse(
+            items,
+            validatedPage.page(),
+            validatedPage.size(),
+            validatedPage.totalElements(),
+            validatedPage.totalPages(),
+            validatedPage.first(),
+            validatedPage.last(),
+            validatedPage.hasNext(),
+            validatedPage.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterRecordSummaryResponse.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterRecordSummaryResponse.java
@@ -1,0 +1,163 @@
+package com.nursena.payflow.eventprocessing.adapter.in.web;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordSummary;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "KafkaDeadLetterRecordSummaryResponse",
+    description =
+        "Safe operational metadata for a Kafka "
+            + "dead-letter record."
+)
+public record KafkaDeadLetterRecordSummaryResponse(
+
+    @Schema(
+        description = "Dead-letter record identifier.",
+        format = "uuid"
+    )
+    UUID id,
+
+    @Schema(
+        description = "Current administration status.",
+        example = "REPLAY_FAILED"
+    )
+    KafkaDeadLetterRecordStatus status,
+
+    @Schema(
+        description = "Kafka dead-letter topic.",
+        example = "wallet.transfer.completed.dlt"
+    )
+    String deadLetterTopic,
+
+    @Schema(
+        description = "Dead-letter partition.",
+        example = "0",
+        minimum = "0"
+    )
+    int deadLetterPartition,
+
+    @Schema(
+        description = "Dead-letter offset.",
+        example = "203",
+        minimum = "0"
+    )
+    long deadLetterOffset,
+
+    @Schema(
+        description = "Original Kafka topic.",
+        example = "wallet.transfer.completed"
+    )
+    String originalTopic,
+
+    @Schema(
+        description = "Original Kafka partition.",
+        example = "0",
+        minimum = "0"
+    )
+    int originalPartition,
+
+    @Schema(
+        description = "Original Kafka offset.",
+        example = "103",
+        minimum = "0"
+    )
+    long originalOffset,
+
+    @Schema(
+        description = "Original Kafka consumer group.",
+        example = "payflow-transfer-completed-audit-v1"
+    )
+    String originalConsumerGroup,
+
+    @Schema(
+        description = "Exception type recorded by the consumer.",
+        example = "java.lang.IllegalStateException"
+    )
+    String exceptionType,
+
+    @Schema(
+        description =
+            "Replay attempts performed for this record.",
+        example = "1",
+        minimum = "0"
+    )
+    int replayCount,
+
+    @Schema(
+        description =
+            "Replay attempts inherited from prior "
+                + "records in the replay lineage.",
+        example = "2",
+        minimum = "0"
+    )
+    int replayAttemptBase,
+
+    @Schema(
+        description =
+            "Total replay attempts across the lineage.",
+        example = "3",
+        minimum = "0"
+    )
+    int totalReplayAttempts,
+
+    @Schema(
+        description = "Time the dead-letter record was received.",
+        format = "date-time"
+    )
+    Instant receivedAt,
+
+    @Schema(
+        description = "Most recent replay attempt time.",
+        format = "date-time"
+    )
+    Instant lastReplayedAt,
+
+    @Schema(
+        description = "Original record in the replay lineage.",
+        format = "uuid"
+    )
+    UUID replayOriginId,
+
+    @Schema(
+        description =
+            "Whether replayable payload content exists.",
+        example = "true"
+    )
+    boolean payloadAvailable
+) {
+
+    static KafkaDeadLetterRecordSummaryResponse from(
+        KafkaDeadLetterRecordSummary summary
+    ) {
+        KafkaDeadLetterRecordSummary validatedSummary =
+            Objects.requireNonNull(
+                summary,
+                "summary must not be null"
+            );
+
+        return new KafkaDeadLetterRecordSummaryResponse(
+            validatedSummary.id(),
+            validatedSummary.status(),
+            validatedSummary.deadLetterTopic(),
+            validatedSummary.deadLetterPartition(),
+            validatedSummary.deadLetterOffset(),
+            validatedSummary.originalTopic(),
+            validatedSummary.originalPartition(),
+            validatedSummary.originalOffset(),
+            validatedSummary.originalConsumerGroup(),
+            validatedSummary.exceptionType(),
+            validatedSummary.replayCount(),
+            validatedSummary.replayAttemptBase(),
+            validatedSummary.totalReplayAttempts(),
+            validatedSummary.receivedAt(),
+            validatedSummary.lastReplayedAt(),
+            validatedSummary.replayOriginId(),
+            validatedSummary.payloadAvailable()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterQueryAdapter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterQueryAdapter.java
@@ -1,0 +1,411 @@
+package com.nursena.payflow.eventprocessing.adapter.out.persistence;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordDetails;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordFilter;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordPage;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordSummary;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterQueryPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class JdbcKafkaDeadLetterQueryAdapter
+    implements KafkaDeadLetterQueryPort {
+
+    private static final String SUMMARY_SELECT = """
+        SELECT
+            id,
+            status,
+            dlt_topic,
+            dlt_partition,
+            dlt_offset,
+            original_topic,
+            original_partition,
+            original_offset,
+            original_consumer_group,
+            exception_type,
+            replay_count,
+            replay_attempt_base,
+            received_at,
+            last_replayed_at,
+            replay_origin_id,
+            (
+                payload IS NOT NULL
+                AND btrim(payload) <> ''
+            ) AS payload_available
+        FROM kafka_dead_letter_records
+        """;
+
+    private static final String LIST_ALL_SQL =
+        SUMMARY_SELECT + """
+        ORDER BY
+            received_at DESC,
+            id DESC
+        LIMIT ?
+        OFFSET ?
+        """;
+
+    private static final String LIST_BY_STATUS_SQL =
+        SUMMARY_SELECT + """
+        WHERE status = ?
+        ORDER BY
+            received_at DESC,
+            id DESC
+        LIMIT ?
+        OFFSET ?
+        """;
+
+    private static final String COUNT_ALL_SQL = """
+        SELECT COUNT(*)
+        FROM kafka_dead_letter_records
+        """;
+
+    private static final String
+        COUNT_BY_STATUS_SQL = """
+        SELECT COUNT(*)
+        FROM kafka_dead_letter_records
+        WHERE status = ?
+        """;
+
+    private static final String FIND_BY_ID_SQL = """
+        SELECT
+            id,
+            status,
+            dlt_topic,
+            dlt_partition,
+            dlt_offset,
+            original_topic,
+            original_partition,
+            original_offset,
+            original_consumer_group,
+            exception_type,
+            replay_count,
+            replay_attempt_base,
+            received_at,
+            last_replayed_at,
+            replay_origin_id,
+            (
+                payload IS NOT NULL
+                AND btrim(payload) <> ''
+            ) AS payload_available,
+            exception_message,
+            last_replay_error,
+            replay_lease_until
+        FROM kafka_dead_letter_records
+        WHERE id = ?
+        """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    JdbcKafkaDeadLetterQueryAdapter(
+        JdbcTemplate jdbcTemplate
+    ) {
+        this.jdbcTemplate =
+            Objects.requireNonNull(
+                jdbcTemplate,
+                "jdbcTemplate must not be null"
+            );
+    }
+
+    @Override
+    public KafkaDeadLetterRecordPage findPage(
+        int page,
+        int size,
+        KafkaDeadLetterRecordFilter filter
+    ) {
+        validatePage(page);
+        validateSize(size);
+
+        KafkaDeadLetterRecordFilter
+            validatedFilter =
+            Objects.requireNonNull(
+                filter,
+                "filter must not be null"
+            );
+
+        long totalElements =
+            countRecords(validatedFilter);
+
+        List<KafkaDeadLetterRecordSummary> items =
+            totalElements == 0
+                ? List.of()
+                : findRecords(
+                page,
+                size,
+                validatedFilter
+            );
+
+        return new KafkaDeadLetterRecordPage(
+            items,
+            page,
+            size,
+            totalElements,
+            calculateTotalPages(
+                totalElements,
+                size
+            )
+        );
+    }
+
+    @Override
+    public Optional<KafkaDeadLetterRecordDetails>
+    findById(
+        UUID recordId
+    ) {
+        UUID validatedRecordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+
+        List<KafkaDeadLetterRecordDetails> records =
+            jdbcTemplate.query(
+                FIND_BY_ID_SQL,
+                JdbcKafkaDeadLetterQueryAdapter
+                    ::mapDetails,
+                validatedRecordId
+            );
+
+        if (records.size() > 1) {
+            throw new IllegalStateException(
+                "Kafka dead-letter query returned "
+                    + records.size()
+                    + " records for identifier "
+                    + validatedRecordId
+                    + "."
+            );
+        }
+
+        return records.stream()
+            .findFirst();
+    }
+
+    private List<KafkaDeadLetterRecordSummary>
+    findRecords(
+        int page,
+        int size,
+        KafkaDeadLetterRecordFilter filter
+    ) {
+        long offset =
+            calculateOffset(
+                page,
+                size
+            );
+
+        if (filter.status() == null) {
+            return jdbcTemplate.query(
+                LIST_ALL_SQL,
+                JdbcKafkaDeadLetterQueryAdapter
+                    ::mapSummary,
+                size,
+                offset
+            );
+        }
+
+        return jdbcTemplate.query(
+            LIST_BY_STATUS_SQL,
+            JdbcKafkaDeadLetterQueryAdapter
+                ::mapSummary,
+            filter.status().name(),
+            size,
+            offset
+        );
+    }
+
+    private long countRecords(
+        KafkaDeadLetterRecordFilter filter
+    ) {
+        Long result;
+
+        if (filter.status() == null) {
+            result =
+                jdbcTemplate.queryForObject(
+                    COUNT_ALL_SQL,
+                    Long.class
+                );
+        } else {
+            result =
+                jdbcTemplate.queryForObject(
+                    COUNT_BY_STATUS_SQL,
+                    Long.class,
+                    filter.status().name()
+                );
+        }
+
+        return Objects.requireNonNull(
+            result,
+            "Kafka dead-letter count "
+                + "must not be null"
+        );
+    }
+
+    private static KafkaDeadLetterRecordSummary
+    mapSummary(
+        ResultSet resultSet,
+        int rowNumber
+    ) throws SQLException {
+
+        return new KafkaDeadLetterRecordSummary(
+            resultSet.getObject(
+                "id",
+                UUID.class
+            ),
+            KafkaDeadLetterRecordStatus.valueOf(
+                resultSet.getString(
+                    "status"
+                )
+            ),
+            resultSet.getString(
+                "dlt_topic"
+            ),
+            resultSet.getInt(
+                "dlt_partition"
+            ),
+            resultSet.getLong(
+                "dlt_offset"
+            ),
+            resultSet.getString(
+                "original_topic"
+            ),
+            resultSet.getInt(
+                "original_partition"
+            ),
+            resultSet.getLong(
+                "original_offset"
+            ),
+            resultSet.getString(
+                "original_consumer_group"
+            ),
+            resultSet.getString(
+                "exception_type"
+            ),
+            resultSet.getInt(
+                "replay_count"
+            ),
+            resultSet.getInt(
+                "replay_attempt_base"
+            ),
+            instant(
+                resultSet,
+                "received_at"
+            ),
+            instant(
+                resultSet,
+                "last_replayed_at"
+            ),
+            resultSet.getObject(
+                "replay_origin_id",
+                UUID.class
+            ),
+            resultSet.getBoolean(
+                "payload_available"
+            )
+        );
+    }
+
+    private static KafkaDeadLetterRecordDetails
+    mapDetails(
+        ResultSet resultSet,
+        int rowNumber
+    ) throws SQLException {
+
+        return new KafkaDeadLetterRecordDetails(
+            mapSummary(
+                resultSet,
+                rowNumber
+            ),
+            resultSet.getString(
+                "exception_message"
+            ),
+            resultSet.getString(
+                "last_replay_error"
+            ),
+            instant(
+                resultSet,
+                "replay_lease_until"
+            )
+        );
+    }
+
+    private static Instant instant(
+        ResultSet resultSet,
+        String columnName
+    ) throws SQLException {
+
+        Timestamp timestamp =
+            resultSet.getTimestamp(
+                columnName
+            );
+
+        return timestamp == null
+            ? null
+            : timestamp.toInstant();
+    }
+
+    private static void validatePage(
+        int page
+    ) {
+        if (page < 0) {
+            throw new IllegalArgumentException(
+                "page must not be negative"
+            );
+        }
+    }
+
+    private static void validateSize(
+        int size
+    ) {
+        if (size < 1) {
+            throw new IllegalArgumentException(
+                "size must be greater than zero"
+            );
+        }
+    }
+
+    private static long calculateOffset(
+        int page,
+        int size
+    ) {
+        return Math.multiplyExact(
+            (long) page,
+            size
+        );
+    }
+
+    private static int calculateTotalPages(
+        long totalElements,
+        int size
+    ) {
+        if (totalElements == 0) {
+            return 0;
+        }
+
+        long totalPages =
+            Math.floorDiv(
+                totalElements - 1,
+                size
+            ) + 1;
+
+        try {
+            return Math.toIntExact(
+                totalPages
+            );
+        } catch (ArithmeticException exception) {
+            throw new IllegalStateException(
+                "Kafka dead-letter page count "
+                    + "exceeds the supported range.",
+                exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterRecordDetails.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterRecordDetails.java
@@ -1,0 +1,20 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record KafkaDeadLetterRecordDetails(
+    KafkaDeadLetterRecordSummary summary,
+    String exceptionMessage,
+    String lastReplayError,
+    Instant replayLeaseUntil
+) {
+
+    public KafkaDeadLetterRecordDetails {
+        summary =
+            Objects.requireNonNull(
+                summary,
+                "summary must not be null"
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterRecordFilter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterRecordFilter.java
@@ -1,0 +1,15 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+
+public record KafkaDeadLetterRecordFilter(
+    KafkaDeadLetterRecordStatus status
+) {
+
+    public static KafkaDeadLetterRecordFilter
+    unfiltered() {
+        return new KafkaDeadLetterRecordFilter(
+            null
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterRecordPage.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterRecordPage.java
@@ -1,0 +1,64 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.util.List;
+import java.util.Objects;
+
+public record KafkaDeadLetterRecordPage(
+    List<KafkaDeadLetterRecordSummary> items,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages
+) {
+
+    public KafkaDeadLetterRecordPage {
+        items =
+            List.copyOf(
+                Objects.requireNonNull(
+                    items,
+                    "items must not be null"
+                )
+            );
+
+        if (page < 0) {
+            throw new IllegalArgumentException(
+                "page must not be negative"
+            );
+        }
+
+        if (size < 1) {
+            throw new IllegalArgumentException(
+                "size must be greater than zero"
+            );
+        }
+
+        if (totalElements < 0) {
+            throw new IllegalArgumentException(
+                "totalElements must not be negative"
+            );
+        }
+
+        if (totalPages < 0) {
+            throw new IllegalArgumentException(
+                "totalPages must not be negative"
+            );
+        }
+    }
+
+    public boolean first() {
+        return page == 0;
+    }
+
+    public boolean last() {
+        return totalPages == 0
+            || page >= totalPages - 1;
+    }
+
+    public boolean hasNext() {
+        return !last();
+    }
+
+    public boolean hasPrevious() {
+        return page > 0;
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterRecordSummary.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterRecordSummary.java
@@ -1,0 +1,178 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.domain.model
+    .KafkaDeadLetterRecordStatus;
+
+public record KafkaDeadLetterRecordSummary(
+    UUID id,
+    KafkaDeadLetterRecordStatus status,
+    String deadLetterTopic,
+    int deadLetterPartition,
+    long deadLetterOffset,
+    String originalTopic,
+    int originalPartition,
+    long originalOffset,
+    String originalConsumerGroup,
+    String exceptionType,
+    int replayCount,
+    int replayAttemptBase,
+    Instant receivedAt,
+    Instant lastReplayedAt,
+    UUID replayOriginId,
+    boolean payloadAvailable
+) {
+
+    public KafkaDeadLetterRecordSummary {
+        id =
+            Objects.requireNonNull(
+                id,
+                "id must not be null"
+            );
+
+        status =
+            Objects.requireNonNull(
+                status,
+                "status must not be null"
+            );
+
+        deadLetterTopic =
+            validateText(
+                deadLetterTopic,
+                "deadLetterTopic"
+            );
+
+        originalTopic =
+            validateText(
+                originalTopic,
+                "originalTopic"
+            );
+
+        originalConsumerGroup =
+            validateText(
+                originalConsumerGroup,
+                "originalConsumerGroup"
+            );
+
+        exceptionType =
+            validateText(
+                exceptionType,
+                "exceptionType"
+            );
+
+        validateNonNegative(
+            deadLetterPartition,
+            "deadLetterPartition"
+        );
+
+        validateNonNegative(
+            deadLetterOffset,
+            "deadLetterOffset"
+        );
+
+        validateNonNegative(
+            originalPartition,
+            "originalPartition"
+        );
+
+        validateNonNegative(
+            originalOffset,
+            "originalOffset"
+        );
+
+        validateNonNegative(
+            replayCount,
+            "replayCount"
+        );
+
+        validateNonNegative(
+            replayAttemptBase,
+            "replayAttemptBase"
+        );
+
+        receivedAt =
+            Objects.requireNonNull(
+                receivedAt,
+                "receivedAt must not be null"
+            );
+
+        if (
+            lastReplayedAt != null
+                && lastReplayedAt.isBefore(receivedAt)
+        ) {
+            throw new IllegalArgumentException(
+                "lastReplayedAt must not be "
+                    + "before receivedAt"
+            );
+        }
+
+        replayOriginId =
+            Objects.requireNonNull(
+                replayOriginId,
+                "replayOriginId must not be null"
+            );
+
+        validateTotalReplayAttempts(
+            replayAttemptBase,
+            replayCount
+        );
+    }
+
+    public int totalReplayAttempts() {
+        return Math.addExact(
+            replayAttemptBase,
+            replayCount
+        );
+    }
+
+    private static String validateText(
+        String value,
+        String fieldName
+    ) {
+        if (
+            value == null
+                || value.isBlank()
+        ) {
+            throw new IllegalArgumentException(
+                fieldName
+                    + " must not be blank"
+            );
+        }
+
+        return value;
+    }
+
+    private static void validateNonNegative(
+        long value,
+        String fieldName
+    ) {
+        if (value < 0) {
+            throw new IllegalArgumentException(
+                fieldName
+                    + " must not be negative"
+            );
+        }
+    }
+
+    private static void
+    validateTotalReplayAttempts(
+        int replayAttemptBase,
+        int replayCount
+    ) {
+        try {
+            Math.addExact(
+                replayAttemptBase,
+                replayCount
+            );
+        } catch (ArithmeticException exception) {
+            throw new IllegalArgumentException(
+                "total replay attempt count "
+                    + "must not overflow",
+                exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/GetKafkaDeadLetterRecordUseCase.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/GetKafkaDeadLetterRecordUseCase.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.eventprocessing.application.port.in;
+
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model
+    .KafkaDeadLetterRecordDetails;
+
+public interface GetKafkaDeadLetterRecordUseCase {
+
+    KafkaDeadLetterRecordDetails
+    getKafkaDeadLetterRecord(
+        UUID recordId
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/ListKafkaDeadLetterRecordsQuery.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/ListKafkaDeadLetterRecordsQuery.java
@@ -1,0 +1,41 @@
+package com.nursena.payflow.eventprocessing.application.port.in;
+
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordFilter;
+
+public record ListKafkaDeadLetterRecordsQuery(
+    int page,
+    int size,
+    KafkaDeadLetterRecordFilter filter
+) {
+
+    public static final int MAX_SIZE = 100;
+
+    public ListKafkaDeadLetterRecordsQuery {
+        if (page < 0) {
+            throw new IllegalArgumentException(
+                "page must not be negative"
+            );
+        }
+
+        if (size < 1) {
+            throw new IllegalArgumentException(
+                "size must be greater than zero"
+            );
+        }
+
+        if (size > MAX_SIZE) {
+            throw new IllegalArgumentException(
+                "size must not exceed "
+                    + MAX_SIZE
+            );
+        }
+
+        filter =
+            Objects.requireNonNull(
+                filter,
+                "filter must not be null"
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/ListKafkaDeadLetterRecordsUseCase.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/ListKafkaDeadLetterRecordsUseCase.java
@@ -1,0 +1,12 @@
+package com.nursena.payflow.eventprocessing.application.port.in;
+
+import com.nursena.payflow.eventprocessing.application.model
+    .KafkaDeadLetterRecordPage;
+
+public interface ListKafkaDeadLetterRecordsUseCase {
+
+    KafkaDeadLetterRecordPage
+    listKafkaDeadLetterRecords(
+        ListKafkaDeadLetterRecordsQuery query
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterQueryPort.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterQueryPort.java
@@ -1,0 +1,25 @@
+package com.nursena.payflow.eventprocessing.application.port.out;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model
+    .KafkaDeadLetterRecordDetails;
+import com.nursena.payflow.eventprocessing.application.model
+    .KafkaDeadLetterRecordFilter;
+import com.nursena.payflow.eventprocessing.application.model
+    .KafkaDeadLetterRecordPage;
+
+public interface KafkaDeadLetterQueryPort {
+
+    KafkaDeadLetterRecordPage findPage(
+        int page,
+        int size,
+        KafkaDeadLetterRecordFilter filter
+    );
+
+    Optional<KafkaDeadLetterRecordDetails>
+    findById(
+        UUID recordId
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/GetKafkaDeadLetterRecordService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/GetKafkaDeadLetterRecordService.java
@@ -1,0 +1,52 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model
+    .KafkaDeadLetterRecordDetails;
+import com.nursena.payflow.eventprocessing.application.port.in
+    .GetKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out
+    .KafkaDeadLetterQueryPort;
+import com.nursena.payflow.eventprocessing.domain.exception
+    .KafkaDeadLetterRecordNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
+
+public class GetKafkaDeadLetterRecordService
+    implements GetKafkaDeadLetterRecordUseCase {
+
+    private final KafkaDeadLetterQueryPort queryPort;
+
+    public GetKafkaDeadLetterRecordService(
+        KafkaDeadLetterQueryPort queryPort
+    ) {
+        this.queryPort =
+            Objects.requireNonNull(
+                queryPort,
+                "queryPort must not be null"
+            );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public KafkaDeadLetterRecordDetails
+    getKafkaDeadLetterRecord(
+        UUID recordId
+    ) {
+        UUID validatedRecordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+
+        return queryPort
+            .findById(validatedRecordId)
+            .orElseThrow(
+                () ->
+                    new KafkaDeadLetterRecordNotFoundException(
+                        validatedRecordId
+                    )
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/ListKafkaDeadLetterRecordsService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/ListKafkaDeadLetterRecordsService.java
@@ -1,0 +1,49 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.model
+    .KafkaDeadLetterRecordPage;
+import com.nursena.payflow.eventprocessing.application.port.in
+    .ListKafkaDeadLetterRecordsQuery;
+import com.nursena.payflow.eventprocessing.application.port.in
+    .ListKafkaDeadLetterRecordsUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out
+    .KafkaDeadLetterQueryPort;
+import org.springframework.transaction.annotation.Transactional;
+
+public class ListKafkaDeadLetterRecordsService
+    implements ListKafkaDeadLetterRecordsUseCase {
+
+    private final KafkaDeadLetterQueryPort queryPort;
+
+    public ListKafkaDeadLetterRecordsService(
+        KafkaDeadLetterQueryPort queryPort
+    ) {
+        this.queryPort =
+            Objects.requireNonNull(
+                queryPort,
+                "queryPort must not be null"
+            );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public KafkaDeadLetterRecordPage
+    listKafkaDeadLetterRecords(
+        ListKafkaDeadLetterRecordsQuery query
+    ) {
+        ListKafkaDeadLetterRecordsQuery
+            validatedQuery =
+            Objects.requireNonNull(
+                query,
+                "query must not be null"
+            );
+
+        return queryPort.findPage(
+            validatedQuery.page(),
+            validatedQuery.size(),
+            validatedQuery.filter()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterQueryConfiguration.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterQueryConfiguration.java
@@ -1,0 +1,33 @@
+package com.nursena.payflow.eventprocessing.configuration;
+
+import com.nursena.payflow.eventprocessing.application.port.in.GetKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.in.ListKafkaDeadLetterRecordsUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterQueryPort;
+import com.nursena.payflow.eventprocessing.application.service.GetKafkaDeadLetterRecordService;
+import com.nursena.payflow.eventprocessing.application.service.ListKafkaDeadLetterRecordsService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class KafkaDeadLetterQueryConfiguration {
+
+    @Bean
+    ListKafkaDeadLetterRecordsUseCase
+    listKafkaDeadLetterRecordsUseCase(
+        KafkaDeadLetterQueryPort queryPort
+    ) {
+        return new ListKafkaDeadLetterRecordsService(
+            queryPort
+        );
+    }
+
+    @Bean
+    GetKafkaDeadLetterRecordUseCase
+    getKafkaDeadLetterRecordUseCase(
+        KafkaDeadLetterQueryPort queryPort
+    ) {
+        return new GetKafkaDeadLetterRecordService(
+            queryPort
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/domain/exception/KafkaDeadLetterRecordNotFoundException.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/domain/exception/KafkaDeadLetterRecordNotFoundException.java
@@ -1,0 +1,37 @@
+package com.nursena.payflow.eventprocessing.domain.exception;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public final class
+KafkaDeadLetterRecordNotFoundException
+    extends RuntimeException {
+
+    public static final String CODE =
+        "KAFKA_DEAD_LETTER_RECORD_NOT_FOUND";
+
+    private final UUID recordId;
+
+    public KafkaDeadLetterRecordNotFoundException(
+        UUID recordId
+    ) {
+        super(
+            "Kafka dead-letter record "
+                + "was not found."
+        );
+
+        this.recordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+    }
+
+    public String getCode() {
+        return CODE;
+    }
+
+    public UUID getRecordId() {
+        return recordId;
+    }
+}

--- a/src/main/resources/db/migration/V11__index_kafka_dead_letter_queries.sql
+++ b/src/main/resources/db/migration/V11__index_kafka_dead_letter_queries.sql
@@ -1,0 +1,17 @@
+DROP INDEX
+    idx_kafka_dead_letter_records_status_received;
+
+CREATE INDEX
+    idx_kafka_dead_letter_records_status_received_id
+ON kafka_dead_letter_records (
+    status,
+    received_at DESC,
+    id DESC
+);
+
+CREATE INDEX
+    idx_kafka_dead_letter_records_received_id
+ON kafka_dead_letter_records (
+    received_at DESC,
+    id DESC
+);

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -64,6 +64,15 @@ class OpenApiJsonContractIntegrationTest {
     private static final String TRANSACTIONS_PATH =
         "/api/v1/transactions/me";
 
+    private static final String
+        KAFKA_DEAD_LETTERS_PATH =
+        "/api/v1/operations/kafka/dead-letters";
+
+    private static final String
+        KAFKA_DEAD_LETTER_DETAILS_PATH =
+        KAFKA_DEAD_LETTERS_PATH
+            + "/{recordId}";
+
     @Container
     @ServiceConnection
     private static final PostgreSQLContainer<?> POSTGRES =
@@ -159,7 +168,9 @@ class OpenApiJsonContractIntegrationTest {
             CURRENT_WALLET_PATH,
             TOP_UP_PATH,
             TRANSFERS_PATH,
-            TRANSACTIONS_PATH
+            TRANSACTIONS_PATH,
+            KAFKA_DEAD_LETTERS_PATH,
+            KAFKA_DEAD_LETTER_DETAILS_PATH
         );
 
         JsonNode health =
@@ -328,6 +339,52 @@ class OpenApiJsonContractIntegrationTest {
             "status",
             "from",
             "to"
+        );
+        JsonNode deadLetters =
+            operation(
+                KAFKA_DEAD_LETTERS_PATH,
+                "get"
+            );
+
+        assertAuthenticatedOperation(
+            deadLetters,
+            "listKafkaDeadLetterRecords",
+            new String[] {
+                "200",
+                "400",
+                "401",
+                "403"
+            }
+        );
+
+        assertParameterNames(
+            deadLetters,
+            "page",
+            "size",
+            "status"
+        );
+
+        JsonNode deadLetterDetails =
+            operation(
+                KAFKA_DEAD_LETTER_DETAILS_PATH,
+                "get"
+            );
+
+        assertAuthenticatedOperation(
+            deadLetterDetails,
+            "getKafkaDeadLetterRecord",
+            new String[] {
+                "200",
+                "400",
+                "401",
+                "403",
+                "404"
+            }
+        );
+
+        assertParameterNames(
+            deadLetterDetails,
+            "recordId"
         );
     }
 
@@ -534,6 +591,191 @@ class OpenApiJsonContractIntegrationTest {
         assertThat(
             fieldNames(historyItemProperties)
         ).doesNotContain("idempotencyKey");
+    }
+
+    @Test
+    void shouldExposeKafkaDeadLetterQueryContract() {
+        JsonNode deadLetters =
+            operation(
+                KAFKA_DEAD_LETTERS_PATH,
+                "get"
+            );
+
+        JsonNode page =
+            findParameter(
+                deadLetters,
+                "page"
+            );
+
+        assertQueryParameter(page);
+
+        assertThat(
+            page.path("schema")
+                .path("minimum")
+                .asInt()
+        ).isZero();
+
+        assertThat(
+            page.path("schema")
+                .path("default")
+                .asInt()
+        ).isZero();
+
+        JsonNode size =
+            findParameter(
+                deadLetters,
+                "size"
+            );
+
+        assertQueryParameter(size);
+
+        assertThat(
+            size.path("schema")
+                .path("minimum")
+                .asInt()
+        ).isEqualTo(1);
+
+        assertThat(
+            size.path("schema")
+                .path("maximum")
+                .asInt()
+        ).isEqualTo(100);
+
+        assertThat(
+            size.path("schema")
+                .path("default")
+                .asInt()
+        ).isEqualTo(20);
+
+        JsonNode status =
+            findParameter(
+                deadLetters,
+                "status"
+            );
+
+        assertQueryParameter(status);
+
+        assertThat(
+            textValues(
+                status.path("schema")
+                    .path("enum")
+            )
+        ).containsExactlyInAnyOrder(
+            "RECEIVED",
+            "REPLAYING",
+            "REPLAYED",
+            "REPLAY_FAILED",
+            "DISCARDED"
+        );
+
+        JsonNode deadLetterDetails =
+            operation(
+                KAFKA_DEAD_LETTER_DETAILS_PATH,
+                "get"
+            );
+
+        JsonNode recordId =
+            findParameter(
+                deadLetterDetails,
+                "recordId"
+            );
+
+        assertThat(
+            recordId.path("in").asText()
+        ).isEqualTo("path");
+
+        assertThat(
+            recordId.path("required").asBoolean()
+        ).isTrue();
+
+        assertThat(
+            recordId.path("schema")
+                .path("type")
+                .asText()
+        ).isEqualTo("string");
+
+        assertThat(
+            recordId.path("schema")
+                .path("format")
+                .asText()
+        ).isEqualTo("uuid");
+
+        JsonNode schemas =
+            openApi
+                .path("components")
+                .path("schemas");
+
+        JsonNode summaryProperties =
+            schemas
+                .path(
+                    "KafkaDeadLetterRecordSummaryResponse"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(summaryProperties)
+        )
+            .contains(
+                "id",
+                "status",
+                "deadLetterTopic",
+                "originalTopic",
+                "replayCount",
+                "replayAttemptBase",
+                "totalReplayAttempts",
+                "payloadAvailable"
+            )
+            .doesNotContain(
+                "payload",
+                "recordKey",
+                "replayLeaseOwner"
+            );
+
+        JsonNode detailsProperties =
+            schemas
+                .path(
+                    "KafkaDeadLetterRecordDetailsResponse"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(detailsProperties)
+        )
+            .contains(
+                "id",
+                "status",
+                "exceptionMessage",
+                "lastReplayError",
+                "replayLeaseUntil",
+                "payloadAvailable"
+            )
+            .doesNotContain(
+                "summary",
+                "payload",
+                "recordKey",
+                "replayLeaseOwner"
+            );
+
+        JsonNode pageProperties =
+            schemas
+                .path(
+                    "KafkaDeadLetterRecordPageResponse"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(pageProperties)
+        ).containsExactlyInAnyOrder(
+            "items",
+            "page",
+            "size",
+            "totalElements",
+            "totalPages",
+            "first",
+            "last",
+            "hasNext",
+            "hasPrevious"
+        );
     }
 
     private JsonNode operation(

--- a/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterQueryControllerTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterQueryControllerTest.java
@@ -1,0 +1,733 @@
+package com.nursena.payflow.eventprocessing.adapter.in.web;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet
+    .request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet
+    .request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet
+    .result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet
+    .result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.nursena.payflow.configuration
+    .SecurityConfiguration;
+import com.nursena.payflow.configuration.security
+    .OperationsAuthorities;
+import com.nursena.payflow.eventprocessing.application.model
+    .KafkaDeadLetterRecordDetails;
+import com.nursena.payflow.eventprocessing.application.model
+    .KafkaDeadLetterRecordFilter;
+import com.nursena.payflow.eventprocessing.application.model
+    .KafkaDeadLetterRecordPage;
+import com.nursena.payflow.eventprocessing.application.model
+    .KafkaDeadLetterRecordSummary;
+import com.nursena.payflow.eventprocessing.application.port.in
+    .GetKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.in
+    .ListKafkaDeadLetterRecordsQuery;
+import com.nursena.payflow.eventprocessing.application.port.in
+    .ListKafkaDeadLetterRecordsUseCase;
+import com.nursena.payflow.eventprocessing.domain.exception
+    .KafkaDeadLetterRecordNotFoundException;
+import com.nursena.payflow.eventprocessing.domain.model
+    .KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet
+    .WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.authority
+    .SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito
+    .MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(KafkaDeadLetterQueryController.class)
+@Import({
+    SecurityConfiguration.class,
+    KafkaDeadLetterQueryExceptionHandler.class
+})
+class KafkaDeadLetterQueryControllerTest {
+
+    private static final String COLLECTION_PATH =
+        "/api/v1/operations/kafka/dead-letters";
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001203"
+        );
+
+    private static final UUID REPLAY_ORIGIN_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001200"
+        );
+
+    private static final Instant RECEIVED_AT =
+        Instant.parse(
+            "2026-07-22T12:02:00Z"
+        );
+
+    private static final Instant LAST_REPLAYED_AT =
+        Instant.parse(
+            "2026-07-22T12:03:00Z"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ListKafkaDeadLetterRecordsUseCase
+        listUseCase;
+
+    @MockitoBean
+    private GetKafkaDeadLetterRecordUseCase
+        getUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldReturnAuthorizedDeadLetterPage()
+        throws Exception {
+
+        ListKafkaDeadLetterRecordsQuery expectedQuery =
+            new ListKafkaDeadLetterRecordsQuery(
+                0,
+                20,
+                KafkaDeadLetterRecordFilter
+                    .unfiltered()
+            );
+
+        when(
+            listUseCase.listKafkaDeadLetterRecords(
+                expectedQuery
+            )
+        ).thenReturn(
+            new KafkaDeadLetterRecordPage(
+                List.of(summary()),
+                0,
+                20,
+                1,
+                1
+            )
+        );
+
+        mockMvc.perform(
+                get(COLLECTION_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.items.length()")
+                    .value(1)
+            )
+            .andExpect(
+                jsonPath("$.items[0].id")
+                    .value(RECORD_ID.toString())
+            )
+            .andExpect(
+                jsonPath("$.items[0].status")
+                    .value("REPLAY_FAILED")
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].deadLetterTopic"
+                )
+                    .value(
+                        "wallet.transfer.completed.dlt"
+                    )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].deadLetterPartition"
+                )
+                    .value(0)
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].deadLetterOffset"
+                )
+                    .value(203)
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].originalTopic"
+                )
+                    .value(
+                        "wallet.transfer.completed"
+                    )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].originalPartition"
+                )
+                    .value(0)
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].originalOffset"
+                )
+                    .value(103)
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].originalConsumerGroup"
+                )
+                    .value(
+                        "payflow-transfer-"
+                            + "completed-audit-v1"
+                    )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].exceptionType"
+                )
+                    .value(
+                        "java.lang."
+                            + "IllegalStateException"
+                    )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].replayCount"
+                )
+                    .value(1)
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].replayAttemptBase"
+                )
+                    .value(2)
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].totalReplayAttempts"
+                )
+                    .value(3)
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].receivedAt"
+                )
+                    .value(RECEIVED_AT.toString())
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].lastReplayedAt"
+                )
+                    .value(
+                        LAST_REPLAYED_AT.toString()
+                    )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].replayOriginId"
+                )
+                    .value(
+                        REPLAY_ORIGIN_ID.toString()
+                    )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].payloadAvailable"
+                )
+                    .value(true)
+            )
+            .andExpect(
+                jsonPath("$.items[0].payload")
+                    .doesNotExist()
+            )
+            .andExpect(
+                jsonPath("$.items[0].recordKey")
+                    .doesNotExist()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.items[0].replayLeaseOwner"
+                )
+                    .doesNotExist()
+            )
+            .andExpect(
+                jsonPath("$.page")
+                    .value(0)
+            )
+            .andExpect(
+                jsonPath("$.size")
+                    .value(20)
+            )
+            .andExpect(
+                jsonPath("$.totalElements")
+                    .value(1)
+            )
+            .andExpect(
+                jsonPath("$.totalPages")
+                    .value(1)
+            )
+            .andExpect(
+                jsonPath("$.first")
+                    .value(true)
+            )
+            .andExpect(
+                jsonPath("$.last")
+                    .value(true)
+            )
+            .andExpect(
+                jsonPath("$.hasNext")
+                    .value(false)
+            )
+            .andExpect(
+                jsonPath("$.hasPrevious")
+                    .value(false)
+            );
+
+        verify(listUseCase)
+            .listKafkaDeadLetterRecords(
+                expectedQuery
+            );
+
+        verifyNoInteractions(getUseCase);
+    }
+
+    @Test
+    void shouldApplyPaginationAndStatusFilter()
+        throws Exception {
+
+        KafkaDeadLetterRecordFilter filter =
+            new KafkaDeadLetterRecordFilter(
+                KafkaDeadLetterRecordStatus
+                    .REPLAY_FAILED
+            );
+
+        ListKafkaDeadLetterRecordsQuery expectedQuery =
+            new ListKafkaDeadLetterRecordsQuery(
+                2,
+                10,
+                filter
+            );
+
+        when(
+            listUseCase.listKafkaDeadLetterRecords(
+                expectedQuery
+            )
+        ).thenReturn(
+            new KafkaDeadLetterRecordPage(
+                List.of(),
+                2,
+                10,
+                21,
+                3
+            )
+        );
+
+        mockMvc.perform(
+                get(COLLECTION_PATH)
+                    .param("page", "2")
+                    .param("size", "10")
+                    .param(
+                        "status",
+                        "REPLAY_FAILED"
+                    )
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.items.length()")
+                    .value(0)
+            )
+            .andExpect(
+                jsonPath("$.page")
+                    .value(2)
+            )
+            .andExpect(
+                jsonPath("$.size")
+                    .value(10)
+            )
+            .andExpect(
+                jsonPath("$.totalElements")
+                    .value(21)
+            )
+            .andExpect(
+                jsonPath("$.totalPages")
+                    .value(3)
+            )
+            .andExpect(
+                jsonPath("$.first")
+                    .value(false)
+            )
+            .andExpect(
+                jsonPath("$.last")
+                    .value(true)
+            );
+
+        verify(listUseCase)
+            .listKafkaDeadLetterRecords(
+                expectedQuery
+            );
+    }
+
+    @Test
+    void shouldReturnAuthorizedRecordDetails()
+        throws Exception {
+
+        when(
+            getUseCase.getKafkaDeadLetterRecord(
+                RECORD_ID
+            )
+        ).thenReturn(details());
+
+        mockMvc.perform(
+                get(
+                    COLLECTION_PATH + "/{recordId}",
+                    RECORD_ID
+                )
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.id")
+                    .value(RECORD_ID.toString())
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value("REPLAY_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.totalReplayAttempts")
+                    .value(3)
+            )
+            .andExpect(
+                jsonPath("$.payloadAvailable")
+                    .value(true)
+            )
+            .andExpect(
+                jsonPath("$.exceptionMessage")
+                    .value(
+                        "Transfer processing failed."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.lastReplayError")
+                    .value(
+                        "Replay publication failed."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.replayLeaseUntil")
+                    .doesNotExist()
+            )
+            .andExpect(
+                jsonPath("$.summary")
+                    .doesNotExist()
+            )
+            .andExpect(
+                jsonPath("$.payload")
+                    .doesNotExist()
+            )
+            .andExpect(
+                jsonPath("$.recordKey")
+                    .doesNotExist()
+            )
+            .andExpect(
+                jsonPath("$.replayLeaseOwner")
+                    .doesNotExist()
+            );
+
+        verify(getUseCase)
+            .getKafkaDeadLetterRecord(
+                RECORD_ID
+            );
+
+        verifyNoInteractions(listUseCase);
+    }
+
+    @Test
+    void shouldRejectAnonymousCollectionRequest()
+        throws Exception {
+
+        mockMvc.perform(
+                get(COLLECTION_PATH)
+            )
+            .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(
+            listUseCase,
+            getUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectAuthenticatedNonOperator()
+        throws Exception {
+
+        mockMvc.perform(
+                get(COLLECTION_PATH)
+                    .with(nonOperatorJwt())
+            )
+            .andExpect(status().isForbidden());
+
+        verifyNoInteractions(
+            listUseCase,
+            getUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectAnonymousDetailRequest()
+        throws Exception {
+
+        mockMvc.perform(
+                get(
+                    COLLECTION_PATH + "/{recordId}",
+                    RECORD_ID
+                )
+            )
+            .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(
+            listUseCase,
+            getUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectNonOperatorDetailRequest()
+        throws Exception {
+
+        mockMvc.perform(
+                get(
+                    COLLECTION_PATH + "/{recordId}",
+                    RECORD_ID
+                )
+                    .with(nonOperatorJwt())
+            )
+            .andExpect(status().isForbidden());
+
+        verifyNoInteractions(
+            listUseCase,
+            getUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectNegativePage()
+        throws Exception {
+
+        mockMvc.perform(
+                get(COLLECTION_PATH)
+                    .param("page", "-1")
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Request validation failed."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(COLLECTION_PATH)
+            );
+
+        verifyNoInteractions(
+            listUseCase,
+            getUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectPageSizeAboveMaximum()
+        throws Exception {
+
+        mockMvc.perform(
+                get(COLLECTION_PATH)
+                    .param("size", "101")
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            );
+
+        verifyNoInteractions(
+            listUseCase,
+            getUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectUnknownStatus()
+        throws Exception {
+
+        mockMvc.perform(
+                get(COLLECTION_PATH)
+                    .param("status", "UNKNOWN")
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(COLLECTION_PATH)
+            );
+
+        verifyNoInteractions(
+            listUseCase,
+            getUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectMalformedRecordIdentifier()
+        throws Exception {
+
+        mockMvc.perform(
+                get(
+                    COLLECTION_PATH
+                        + "/not-a-uuid"
+                )
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        COLLECTION_PATH
+                            + "/not-a-uuid"
+                    )
+            );
+
+        verifyNoInteractions(
+            listUseCase,
+            getUseCase
+        );
+    }
+
+    @Test
+    void shouldReturnNotFoundForUnknownRecord()
+        throws Exception {
+
+        when(
+            getUseCase.getKafkaDeadLetterRecord(
+                RECORD_ID
+            )
+        ).thenThrow(
+            new KafkaDeadLetterRecordNotFoundException(
+                RECORD_ID
+            )
+        );
+
+        mockMvc.perform(
+                get(
+                    COLLECTION_PATH + "/{recordId}",
+                    RECORD_ID
+                )
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isNotFound())
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "KAFKA_DEAD_LETTER_"
+                            + "RECORD_NOT_FOUND"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Kafka dead-letter record "
+                            + "was not found."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        COLLECTION_PATH
+                            + "/"
+                            + RECORD_ID
+                    )
+            );
+
+        verify(getUseCase)
+            .getKafkaDeadLetterRecord(
+                RECORD_ID
+            );
+
+        verifyNoInteractions(listUseCase);
+    }
+
+    private static KafkaDeadLetterRecordSummary
+    summary() {
+        return new KafkaDeadLetterRecordSummary(
+            RECORD_ID,
+            KafkaDeadLetterRecordStatus
+                .REPLAY_FAILED,
+            "wallet.transfer.completed.dlt",
+            0,
+            203L,
+            "wallet.transfer.completed",
+            0,
+            103L,
+            "payflow-transfer-completed-audit-v1",
+            "java.lang.IllegalStateException",
+            1,
+            2,
+            RECEIVED_AT,
+            LAST_REPLAYED_AT,
+            REPLAY_ORIGIN_ID,
+            true
+        );
+    }
+
+    private static KafkaDeadLetterRecordDetails
+    details() {
+        return new KafkaDeadLetterRecordDetails(
+            summary(),
+            "Transfer processing failed.",
+            "Replay publication failed.",
+            null
+        );
+    }
+
+    private static org.springframework.test.web.servlet
+        .request.RequestPostProcessor
+    operatorJwt() {
+        return jwt()
+            .authorities(
+                new SimpleGrantedAuthority(
+                    OperationsAuthorities.OPERATIONS
+                )
+            );
+    }
+
+    private static org.springframework.test.web.servlet
+        .request.RequestPostProcessor
+    nonOperatorJwt() {
+        return jwt()
+            .authorities(
+                new SimpleGrantedAuthority(
+                    "PAYFLOW_CUSTOMER"
+                )
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterRecordPageTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterRecordPageTest.java
@@ -1,0 +1,168 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.Test;
+
+class KafkaDeadLetterRecordPageTest {
+
+    @Test
+    void shouldCreateImmutableCopyOfItems() {
+        KafkaDeadLetterRecordSummary item =
+            createSummary();
+
+        List<KafkaDeadLetterRecordSummary>
+            sourceItems =
+            new ArrayList<>();
+
+        sourceItems.add(item);
+
+        KafkaDeadLetterRecordPage page =
+            new KafkaDeadLetterRecordPage(
+                sourceItems,
+                0,
+                20,
+                1,
+                1
+            );
+
+        sourceItems.clear();
+
+        assertThat(page.items())
+            .containsExactly(item);
+
+        assertThatThrownBy(
+            () -> page.items().clear()
+        )
+            .isInstanceOf(
+                UnsupportedOperationException.class
+            );
+    }
+
+    @Test
+    void shouldDescribeFirstPage() {
+        KafkaDeadLetterRecordPage page =
+            new KafkaDeadLetterRecordPage(
+                List.of(createSummary()),
+                0,
+                20,
+                41,
+                3
+            );
+
+        assertThat(page.first()).isTrue();
+        assertThat(page.last()).isFalse();
+        assertThat(page.hasNext()).isTrue();
+        assertThat(page.hasPrevious()).isFalse();
+    }
+
+    @Test
+    void shouldDescribeLastPage() {
+        KafkaDeadLetterRecordPage page =
+            new KafkaDeadLetterRecordPage(
+                List.of(createSummary()),
+                2,
+                20,
+                41,
+                3
+            );
+
+        assertThat(page.first()).isFalse();
+        assertThat(page.last()).isTrue();
+        assertThat(page.hasNext()).isFalse();
+        assertThat(page.hasPrevious()).isTrue();
+    }
+
+    @Test
+    void shouldTreatEmptyResultAsFirstAndLastPage() {
+        KafkaDeadLetterRecordPage page =
+            new KafkaDeadLetterRecordPage(
+                List.of(),
+                0,
+                20,
+                0,
+                0
+            );
+
+        assertThat(page.first()).isTrue();
+        assertThat(page.last()).isTrue();
+        assertThat(page.hasNext()).isFalse();
+        assertThat(page.hasPrevious()).isFalse();
+    }
+
+    @Test
+    void shouldRejectNegativeTotalElements() {
+        assertThatThrownBy(
+            () ->
+                new KafkaDeadLetterRecordPage(
+                    List.of(),
+                    0,
+                    20,
+                    -1,
+                    0
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "totalElements must not be negative"
+            );
+    }
+
+    @Test
+    void shouldRejectNegativeTotalPages() {
+        assertThatThrownBy(
+            () ->
+                new KafkaDeadLetterRecordPage(
+                    List.of(),
+                    0,
+                    20,
+                    0,
+                    -1
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "totalPages must not be negative"
+            );
+    }
+
+    private static KafkaDeadLetterRecordSummary
+    createSummary() {
+        UUID recordId =
+            UUID.fromString(
+                "637398d5-0a02-4d10-a9af-c783ef92778b"
+            );
+
+        return new KafkaDeadLetterRecordSummary(
+            recordId,
+            KafkaDeadLetterRecordStatus.RECEIVED,
+            "wallet.transfer.completed.dlt",
+            0,
+            42L,
+            "wallet.transfer.completed",
+            0,
+            41L,
+            "payflow-transfer-consumer",
+            "java.lang.IllegalStateException",
+            0,
+            0,
+            Instant.parse(
+                "2026-07-22T12:00:00Z"
+            ),
+            null,
+            recordId,
+            true
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterRecordSummaryTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterRecordSummaryTest.java
@@ -1,0 +1,175 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.Test;
+
+class KafkaDeadLetterRecordSummaryTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "637398d5-0a02-4d10-a9af-c783ef92778b"
+        );
+
+    private static final UUID REPLAY_ORIGIN_ID =
+        UUID.fromString(
+            "6622b3c7-582e-47df-b6f4-8397ab487add"
+        );
+
+    private static final Instant RECEIVED_AT =
+        Instant.parse(
+            "2026-07-22T12:00:00Z"
+        );
+
+    @Test
+    void shouldCalculateTotalReplayAttempts() {
+        KafkaDeadLetterRecordSummary summary =
+            createSummary(
+                RECORD_ID,
+                2,
+                3
+            );
+
+        assertThat(
+            summary.totalReplayAttempts()
+        ).isEqualTo(5);
+    }
+
+    @Test
+    void shouldRejectNegativeReplayCount() {
+        assertThatThrownBy(
+            () ->
+                createSummary(
+                    RECORD_ID,
+                    -1,
+                    0
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "replayCount must not be negative"
+            );
+    }
+
+    @Test
+    void shouldRejectNegativeReplayAttemptBase() {
+        assertThatThrownBy(
+            () ->
+                createSummary(
+                    RECORD_ID,
+                    1,
+                    -1
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "replayAttemptBase must not be negative"
+            );
+    }
+
+    @Test
+    void shouldRejectTotalReplayAttemptOverflow() {
+        assertThatThrownBy(
+            () ->
+                createSummary(
+                    RECORD_ID,
+                    1,
+                    Integer.MAX_VALUE
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "total replay attempt count "
+                    + "must not overflow"
+            );
+    }
+
+    @Test
+    void shouldRejectNullIdentifier() {
+        assertThatThrownBy(
+            () ->
+                createSummary(
+                    null,
+                    1,
+                    0
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "id must not be null"
+            );
+    }
+
+    @Test
+    void shouldRejectLastReplayTimeBeforeReceivedTime() {
+        assertThatThrownBy(
+            () ->
+                new KafkaDeadLetterRecordSummary(
+                    RECORD_ID,
+                    KafkaDeadLetterRecordStatus
+                        .REPLAY_FAILED,
+                    "wallet.transfer.completed.dlt",
+                    0,
+                    42L,
+                    "wallet.transfer.completed",
+                    0,
+                    41L,
+                    "payflow-transfer-consumer",
+                    "java.lang.IllegalStateException",
+                    1,
+                    0,
+                    RECEIVED_AT,
+                    RECEIVED_AT.minusSeconds(1),
+                    REPLAY_ORIGIN_ID,
+                    true
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "lastReplayedAt must not be "
+                    + "before receivedAt"
+            );
+    }
+
+    private static KafkaDeadLetterRecordSummary
+    createSummary(
+        UUID id,
+        int replayCount,
+        int replayAttemptBase
+    ) {
+        return new KafkaDeadLetterRecordSummary(
+            id,
+            KafkaDeadLetterRecordStatus
+                .REPLAY_FAILED,
+            "wallet.transfer.completed.dlt",
+            0,
+            42L,
+            "wallet.transfer.completed",
+            0,
+            41L,
+            "payflow-transfer-consumer",
+            "java.lang.IllegalStateException",
+            replayCount,
+            replayAttemptBase,
+            RECEIVED_AT,
+            RECEIVED_AT.plusSeconds(30),
+            REPLAY_ORIGIN_ID,
+            true
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/port/in/ListKafkaDeadLetterRecordsQueryTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/port/in/ListKafkaDeadLetterRecordsQueryTest.java
@@ -1,0 +1,107 @@
+package com.nursena.payflow.eventprocessing.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordFilter;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.Test;
+
+class ListKafkaDeadLetterRecordsQueryTest {
+
+    @Test
+    void shouldCreateValidQuery() {
+        KafkaDeadLetterRecordFilter filter =
+            new KafkaDeadLetterRecordFilter(
+                KafkaDeadLetterRecordStatus
+                    .REPLAY_FAILED
+            );
+
+        ListKafkaDeadLetterRecordsQuery query =
+            new ListKafkaDeadLetterRecordsQuery(
+                2,
+                50,
+                filter
+            );
+
+        assertThat(query.page()).isEqualTo(2);
+        assertThat(query.size()).isEqualTo(50);
+        assertThat(query.filter()).isSameAs(filter);
+    }
+
+    @Test
+    void shouldRejectNegativePage() {
+        assertThatThrownBy(
+            () ->
+                new ListKafkaDeadLetterRecordsQuery(
+                    -1,
+                    20,
+                    KafkaDeadLetterRecordFilter
+                        .unfiltered()
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "page must not be negative"
+            );
+    }
+
+    @Test
+    void shouldRejectZeroPageSize() {
+        assertThatThrownBy(
+            () ->
+                new ListKafkaDeadLetterRecordsQuery(
+                    0,
+                    0,
+                    KafkaDeadLetterRecordFilter
+                        .unfiltered()
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "size must be greater than zero"
+            );
+    }
+
+    @Test
+    void shouldRejectPageSizeAboveMaximum() {
+        assertThatThrownBy(
+            () ->
+                new ListKafkaDeadLetterRecordsQuery(
+                    0,
+                    ListKafkaDeadLetterRecordsQuery
+                        .MAX_SIZE + 1,
+                    KafkaDeadLetterRecordFilter
+                        .unfiltered()
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "size must not exceed 100"
+            );
+    }
+
+    @Test
+    void shouldRejectNullFilter() {
+        assertThatThrownBy(
+            () ->
+                new ListKafkaDeadLetterRecordsQuery(
+                    0,
+                    20,
+                    null
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "filter must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/GetKafkaDeadLetterRecordServiceTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/GetKafkaDeadLetterRecordServiceTest.java
@@ -1,0 +1,158 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordDetails;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordSummary;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterQueryPort;
+import com.nursena.payflow.eventprocessing.domain.exception.KafkaDeadLetterRecordNotFoundException;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GetKafkaDeadLetterRecordServiceTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "637398d5-0a02-4d10-a9af-c783ef92778b"
+        );
+
+    @Mock
+    private KafkaDeadLetterQueryPort queryPort;
+
+    private GetKafkaDeadLetterRecordService service;
+
+    @BeforeEach
+    void setUp() {
+        service =
+            new GetKafkaDeadLetterRecordService(
+                queryPort
+            );
+    }
+
+    @Test
+    void shouldReturnExistingRecord() {
+        KafkaDeadLetterRecordDetails details =
+            createDetails();
+
+        when(
+            queryPort.findById(RECORD_ID)
+        ).thenReturn(
+            Optional.of(details)
+        );
+
+        KafkaDeadLetterRecordDetails result =
+            service.getKafkaDeadLetterRecord(
+                RECORD_ID
+            );
+
+        assertThat(result).isSameAs(details);
+
+        verify(queryPort).findById(RECORD_ID);
+    }
+
+    @Test
+    void shouldThrowWhenRecordDoesNotExist() {
+        when(
+            queryPort.findById(RECORD_ID)
+        ).thenReturn(
+            Optional.empty()
+        );
+
+        KafkaDeadLetterRecordNotFoundException
+            exception =
+            catchThrowableOfType(
+                () ->
+                    service
+                        .getKafkaDeadLetterRecord(
+                            RECORD_ID
+                        ),
+                KafkaDeadLetterRecordNotFoundException
+                    .class
+            );
+
+        assertThat(exception.getCode())
+            .isEqualTo(
+                KafkaDeadLetterRecordNotFoundException
+                    .CODE
+            );
+
+        assertThat(exception.getRecordId())
+            .isEqualTo(RECORD_ID);
+
+        assertThat(exception)
+            .hasMessage(
+                "Kafka dead-letter record "
+                    + "was not found."
+            );
+
+        verify(queryPort).findById(RECORD_ID);
+    }
+
+    @Test
+    void shouldRejectNullRecordIdentifier() {
+        assertThatThrownBy(
+            () ->
+                service.getKafkaDeadLetterRecord(
+                    null
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "recordId must not be null"
+            );
+
+        verifyNoInteractions(queryPort);
+    }
+
+    private static KafkaDeadLetterRecordDetails
+    createDetails() {
+        Instant receivedAt =
+            Instant.parse(
+                "2026-07-22T12:00:00Z"
+            );
+
+        KafkaDeadLetterRecordSummary summary =
+            new KafkaDeadLetterRecordSummary(
+                RECORD_ID,
+                KafkaDeadLetterRecordStatus
+                    .REPLAY_FAILED,
+                "wallet.transfer.completed.dlt",
+                0,
+                42L,
+                "wallet.transfer.completed",
+                0,
+                41L,
+                "payflow-transfer-consumer",
+                "java.lang.IllegalStateException",
+                1,
+                0,
+                receivedAt,
+                receivedAt.plusSeconds(30),
+                RECORD_ID,
+                true
+            );
+
+        return new KafkaDeadLetterRecordDetails(
+            summary,
+            "Transfer processing failed.",
+            "Replay publication failed.",
+            null
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/ListKafkaDeadLetterRecordsServiceTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/ListKafkaDeadLetterRecordsServiceTest.java
@@ -1,0 +1,101 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordFilter;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordPage;
+import com.nursena.payflow.eventprocessing.application.port.in.ListKafkaDeadLetterRecordsQuery;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterQueryPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ListKafkaDeadLetterRecordsServiceTest {
+
+    @Mock
+    private KafkaDeadLetterQueryPort queryPort;
+
+    private ListKafkaDeadLetterRecordsService service;
+
+    @BeforeEach
+    void setUp() {
+        service =
+            new ListKafkaDeadLetterRecordsService(
+                queryPort
+            );
+    }
+
+    @Test
+    void shouldDelegatePageQueryToPort() {
+        KafkaDeadLetterRecordFilter filter =
+            new KafkaDeadLetterRecordFilter(
+                KafkaDeadLetterRecordStatus
+                    .REPLAY_FAILED
+            );
+
+        ListKafkaDeadLetterRecordsQuery query =
+            new ListKafkaDeadLetterRecordsQuery(
+                2,
+                20,
+                filter
+            );
+
+        KafkaDeadLetterRecordPage expectedPage =
+            new KafkaDeadLetterRecordPage(
+                List.of(),
+                2,
+                20,
+                0,
+                0
+            );
+
+        when(
+            queryPort.findPage(
+                2,
+                20,
+                filter
+            )
+        ).thenReturn(expectedPage);
+
+        KafkaDeadLetterRecordPage result =
+            service.listKafkaDeadLetterRecords(
+                query
+            );
+
+        assertThat(result).isSameAs(expectedPage);
+
+        verify(queryPort).findPage(
+            2,
+            20,
+            filter
+        );
+    }
+
+    @Test
+    void shouldRejectNullQuery() {
+        assertThatThrownBy(
+            () ->
+                service.listKafkaDeadLetterRecords(
+                    null
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "query must not be null"
+            );
+
+        verifyNoInteractions(queryPort);
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterQueryPersistenceIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterQueryPersistenceIntegrationTest.java
@@ -1,0 +1,525 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordDetails;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordFilter;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordPage;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterRecordSummary;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterQueryPort;
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class KafkaDeadLetterQueryPersistenceIntegrationTest {
+
+    private static final UUID ORIGIN_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001200"
+        );
+
+    private static final UUID RECEIVED_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001201"
+        );
+
+    private static final UUID FAILED_LOW_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001202"
+        );
+
+    private static final UUID FAILED_HIGH_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001203"
+        );
+
+    private static final UUID REPLAYING_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000001204"
+        );
+
+    private static final Instant BASE_TIME =
+        Instant.parse(
+            "2026-07-22T12:00:00Z"
+        );
+
+    private static final Instant
+        REPLAYING_LEASE_UNTIL =
+        BASE_TIME.plusSeconds(240);
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private KafkaDeadLetterQueryPort queryPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void prepareDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM kafka_dead_letter_records"
+        );
+
+        insertFixtures();
+    }
+
+    @Test
+    void shouldListAllRecordsUsingDeterministicPagination() {
+        KafkaDeadLetterRecordPage firstPage =
+            queryPort.findPage(
+                0,
+                2,
+                KafkaDeadLetterRecordFilter
+                    .unfiltered()
+            );
+
+        assertThat(firstPage.items())
+            .extracting(
+                KafkaDeadLetterRecordSummary::id
+            )
+            .containsExactly(
+                FAILED_HIGH_ID,
+                FAILED_LOW_ID
+            );
+
+        assertThat(firstPage.page())
+            .isZero();
+
+        assertThat(firstPage.size())
+            .isEqualTo(2);
+
+        assertThat(firstPage.totalElements())
+            .isEqualTo(4L);
+
+        assertThat(firstPage.totalPages())
+            .isEqualTo(2);
+
+        assertThat(firstPage.first())
+            .isTrue();
+
+        assertThat(firstPage.last())
+            .isFalse();
+
+        assertThat(firstPage.hasNext())
+            .isTrue();
+
+        assertThat(firstPage.hasPrevious())
+            .isFalse();
+
+        KafkaDeadLetterRecordPage secondPage =
+            queryPort.findPage(
+                1,
+                2,
+                KafkaDeadLetterRecordFilter
+                    .unfiltered()
+            );
+
+        assertThat(secondPage.items())
+            .extracting(
+                KafkaDeadLetterRecordSummary::id
+            )
+            .containsExactly(
+                REPLAYING_ID,
+                RECEIVED_ID
+            );
+
+        assertThat(secondPage.first())
+            .isFalse();
+
+        assertThat(secondPage.last())
+            .isTrue();
+
+        assertThat(secondPage.hasNext())
+            .isFalse();
+
+        assertThat(secondPage.hasPrevious())
+            .isTrue();
+    }
+
+    @Test
+    void shouldFilterRecordsByStatus() {
+        KafkaDeadLetterRecordFilter filter =
+            new KafkaDeadLetterRecordFilter(
+                KafkaDeadLetterRecordStatus
+                    .REPLAY_FAILED
+            );
+
+        KafkaDeadLetterRecordPage firstPage =
+            queryPort.findPage(
+                0,
+                1,
+                filter
+            );
+
+        assertThat(firstPage.items())
+            .extracting(
+                KafkaDeadLetterRecordSummary::id
+            )
+            .containsExactly(
+                FAILED_HIGH_ID
+            );
+
+        assertThat(firstPage.totalElements())
+            .isEqualTo(2L);
+
+        assertThat(firstPage.totalPages())
+            .isEqualTo(2);
+
+        KafkaDeadLetterRecordPage secondPage =
+            queryPort.findPage(
+                1,
+                1,
+                filter
+            );
+
+        assertThat(secondPage.items())
+            .extracting(
+                KafkaDeadLetterRecordSummary::id
+            )
+            .containsExactly(
+                FAILED_LOW_ID
+            );
+    }
+
+    @Test
+    void shouldReturnSafeRecordDetails() {
+        KafkaDeadLetterRecordDetails details =
+            queryPort.findById(
+                    FAILED_HIGH_ID
+                )
+                .orElseThrow();
+
+        KafkaDeadLetterRecordSummary summary =
+            details.summary();
+
+        assertThat(summary.id())
+            .isEqualTo(FAILED_HIGH_ID);
+
+        assertThat(summary.status())
+            .isEqualTo(
+                KafkaDeadLetterRecordStatus
+                    .REPLAY_FAILED
+            );
+
+        assertThat(summary.deadLetterTopic())
+            .isEqualTo(
+                "wallet.transfer.completed.dlt"
+            );
+
+        assertThat(summary.originalTopic())
+            .isEqualTo(
+                "wallet.transfer.completed"
+            );
+
+        assertThat(summary.replayCount())
+            .isEqualTo(1);
+
+        assertThat(summary.replayAttemptBase())
+            .isEqualTo(2);
+
+        assertThat(summary.totalReplayAttempts())
+            .isEqualTo(3);
+
+        assertThat(summary.replayOriginId())
+            .isEqualTo(ORIGIN_ID);
+
+        assertThat(summary.payloadAvailable())
+            .isTrue();
+
+        assertThat(details.exceptionMessage())
+            .isEqualTo(
+                "Failure for record "
+                    + FAILED_HIGH_ID
+            );
+
+        assertThat(details.lastReplayError())
+            .isEqualTo(
+                "Replay publication failed."
+            );
+
+        assertThat(details.replayLeaseUntil())
+            .isNull();
+    }
+
+    @Test
+    void shouldReturnReplayLeaseExpiration() {
+        KafkaDeadLetterRecordDetails details =
+            queryPort.findById(
+                    REPLAYING_ID
+                )
+                .orElseThrow();
+
+        assertThat(details.summary().status())
+            .isEqualTo(
+                KafkaDeadLetterRecordStatus
+                    .REPLAYING
+            );
+
+        assertThat(details.replayLeaseUntil())
+            .isEqualTo(
+                REPLAYING_LEASE_UNTIL
+            );
+
+        assertThat(details.lastReplayError())
+            .isNull();
+    }
+
+    @Test
+    void shouldTreatBlankPayloadAsUnavailable() {
+        KafkaDeadLetterRecordDetails details =
+            queryPort.findById(
+                    FAILED_LOW_ID
+                )
+                .orElseThrow();
+
+        assertThat(
+            details.summary()
+                .payloadAvailable()
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldReturnEmptyForUnknownIdentifier() {
+        assertThat(
+            queryPort.findById(
+                UUID.fromString(
+                    "80000000-0000-0000-0000-000000001299"
+                )
+            )
+        )
+            .isEmpty();
+    }
+
+    @Test
+    void shouldCreateQueryIndexes() {
+        Map<String, String> definitions =
+            indexDefinitions();
+
+        assertThat(definitions)
+            .containsKeys(
+                "idx_kafka_dead_letter_records_"
+                    + "status_received_id",
+                "idx_kafka_dead_letter_records_"
+                    + "received_id"
+            );
+
+        assertThat(definitions)
+            .doesNotContainKey(
+                "idx_kafka_dead_letter_records_"
+                    + "status_received"
+            );
+
+        assertThat(
+            definitions.get(
+                "idx_kafka_dead_letter_records_"
+                    + "status_received_id"
+            )
+        )
+            .contains(
+                "(status, received_at DESC, id DESC)"
+            );
+
+        assertThat(
+            definitions.get(
+                "idx_kafka_dead_letter_records_"
+                    + "received_id"
+            )
+        )
+            .contains(
+                "(received_at DESC, id DESC)"
+            );
+    }
+
+    private void insertFixtures() {
+        insertRecord(
+            RECEIVED_ID,
+            201L,
+            BASE_TIME,
+            null,
+            "RECEIVED",
+            0,
+            null,
+            null,
+            null,
+            null,
+            RECEIVED_ID,
+            0
+        );
+
+        insertRecord(
+            REPLAYING_ID,
+            204L,
+            BASE_TIME.plusSeconds(60),
+            "{}",
+            "REPLAYING",
+            2,
+            BASE_TIME.plusSeconds(180),
+            "replay-worker-1",
+            REPLAYING_LEASE_UNTIL,
+            null,
+            REPLAYING_ID,
+            0
+        );
+
+        insertRecord(
+            FAILED_LOW_ID,
+            202L,
+            BASE_TIME.plusSeconds(120),
+            "   ",
+            "REPLAY_FAILED",
+            1,
+            BASE_TIME.plusSeconds(150),
+            null,
+            null,
+            "First replay failure.",
+            FAILED_LOW_ID,
+            0
+        );
+
+        insertRecord(
+            FAILED_HIGH_ID,
+            203L,
+            BASE_TIME.plusSeconds(120),
+            "{}",
+            "REPLAY_FAILED",
+            1,
+            BASE_TIME.plusSeconds(160),
+            null,
+            null,
+            "Replay publication failed.",
+            ORIGIN_ID,
+            2
+        );
+    }
+
+    private void insertRecord(
+        UUID id,
+        long deadLetterOffset,
+        Instant receivedAt,
+        String payload,
+        String status,
+        int replayCount,
+        Instant lastReplayedAt,
+        String replayLeaseOwner,
+        Instant replayLeaseUntil,
+        String lastReplayError,
+        UUID replayOriginId,
+        int replayAttemptBase
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO kafka_dead_letter_records (
+                id,
+                dlt_topic,
+                dlt_partition,
+                dlt_offset,
+                original_topic,
+                original_partition,
+                original_offset,
+                original_consumer_group,
+                record_key,
+                payload,
+                exception_type,
+                exception_message,
+                status,
+                replay_count,
+                received_at,
+                last_replayed_at,
+                replay_lease_owner,
+                replay_lease_until,
+                last_replay_error,
+                replay_origin_id,
+                replay_attempt_base
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?
+            )
+            """,
+            id,
+            "wallet.transfer.completed.dlt",
+            0,
+            deadLetterOffset,
+            "wallet.transfer.completed",
+            0,
+            deadLetterOffset - 100,
+            "payflow-transfer-completed-audit-v1",
+            "sensitive-record-key-" + id,
+            payload,
+            "java.lang.IllegalStateException",
+            "Failure for record " + id,
+            status,
+            replayCount,
+            Timestamp.from(receivedAt),
+            timestamp(lastReplayedAt),
+            replayLeaseOwner,
+            timestamp(replayLeaseUntil),
+            lastReplayError,
+            replayOriginId,
+            replayAttemptBase
+        );
+    }
+
+    private Map<String, String>
+    indexDefinitions() {
+        return jdbcTemplate.query(
+            """
+            SELECT
+                indexname,
+                indexdef
+            FROM pg_indexes
+            WHERE schemaname = current_schema()
+              AND tablename =
+                    'kafka_dead_letter_records'
+            """,
+            resultSet -> {
+                Map<String, String> result =
+                    new LinkedHashMap<>();
+
+                while (resultSet.next()) {
+                    result.put(
+                        resultSet.getString(
+                            "indexname"
+                        ),
+                        resultSet.getString(
+                            "indexdef"
+                        )
+                    );
+                }
+
+                return result;
+            }
+        );
+    }
+
+    private static Timestamp timestamp(
+        Instant value
+    ) {
+        return value == null
+            ? null
+            : Timestamp.from(value);
+    }
+}


### PR DESCRIPTION
## Summary

- add a dedicated read-side application boundary for Kafka dead-letter queries
- add deterministic PostgreSQL pagination and status filtering
- add query indexes through Flyway migration V11
- expose secured list and detail operations endpoints
- publish safe response projections without payload, record key, or replay lease owner
- document the operations endpoints through OpenAPI

## API

- `GET /api/v1/operations/kafka/dead-letters`
- `GET /api/v1/operations/kafka/dead-letters/{recordId}`

The list endpoint supports:

- `page`, default `0`
- `size`, default `20`, maximum `100`
- optional `status` filtering

Records are ordered deterministically by:

- `received_at DESC`
- `id DESC`

## Security

- anonymous requests return `401 Unauthorized`
- authenticated principals without `PAYFLOW_OPERATIONS` return `403 Forbidden`
- authorized operators can access list and detail operations
- unknown records return `404 Not Found`
- malformed identifiers, filters, and pagination values return `400 Bad Request`
- `payload`, `recordKey`, and `replayLeaseOwner` are not exposed

## Persistence

- add safe SQL projections for list and detail queries
- add deterministic status-filtered and unfiltered query indexes
- preserve the existing Kafka dead-letter write and replay boundaries

## Testing

- application model and service unit tests
- PostgreSQL/Testcontainers query integration tests
- MockMvc authorization and HTTP contract tests
- OpenAPI JSON contract tests
- full Maven verification

##text
.\mvnw.cmd clean verify
BUILD SUCCESS