### PR TITLE
feat: add explicit Kafka dead-letter replay and discard operations

### DIFF
--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandController.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandController.java
@@ -1,0 +1,385 @@
+package com.nursena.payflow.eventprocessing.adapter.in.web;
+
+import static org.springframework.http.MediaType
+    .APPLICATION_JSON_VALUE;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration
+    .OpenApiConfiguration;
+import com.nursena.payflow.eventprocessing.application.model
+    .DiscardKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model
+    .DiscardKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.model
+    .ReplayKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model
+    .ReplayKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.in
+    .DiscardKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.in
+    .ReplayKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.domain.exception
+    .KafkaDeadLetterCommandException;
+import com.nursena.payflow.eventprocessing.domain.exception
+    .KafkaDeadLetterRecordNotFoundException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses
+    .ApiResponse;
+import io.swagger.v3.oas.annotations.responses
+    .ApiResponses;
+import io.swagger.v3.oas.annotations.security
+    .SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation
+    .RequestMapping;
+import org.springframework.web.bind.annotation
+    .RestController;
+
+@Tag(
+    name = "Kafka Dead-Letter Commands",
+    description =
+        "Authorized operations for replaying "
+            + "or discarding Kafka dead-letter "
+            + "records."
+)
+@RestController
+@RequestMapping(
+    "/api/v1/operations/kafka/dead-letters"
+)
+public class KafkaDeadLetterCommandController {
+
+    private final ReplayKafkaDeadLetterRecordUseCase
+        replayUseCase;
+
+    private final DiscardKafkaDeadLetterRecordUseCase
+        discardUseCase;
+
+    public KafkaDeadLetterCommandController(
+        ReplayKafkaDeadLetterRecordUseCase
+            replayUseCase,
+        DiscardKafkaDeadLetterRecordUseCase
+            discardUseCase
+    ) {
+        this.replayUseCase =
+            Objects.requireNonNull(
+                replayUseCase,
+                "replayUseCase must not be null"
+            );
+
+        this.discardUseCase =
+            Objects.requireNonNull(
+                discardUseCase,
+                "discardUseCase must not be null"
+            );
+    }
+
+    @Operation(
+        operationId =
+            "replayKafkaDeadLetterRecord",
+        summary =
+            "Replay a Kafka dead-letter record",
+        description =
+            "Claims the record through the "
+                + "controlled replay lifecycle, "
+                + "publishes it to the original "
+                + "topic, and persists the outcome."
+    )
+    @SecurityRequirement(
+        name =
+            OpenApiConfiguration
+                .BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description =
+                "The record was replayed.",
+            content = @Content(
+                mediaType =
+                    APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        KafkaDeadLetterReplayResponse
+                            .class
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description =
+                "The record identifier is invalid.",
+            content = @Content(
+                mediaType =
+                    APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        ApiError.class
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description =
+                "The authenticated principal does "
+                    + "not have operations authority."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The dead-letter record was not found.",
+            content = @Content(
+                mediaType =
+                    APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        ApiError.class
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "The dead-letter record cannot be "
+                    + "replayed in its current state.",
+            content = @Content(
+                mediaType =
+                    APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        ApiError.class
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "502",
+            description =
+                "Kafka replay publication failed.",
+            content = @Content(
+                mediaType =
+                    APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        ApiError.class
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "503",
+            description =
+                "The replay outcome could not be "
+                    + "resolved safely.",
+            content = @Content(
+                mediaType =
+                    APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        ApiError.class
+                )
+            )
+        )
+    })
+    @PostMapping("/{recordId}/replay")
+    public ResponseEntity<KafkaDeadLetterReplayResponse>
+    replayKafkaDeadLetterRecord(
+        @Parameter(
+            description =
+                "Dead-letter record identifier.",
+            schema = @Schema(
+                type = "string",
+                format = "uuid"
+            )
+        )
+        @PathVariable("recordId")
+        UUID recordId
+    ) {
+        ReplayKafkaDeadLetterRecordResult result =
+            Objects.requireNonNull(
+                replayUseCase.replay(
+                    new ReplayKafkaDeadLetterRecordCommand(
+                        recordId
+                    )
+                ),
+                "replay result must not be null"
+            );
+
+        return replayResponse(
+            recordId,
+            result
+        );
+    }
+
+    @Operation(
+        operationId =
+            "discardKafkaDeadLetterRecord",
+        summary =
+            "Discard a Kafka dead-letter record",
+        description =
+            "Atomically transitions a RECEIVED or "
+                + "REPLAY_FAILED record to DISCARDED. "
+                + "Repeated discard requests are "
+                + "idempotent."
+    )
+    @SecurityRequirement(
+        name =
+            OpenApiConfiguration
+                .BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description =
+                "The record is discarded."
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description =
+                "The record identifier is invalid.",
+            content = @Content(
+                mediaType =
+                    APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        ApiError.class
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "Bearer token is missing or invalid."
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description =
+                "The authenticated principal does "
+                    + "not have operations authority."
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description =
+                "The dead-letter record was not found.",
+            content = @Content(
+                mediaType =
+                    APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        ApiError.class
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "The dead-letter record cannot be "
+                    + "discarded in its current state.",
+            content = @Content(
+                mediaType =
+                    APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        ApiError.class
+                )
+            )
+        )
+    })
+    @PostMapping("/{recordId}/discard")
+    public ResponseEntity<Void>
+    discardKafkaDeadLetterRecord(
+        @Parameter(
+            description =
+                "Dead-letter record identifier.",
+            schema = @Schema(
+                type = "string",
+                format = "uuid"
+            )
+        )
+        @PathVariable("recordId")
+        UUID recordId
+    ) {
+        DiscardKafkaDeadLetterRecordResult result =
+            Objects.requireNonNull(
+                discardUseCase.discard(
+                    new DiscardKafkaDeadLetterRecordCommand(
+                        recordId
+                    )
+                ),
+                "discard result must not be null"
+            );
+
+        return discardResponse(
+            recordId,
+            result
+        );
+    }
+
+    private static ResponseEntity<
+        KafkaDeadLetterReplayResponse
+        > replayResponse(
+        UUID recordId,
+        ReplayKafkaDeadLetterRecordResult result
+    ) {
+        return switch (result.outcome()) {
+            case REPLAYED ->
+                ResponseEntity.ok(
+                    KafkaDeadLetterReplayResponse
+                        .replayed(recordId)
+                );
+
+            case NOT_FOUND ->
+                throw new
+                    KafkaDeadLetterRecordNotFoundException(
+                    recordId
+                );
+
+            case NOT_CLAIMABLE ->
+                throw KafkaDeadLetterCommandException
+                    .notClaimable(recordId);
+
+            case REPLAY_FAILED ->
+                throw KafkaDeadLetterCommandException
+                    .replayFailed(recordId);
+
+            case UNRESOLVED ->
+                throw KafkaDeadLetterCommandException
+                    .replayUnresolved(recordId);
+        };
+    }
+
+    private static ResponseEntity<Void>
+    discardResponse(
+        UUID recordId,
+        DiscardKafkaDeadLetterRecordResult result
+    ) {
+        return switch (result.outcome()) {
+            case DISCARDED,
+                 ALREADY_DISCARDED ->
+                ResponseEntity
+                    .noContent()
+                    .build();
+
+            case NOT_FOUND ->
+                throw new
+                    KafkaDeadLetterRecordNotFoundException(
+                    recordId
+                );
+
+            case NOT_DISCARDABLE ->
+                throw KafkaDeadLetterCommandException
+                    .notDiscardable(recordId);
+        };
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandExceptionHandler.java
@@ -1,0 +1,117 @@
+package com.nursena.payflow.eventprocessing.adapter.in.web;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.eventprocessing.domain.exception
+    .KafkaDeadLetterCommandException;
+import com.nursena.payflow.eventprocessing.domain.exception
+    .KafkaDeadLetterRecordNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation
+    .ExceptionHandler;
+import org.springframework.web.bind.annotation
+    .RestControllerAdvice;
+import org.springframework.web.method.annotation
+    .HandlerMethodValidationException;
+import org.springframework.web.method.annotation
+    .MethodArgumentTypeMismatchException;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(
+    assignableTypes =
+        KafkaDeadLetterCommandController.class
+)
+public class
+KafkaDeadLetterCommandExceptionHandler {
+
+    @ExceptionHandler(
+        KafkaDeadLetterRecordNotFoundException.class
+    )
+    ResponseEntity<ApiError> handleNotFound(
+        KafkaDeadLetterRecordNotFoundException
+            exception,
+        HttpServletRequest request
+    ) {
+        return response(
+            HttpStatus.NOT_FOUND,
+            exception.getCode(),
+            exception.getMessage(),
+            request
+        );
+    }
+
+    @ExceptionHandler(
+        KafkaDeadLetterCommandException.class
+    )
+    ResponseEntity<ApiError> handleCommandFailure(
+        KafkaDeadLetterCommandException exception,
+        HttpServletRequest request
+    ) {
+        return response(
+            statusOf(exception),
+            exception.getCode(),
+            exception.getMessage(),
+            request
+        );
+    }
+
+    @ExceptionHandler({
+        HandlerMethodValidationException.class,
+        MethodArgumentTypeMismatchException.class
+    })
+    ResponseEntity<ApiError> handleValidationFailure(
+        Exception exception,
+        HttpServletRequest request
+    ) {
+        return response(
+            HttpStatus.BAD_REQUEST,
+            "VALIDATION_FAILED",
+            "Request validation failed.",
+            request
+        );
+    }
+
+    private static HttpStatus statusOf(
+        KafkaDeadLetterCommandException
+            exception
+    ) {
+        return switch (exception.getReason()) {
+            case NOT_CLAIMABLE,
+                 NOT_DISCARDABLE ->
+                HttpStatus.CONFLICT;
+
+            case REPLAY_FAILED ->
+                HttpStatus.BAD_GATEWAY;
+
+            case REPLAY_UNRESOLVED ->
+                HttpStatus.SERVICE_UNAVAILABLE;
+        };
+    }
+
+    private static ResponseEntity<ApiError> response(
+        HttpStatus status,
+        String code,
+        String message,
+        HttpServletRequest request
+    ) {
+        ApiError body =
+            new ApiError(
+                Instant.now(),
+                status.value(),
+                code,
+                message,
+                request.getRequestURI(),
+                List.of()
+            );
+
+        return ResponseEntity
+            .status(status)
+            .body(body);
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterReplayResponse.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterReplayResponse.java
@@ -1,0 +1,69 @@
+package com.nursena.payflow.eventprocessing.adapter.in.web;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "KafkaDeadLetterReplayResponse",
+    description =
+        "Result of a successfully completed "
+            + "Kafka dead-letter replay."
+)
+public record KafkaDeadLetterReplayResponse(
+
+    @Schema(
+        description =
+            "Identifier of the replayed "
+                + "dead-letter record.",
+        format = "uuid"
+    )
+    UUID recordId,
+
+    @Schema(
+        description =
+            "Persisted status after replay.",
+        example = "REPLAYED",
+        allowableValues = {
+            "REPLAYED"
+        }
+    )
+    KafkaDeadLetterRecordStatus status
+) {
+
+    public KafkaDeadLetterReplayResponse {
+        recordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+
+        status =
+            Objects.requireNonNull(
+                status,
+                "status must not be null"
+            );
+
+        if (
+            status
+                != KafkaDeadLetterRecordStatus
+                .REPLAYED
+        ) {
+            throw new IllegalArgumentException(
+                "Replay response status must be "
+                    + "REPLAYED."
+            );
+        }
+    }
+
+    static KafkaDeadLetterReplayResponse replayed(
+        UUID recordId
+    ) {
+        return new KafkaDeadLetterReplayResponse(
+            recordId,
+            KafkaDeadLetterRecordStatus.REPLAYED
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterDiscardAdapter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterDiscardAdapter.java
@@ -1,0 +1,125 @@
+package com.nursena.payflow.eventprocessing.adapter.out.persistence;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterDiscardPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+class JdbcKafkaDeadLetterDiscardAdapter
+    implements KafkaDeadLetterDiscardPort {
+
+    private static final String DISCARD_SQL = """
+        WITH target AS MATERIALIZED (
+            SELECT
+                id,
+                status
+            FROM kafka_dead_letter_records
+            WHERE id = ?
+            FOR UPDATE
+        ),
+        discarded AS (
+            UPDATE kafka_dead_letter_records
+                AS record
+            SET status = 'DISCARDED'
+            FROM target
+            WHERE record.id = target.id
+              AND target.status IN (
+                    'RECEIVED',
+                    'REPLAY_FAILED'
+              )
+            RETURNING record.id
+        )
+        SELECT
+            CASE
+                WHEN EXISTS (
+                    SELECT 1
+                    FROM discarded
+                )
+                    THEN 'DISCARDED'
+                WHEN NOT EXISTS (
+                    SELECT 1
+                    FROM target
+                )
+                    THEN 'NOT_FOUND'
+                WHEN (
+                    SELECT status
+                    FROM target
+                ) = 'DISCARDED'
+                    THEN 'ALREADY_DISCARDED'
+                ELSE 'NOT_DISCARDABLE'
+            END AS discard_outcome
+        """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    JdbcKafkaDeadLetterDiscardAdapter(
+        JdbcTemplate jdbcTemplate
+    ) {
+        this.jdbcTemplate =
+            Objects.requireNonNull(
+                jdbcTemplate,
+                "jdbcTemplate must not be null"
+            );
+    }
+
+    @Override
+    public DiscardKafkaDeadLetterRecordResult
+    discard(
+        UUID recordId
+    ) {
+        UUID validatedRecordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+
+        String outcome =
+            jdbcTemplate.queryForObject(
+                DISCARD_SQL,
+                String.class,
+                validatedRecordId
+            );
+
+        return resultOf(
+            Objects.requireNonNull(
+                outcome,
+                "Kafka dead-letter discard "
+                    + "outcome must not be null"
+            )
+        );
+    }
+
+    private static DiscardKafkaDeadLetterRecordResult
+    resultOf(
+        String outcome
+    ) {
+        return switch (outcome) {
+            case "DISCARDED" ->
+                DiscardKafkaDeadLetterRecordResult
+                    .discarded();
+
+            case "ALREADY_DISCARDED" ->
+                DiscardKafkaDeadLetterRecordResult
+                    .alreadyDiscarded();
+
+            case "NOT_FOUND" ->
+                DiscardKafkaDeadLetterRecordResult
+                    .notFound();
+
+            case "NOT_DISCARDABLE" ->
+                DiscardKafkaDeadLetterRecordResult
+                    .notDiscardable();
+
+            default ->
+                throw new IllegalStateException(
+                    "Unknown Kafka dead-letter "
+                        + "discard outcome: "
+                        + outcome
+                );
+        };
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterReplayRepositoryAdapter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterReplayRepositoryAdapter.java
@@ -6,11 +6,10 @@ import java.sql.Timestamp;
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordResult;
 import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayLifecyclePort;
 import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayRepositoryPort;
 import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
@@ -28,55 +27,105 @@ class JdbcKafkaDeadLetterReplayRepositoryAdapter
         MAX_WORKER_ID_LENGTH = 200;
 
     private static final String CLAIM_SQL = """
+    WITH target AS MATERIALIZED (
+        SELECT id
+        FROM kafka_dead_letter_records
+        WHERE id = ?
+        FOR UPDATE
+    ),
+    claimed AS (
         UPDATE kafka_dead_letter_records
+            AS record
         SET
             status = 'REPLAYING',
-            replay_count = replay_count + 1,
+            replay_count =
+                record.replay_count + 1,
             last_replayed_at = ?,
             replay_lease_owner = ?,
             replay_lease_until = ?,
             last_replay_error = NULL
-        WHERE id = ?
+        FROM target
+        WHERE record.id = target.id
           AND (
-                replay_attempt_base::BIGINT
-                + replay_count::BIGINT
+                record.replay_attempt_base::BIGINT
+                + record.replay_count::BIGINT
               ) < ?
-          AND payload IS NOT NULL
-          AND btrim(payload) <> ''
-          AND original_topic <> dlt_topic
+          AND record.payload IS NOT NULL
+          AND btrim(record.payload) <> ''
+          AND record.original_topic
+                <> record.dlt_topic
           AND (
-                status IN (
+                record.status IN (
                     'RECEIVED',
                     'REPLAY_FAILED'
                 )
                 OR (
-                    status = 'REPLAYING'
-                    AND replay_lease_until <= ?
+                    record.status = 'REPLAYING'
+                    AND record.replay_lease_until <= ?
                 )
           )
         RETURNING
-            id,
-            dlt_topic,
-            dlt_partition,
-            dlt_offset,
-            original_topic,
-            original_partition,
-            original_offset,
-            original_consumer_group,
-            record_key,
-            payload,
-            exception_type,
-            exception_message,
-            status,
-            replay_count,
-            received_at,
-            last_replayed_at,
-            replay_lease_owner,
-            replay_lease_until,
-            last_replay_error,
-            replay_origin_id,
-            replay_attempt_base
-        """;
+            record.id,
+            record.dlt_topic,
+            record.dlt_partition,
+            record.dlt_offset,
+            record.original_topic,
+            record.original_partition,
+            record.original_offset,
+            record.original_consumer_group,
+            record.record_key,
+            record.payload,
+            record.exception_type,
+            record.exception_message,
+            record.status,
+            record.replay_count,
+            record.received_at,
+            record.last_replayed_at,
+            record.replay_lease_owner,
+            record.replay_lease_until,
+            record.last_replay_error,
+            record.replay_origin_id,
+            record.replay_attempt_base
+    )
+    SELECT
+        CASE
+            WHEN claimed.id IS NOT NULL
+                THEN 'CLAIMED'
+            WHEN EXISTS (
+                SELECT 1
+                FROM target
+            )
+                THEN 'NOT_CLAIMABLE'
+            ELSE 'NOT_FOUND'
+        END AS claim_outcome,
+        claimed.id,
+        claimed.dlt_topic,
+        claimed.dlt_partition,
+        claimed.dlt_offset,
+        claimed.original_topic,
+        claimed.original_partition,
+        claimed.original_offset,
+        claimed.original_consumer_group,
+        claimed.record_key,
+        claimed.payload,
+        claimed.exception_type,
+        claimed.exception_message,
+        claimed.status,
+        claimed.replay_count,
+        claimed.received_at,
+        claimed.last_replayed_at,
+        claimed.replay_lease_owner,
+        claimed.replay_lease_until,
+        claimed.last_replay_error,
+        claimed.replay_origin_id,
+        claimed.replay_attempt_base
+    FROM (
+        VALUES (1)
+    ) AS anchor(value)
+    LEFT JOIN claimed
+        ON TRUE
+    """;
+
     private static final String
         MARK_REPLAYED_SQL = """
         UPDATE kafka_dead_letter_records
@@ -120,7 +169,7 @@ class JdbcKafkaDeadLetterReplayRepositoryAdapter
     }
 
     @Override
-    public Optional<KafkaDeadLetterRecord>
+    public ClaimKafkaDeadLetterRecordResult
     tryClaim(
         UUID recordId,
         String workerId,
@@ -161,34 +210,30 @@ class JdbcKafkaDeadLetterReplayRepositoryAdapter
                 validatedLeaseDuration
             );
 
-        List<KafkaDeadLetterRecord> claimed =
-            jdbcTemplate.query(
+        ClaimKafkaDeadLetterRecordResult result =
+            jdbcTemplate.queryForObject(
                 CLAIM_SQL,
                 JdbcKafkaDeadLetterReplayRepositoryAdapter
-                    ::mapRecord,
+                    ::mapClaimResult,
+                validatedRecordId,
                 Timestamp.from(
                     validatedClaimedAt
                 ),
                 validatedWorkerId,
                 Timestamp.from(leaseUntil),
-                validatedRecordId,
                 maxReplayAttempts,
                 Timestamp.from(
                     validatedClaimedAt
                 )
             );
 
-        if (claimed.size() > 1) {
-            throw new IllegalStateException(
-                "Kafka dead-letter claim returned "
-                    + claimed.size()
-                    + " records."
-            );
-        }
-
-        return claimed.stream()
-            .findFirst();
+        return Objects.requireNonNull(
+            result,
+            "Kafka dead-letter claim result "
+                + "must not be null"
+        );
     }
+
     @Override
     public boolean tryMarkReplayed(
         UUID recordId,
@@ -273,6 +318,44 @@ class JdbcKafkaDeadLetterReplayRepositoryAdapter
             "mark replay failed"
         );
     }
+    private static ClaimKafkaDeadLetterRecordResult
+    mapClaimResult(
+        ResultSet resultSet,
+        int rowNumber
+    ) throws SQLException {
+
+        String outcome =
+            resultSet.getString(
+                "claim_outcome"
+            );
+
+        return switch (outcome) {
+            case "CLAIMED" ->
+                ClaimKafkaDeadLetterRecordResult
+                    .claimed(
+                        mapRecord(
+                            resultSet,
+                            rowNumber
+                        )
+                    );
+
+            case "NOT_FOUND" ->
+                ClaimKafkaDeadLetterRecordResult
+                    .notFound();
+
+            case "NOT_CLAIMABLE" ->
+                ClaimKafkaDeadLetterRecordResult
+                    .notClaimable();
+
+            default ->
+                throw new SQLException(
+                    "Unknown Kafka dead-letter "
+                        + "claim outcome: "
+                        + outcome
+                );
+        };
+    }
+
     private static KafkaDeadLetterRecord
     mapRecord(
         ResultSet resultSet,

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/ClaimKafkaDeadLetterRecordResult.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/ClaimKafkaDeadLetterRecordResult.java
@@ -27,12 +27,13 @@ public record ClaimKafkaDeadLetterRecordResult(
         }
 
         if (
-            outcome == Outcome.NOT_CLAIMABLE
+            outcome != Outcome.CLAIMED
                 && record != null
         ) {
             throw new IllegalArgumentException(
-                "NOT_CLAIMABLE result must not "
-                    + "contain a record."
+                outcome
+                    + " result must not contain "
+                    + "a record."
             );
         }
     }
@@ -51,6 +52,14 @@ public record ClaimKafkaDeadLetterRecordResult(
     }
 
     public static ClaimKafkaDeadLetterRecordResult
+    notFound() {
+        return new ClaimKafkaDeadLetterRecordResult(
+            Outcome.NOT_FOUND,
+            null
+        );
+    }
+
+    public static ClaimKafkaDeadLetterRecordResult
     notClaimable() {
         return new ClaimKafkaDeadLetterRecordResult(
             Outcome.NOT_CLAIMABLE,
@@ -62,9 +71,18 @@ public record ClaimKafkaDeadLetterRecordResult(
         return outcome == Outcome.CLAIMED;
     }
 
+    public boolean isNotFound() {
+        return outcome == Outcome.NOT_FOUND;
+    }
+
+    public boolean isNotClaimable() {
+        return outcome == Outcome.NOT_CLAIMABLE;
+    }
+
     public enum Outcome {
 
         CLAIMED,
+        NOT_FOUND,
         NOT_CLAIMABLE
     }
 }

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/DiscardKafkaDeadLetterRecordCommand.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/DiscardKafkaDeadLetterRecordCommand.java
@@ -1,0 +1,17 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record DiscardKafkaDeadLetterRecordCommand(
+    UUID recordId
+) {
+
+    public DiscardKafkaDeadLetterRecordCommand {
+        recordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/DiscardKafkaDeadLetterRecordResult.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/DiscardKafkaDeadLetterRecordResult.java
@@ -1,0 +1,75 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.util.Objects;
+
+public record DiscardKafkaDeadLetterRecordResult(
+    Outcome outcome
+) {
+
+    public DiscardKafkaDeadLetterRecordResult {
+        outcome =
+            Objects.requireNonNull(
+                outcome,
+                "outcome must not be null"
+            );
+    }
+
+    public static DiscardKafkaDeadLetterRecordResult
+    discarded() {
+        return new DiscardKafkaDeadLetterRecordResult(
+            Outcome.DISCARDED
+        );
+    }
+
+    public static DiscardKafkaDeadLetterRecordResult
+    alreadyDiscarded() {
+        return new DiscardKafkaDeadLetterRecordResult(
+            Outcome.ALREADY_DISCARDED
+        );
+    }
+
+    public static DiscardKafkaDeadLetterRecordResult
+    notFound() {
+        return new DiscardKafkaDeadLetterRecordResult(
+            Outcome.NOT_FOUND
+        );
+    }
+
+    public static DiscardKafkaDeadLetterRecordResult
+    notDiscardable() {
+        return new DiscardKafkaDeadLetterRecordResult(
+            Outcome.NOT_DISCARDABLE
+        );
+    }
+
+    public boolean isDiscarded() {
+        return outcome == Outcome.DISCARDED;
+    }
+
+    public boolean isAlreadyDiscarded() {
+        return outcome
+            == Outcome.ALREADY_DISCARDED;
+    }
+
+    public boolean isSuccessful() {
+        return isDiscarded()
+            || isAlreadyDiscarded();
+    }
+
+    public boolean isNotFound() {
+        return outcome == Outcome.NOT_FOUND;
+    }
+
+    public boolean isNotDiscardable() {
+        return outcome
+            == Outcome.NOT_DISCARDABLE;
+    }
+
+    public enum Outcome {
+
+        DISCARDED,
+        ALREADY_DISCARDED,
+        NOT_FOUND,
+        NOT_DISCARDABLE
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/ReplayKafkaDeadLetterRecordResult.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/ReplayKafkaDeadLetterRecordResult.java
@@ -15,6 +15,13 @@ public record ReplayKafkaDeadLetterRecordResult(
     }
 
     public static ReplayKafkaDeadLetterRecordResult
+    notFound() {
+        return new ReplayKafkaDeadLetterRecordResult(
+            Outcome.NOT_FOUND
+        );
+    }
+
+    public static ReplayKafkaDeadLetterRecordResult
     notClaimable() {
         return new ReplayKafkaDeadLetterRecordResult(
             Outcome.NOT_CLAIMABLE
@@ -42,6 +49,10 @@ public record ReplayKafkaDeadLetterRecordResult(
         );
     }
 
+    public boolean isNotFound() {
+        return outcome == Outcome.NOT_FOUND;
+    }
+
     public boolean isNotClaimable() {
         return outcome == Outcome.NOT_CLAIMABLE;
     }
@@ -60,6 +71,7 @@ public record ReplayKafkaDeadLetterRecordResult(
 
     public enum Outcome {
 
+        NOT_FOUND,
         NOT_CLAIMABLE,
         REPLAYED,
         REPLAY_FAILED,

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/DiscardKafkaDeadLetterRecordUseCase.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/DiscardKafkaDeadLetterRecordUseCase.java
@@ -1,0 +1,11 @@
+package com.nursena.payflow.eventprocessing.application.port.in;
+
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordResult;
+
+public interface DiscardKafkaDeadLetterRecordUseCase {
+
+    DiscardKafkaDeadLetterRecordResult discard(
+        DiscardKafkaDeadLetterRecordCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterDiscardPort.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterDiscardPort.java
@@ -1,0 +1,12 @@
+package com.nursena.payflow.eventprocessing.application.port.out;
+
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordResult;
+
+public interface KafkaDeadLetterDiscardPort {
+
+    DiscardKafkaDeadLetterRecordResult discard(
+        UUID recordId
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterReplayRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterReplayRepositoryPort.java
@@ -2,14 +2,13 @@ package com.nursena.payflow.eventprocessing.application.port.out;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Optional;
 import java.util.UUID;
 
-import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordResult;
 
 public interface KafkaDeadLetterReplayRepositoryPort {
 
-    Optional<KafkaDeadLetterRecord> tryClaim(
+    ClaimKafkaDeadLetterRecordResult tryClaim(
         UUID recordId,
         String workerId,
         Instant claimedAt,

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/ClaimKafkaDeadLetterRecordService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/ClaimKafkaDeadLetterRecordService.java
@@ -69,30 +69,26 @@ public class ClaimKafkaDeadLetterRecordService
     public ClaimKafkaDeadLetterRecordResult claim(
         ClaimKafkaDeadLetterRecordCommand command
     ) {
-        Objects.requireNonNull(
-            command,
-            "command must not be null"
-        );
+        ClaimKafkaDeadLetterRecordCommand
+            validatedCommand =
+            Objects.requireNonNull(
+                command,
+                "command must not be null"
+            );
 
-        Instant claimedAt =
-            currentTime();
-
-        return repository
-            .tryClaim(
-                command.recordId(),
+        ClaimKafkaDeadLetterRecordResult result =
+            repository.tryClaim(
+                validatedCommand.recordId(),
                 workerId,
-                claimedAt,
+                currentTime(),
                 leaseDuration,
                 maxReplayAttempts
-            )
-            .map(
-                ClaimKafkaDeadLetterRecordResult
-                    ::claimed
-            )
-            .orElseGet(
-                ClaimKafkaDeadLetterRecordResult
-                    ::notClaimable
             );
+
+        return Objects.requireNonNull(
+            result,
+            "claim result must not be null"
+        );
     }
 
     private Instant currentTime() {

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/DiscardKafkaDeadLetterRecordService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/DiscardKafkaDeadLetterRecordService.java
@@ -1,0 +1,49 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.in.DiscardKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterDiscardPort;
+import org.springframework.transaction.annotation.Transactional;
+
+public class DiscardKafkaDeadLetterRecordService
+    implements DiscardKafkaDeadLetterRecordUseCase {
+
+    private final KafkaDeadLetterDiscardPort
+        discardPort;
+
+    public DiscardKafkaDeadLetterRecordService(
+        KafkaDeadLetterDiscardPort discardPort
+    ) {
+        this.discardPort =
+            Objects.requireNonNull(
+                discardPort,
+                "discardPort must not be null"
+            );
+    }
+
+    @Override
+    @Transactional
+    public DiscardKafkaDeadLetterRecordResult discard(
+        DiscardKafkaDeadLetterRecordCommand command
+    ) {
+        DiscardKafkaDeadLetterRecordCommand
+            validatedCommand =
+            Objects.requireNonNull(
+                command,
+                "command must not be null"
+            );
+
+        DiscardKafkaDeadLetterRecordResult result =
+            discardPort.discard(
+                validatedCommand.recordId()
+            );
+
+        return Objects.requireNonNull(
+            result,
+            "discard result must not be null"
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/ReplayKafkaDeadLetterRecordService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/ReplayKafkaDeadLetterRecordService.java
@@ -93,6 +93,11 @@ public class ReplayKafkaDeadLetterRecordService
                 )
             );
 
+        if (claimResult.isNotFound()) {
+            return ReplayKafkaDeadLetterRecordResult
+                .notFound();
+        }
+
         if (!claimResult.isClaimed()) {
             return ReplayKafkaDeadLetterRecordResult
                 .notClaimable();

--- a/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterDiscardConfiguration.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterDiscardConfiguration.java
@@ -1,0 +1,21 @@
+package com.nursena.payflow.eventprocessing.configuration;
+
+import com.nursena.payflow.eventprocessing.application.port.in.DiscardKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterDiscardPort;
+import com.nursena.payflow.eventprocessing.application.service.DiscardKafkaDeadLetterRecordService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class KafkaDeadLetterDiscardConfiguration {
+
+    @Bean
+    DiscardKafkaDeadLetterRecordUseCase
+    discardKafkaDeadLetterRecordUseCase(
+        KafkaDeadLetterDiscardPort discardPort
+    ) {
+        return new DiscardKafkaDeadLetterRecordService(
+            discardPort
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/domain/exception/KafkaDeadLetterCommandException.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/domain/exception/KafkaDeadLetterCommandException.java
@@ -1,0 +1,131 @@
+package com.nursena.payflow.eventprocessing.domain.exception;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public final class KafkaDeadLetterCommandException
+    extends RuntimeException {
+
+    private final Reason reason;
+
+    private final UUID recordId;
+
+    private KafkaDeadLetterCommandException(
+        UUID recordId,
+        Reason reason
+    ) {
+        super(
+            Objects.requireNonNull(
+                reason,
+                "reason must not be null"
+            ).message()
+        );
+
+        this.recordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+
+        this.reason = reason;
+    }
+
+    public static KafkaDeadLetterCommandException
+    notClaimable(
+        UUID recordId
+    ) {
+        return new KafkaDeadLetterCommandException(
+            recordId,
+            Reason.NOT_CLAIMABLE
+        );
+    }
+
+    public static KafkaDeadLetterCommandException
+    notDiscardable(
+        UUID recordId
+    ) {
+        return new KafkaDeadLetterCommandException(
+            recordId,
+            Reason.NOT_DISCARDABLE
+        );
+    }
+
+    public static KafkaDeadLetterCommandException
+    replayFailed(
+        UUID recordId
+    ) {
+        return new KafkaDeadLetterCommandException(
+            recordId,
+            Reason.REPLAY_FAILED
+        );
+    }
+
+    public static KafkaDeadLetterCommandException
+    replayUnresolved(
+        UUID recordId
+    ) {
+        return new KafkaDeadLetterCommandException(
+            recordId,
+            Reason.REPLAY_UNRESOLVED
+        );
+    }
+
+    public String getCode() {
+        return reason.code();
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+
+    public UUID getRecordId() {
+        return recordId;
+    }
+
+    public enum Reason {
+
+        NOT_CLAIMABLE(
+            "KAFKA_DEAD_LETTER_RECORD_NOT_CLAIMABLE",
+            "Kafka dead-letter record cannot be "
+                + "replayed in its current state."
+        ),
+
+        NOT_DISCARDABLE(
+            "KAFKA_DEAD_LETTER_RECORD_NOT_DISCARDABLE",
+            "Kafka dead-letter record cannot be "
+                + "discarded in its current state."
+        ),
+
+        REPLAY_FAILED(
+            "KAFKA_DEAD_LETTER_REPLAY_FAILED",
+            "Kafka dead-letter replay publication "
+                + "failed."
+        ),
+
+        REPLAY_UNRESOLVED(
+            "KAFKA_DEAD_LETTER_REPLAY_UNRESOLVED",
+            "Kafka dead-letter replay outcome "
+                + "could not be resolved."
+        );
+
+        private final String code;
+
+        private final String message;
+
+        Reason(
+            String code,
+            String message
+        ) {
+            this.code = code;
+            this.message = message;
+        }
+
+        String code() {
+            return code;
+        }
+
+        String message() {
+            return message;
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -73,6 +73,16 @@ class OpenApiJsonContractIntegrationTest {
         KAFKA_DEAD_LETTERS_PATH
             + "/{recordId}";
 
+    private static final String
+        KAFKA_DEAD_LETTER_REPLAY_PATH =
+        KAFKA_DEAD_LETTERS_PATH
+            + "/{recordId}/replay";
+
+    private static final String
+        KAFKA_DEAD_LETTER_DISCARD_PATH =
+        KAFKA_DEAD_LETTERS_PATH
+            + "/{recordId}/discard";
+
     @Container
     @ServiceConnection
     private static final PostgreSQLContainer<?> POSTGRES =
@@ -170,7 +180,9 @@ class OpenApiJsonContractIntegrationTest {
             TRANSFERS_PATH,
             TRANSACTIONS_PATH,
             KAFKA_DEAD_LETTERS_PATH,
-            KAFKA_DEAD_LETTER_DETAILS_PATH
+            KAFKA_DEAD_LETTER_DETAILS_PATH,
+            KAFKA_DEAD_LETTER_REPLAY_PATH,
+            KAFKA_DEAD_LETTER_DISCARD_PATH
         );
 
         JsonNode health =
@@ -369,6 +381,56 @@ class OpenApiJsonContractIntegrationTest {
                 KAFKA_DEAD_LETTER_DETAILS_PATH,
                 "get"
             );
+
+        JsonNode replayDeadLetter =
+            operation(
+                KAFKA_DEAD_LETTER_REPLAY_PATH,
+                "post"
+            );
+
+        assertAuthenticatedOperation(
+            replayDeadLetter,
+            "replayKafkaDeadLetterRecord",
+            new String[] {
+                "200",
+                "400",
+                "401",
+                "403",
+                "404",
+                "409",
+                "502",
+                "503"
+            }
+        );
+
+        assertParameterNames(
+            replayDeadLetter,
+            "recordId"
+        );
+
+        JsonNode discardDeadLetter =
+            operation(
+                KAFKA_DEAD_LETTER_DISCARD_PATH,
+                "post"
+            );
+
+        assertAuthenticatedOperation(
+            discardDeadLetter,
+            "discardKafkaDeadLetterRecord",
+            new String[] {
+                "204",
+                "400",
+                "401",
+                "403",
+                "404",
+                "409"
+            }
+        );
+
+        assertParameterNames(
+            discardDeadLetter,
+            "recordId"
+        );
 
         assertAuthenticatedOperation(
             deadLetterDetails,
@@ -680,25 +742,7 @@ class OpenApiJsonContractIntegrationTest {
                 "recordId"
             );
 
-        assertThat(
-            recordId.path("in").asText()
-        ).isEqualTo("path");
-
-        assertThat(
-            recordId.path("required").asBoolean()
-        ).isTrue();
-
-        assertThat(
-            recordId.path("schema")
-                .path("type")
-                .asText()
-        ).isEqualTo("string");
-
-        assertThat(
-            recordId.path("schema")
-                .path("format")
-                .asText()
-        ).isEqualTo("uuid");
+        assertUuidPathParameter(recordId);
 
         JsonNode schemas =
             openApi
@@ -777,6 +821,118 @@ class OpenApiJsonContractIntegrationTest {
             "hasPrevious"
         );
     }
+
+    @Test
+    void shouldExposeKafkaDeadLetterCommandContract() {
+        JsonNode replay =
+            operation(
+                KAFKA_DEAD_LETTER_REPLAY_PATH,
+                "post"
+            );
+
+        JsonNode replayRecordId =
+            findParameter(
+                replay,
+                "recordId"
+            );
+
+        assertUuidPathParameter(replayRecordId);
+
+        JsonNode replaySuccess =
+            replay
+                .path("responses")
+                .path("200")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .path("schema");
+
+        assertThat(
+            replaySuccess.path("$ref").asText()
+        ).isEqualTo(
+            "#/components/schemas/"
+                + "KafkaDeadLetterReplayResponse"
+        );
+
+        JsonNode replayProperties =
+            openApi
+                .path("components")
+                .path("schemas")
+                .path(
+                    "KafkaDeadLetterReplayResponse"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(replayProperties)
+        )
+            .containsExactlyInAnyOrder(
+                "recordId",
+                "status"
+            )
+            .doesNotContain(
+                "payload",
+                "recordKey",
+                "replayLeaseOwner",
+                "exceptionMessage",
+                "lastReplayError"
+            );
+
+        JsonNode replayResponseRecordId =
+            replayProperties.path("recordId");
+
+        assertThat(
+            replayResponseRecordId
+                .path("type")
+                .asText()
+        ).isEqualTo("string");
+
+        assertThat(
+            replayResponseRecordId
+                .path("format")
+                .asText()
+        ).isEqualTo("uuid");
+
+        JsonNode replayStatus =
+            replayProperties.path("status");
+
+        assertThat(
+            replayStatus.path("type").asText()
+        ).isEqualTo("string");
+
+        assertThat(
+            textValues(
+                replayStatus.path("enum")
+            )
+        ).containsExactly("REPLAYED");
+
+        JsonNode discard =
+            operation(
+                KAFKA_DEAD_LETTER_DISCARD_PATH,
+                "post"
+            );
+
+        JsonNode discardRecordId =
+            findParameter(
+                discard,
+                "recordId"
+            );
+
+        assertUuidPathParameter(discardRecordId);
+
+        JsonNode discardSuccess =
+            discard
+                .path("responses")
+                .path("204");
+
+        assertThat(discardSuccess.isObject())
+            .isTrue();
+
+        assertThat(discardSuccess.has("content"))
+            .isFalse();
+    }
+
 
     private JsonNode operation(
         String path,
@@ -919,6 +1075,28 @@ class OpenApiJsonContractIntegrationTest {
                         + expectedName
                 )
             );
+    }
+    private static void assertUuidPathParameter(
+        JsonNode parameter
+    ) {
+        assertThat(parameter.path("in").asText())
+            .isEqualTo("path");
+
+        assertThat(
+            parameter.path("required").asBoolean()
+        ).isTrue();
+
+        assertThat(
+            parameter.path("schema")
+                .path("type")
+                .asText()
+        ).isEqualTo("string");
+
+        assertThat(
+            parameter.path("schema")
+                .path("format")
+                .asText()
+        ).isEqualTo("uuid");
     }
 
     private static void assertQueryParameter(

--- a/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandControllerTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandControllerTest.java
@@ -1,0 +1,639 @@
+package com.nursena.payflow.eventprocessing.adapter.in.web;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet
+    .request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet
+    .request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet
+    .result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet
+    .result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet
+    .result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import com.nursena.payflow.configuration
+    .SecurityConfiguration;
+import com.nursena.payflow.configuration.security
+    .OperationsAuthorities;
+import com.nursena.payflow.eventprocessing.application.model
+    .DiscardKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model
+    .DiscardKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.model
+    .ReplayKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model
+    .ReplayKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.in
+    .DiscardKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.in
+    .ReplayKafkaDeadLetterRecordUseCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet
+    .WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.authority
+    .SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito
+    .MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request
+    .RequestPostProcessor;
+
+@WebMvcTest(
+    KafkaDeadLetterCommandController.class
+)
+@Import({
+    SecurityConfiguration.class,
+    KafkaDeadLetterCommandExceptionHandler.class
+})
+class KafkaDeadLetterCommandControllerTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002401"
+        );
+
+    private static final String BASE_PATH =
+        "/api/v1/operations/kafka/dead-letters";
+
+    private static final String REPLAY_PATH =
+        BASE_PATH + "/" + RECORD_ID + "/replay";
+
+    private static final String DISCARD_PATH =
+        BASE_PATH + "/" + RECORD_ID + "/discard";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ReplayKafkaDeadLetterRecordUseCase
+        replayUseCase;
+
+    @MockitoBean
+    private DiscardKafkaDeadLetterRecordUseCase
+        discardUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldReplayRecordForAuthorizedOperator()
+        throws Exception {
+
+        ReplayKafkaDeadLetterRecordCommand command =
+            new ReplayKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            );
+
+        when(
+            replayUseCase.replay(command)
+        ).thenReturn(
+            ReplayKafkaDeadLetterRecordResult
+                .replayed()
+        );
+
+        mockMvc.perform(
+                post(REPLAY_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.recordId")
+                    .value(RECORD_ID.toString())
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value("REPLAYED")
+            )
+            .andExpect(
+                jsonPath("$.payload")
+                    .doesNotExist()
+            )
+            .andExpect(
+                jsonPath("$.recordKey")
+                    .doesNotExist()
+            )
+            .andExpect(
+                jsonPath("$.replayLeaseOwner")
+                    .doesNotExist()
+            );
+
+        verify(replayUseCase)
+            .replay(command);
+
+        verifyNoInteractions(discardUseCase);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenReplayRecordIsMissing()
+        throws Exception {
+
+        ReplayKafkaDeadLetterRecordCommand command =
+            new ReplayKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            );
+
+        when(
+            replayUseCase.replay(command)
+        ).thenReturn(
+            ReplayKafkaDeadLetterRecordResult
+                .notFound()
+        );
+
+        mockMvc.perform(
+                post(REPLAY_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isNotFound())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(404)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "KAFKA_DEAD_LETTER_"
+                            + "RECORD_NOT_FOUND"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Kafka dead-letter record "
+                            + "was not found."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(REPLAY_PATH)
+            );
+
+        verify(replayUseCase)
+            .replay(command);
+
+        verifyNoInteractions(discardUseCase);
+    }
+
+    @Test
+    void shouldReturnConflictWhenRecordCannotBeReplayed()
+        throws Exception {
+
+        ReplayKafkaDeadLetterRecordCommand command =
+            new ReplayKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            );
+
+        when(
+            replayUseCase.replay(command)
+        ).thenReturn(
+            ReplayKafkaDeadLetterRecordResult
+                .notClaimable()
+        );
+
+        mockMvc.perform(
+                post(REPLAY_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isConflict())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(409)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "KAFKA_DEAD_LETTER_"
+                            + "RECORD_NOT_CLAIMABLE"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Kafka dead-letter record "
+                            + "cannot be replayed in "
+                            + "its current state."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(REPLAY_PATH)
+            );
+
+        verify(replayUseCase)
+            .replay(command);
+
+        verifyNoInteractions(discardUseCase);
+    }
+
+    @Test
+    void shouldReturnBadGatewayWhenReplayPublicationFails()
+        throws Exception {
+
+        ReplayKafkaDeadLetterRecordCommand command =
+            new ReplayKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            );
+
+        when(
+            replayUseCase.replay(command)
+        ).thenReturn(
+            ReplayKafkaDeadLetterRecordResult
+                .replayFailed()
+        );
+
+        mockMvc.perform(
+                post(REPLAY_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isBadGateway())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(502)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "KAFKA_DEAD_LETTER_"
+                            + "REPLAY_FAILED"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Kafka dead-letter replay "
+                            + "publication failed."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(REPLAY_PATH)
+            );
+
+        verify(replayUseCase)
+            .replay(command);
+
+        verifyNoInteractions(discardUseCase);
+    }
+
+    @Test
+    void shouldReturnServiceUnavailableForUnresolvedReplay()
+        throws Exception {
+
+        ReplayKafkaDeadLetterRecordCommand command =
+            new ReplayKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            );
+
+        when(
+            replayUseCase.replay(command)
+        ).thenReturn(
+            ReplayKafkaDeadLetterRecordResult
+                .unresolved()
+        );
+
+        mockMvc.perform(
+                post(REPLAY_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(
+                status().isServiceUnavailable()
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value(503)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "KAFKA_DEAD_LETTER_"
+                            + "REPLAY_UNRESOLVED"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Kafka dead-letter replay "
+                            + "outcome could not be "
+                            + "resolved."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(REPLAY_PATH)
+            );
+
+        verify(replayUseCase)
+            .replay(command);
+
+        verifyNoInteractions(discardUseCase);
+    }
+
+    @Test
+    void shouldDiscardRecordForAuthorizedOperator()
+        throws Exception {
+
+        DiscardKafkaDeadLetterRecordCommand command =
+            new DiscardKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            );
+
+        when(
+            discardUseCase.discard(command)
+        ).thenReturn(
+            DiscardKafkaDeadLetterRecordResult
+                .discarded()
+        );
+
+        mockMvc.perform(
+                post(DISCARD_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isNoContent())
+            .andExpect(content().string(""));
+
+        verify(discardUseCase)
+            .discard(command);
+
+        verifyNoInteractions(replayUseCase);
+    }
+
+    @Test
+    void shouldTreatRepeatedDiscardAsSuccessful()
+        throws Exception {
+
+        DiscardKafkaDeadLetterRecordCommand command =
+            new DiscardKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            );
+
+        when(
+            discardUseCase.discard(command)
+        ).thenReturn(
+            DiscardKafkaDeadLetterRecordResult
+                .alreadyDiscarded()
+        );
+
+        mockMvc.perform(
+                post(DISCARD_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isNoContent())
+            .andExpect(content().string(""));
+
+        verify(discardUseCase)
+            .discard(command);
+
+        verifyNoInteractions(replayUseCase);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenDiscardRecordIsMissing()
+        throws Exception {
+
+        DiscardKafkaDeadLetterRecordCommand command =
+            new DiscardKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            );
+
+        when(
+            discardUseCase.discard(command)
+        ).thenReturn(
+            DiscardKafkaDeadLetterRecordResult
+                .notFound()
+        );
+
+        mockMvc.perform(
+                post(DISCARD_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isNotFound())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(404)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "KAFKA_DEAD_LETTER_"
+                            + "RECORD_NOT_FOUND"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(DISCARD_PATH)
+            );
+
+        verify(discardUseCase)
+            .discard(command);
+
+        verifyNoInteractions(replayUseCase);
+    }
+
+    @Test
+    void shouldReturnConflictWhenRecordCannotBeDiscarded()
+        throws Exception {
+
+        DiscardKafkaDeadLetterRecordCommand command =
+            new DiscardKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            );
+
+        when(
+            discardUseCase.discard(command)
+        ).thenReturn(
+            DiscardKafkaDeadLetterRecordResult
+                .notDiscardable()
+        );
+
+        mockMvc.perform(
+                post(DISCARD_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isConflict())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(409)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "KAFKA_DEAD_LETTER_"
+                            + "RECORD_NOT_DISCARDABLE"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Kafka dead-letter record "
+                            + "cannot be discarded in "
+                            + "its current state."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(DISCARD_PATH)
+            );
+
+        verify(discardUseCase)
+            .discard(command);
+
+        verifyNoInteractions(replayUseCase);
+    }
+
+    @Test
+    void shouldRejectAnonymousReplayRequest()
+        throws Exception {
+
+        mockMvc.perform(
+                post(REPLAY_PATH)
+            )
+            .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(
+            replayUseCase,
+            discardUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectNonOperatorReplayRequest()
+        throws Exception {
+
+        mockMvc.perform(
+                post(REPLAY_PATH)
+                    .with(nonOperatorJwt())
+            )
+            .andExpect(status().isForbidden());
+
+        verifyNoInteractions(
+            replayUseCase,
+            discardUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectAnonymousDiscardRequest()
+        throws Exception {
+
+        mockMvc.perform(
+                post(DISCARD_PATH)
+            )
+            .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(
+            replayUseCase,
+            discardUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectNonOperatorDiscardRequest()
+        throws Exception {
+
+        mockMvc.perform(
+                post(DISCARD_PATH)
+                    .with(nonOperatorJwt())
+            )
+            .andExpect(status().isForbidden());
+
+        verifyNoInteractions(
+            replayUseCase,
+            discardUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectMalformedReplayRecordIdentifier()
+        throws Exception {
+
+        String path =
+            BASE_PATH + "/not-a-uuid/replay";
+
+        mockMvc.perform(
+                post(path)
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(400)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Request validation failed."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(path)
+            );
+
+        verifyNoInteractions(
+            replayUseCase,
+            discardUseCase
+        );
+    }
+
+    @Test
+    void shouldRejectMalformedDiscardRecordIdentifier()
+        throws Exception {
+
+        String path =
+            BASE_PATH + "/not-a-uuid/discard";
+
+        mockMvc.perform(
+                post(path)
+                    .with(operatorJwt())
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(400)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(path)
+            );
+
+        verifyNoInteractions(
+            replayUseCase,
+            discardUseCase
+        );
+    }
+
+    private static RequestPostProcessor
+    operatorJwt() {
+        return jwt()
+            .authorities(
+                new SimpleGrantedAuthority(
+                    OperationsAuthorities.OPERATIONS
+                )
+            );
+    }
+
+    private static RequestPostProcessor
+    nonOperatorJwt() {
+        return jwt()
+            .authorities(
+                new SimpleGrantedAuthority(
+                    "PAYFLOW_CUSTOMER"
+                )
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/ClaimKafkaDeadLetterRecordResultTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/ClaimKafkaDeadLetterRecordResultTest.java
@@ -29,6 +29,12 @@ class ClaimKafkaDeadLetterRecordResultTest {
         assertThat(result.isClaimed())
             .isTrue();
 
+        assertThat(result.isNotFound())
+            .isFalse();
+
+        assertThat(result.isNotClaimable())
+            .isFalse();
+
         assertThat(result.outcome())
             .isEqualTo(
                 ClaimKafkaDeadLetterRecordResult
@@ -40,12 +46,43 @@ class ClaimKafkaDeadLetterRecordResultTest {
     }
 
     @Test
+    void shouldCreateNotFoundResult() {
+        ClaimKafkaDeadLetterRecordResult result =
+            ClaimKafkaDeadLetterRecordResult
+                .notFound();
+
+        assertThat(result.isNotFound())
+            .isTrue();
+
+        assertThat(result.isClaimed())
+            .isFalse();
+
+        assertThat(result.isNotClaimable())
+            .isFalse();
+
+        assertThat(result.outcome())
+            .isEqualTo(
+                ClaimKafkaDeadLetterRecordResult
+                    .Outcome.NOT_FOUND
+            );
+
+        assertThat(result.record())
+            .isNull();
+    }
+
+    @Test
     void shouldCreateNotClaimableResult() {
         ClaimKafkaDeadLetterRecordResult result =
             ClaimKafkaDeadLetterRecordResult
                 .notClaimable();
 
+        assertThat(result.isNotClaimable())
+            .isTrue();
+
         assertThat(result.isClaimed())
+            .isFalse();
+
+        assertThat(result.isNotFound())
             .isFalse();
 
         assertThat(result.outcome())
@@ -78,6 +115,25 @@ class ClaimKafkaDeadLetterRecordResultTest {
     }
 
     @Test
+    void shouldRejectNotFoundResultWithRecord() {
+        assertThatThrownBy(
+            () ->
+                new ClaimKafkaDeadLetterRecordResult(
+                    ClaimKafkaDeadLetterRecordResult
+                        .Outcome.NOT_FOUND,
+                    claimedRecord()
+                )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "NOT_FOUND result must not contain "
+                    + "a record."
+            );
+    }
+
+    @Test
     void shouldRejectNotClaimableResultWithRecord() {
         assertThatThrownBy(
             () ->
@@ -93,6 +149,23 @@ class ClaimKafkaDeadLetterRecordResultTest {
             .hasMessage(
                 "NOT_CLAIMABLE result must not "
                     + "contain a record."
+            );
+    }
+
+    @Test
+    void shouldRequireOutcome() {
+        assertThatThrownBy(
+            () ->
+                new ClaimKafkaDeadLetterRecordResult(
+                    null,
+                    null
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "outcome must not be null"
             );
     }
 

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/DiscardKafkaDeadLetterRecordCommandTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/DiscardKafkaDeadLetterRecordCommandTest.java
@@ -1,0 +1,43 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class DiscardKafkaDeadLetterRecordCommandTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002201"
+        );
+
+    @Test
+    void shouldCreateCommand() {
+        DiscardKafkaDeadLetterRecordCommand command =
+            new DiscardKafkaDeadLetterRecordCommand(
+                RECORD_ID
+            );
+
+        assertThat(command.recordId())
+            .isEqualTo(RECORD_ID);
+    }
+
+    @Test
+    void shouldRequireRecordIdentifier() {
+        assertThatThrownBy(
+            () ->
+                new DiscardKafkaDeadLetterRecordCommand(
+                    null
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "recordId must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/DiscardKafkaDeadLetterRecordResultTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/DiscardKafkaDeadLetterRecordResultTest.java
@@ -1,0 +1,101 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class DiscardKafkaDeadLetterRecordResultTest {
+
+    @Test
+    void shouldCreateDiscardedResult() {
+        DiscardKafkaDeadLetterRecordResult result =
+            DiscardKafkaDeadLetterRecordResult
+                .discarded();
+
+        assertThat(result.outcome())
+            .isEqualTo(
+                DiscardKafkaDeadLetterRecordResult
+                    .Outcome.DISCARDED
+            );
+
+        assertThat(result.isDiscarded())
+            .isTrue();
+
+        assertThat(result.isSuccessful())
+            .isTrue();
+
+        assertThat(result.isAlreadyDiscarded())
+            .isFalse();
+
+        assertThat(result.isNotFound())
+            .isFalse();
+
+        assertThat(result.isNotDiscardable())
+            .isFalse();
+    }
+
+    @Test
+    void shouldCreateAlreadyDiscardedResult() {
+        DiscardKafkaDeadLetterRecordResult result =
+            DiscardKafkaDeadLetterRecordResult
+                .alreadyDiscarded();
+
+        assertThat(result.isAlreadyDiscarded())
+            .isTrue();
+
+        assertThat(result.isSuccessful())
+            .isTrue();
+
+        assertThat(result.isDiscarded())
+            .isFalse();
+    }
+
+    @Test
+    void shouldCreateNotFoundResult() {
+        DiscardKafkaDeadLetterRecordResult result =
+            DiscardKafkaDeadLetterRecordResult
+                .notFound();
+
+        assertThat(result.isNotFound())
+            .isTrue();
+
+        assertThat(result.isSuccessful())
+            .isFalse();
+
+        assertThat(result.isNotDiscardable())
+            .isFalse();
+    }
+
+    @Test
+    void shouldCreateNotDiscardableResult() {
+        DiscardKafkaDeadLetterRecordResult result =
+            DiscardKafkaDeadLetterRecordResult
+                .notDiscardable();
+
+        assertThat(result.isNotDiscardable())
+            .isTrue();
+
+        assertThat(result.isSuccessful())
+            .isFalse();
+
+        assertThat(result.isNotFound())
+            .isFalse();
+    }
+
+    @Test
+    void shouldRequireOutcome() {
+        assertThatThrownBy(
+            () ->
+                new DiscardKafkaDeadLetterRecordResult(
+                    null
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "outcome must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/ReplayKafkaDeadLetterRecordResultTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/ReplayKafkaDeadLetterRecordResultTest.java
@@ -8,6 +8,24 @@ import org.junit.jupiter.api.Test;
 class ReplayKafkaDeadLetterRecordResultTest {
 
     @Test
+    void shouldCreateNotFoundResult() {
+        ReplayKafkaDeadLetterRecordResult result =
+            ReplayKafkaDeadLetterRecordResult
+                .notFound();
+
+        assertThat(result.outcome())
+            .isEqualTo(
+                ReplayKafkaDeadLetterRecordResult
+                    .Outcome.NOT_FOUND
+            );
+
+        assertThat(result.isNotFound())
+            .isTrue();
+
+        assertOtherOutcomesAreFalse(result);
+    }
+
+    @Test
     void shouldCreateNotClaimableResult() {
         ReplayKafkaDeadLetterRecordResult result =
             ReplayKafkaDeadLetterRecordResult
@@ -21,6 +39,9 @@ class ReplayKafkaDeadLetterRecordResultTest {
 
         assertThat(result.isNotClaimable())
             .isTrue();
+
+        assertThat(result.isNotFound())
+            .isFalse();
 
         assertThat(result.isReplayed())
             .isFalse();
@@ -47,6 +68,9 @@ class ReplayKafkaDeadLetterRecordResultTest {
         assertThat(result.isReplayed())
             .isTrue();
 
+        assertThat(result.isNotFound())
+            .isFalse();
+
         assertThat(result.isNotClaimable())
             .isFalse();
 
@@ -71,6 +95,9 @@ class ReplayKafkaDeadLetterRecordResultTest {
 
         assertThat(result.isReplayFailed())
             .isTrue();
+
+        assertThat(result.isNotFound())
+            .isFalse();
 
         assertThat(result.isNotClaimable())
             .isFalse();
@@ -97,6 +124,9 @@ class ReplayKafkaDeadLetterRecordResultTest {
         assertThat(result.isUnresolved())
             .isTrue();
 
+        assertThat(result.isNotFound())
+            .isFalse();
+
         assertThat(result.isNotClaimable())
             .isFalse();
 
@@ -120,5 +150,22 @@ class ReplayKafkaDeadLetterRecordResultTest {
             .hasMessage(
                 "outcome must not be null"
             );
+    }
+
+    private static void
+    assertOtherOutcomesAreFalse(
+        ReplayKafkaDeadLetterRecordResult result
+    ) {
+        assertThat(result.isNotClaimable())
+            .isFalse();
+
+        assertThat(result.isReplayed())
+            .isFalse();
+
+        assertThat(result.isReplayFailed())
+            .isFalse();
+
+        assertThat(result.isUnresolved())
+            .isFalse();
     }
 }

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/ClaimKafkaDeadLetterRecordServiceTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/ClaimKafkaDeadLetterRecordServiceTest.java
@@ -3,13 +3,13 @@ package com.nursena.payflow.eventprocessing.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
-import java.util.Optional;
 import java.util.UUID;
 
 import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordCommand;
@@ -71,6 +71,11 @@ class ClaimKafkaDeadLetterRecordServiceTest {
         KafkaDeadLetterRecord record =
             claimedRecord();
 
+        ClaimKafkaDeadLetterRecordResult
+            repositoryResult =
+            ClaimKafkaDeadLetterRecordResult
+                .claimed(record);
+
         when(
             repository.tryClaim(
                 RECORD_ID,
@@ -79,10 +84,7 @@ class ClaimKafkaDeadLetterRecordServiceTest {
                 LEASE_DURATION,
                 MAX_ATTEMPTS
             )
-        )
-            .thenReturn(
-                Optional.of(record)
-            );
+        ).thenReturn(repositoryResult);
 
         ClaimKafkaDeadLetterRecordResult result =
             service.claim(
@@ -90,6 +92,9 @@ class ClaimKafkaDeadLetterRecordServiceTest {
                     RECORD_ID
                 )
             );
+
+        assertThat(result)
+            .isSameAs(repositoryResult);
 
         assertThat(result.isClaimed())
             .isTrue();
@@ -108,7 +113,12 @@ class ClaimKafkaDeadLetterRecordServiceTest {
     }
 
     @Test
-    void shouldReturnNotClaimableWhenRepositoryCannotClaim() {
+    void shouldReturnNotFoundResult() {
+        ClaimKafkaDeadLetterRecordResult
+            repositoryResult =
+            ClaimKafkaDeadLetterRecordResult
+                .notFound();
+
         when(
             repository.tryClaim(
                 RECORD_ID,
@@ -117,10 +127,7 @@ class ClaimKafkaDeadLetterRecordServiceTest {
                 LEASE_DURATION,
                 MAX_ATTEMPTS
             )
-        )
-            .thenReturn(
-                Optional.empty()
-            );
+        ).thenReturn(repositoryResult);
 
         ClaimKafkaDeadLetterRecordResult result =
             service.claim(
@@ -129,11 +136,70 @@ class ClaimKafkaDeadLetterRecordServiceTest {
                 )
             );
 
-        assertThat(result.isClaimed())
-            .isFalse();
+        assertThat(result)
+            .isSameAs(repositoryResult);
 
-        assertThat(result.record())
-            .isNull();
+        assertThat(result.isNotFound())
+            .isTrue();
+    }
+
+    @Test
+    void shouldReturnNotClaimableResult() {
+        ClaimKafkaDeadLetterRecordResult
+            repositoryResult =
+            ClaimKafkaDeadLetterRecordResult
+                .notClaimable();
+
+        when(
+            repository.tryClaim(
+                RECORD_ID,
+                WORKER_ID,
+                CLAIMED_AT,
+                LEASE_DURATION,
+                MAX_ATTEMPTS
+            )
+        ).thenReturn(repositoryResult);
+
+        ClaimKafkaDeadLetterRecordResult result =
+            service.claim(
+                new ClaimKafkaDeadLetterRecordCommand(
+                    RECORD_ID
+                )
+            );
+
+        assertThat(result)
+            .isSameAs(repositoryResult);
+
+        assertThat(result.isNotClaimable())
+            .isTrue();
+    }
+
+    @Test
+    void shouldRejectNullRepositoryResult() {
+        when(
+            repository.tryClaim(
+                RECORD_ID,
+                WORKER_ID,
+                CLAIMED_AT,
+                LEASE_DURATION,
+                MAX_ATTEMPTS
+            )
+        ).thenReturn(null);
+
+        assertThatThrownBy(
+            () ->
+                service.claim(
+                    new ClaimKafkaDeadLetterRecordCommand(
+                        RECORD_ID
+                    )
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "claim result must not be null"
+            );
     }
 
     @Test
@@ -147,6 +213,8 @@ class ClaimKafkaDeadLetterRecordServiceTest {
             .hasMessage(
                 "command must not be null"
             );
+
+        verifyNoInteractions(repository);
     }
 
     @Test

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/DiscardKafkaDeadLetterRecordServiceTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/DiscardKafkaDeadLetterRecordServiceTest.java
@@ -1,0 +1,145 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterDiscardPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DiscardKafkaDeadLetterRecordServiceTest {
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002202"
+        );
+
+    private static final DiscardKafkaDeadLetterRecordCommand
+        COMMAND =
+        new DiscardKafkaDeadLetterRecordCommand(
+            RECORD_ID
+        );
+
+    @Mock
+    private KafkaDeadLetterDiscardPort discardPort;
+
+    private DiscardKafkaDeadLetterRecordService
+        service;
+
+    @BeforeEach
+    void setUp() {
+        service =
+            new DiscardKafkaDeadLetterRecordService(
+                discardPort
+            );
+    }
+
+    @Test
+    void shouldReturnDiscardedResult() {
+        assertPortResultIsPassedThrough(
+            DiscardKafkaDeadLetterRecordResult
+                .discarded()
+        );
+    }
+
+    @Test
+    void shouldReturnAlreadyDiscardedResult() {
+        assertPortResultIsPassedThrough(
+            DiscardKafkaDeadLetterRecordResult
+                .alreadyDiscarded()
+        );
+    }
+
+    @Test
+    void shouldReturnNotFoundResult() {
+        assertPortResultIsPassedThrough(
+            DiscardKafkaDeadLetterRecordResult
+                .notFound()
+        );
+    }
+
+    @Test
+    void shouldReturnNotDiscardableResult() {
+        assertPortResultIsPassedThrough(
+            DiscardKafkaDeadLetterRecordResult
+                .notDiscardable()
+        );
+    }
+
+    @Test
+    void shouldRejectNullPortResult() {
+        when(
+            discardPort.discard(RECORD_ID)
+        ).thenReturn(null);
+
+        assertThatThrownBy(
+            () -> service.discard(COMMAND)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "discard result must not be null"
+            );
+    }
+
+    @Test
+    void shouldRequireCommand() {
+        assertThatThrownBy(
+            () -> service.discard(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "command must not be null"
+            );
+
+        verifyNoInteractions(discardPort);
+    }
+
+    @Test
+    void shouldRequireDiscardPort() {
+        assertThatThrownBy(
+            () ->
+                new DiscardKafkaDeadLetterRecordService(
+                    null
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "discardPort must not be null"
+            );
+    }
+
+    private void assertPortResultIsPassedThrough(
+        DiscardKafkaDeadLetterRecordResult
+            portResult
+    ) {
+        when(
+            discardPort.discard(RECORD_ID)
+        ).thenReturn(portResult);
+
+        DiscardKafkaDeadLetterRecordResult result =
+            service.discard(COMMAND);
+
+        assertThat(result)
+            .isSameAs(portResult);
+
+        verify(discardPort)
+            .discard(RECORD_ID);
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/ReplayKafkaDeadLetterRecordServiceTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/ReplayKafkaDeadLetterRecordServiceTest.java
@@ -105,6 +105,34 @@ class ReplayKafkaDeadLetterRecordServiceTest {
     }
 
     @Test
+    void shouldReturnNotFoundWithoutPublishing() {
+        when(
+            claimUseCase.claim(
+                new ClaimKafkaDeadLetterRecordCommand(
+                    RECORD_ID
+                )
+            )
+        ).thenReturn(
+            ClaimKafkaDeadLetterRecordResult
+                .notFound()
+        );
+
+        ReplayKafkaDeadLetterRecordResult result =
+            service.replay(COMMAND);
+
+        assertThat(result.isNotFound())
+            .isTrue();
+
+        assertThat(result.isNotClaimable())
+            .isFalse();
+
+        verifyNoInteractions(
+            publisherPort,
+            lifecyclePort
+        );
+    }
+
+    @Test
     void shouldReturnNotClaimableWithoutPublishing() {
         when(claimUseCase.claim(
             new ClaimKafkaDeadLetterRecordCommand(
@@ -125,6 +153,8 @@ class ReplayKafkaDeadLetterRecordServiceTest {
             publisherPort,
             lifecyclePort
         );
+        assertThat(result.isNotFound())
+            .isFalse();
     }
 
     @Test

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterDiscardPersistenceIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterDiscardPersistenceIntegrationTest.java
@@ -1,0 +1,612 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterDiscardPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class KafkaDeadLetterDiscardPersistenceIntegrationTest {
+
+    private static final Instant RECEIVED_AT =
+        Instant.parse(
+            "2026-07-22T20:00:00Z"
+        );
+
+    private static final Instant LAST_REPLAYED_AT =
+        Instant.parse(
+            "2026-07-22T20:05:00Z"
+        );
+
+    private static final Instant LEASE_UNTIL =
+        Instant.parse(
+            "2026-07-22T20:10:00Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private KafkaDeadLetterDiscardPort discardPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM kafka_dead_letter_records"
+        );
+    }
+
+    @Test
+    void shouldDiscardReceivedRecord() {
+        UUID recordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000002301"
+            );
+
+        insertRecord(
+            recordId,
+            "RECEIVED",
+            0,
+            null,
+            null,
+            null,
+            null
+        );
+
+        DiscardKafkaDeadLetterRecordResult result =
+            discardPort.discard(recordId);
+
+        assertThat(result.isDiscarded())
+            .isTrue();
+
+        assertThat(result.isSuccessful())
+            .isTrue();
+
+        assertThat(result.isAlreadyDiscarded())
+            .isFalse();
+
+        ReplayState state =
+            stateOf(recordId);
+
+        assertThat(state.status())
+            .isEqualTo("DISCARDED");
+
+        assertThat(state.replayCount())
+            .isZero();
+
+        assertThat(state.lastReplayedAt())
+            .isNull();
+
+        assertThat(state.replayLeaseOwner())
+            .isNull();
+
+        assertThat(state.replayLeaseUntil())
+            .isNull();
+
+        assertThat(state.lastReplayError())
+            .isNull();
+    }
+
+    @Test
+    void shouldDiscardReplayFailedRecord() {
+        UUID recordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000002302"
+            );
+
+        insertRecord(
+            recordId,
+            "REPLAY_FAILED",
+            2,
+            LAST_REPLAYED_AT,
+            null,
+            null,
+            "Kafka broker rejected publication."
+        );
+
+        DiscardKafkaDeadLetterRecordResult result =
+            discardPort.discard(recordId);
+
+        assertThat(result.isDiscarded())
+            .isTrue();
+
+        ReplayState state =
+            stateOf(recordId);
+
+        assertThat(state.status())
+            .isEqualTo("DISCARDED");
+
+        /*
+         * Discarding is a status transition. Replay
+         * history remains available for operations
+         * and future auditing.
+         */
+        assertThat(state.replayCount())
+            .isEqualTo(2);
+
+        assertThat(state.lastReplayedAt())
+            .isEqualTo(LAST_REPLAYED_AT);
+
+        assertThat(state.lastReplayError())
+            .isEqualTo(
+                "Kafka broker rejected publication."
+            );
+
+        assertThat(state.replayLeaseOwner())
+            .isNull();
+
+        assertThat(state.replayLeaseUntil())
+            .isNull();
+    }
+
+    @Test
+    void shouldTreatRepeatedDiscardAsIdempotent() {
+        UUID recordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000002303"
+            );
+
+        insertRecord(
+            recordId,
+            "DISCARDED",
+            1,
+            LAST_REPLAYED_AT,
+            null,
+            null,
+            "Previous replay failure."
+        );
+
+        DiscardKafkaDeadLetterRecordResult first =
+            discardPort.discard(recordId);
+
+        DiscardKafkaDeadLetterRecordResult second =
+            discardPort.discard(recordId);
+
+        assertThat(first.isAlreadyDiscarded())
+            .isTrue();
+
+        assertThat(first.isSuccessful())
+            .isTrue();
+
+        assertThat(second.isAlreadyDiscarded())
+            .isTrue();
+
+        assertThat(second.isSuccessful())
+            .isTrue();
+
+        ReplayState state =
+            stateOf(recordId);
+
+        assertThat(state.status())
+            .isEqualTo("DISCARDED");
+
+        assertThat(state.replayCount())
+            .isEqualTo(1);
+
+        assertThat(state.lastReplayedAt())
+            .isEqualTo(LAST_REPLAYED_AT);
+
+        assertThat(state.lastReplayError())
+            .isEqualTo(
+                "Previous replay failure."
+            );
+    }
+
+    @Test
+    void shouldRejectReplayingAndReplayedRecords() {
+        UUID replayingRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000002304"
+            );
+
+        UUID replayedRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000002305"
+            );
+
+        insertRecord(
+            replayingRecordId,
+            "REPLAYING",
+            1,
+            LAST_REPLAYED_AT,
+            "replay-worker-1",
+            LEASE_UNTIL,
+            null
+        );
+
+        insertRecord(
+            replayedRecordId,
+            "REPLAYED",
+            1,
+            LAST_REPLAYED_AT,
+            null,
+            null,
+            null
+        );
+
+        DiscardKafkaDeadLetterRecordResult
+            replayingResult =
+            discardPort.discard(
+                replayingRecordId
+            );
+
+        DiscardKafkaDeadLetterRecordResult
+            replayedResult =
+            discardPort.discard(
+                replayedRecordId
+            );
+
+        assertThat(
+            replayingResult.isNotDiscardable()
+        )
+            .isTrue();
+
+        assertThat(
+            replayedResult.isNotDiscardable()
+        )
+            .isTrue();
+
+        ReplayState replayingState =
+            stateOf(replayingRecordId);
+
+        assertThat(replayingState.status())
+            .isEqualTo("REPLAYING");
+
+        assertThat(
+            replayingState.replayLeaseOwner()
+        )
+            .isEqualTo("replay-worker-1");
+
+        assertThat(
+            replayingState.replayLeaseUntil()
+        )
+            .isEqualTo(LEASE_UNTIL);
+
+        assertThat(
+            stateOf(replayedRecordId).status()
+        )
+            .isEqualTo("REPLAYED");
+    }
+
+    @Test
+    void shouldReturnNotFoundForMissingRecord() {
+        UUID missingRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000002306"
+            );
+
+        DiscardKafkaDeadLetterRecordResult result =
+            discardPort.discard(
+                missingRecordId
+            );
+
+        assertThat(result.isNotFound())
+            .isTrue();
+
+        assertThat(result.isSuccessful())
+            .isFalse();
+
+        assertThat(result.isNotDiscardable())
+            .isFalse();
+    }
+
+    @Test
+    void shouldAllowOnlyOneConcurrentDiscardTransition()
+        throws Exception {
+
+        UUID recordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000002307"
+            );
+
+        insertRecord(
+            recordId,
+            "RECEIVED",
+            0,
+            null,
+            null,
+            null,
+            null
+        );
+
+        int operationCount = 8;
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(
+                operationCount
+            );
+
+        CountDownLatch ready =
+            new CountDownLatch(
+                operationCount
+            );
+
+        CountDownLatch start =
+            new CountDownLatch(1);
+
+        List<Future<
+            DiscardKafkaDeadLetterRecordResult
+            >> futures =
+            new ArrayList<>();
+
+        try {
+            for (
+                int index = 0;
+                index < operationCount;
+                index++
+            ) {
+                futures.add(
+                    executor.submit(
+                        () -> {
+                            ready.countDown();
+
+                            boolean started =
+                                start.await(
+                                    10,
+                                    TimeUnit.SECONDS
+                                );
+
+                            if (!started) {
+                                throw new
+                                    IllegalStateException(
+                                    "Concurrent discard "
+                                        + "test start "
+                                        + "timed out."
+                                );
+                            }
+
+                            return discardPort
+                                .discard(recordId);
+                        }
+                    )
+                );
+            }
+
+            assertThat(
+                ready.await(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            )
+                .isTrue();
+
+            start.countDown();
+
+            long discardedCount = 0;
+            long alreadyDiscardedCount = 0;
+
+            for (
+                Future<
+                    DiscardKafkaDeadLetterRecordResult
+                    > future
+                : futures
+            ) {
+                DiscardKafkaDeadLetterRecordResult
+                    result =
+                    future.get(
+                        10,
+                        TimeUnit.SECONDS
+                    );
+
+                if (result.isDiscarded()) {
+                    discardedCount++;
+                } else if (
+                    result.isAlreadyDiscarded()
+                ) {
+                    alreadyDiscardedCount++;
+                } else {
+                    throw new AssertionError(
+                        "Unexpected concurrent "
+                            + "discard outcome: "
+                            + result.outcome()
+                    );
+                }
+            }
+
+            assertThat(discardedCount)
+                .isEqualTo(1);
+
+            assertThat(alreadyDiscardedCount)
+                .isEqualTo(
+                    operationCount - 1L
+                );
+
+            assertThat(stateOf(recordId).status())
+                .isEqualTo("DISCARDED");
+        } finally {
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            )
+                .isTrue();
+        }
+    }
+
+    @Test
+    void shouldValidateRecordIdentifier() {
+        assertThatThrownBy(
+            () -> discardPort.discard(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "recordId must not be null"
+            );
+    }
+
+    private ReplayState stateOf(
+        UUID recordId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT
+                status,
+                replay_count,
+                last_replayed_at,
+                replay_lease_owner,
+                replay_lease_until,
+                last_replay_error
+            FROM kafka_dead_letter_records
+            WHERE id = ?
+            """,
+            (resultSet, rowNumber) ->
+                new ReplayState(
+                    resultSet.getString(
+                        "status"
+                    ),
+                    resultSet.getInt(
+                        "replay_count"
+                    ),
+                    instant(
+                        resultSet.getTimestamp(
+                            "last_replayed_at"
+                        )
+                    ),
+                    resultSet.getString(
+                        "replay_lease_owner"
+                    ),
+                    instant(
+                        resultSet.getTimestamp(
+                            "replay_lease_until"
+                        )
+                    ),
+                    resultSet.getString(
+                        "last_replay_error"
+                    )
+                ),
+            recordId
+        );
+    }
+
+    private void insertRecord(
+        UUID id,
+        String status,
+        int replayCount,
+        Instant lastReplayedAt,
+        String replayLeaseOwner,
+        Instant replayLeaseUntil,
+        String lastReplayError
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO kafka_dead_letter_records (
+                id,
+                dlt_topic,
+                dlt_partition,
+                dlt_offset,
+                original_topic,
+                original_partition,
+                original_offset,
+                original_consumer_group,
+                record_key,
+                payload,
+                exception_type,
+                exception_message,
+                status,
+                replay_count,
+                received_at,
+                last_replayed_at,
+                replay_lease_owner,
+                replay_lease_until,
+                last_replay_error,
+                replay_origin_id,
+                replay_attempt_base
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?
+            )
+            """,
+            id,
+            "wallet.transfer.completed.dlt",
+            0,
+            deadLetterOffset(id),
+            "wallet.transfer.completed",
+            0,
+            10L,
+            "payflow-transfer-completed-audit-v1",
+            "transaction-id",
+            "{}",
+            "java.lang.IllegalStateException",
+            "Temporary processing failure.",
+            status,
+            replayCount,
+            Timestamp.from(RECEIVED_AT),
+            timestamp(lastReplayedAt),
+            replayLeaseOwner,
+            timestamp(replayLeaseUntil),
+            lastReplayError,
+            id,
+            0
+        );
+    }
+
+    private static long deadLetterOffset(
+        UUID id
+    ) {
+        return Integer.toUnsignedLong(
+            id.hashCode()
+        );
+    }
+
+    private static Timestamp timestamp(
+        Instant value
+    ) {
+        return value == null
+            ? null
+            : Timestamp.from(value);
+    }
+
+    private static Instant instant(
+        Timestamp value
+    ) {
+        return value == null
+            ? null
+            : value.toInstant();
+    }
+
+    private record ReplayState(
+        String status,
+        int replayCount,
+        Instant lastReplayedAt,
+        String replayLeaseOwner,
+        Instant replayLeaseUntil,
+        String lastReplayError
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterReplayClaimIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterReplayClaimIntegrationTest.java
@@ -7,7 +7,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -15,6 +14,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import com.nursena.payflow.eventprocessing.application.model.ClaimKafkaDeadLetterRecordResult;
 import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterReplayRepositoryPort;
 import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecord;
 import com.nursena.payflow.eventprocessing.domain.model.KafkaDeadLetterRecordStatus;
@@ -99,7 +99,7 @@ class KafkaDeadLetterReplayClaimIntegrationTest {
             0
         );
 
-        Optional<KafkaDeadLetterRecord> result =
+        ClaimKafkaDeadLetterRecordResult result =
             repositoryPort.tryClaim(
                 recordId,
                 "replay-worker-1",
@@ -108,11 +108,14 @@ class KafkaDeadLetterReplayClaimIntegrationTest {
                 3
             );
 
-        assertThat(result)
-            .isPresent();
+        assertThat(result.isClaimed())
+            .isTrue();
 
         KafkaDeadLetterRecord claimed =
-            result.orElseThrow();
+            result.record();
+
+        assertThat(claimed)
+            .isNotNull();
 
         assertThat(claimed.status())
             .isEqualTo(
@@ -193,18 +196,22 @@ class KafkaDeadLetterReplayClaimIntegrationTest {
             0
         );
 
-        assertThat(
+        ClaimKafkaDeadLetterRecordResult
+            activeLeaseResult =
             repositoryPort.tryClaim(
                 activeRecordId,
                 "new-worker",
                 CLAIMED_AT,
                 LEASE_DURATION,
                 3
-            )
-        )
-            .isEmpty();
+            );
 
-        Optional<KafkaDeadLetterRecord> reclaimed =
+        assertThat(
+            activeLeaseResult.isNotClaimable()
+        )
+            .isTrue();
+
+        ClaimKafkaDeadLetterRecordResult reclaimed =
             repositoryPort.tryClaim(
                 expiredRecordId,
                 "new-worker",
@@ -213,11 +220,11 @@ class KafkaDeadLetterReplayClaimIntegrationTest {
                 3
             );
 
-        assertThat(reclaimed)
-            .isPresent();
+        assertThat(reclaimed.isClaimed())
+            .isTrue();
 
         assertThat(
-            reclaimed.orElseThrow().replayCount()
+            reclaimed.record().replayCount()
         )
             .isEqualTo(2);
 
@@ -259,7 +266,7 @@ class KafkaDeadLetterReplayClaimIntegrationTest {
             2
         );
 
-        Optional<KafkaDeadLetterRecord> firstClaim =
+        ClaimKafkaDeadLetterRecordResult firstClaim =
             repositoryPort.tryClaim(
                 derivedRecordId,
                 "replay-worker-1",
@@ -268,22 +275,22 @@ class KafkaDeadLetterReplayClaimIntegrationTest {
                 3
             );
 
-        assertThat(firstClaim)
-            .isPresent();
+        assertThat(firstClaim.isClaimed())
+            .isTrue();
 
         assertThat(
-            firstClaim.orElseThrow()
+            firstClaim.record()
                 .replayAttemptBase()
         )
             .isEqualTo(2);
 
         assertThat(
-            firstClaim.orElseThrow()
+            firstClaim.record()
                 .replayCount()
         )
             .isEqualTo(1);
 
-        Optional<KafkaDeadLetterRecord> secondClaim =
+        ClaimKafkaDeadLetterRecordResult secondClaim =
             repositoryPort.tryClaim(
                 derivedRecordId,
                 "replay-worker-2",
@@ -294,8 +301,8 @@ class KafkaDeadLetterReplayClaimIntegrationTest {
                 3
             );
 
-        assertThat(secondClaim)
-            .isEmpty();
+        assertThat(secondClaim.isNotClaimable())
+            .isTrue();
 
         assertThat(
             stateOf(derivedRecordId)
@@ -346,27 +353,96 @@ class KafkaDeadLetterReplayClaimIntegrationTest {
             0
         );
 
-        assertThat(
+        ClaimKafkaDeadLetterRecordResult
+            nullPayloadResult =
             repositoryPort.tryClaim(
                 nullPayloadId,
                 "replay-worker-1",
                 CLAIMED_AT,
                 LEASE_DURATION,
                 3
-            )
-        )
-            .isEmpty();
+            );
 
         assertThat(
+            nullPayloadResult.isNotClaimable()
+        )
+            .isTrue();
+
+        ClaimKafkaDeadLetterRecordResult
+            deadLetterSourceResult =
             repositoryPort.tryClaim(
                 deadLetterSourceId,
                 "replay-worker-1",
                 CLAIMED_AT,
                 LEASE_DURATION,
                 3
-            )
+            );
+
+        assertThat(
+            deadLetterSourceResult.isNotClaimable()
         )
-            .isEmpty();
+            .isTrue();
+    }
+
+    @Test
+    void shouldDistinguishMissingRecordFromUnclaimableRecord() {
+        UUID missingRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001408"
+            );
+
+        UUID replayedRecordId =
+            UUID.fromString(
+                "80000000-0000-0000-0000-000000001409"
+            );
+
+        insertRecord(
+            replayedRecordId,
+            49L,
+            ORIGINAL_TOPIC,
+            "{}",
+            "REPLAYED",
+            1,
+            CLAIMED_AT.minusSeconds(30),
+            null,
+            null,
+            null,
+            replayedRecordId,
+            0
+        );
+
+        ClaimKafkaDeadLetterRecordResult
+            missingResult =
+            repositoryPort.tryClaim(
+                missingRecordId,
+                "replay-worker-1",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                3
+            );
+
+        ClaimKafkaDeadLetterRecordResult
+            unclaimableResult =
+            repositoryPort.tryClaim(
+                replayedRecordId,
+                "replay-worker-1",
+                CLAIMED_AT,
+                LEASE_DURATION,
+                3
+            );
+
+        assertThat(missingResult.isNotFound())
+            .isTrue();
+
+        assertThat(
+            unclaimableResult.isNotClaimable()
+        )
+            .isTrue();
+
+        assertThat(
+            stateOf(replayedRecordId).status()
+        )
+            .isEqualTo("REPLAYED");
     }
 
     @Test
@@ -408,7 +484,7 @@ class KafkaDeadLetterReplayClaimIntegrationTest {
         CountDownLatch start =
             new CountDownLatch(1);
 
-        List<Future<Optional<KafkaDeadLetterRecord>>>
+        List<Future<ClaimKafkaDeadLetterRecordResult>>
             futures =
             new ArrayList<>();
 
@@ -465,7 +541,7 @@ class KafkaDeadLetterReplayClaimIntegrationTest {
             long successfulClaims = 0;
 
             for (
-                Future<Optional<KafkaDeadLetterRecord>>
+                Future<ClaimKafkaDeadLetterRecordResult>
                     future
                 : futures
             ) {
@@ -473,7 +549,7 @@ class KafkaDeadLetterReplayClaimIntegrationTest {
                     future.get(
                         10,
                         TimeUnit.SECONDS
-                    ).isPresent()
+                    ).isClaimed()
                 ) {
                     successfulClaims++;
                 }


### PR DESCRIPTION
## Summary

- expose operator-only Kafka dead-letter replay and discard endpoints
- distinguish missing records from non-claimable replay states atomically
- add atomic and idempotent discard state transitions
- map replay and discard outcomes to explicit HTTP responses
- document and verify the command API through OpenAPI contract tests

## API

- POST /api/v1/operations/kafka/dead-letters/{recordId}/replay
- POST /api/v1/operations/kafka/dead-letters/{recordId}/discard

## Behavior

- replay success returns 200 OK
- discard success and repeated discard return 204 No Content
- missing records return 404 Not Found
- invalid state transitions return 409 Conflict
- replay publication failures return 502 Bad Gateway
- unresolved replay outcomes return 503 Service Unavailable
- anonymous requests return 401 Unauthorized
- non-operations users return 403 Forbidden

## Verification

- full Maven clean verify
- PostgreSQL state-transition and concurrency integration tests
- replay lifecycle and Kafka publication regression tests
- MockMvc authorization and response-mapping tests
- OpenAPI JSON contract integration tests

Refs #51