### PR TITLE
feat: add operator audit trail for Kafka dead-letter commands

### DIFF
--- a/docs/adr/0007-audit-kafka-dead-letter-operator-commands.md
+++ b/docs/adr/0007-audit-kafka-dead-letter-operator-commands.md
@@ -1,0 +1,391 @@
+# ADR 0007: Audit authorized Kafka dead-letter commands
+
+- Status: Accepted
+- Date: 2026-07-23
+
+## Context
+
+PayFlow exposes authorized operations for replaying and discarding
+durably stored Kafka dead-letter records. These operations are protected
+by the explicit `PAYFLOW_OPERATIONS` authority.
+
+Replay and discard change operational state. Replay may also publish a
+Kafka record again. The system must therefore retain durable evidence of:
+
+- which authenticated operator issued the command
+- which dead-letter record was targeted
+- whether the command was replay or discard
+- when processing started
+- how processing completed
+- which safe error classification applies when processing does not succeed
+
+HTTP access logs, application logs, and the mutable dead-letter lifecycle
+row are not sufficient as the authoritative command history. Logs may be
+unavailable or retained for a limited period, while the lifecycle row
+represents current state rather than every authorized command attempt.
+
+The audit trail must minimize stored data. It must not contain:
+
+- Kafka payloads
+- Kafka record keys
+- JWTs or access tokens
+- operator email addresses
+- exception messages
+- stack traces
+- replay lease owners
+
+## Decision
+
+PayFlow will persist an append-only PostgreSQL audit trail for authorized
+Kafka dead-letter replay and discard commands.
+
+Auditing will be implemented by operator-aware application orchestration
+that wraps the existing replay and discard use cases. The existing use
+cases remain responsible for their current lifecycle outcomes. The web
+adapter retains its existing mapping from application results to HTTP
+responses.
+
+The audited flow is:
+
+```text
+authorized operations request
+        |
+verified JWT subject -> operator UUID
+        |
+operator-aware application command
+        |
+ATTEMPTED audit append
+        |
+existing replay or discard use case
+        |
+COMPLETED audit append
+        |
+existing web outcome mapping
+```
+
+The controller supplies trusted operator identity and the target record
+identifier. It does not perform audit persistence or derive audit
+outcomes. It continues to map audited application results to the existing
+HTTP contract.
+
+The existing replay and discard services do not become aware of JWT,
+Spring Security, HTTP, JDBC, or the audit table.
+
+## Operator identity
+
+The web adapter derives `operatorId` from the verified JWT `sub` claim and
+parses it as a UUID.
+
+The application command contains only:
+
+- `operatorId`
+- `recordId`
+
+The complete JWT and Spring Security types do not cross into the
+application layer. Request headers and email addresses are not accepted
+as operator identity.
+
+A request whose verified token does not provide a valid UUID subject is
+rejected before an audited command use case is invoked. No audit row is
+created because a trustworthy operator identifier is unavailable.
+
+## Command identity and stages
+
+Each operator command invocation receives one generated `commandId`.
+The same value correlates its two audit rows. Each row also receives its
+own generated `id`.
+
+Supported stages are:
+
+- `ATTEMPTED`
+- `COMPLETED`
+
+An `ATTEMPTED` row proves that PayFlow durably accepted an authorized
+operator command before invoking the existing command use case. It has no
+outcome and no error code.
+
+A `COMPLETED` row records the safe application result observed after the
+existing command use case returns or throws. It must have an outcome.
+
+PostgreSQL enforces `UNIQUE (command_id, stage)` so one command cannot
+persist the same stage more than once.
+
+## Audit data model
+
+Each row contains only:
+
+- `id`
+- `commandId`
+- `stage`
+- `operatorId`
+- `deadLetterRecordId`
+- `commandType`
+- `outcome`
+- `errorCode`
+- `occurredAt`
+
+Supported command types are:
+
+- `REPLAY`
+- `DISCARD`
+
+Timestamps use the shared UTC `Clock` and are truncated to PostgreSQL
+microsecond precision before persistence.
+
+## Outcomes and safe error codes
+
+Supported completed outcomes are:
+
+- `REPLAYED`
+- `REPLAY_NOT_FOUND`
+- `REPLAY_NOT_CLAIMABLE`
+- `REPLAY_FAILED`
+- `REPLAY_UNRESOLVED`
+- `DISCARDED`
+- `ALREADY_DISCARDED`
+- `DISCARD_NOT_FOUND`
+- `DISCARD_NOT_DISCARDABLE`
+- `INTERNAL_FAILURE`
+
+Successful outcomes have no error code:
+
+- `REPLAYED`
+- `DISCARDED`
+- `ALREADY_DISCARDED`
+
+Controlled unsuccessful outcomes map to fixed safe codes:
+
+| Outcome | Safe error code |
+|---|---|
+| `REPLAY_NOT_FOUND` | `KAFKA_DEAD_LETTER_RECORD_NOT_FOUND` |
+| `REPLAY_NOT_CLAIMABLE` | `KAFKA_DEAD_LETTER_RECORD_NOT_CLAIMABLE` |
+| `REPLAY_FAILED` | `KAFKA_DEAD_LETTER_REPLAY_FAILED` |
+| `REPLAY_UNRESOLVED` | `KAFKA_DEAD_LETTER_REPLAY_UNRESOLVED` |
+| `DISCARD_NOT_FOUND` | `KAFKA_DEAD_LETTER_RECORD_NOT_FOUND` |
+| `DISCARD_NOT_DISCARDABLE` | `KAFKA_DEAD_LETTER_RECORD_NOT_DISCARDABLE` |
+| `INTERNAL_FAILURE` | `KAFKA_DEAD_LETTER_COMMAND_INTERNAL_FAILURE` |
+
+The application model uses explicit enums. A safe error code is derived
+from the selected outcome rather than accepted as arbitrary text.
+
+The model rejects:
+
+- an outcome on an `ATTEMPTED` row
+- a missing outcome on a `COMPLETED` row
+- a replay outcome for a discard command
+- a discard outcome for a replay command
+- an error-code state inconsistent with the selected outcome
+
+## Transaction boundaries
+
+Audit appends execute through a dedicated Spring bean with
+`PROPAGATION_REQUIRES_NEW`.
+
+The transactional component is separate from the audited orchestrator.
+The implementation does not rely on same-class self-invocation because
+Spring transaction interception would not apply to that call.
+
+Each audit row commits independently from replay or discard processing.
+The outer audited orchestration does not open a transaction around the
+complete delegate invocation.
+
+### ATTEMPTED persistence failure
+
+Audit availability is a prerequisite for executing an authorized
+operator command.
+
+When the `ATTEMPTED` row cannot be committed:
+
+- replay or discard is not invoked
+- the operation fails closed
+- the web boundary returns a safe service-unavailable response
+- no persistence or exception detail is returned
+
+### Existing command transaction behavior
+
+The existing replay transaction design remains unchanged. Kafka
+publication must not execute inside a long PostgreSQL transaction added
+by this feature.
+
+Replay continues to use its current claim, publish, and lifecycle-update
+boundaries. The existing transactional discard use case also remains
+unchanged.
+
+### COMPLETED persistence failure
+
+The delegated command may already have changed PostgreSQL state or
+published to Kafka before the `COMPLETED` row is appended.
+
+When the `COMPLETED` row cannot be committed:
+
+- the durable `ATTEMPTED` row remains
+- the command is not automatically executed again by the server
+- the application raises a dedicated safe audit-persistence failure
+- the web boundary returns service unavailable
+- the response does not claim a successfully audited completion
+- audit storage still receives no exception message or stack trace
+
+The incomplete pair represents an operationally ambiguous completion and
+must be visible through safe logs or metrics without exposing payloads,
+keys, tokens, or exception details in audit persistence.
+
+### Unexpected runtime failure
+
+When the delegated command throws an unexpected runtime exception, the
+orchestrator attempts to append:
+
+```text
+stage = COMPLETED
+outcome = INTERNAL_FAILURE
+errorCode = KAFKA_DEAD_LETTER_COMMAND_INTERNAL_FAILURE
+```
+
+The exception message and stack trace are not stored. After the audit
+attempt, the original failure remains available only as internal
+diagnostic context. The application raises a dedicated safe failure that
+the web boundary maps without exposing the original exception message.
+
+## Append-only persistence
+
+The application output port exposes only an append operation. It does not
+expose update or delete operations.
+
+PostgreSQL reinforces append-only behavior by rejecting `UPDATE` and
+`DELETE` operations on the audit table.
+
+The schema also enforces:
+
+- supported stage values
+- supported command types
+- supported outcome values
+- supported safe error-code values
+- stage and outcome consistency
+- command type and outcome consistency
+- `UNIQUE (command_id, stage)`
+
+Indexes support investigation by operator identifier, dead-letter record
+identifier, command type, and occurrence time.
+
+## Foreign-key policy
+
+The audit table does not use foreign keys for `operatorId` or
+`deadLetterRecordId`.
+
+A `NOT_FOUND` command result must remain auditable even though no target
+record exists. Audit history must also survive future retention or
+deletion policies applied to users or dead-letter records.
+
+The stored UUID values are immutable historical identifiers, not
+references that require cascading lifecycle behavior.
+
+## Authorization boundary
+
+Anonymous and unauthorized requests are rejected by Spring Security
+before the controller and audited application use cases are invoked.
+They create no operator audit rows.
+
+Only requests that cross the authenticated and authorized operations
+boundary are audited.
+
+Audit persistence must never receive or derive values from:
+
+- untrusted identity headers
+- request email addresses
+- Kafka payloads
+- Kafka record keys
+- access tokens
+- exception messages
+- stack traces
+- replay lease metadata
+
+## Consequences
+
+### Positive
+
+- every authorized command attempt leaves a durable initial trace
+- successful, rejected, and failed commands receive explicit outcomes
+- operator identity comes from a trusted token claim
+- replay and discard behavior remains independently testable
+- audit persistence cannot silently expand into sensitive-data storage
+- PostgreSQL constraints reinforce application invariants
+- audit history survives changes to mutable operational state
+
+### Negative
+
+- one operator command creates two database rows
+- each command requires additional independent transactions
+- audit database unavailability prevents new operator commands
+- a completed command may have an ambiguous HTTP result when its final
+  audit row cannot be committed
+- database-level append-only enforcement adds migration and integration
+  test complexity
+
+## Alternatives considered
+
+### Write one audit row after command completion
+
+Rejected because a process or persistence failure could leave no durable
+evidence that an authorized command started.
+
+### Update one row from attempted to completed
+
+Rejected because mutation weakens the append-only history and removes the
+distinction between facts observed at different times.
+
+### Audit directly inside the controller
+
+Rejected because it would couple HTTP and Spring Security concerns to
+persistence and duplicate orchestration behavior.
+
+### Add audit calls inside the existing replay and discard services
+
+Rejected because those services already have focused lifecycle
+responsibilities and are useful independently of the operator HTTP
+boundary.
+
+### Wrap Kafka replay publication in one database transaction
+
+Rejected because Kafka and PostgreSQL do not share a local transaction,
+and broker publication must not hold a long PostgreSQL transaction open.
+
+### Store the operator email address
+
+Rejected because email is mutable personal data. The verified UUID
+subject is the stable identity required by the audit use case.
+
+### Store exception messages
+
+Rejected because exception text may contain payload fragments,
+infrastructure details, identifiers, or other sensitive information.
+
+### Use only application-level append enforcement
+
+Rejected as the sole guarantee because accidental SQL could still mutate
+or delete historical rows.
+
+## Verification
+
+The decision is verified through:
+
+- audit model invariant tests
+- replay and discard outcome-mapping tests
+- audited orchestration unit tests
+- PostgreSQL schema and constraint tests
+- PostgreSQL append-only tests
+- independent transaction integration tests
+- MockMvc authentication and authorization tests
+- tests proving denied requests do not invoke audit collaborators
+- tests proving sensitive fields are absent
+- the complete Maven verification build
+
+## Out of scope
+
+The following capabilities are not required for Issue #53:
+
+- public audit query endpoints
+- audit export
+- audit retention jobs
+- command approval workflows
+- command rate limiting
+- payload remediation
+- operator email snapshots

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandController.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandController.java
@@ -10,17 +10,17 @@ import com.nursena.payflow.common.api.ApiError;
 import com.nursena.payflow.configuration
     .OpenApiConfiguration;
 import com.nursena.payflow.eventprocessing.application.model
-    .DiscardKafkaDeadLetterRecordCommand;
+    .OperatorDiscardKafkaDeadLetterRecordCommand;
 import com.nursena.payflow.eventprocessing.application.model
     .DiscardKafkaDeadLetterRecordResult;
 import com.nursena.payflow.eventprocessing.application.model
-    .ReplayKafkaDeadLetterRecordCommand;
+    .OperatorReplayKafkaDeadLetterRecordCommand;
 import com.nursena.payflow.eventprocessing.application.model
     .ReplayKafkaDeadLetterRecordResult;
 import com.nursena.payflow.eventprocessing.application.port.in
-    .DiscardKafkaDeadLetterRecordUseCase;
+    .OperatorDiscardKafkaDeadLetterRecordUseCase;
 import com.nursena.payflow.eventprocessing.application.port.in
-    .ReplayKafkaDeadLetterRecordUseCase;
+    .OperatorReplayKafkaDeadLetterRecordUseCase;
 import com.nursena.payflow.eventprocessing.domain.exception
     .KafkaDeadLetterCommandException;
 import com.nursena.payflow.eventprocessing.domain.exception
@@ -37,6 +37,9 @@ import io.swagger.v3.oas.annotations.security
     .SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation
+    .AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation
@@ -57,16 +60,16 @@ import org.springframework.web.bind.annotation
 )
 public class KafkaDeadLetterCommandController {
 
-    private final ReplayKafkaDeadLetterRecordUseCase
+    private final OperatorReplayKafkaDeadLetterRecordUseCase
         replayUseCase;
 
-    private final DiscardKafkaDeadLetterRecordUseCase
+    private final OperatorDiscardKafkaDeadLetterRecordUseCase
         discardUseCase;
 
     public KafkaDeadLetterCommandController(
-        ReplayKafkaDeadLetterRecordUseCase
+        OperatorReplayKafkaDeadLetterRecordUseCase
             replayUseCase,
-        DiscardKafkaDeadLetterRecordUseCase
+        OperatorDiscardKafkaDeadLetterRecordUseCase
             discardUseCase
     ) {
         this.replayUseCase =
@@ -129,7 +132,9 @@ public class KafkaDeadLetterCommandController {
         @ApiResponse(
             responseCode = "401",
             description =
-                "Bearer token is missing or invalid."
+                "Bearer token or authenticated "
+                    + "operator identity is missing "
+                    + "or invalid."
         ),
         @ApiResponse(
             responseCode = "403",
@@ -178,10 +183,25 @@ public class KafkaDeadLetterCommandController {
             )
         ),
         @ApiResponse(
+            responseCode = "500",
+            description =
+                "The authorized command failed "
+                    + "unexpectedly.",
+            content = @Content(
+                mediaType =
+                    APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        ApiError.class
+                )
+            )
+        ),
+        @ApiResponse(
             responseCode = "503",
             description =
                 "The replay outcome could not be "
-                    + "resolved safely.",
+                    + "resolved safely or command "
+                    + "auditing is unavailable.",
             content = @Content(
                 mediaType =
                     APPLICATION_JSON_VALUE,
@@ -195,6 +215,10 @@ public class KafkaDeadLetterCommandController {
     @PostMapping("/{recordId}/replay")
     public ResponseEntity<KafkaDeadLetterReplayResponse>
     replayKafkaDeadLetterRecord(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt,
+
         @Parameter(
             description =
                 "Dead-letter record identifier.",
@@ -209,7 +233,8 @@ public class KafkaDeadLetterCommandController {
         ReplayKafkaDeadLetterRecordResult result =
             Objects.requireNonNull(
                 replayUseCase.replay(
-                    new ReplayKafkaDeadLetterRecordCommand(
+                    new OperatorReplayKafkaDeadLetterRecordCommand(
+                        operatorId(jwt),
                         recordId
                     )
                 ),
@@ -260,7 +285,9 @@ public class KafkaDeadLetterCommandController {
         @ApiResponse(
             responseCode = "401",
             description =
-                "Bearer token is missing or invalid."
+                "Bearer token or authenticated "
+                    + "operator identity is missing "
+                    + "or invalid."
         ),
         @ApiResponse(
             responseCode = "403",
@@ -294,11 +321,42 @@ public class KafkaDeadLetterCommandController {
                         ApiError.class
                 )
             )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description =
+                "The authorized command failed "
+                    + "unexpectedly.",
+            content = @Content(
+                mediaType =
+                    APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        ApiError.class
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "503",
+            description =
+                "Command auditing is unavailable.",
+            content = @Content(
+                mediaType =
+                    APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        ApiError.class
+                )
+            )
         )
     })
     @PostMapping("/{recordId}/discard")
     public ResponseEntity<Void>
     discardKafkaDeadLetterRecord(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt,
+
         @Parameter(
             description =
                 "Dead-letter record identifier.",
@@ -313,7 +371,8 @@ public class KafkaDeadLetterCommandController {
         DiscardKafkaDeadLetterRecordResult result =
             Objects.requireNonNull(
                 discardUseCase.discard(
-                    new DiscardKafkaDeadLetterRecordCommand(
+                    new OperatorDiscardKafkaDeadLetterRecordCommand(
+                        operatorId(jwt),
                         recordId
                     )
                 ),
@@ -324,6 +383,24 @@ public class KafkaDeadLetterCommandController {
             recordId,
             result
         );
+    }
+
+    private static UUID operatorId(
+        Jwt jwt
+    ) {
+        if (jwt == null || jwt.getSubject() == null) {
+            throw new
+                KafkaDeadLetterOperatorIdentityException();
+        }
+
+        try {
+            return UUID.fromString(
+                jwt.getSubject()
+            );
+        } catch (IllegalArgumentException ignored) {
+            throw new
+                KafkaDeadLetterOperatorIdentityException();
+        }
     }
 
     private static ResponseEntity<

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandExceptionHandler.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import com.nursena.payflow.common.api.ApiError;
 import com.nursena.payflow.eventprocessing.domain.exception
+    .KafkaDeadLetterCommandAuditException;
+import com.nursena.payflow.eventprocessing.domain.exception
     .KafkaDeadLetterCommandException;
 import com.nursena.payflow.eventprocessing.domain.exception
     .KafkaDeadLetterRecordNotFoundException;
@@ -61,6 +63,39 @@ KafkaDeadLetterCommandExceptionHandler {
         );
     }
 
+    @ExceptionHandler(
+        KafkaDeadLetterCommandAuditException.class
+    )
+    ResponseEntity<ApiError> handleAuditFailure(
+        KafkaDeadLetterCommandAuditException
+            exception,
+        HttpServletRequest request
+    ) {
+        return response(
+            auditStatusOf(exception),
+            auditCodeOf(exception),
+            exception.getMessage(),
+            request
+        );
+    }
+
+    @ExceptionHandler(
+        KafkaDeadLetterOperatorIdentityException.class
+    )
+    ResponseEntity<ApiError> handleInvalidOperatorIdentity(
+        KafkaDeadLetterOperatorIdentityException
+            exception,
+        HttpServletRequest request
+    ) {
+        return response(
+            HttpStatus.UNAUTHORIZED,
+            KafkaDeadLetterOperatorIdentityException
+                .CODE,
+            exception.getMessage(),
+            request
+        );
+    }
+
     @ExceptionHandler({
         HandlerMethodValidationException.class,
         MethodArgumentTypeMismatchException.class
@@ -75,6 +110,39 @@ KafkaDeadLetterCommandExceptionHandler {
             "Request validation failed.",
             request
         );
+    }
+
+    private static HttpStatus auditStatusOf(
+        KafkaDeadLetterCommandAuditException
+            exception
+    ) {
+        return switch (exception.getReason()) {
+            case ATTEMPT_PERSISTENCE_FAILED,
+                 COMPLETION_PERSISTENCE_FAILED ->
+                HttpStatus.SERVICE_UNAVAILABLE;
+
+            case COMMAND_INTERNAL_FAILURE ->
+                HttpStatus.INTERNAL_SERVER_ERROR;
+        };
+    }
+
+    private static String auditCodeOf(
+        KafkaDeadLetterCommandAuditException
+            exception
+    ) {
+        return switch (exception.getReason()) {
+            case ATTEMPT_PERSISTENCE_FAILED ->
+                "KAFKA_DEAD_LETTER_COMMAND_"
+                    + "AUDIT_UNAVAILABLE";
+
+            case COMPLETION_PERSISTENCE_FAILED ->
+                "KAFKA_DEAD_LETTER_COMMAND_"
+                    + "AUDIT_COMPLETION_UNAVAILABLE";
+
+            case COMMAND_INTERNAL_FAILURE ->
+                "KAFKA_DEAD_LETTER_COMMAND_"
+                    + "INTERNAL_FAILURE";
+        };
     }
 
     private static HttpStatus statusOf(

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterOperatorIdentityException.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterOperatorIdentityException.java
@@ -1,0 +1,15 @@
+package com.nursena.payflow.eventprocessing.adapter.in.web;
+
+final class KafkaDeadLetterOperatorIdentityException
+    extends RuntimeException {
+
+    static final String CODE =
+        "KAFKA_DEAD_LETTER_OPERATOR_IDENTITY_INVALID";
+
+    KafkaDeadLetterOperatorIdentityException() {
+        super(
+            "Authenticated operator identity "
+                + "is invalid."
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterCommandAuditAdapter.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/out/persistence/JdbcKafkaDeadLetterCommandAuditAdapter.java
@@ -1,0 +1,94 @@
+package com.nursena.payflow.eventprocessing.adapter.out.persistence;
+
+import java.sql.Timestamp;
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAudit;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterCommandAuditPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+class JdbcKafkaDeadLetterCommandAuditAdapter
+    implements KafkaDeadLetterCommandAuditPort {
+
+    private static final String INSERT_SQL = """
+        INSERT INTO kafka_dead_letter_command_audits (
+            id,
+            command_id,
+            stage,
+            operator_id,
+            dead_letter_record_id,
+            command_type,
+            outcome,
+            error_code,
+            occurred_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    JdbcKafkaDeadLetterCommandAuditAdapter(
+        JdbcTemplate jdbcTemplate
+    ) {
+        this.jdbcTemplate =
+            Objects.requireNonNull(
+                jdbcTemplate,
+                "jdbcTemplate must not be null"
+            );
+    }
+
+    @Override
+    @Transactional(
+        propagation = Propagation.REQUIRES_NEW
+    )
+    public void append(
+        KafkaDeadLetterCommandAudit audit
+    ) {
+        KafkaDeadLetterCommandAudit
+            validatedAudit =
+            Objects.requireNonNull(
+                audit,
+                "audit must not be null"
+            );
+
+        int affectedRows = jdbcTemplate.update(
+            INSERT_SQL,
+            validatedAudit.id(),
+            validatedAudit.commandId(),
+            validatedAudit.stage().name(),
+            validatedAudit.operatorId(),
+            validatedAudit.deadLetterRecordId(),
+            validatedAudit.commandType().name(),
+            enumName(
+                validatedAudit.outcome()
+            ),
+            validatedAudit.errorCode(),
+            Timestamp.from(
+                validatedAudit.occurredAt()
+            )
+        );
+
+        if (affectedRows != 1) {
+            throw new IllegalStateException(
+                "Kafka dead-letter command audit "
+                    + "insert affected "
+                    + affectedRows
+                    + " rows."
+            );
+        }
+    }
+
+    private static String enumName(
+        Enum<?> value
+    ) {
+        if (value == null) {
+            return null;
+        }
+
+        return value.name();
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterCommandAudit.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterCommandAudit.java
@@ -1,0 +1,192 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.UUID;
+
+public record KafkaDeadLetterCommandAudit(
+    UUID id,
+    UUID commandId,
+    KafkaDeadLetterCommandAuditStage stage,
+    UUID operatorId,
+    UUID deadLetterRecordId,
+    KafkaDeadLetterCommandType commandType,
+    KafkaDeadLetterCommandAuditOutcome outcome,
+    String errorCode,
+    Instant occurredAt
+) {
+
+    public KafkaDeadLetterCommandAudit {
+        id = requireIdentifier(id, "id");
+        commandId =
+            requireIdentifier(
+                commandId,
+                "commandId"
+            );
+        stage =
+            Objects.requireNonNull(
+                stage,
+                "stage must not be null"
+            );
+        operatorId =
+            requireIdentifier(
+                operatorId,
+                "operatorId"
+            );
+        deadLetterRecordId =
+            requireIdentifier(
+                deadLetterRecordId,
+                "deadLetterRecordId"
+            );
+        commandType =
+            Objects.requireNonNull(
+                commandType,
+                "commandType must not be null"
+            );
+        occurredAt =
+            Objects.requireNonNull(
+                occurredAt,
+                "occurredAt must not be null"
+            ).truncatedTo(ChronoUnit.MICROS);
+
+        validateStageState(
+            stage,
+            commandType,
+            outcome,
+            errorCode
+        );
+    }
+
+    public static KafkaDeadLetterCommandAudit
+    attempted(
+        UUID id,
+        UUID commandId,
+        UUID operatorId,
+        UUID deadLetterRecordId,
+        KafkaDeadLetterCommandType commandType,
+        Instant occurredAt
+    ) {
+        return new KafkaDeadLetterCommandAudit(
+            id,
+            commandId,
+            KafkaDeadLetterCommandAuditStage
+                .ATTEMPTED,
+            operatorId,
+            deadLetterRecordId,
+            commandType,
+            null,
+            null,
+            occurredAt
+        );
+    }
+
+    public static KafkaDeadLetterCommandAudit
+    completed(
+        UUID id,
+        UUID commandId,
+        UUID operatorId,
+        UUID deadLetterRecordId,
+        KafkaDeadLetterCommandType commandType,
+        KafkaDeadLetterCommandAuditOutcome outcome,
+        Instant occurredAt
+    ) {
+        KafkaDeadLetterCommandAuditOutcome
+            validatedOutcome =
+            Objects.requireNonNull(
+                outcome,
+                "outcome must not be null"
+            );
+
+        return new KafkaDeadLetterCommandAudit(
+            id,
+            commandId,
+            KafkaDeadLetterCommandAuditStage
+                .COMPLETED,
+            operatorId,
+            deadLetterRecordId,
+            commandType,
+            validatedOutcome,
+            validatedOutcome.safeErrorCode(),
+            occurredAt
+        );
+    }
+
+    private static UUID requireIdentifier(
+        UUID value,
+        String fieldName
+    ) {
+        return Objects.requireNonNull(
+            value,
+            fieldName + " must not be null"
+        );
+    }
+
+    private static void validateStageState(
+        KafkaDeadLetterCommandAuditStage stage,
+        KafkaDeadLetterCommandType commandType,
+        KafkaDeadLetterCommandAuditOutcome outcome,
+        String errorCode
+    ) {
+        if (
+            stage
+                == KafkaDeadLetterCommandAuditStage
+                .ATTEMPTED
+        ) {
+            validateAttemptedState(
+                outcome,
+                errorCode
+            );
+            return;
+        }
+
+        validateCompletedState(
+            commandType,
+            outcome,
+            errorCode
+        );
+    }
+
+    private static void validateAttemptedState(
+        KafkaDeadLetterCommandAuditOutcome outcome,
+        String errorCode
+    ) {
+        if (outcome != null || errorCode != null) {
+            throw new IllegalArgumentException(
+                "ATTEMPTED audit must not have "
+                    + "an outcome or errorCode."
+            );
+        }
+    }
+
+    private static void validateCompletedState(
+        KafkaDeadLetterCommandType commandType,
+        KafkaDeadLetterCommandAuditOutcome outcome,
+        String errorCode
+    ) {
+        if (outcome == null) {
+            throw new IllegalArgumentException(
+                "COMPLETED audit must have an outcome."
+            );
+        }
+
+        if (!outcome.supports(commandType)) {
+            throw new IllegalArgumentException(
+                "outcome must be compatible "
+                    + "with commandType."
+            );
+        }
+
+        if (
+            !Objects.equals(
+                outcome.safeErrorCode(),
+                errorCode
+            )
+        ) {
+            throw new IllegalArgumentException(
+                "errorCode must match the "
+                    + "selected outcome."
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterCommandAuditOutcome.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterCommandAuditOutcome.java
@@ -1,0 +1,86 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.util.Objects;
+
+public enum KafkaDeadLetterCommandAuditOutcome {
+
+    REPLAYED(
+        KafkaDeadLetterCommandType.REPLAY,
+        null
+    ),
+
+    REPLAY_NOT_FOUND(
+        KafkaDeadLetterCommandType.REPLAY,
+        "KAFKA_DEAD_LETTER_RECORD_NOT_FOUND"
+    ),
+
+    REPLAY_NOT_CLAIMABLE(
+        KafkaDeadLetterCommandType.REPLAY,
+        "KAFKA_DEAD_LETTER_RECORD_NOT_CLAIMABLE"
+    ),
+
+    REPLAY_FAILED(
+        KafkaDeadLetterCommandType.REPLAY,
+        "KAFKA_DEAD_LETTER_REPLAY_FAILED"
+    ),
+
+    REPLAY_UNRESOLVED(
+        KafkaDeadLetterCommandType.REPLAY,
+        "KAFKA_DEAD_LETTER_REPLAY_UNRESOLVED"
+    ),
+
+    DISCARDED(
+        KafkaDeadLetterCommandType.DISCARD,
+        null
+    ),
+
+    ALREADY_DISCARDED(
+        KafkaDeadLetterCommandType.DISCARD,
+        null
+    ),
+
+    DISCARD_NOT_FOUND(
+        KafkaDeadLetterCommandType.DISCARD,
+        "KAFKA_DEAD_LETTER_RECORD_NOT_FOUND"
+    ),
+
+    DISCARD_NOT_DISCARDABLE(
+        KafkaDeadLetterCommandType.DISCARD,
+        "KAFKA_DEAD_LETTER_RECORD_NOT_DISCARDABLE"
+    ),
+
+    INTERNAL_FAILURE(
+        null,
+        "KAFKA_DEAD_LETTER_COMMAND_INTERNAL_FAILURE"
+    );
+
+    private final KafkaDeadLetterCommandType
+        commandType;
+
+    private final String safeErrorCode;
+
+    KafkaDeadLetterCommandAuditOutcome(
+        KafkaDeadLetterCommandType commandType,
+        String safeErrorCode
+    ) {
+        this.commandType = commandType;
+        this.safeErrorCode = safeErrorCode;
+    }
+
+    public boolean supports(
+        KafkaDeadLetterCommandType candidate
+    ) {
+        KafkaDeadLetterCommandType validatedCandidate =
+            Objects.requireNonNull(
+                candidate,
+                "candidate must not be null"
+            );
+
+        return commandType == null
+            || commandType == validatedCandidate;
+    }
+
+    public String safeErrorCode() {
+        return safeErrorCode;
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterCommandAuditStage.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterCommandAuditStage.java
@@ -1,0 +1,7 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+public enum KafkaDeadLetterCommandAuditStage {
+
+    ATTEMPTED,
+    COMPLETED
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterCommandType.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterCommandType.java
@@ -1,0 +1,7 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+public enum KafkaDeadLetterCommandType {
+
+    REPLAY,
+    DISCARD
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/OperatorDiscardKafkaDeadLetterRecordCommand.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/OperatorDiscardKafkaDeadLetterRecordCommand.java
@@ -1,0 +1,23 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record OperatorDiscardKafkaDeadLetterRecordCommand(
+    UUID operatorId,
+    UUID recordId
+) {
+
+    public OperatorDiscardKafkaDeadLetterRecordCommand {
+        operatorId =
+            Objects.requireNonNull(
+                operatorId,
+                "operatorId must not be null"
+            );
+        recordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/model/OperatorReplayKafkaDeadLetterRecordCommand.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/model/OperatorReplayKafkaDeadLetterRecordCommand.java
@@ -1,0 +1,23 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record OperatorReplayKafkaDeadLetterRecordCommand(
+    UUID operatorId,
+    UUID recordId
+) {
+
+    public OperatorReplayKafkaDeadLetterRecordCommand {
+        operatorId =
+            Objects.requireNonNull(
+                operatorId,
+                "operatorId must not be null"
+            );
+        recordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/OperatorDiscardKafkaDeadLetterRecordUseCase.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/OperatorDiscardKafkaDeadLetterRecordUseCase.java
@@ -1,0 +1,12 @@
+package com.nursena.payflow.eventprocessing.application.port.in;
+
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.model.OperatorDiscardKafkaDeadLetterRecordCommand;
+
+public interface OperatorDiscardKafkaDeadLetterRecordUseCase {
+
+    DiscardKafkaDeadLetterRecordResult discard(
+        OperatorDiscardKafkaDeadLetterRecordCommand
+            command
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/OperatorReplayKafkaDeadLetterRecordUseCase.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/in/OperatorReplayKafkaDeadLetterRecordUseCase.java
@@ -1,0 +1,12 @@
+package com.nursena.payflow.eventprocessing.application.port.in;
+
+import com.nursena.payflow.eventprocessing.application.model.OperatorReplayKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordResult;
+
+public interface OperatorReplayKafkaDeadLetterRecordUseCase {
+
+    ReplayKafkaDeadLetterRecordResult replay(
+        OperatorReplayKafkaDeadLetterRecordCommand
+            command
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterCommandAuditPort.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/port/out/KafkaDeadLetterCommandAuditPort.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.eventprocessing.application.port.out;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAudit;
+
+public interface KafkaDeadLetterCommandAuditPort {
+
+    void append(
+        KafkaDeadLetterCommandAudit audit
+    );
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/AbstractOperatorKafkaDeadLetterCommandService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/AbstractOperatorKafkaDeadLetterCommandService.java
@@ -1,0 +1,238 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import java.time.Clock;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAudit;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAuditOutcome;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandType;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterCommandAuditPort;
+import com.nursena.payflow.eventprocessing.domain.exception.KafkaDeadLetterCommandAuditException;
+
+abstract class
+AbstractOperatorKafkaDeadLetterCommandService {
+
+    private final KafkaDeadLetterCommandAuditPort
+        auditPort;
+
+    private final Clock clock;
+
+    private final Supplier<UUID> idSupplier;
+
+    AbstractOperatorKafkaDeadLetterCommandService(
+        KafkaDeadLetterCommandAuditPort auditPort,
+        Clock clock,
+        Supplier<UUID> idSupplier
+    ) {
+        this.auditPort =
+            Objects.requireNonNull(
+                auditPort,
+                "auditPort must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+
+        this.idSupplier =
+            Objects.requireNonNull(
+                idSupplier,
+                "idSupplier must not be null"
+            );
+    }
+
+    final <R> R executeAudited(
+        UUID operatorId,
+        UUID recordId,
+        KafkaDeadLetterCommandType commandType,
+        Supplier<R> commandAction,
+        Function<R, KafkaDeadLetterCommandAuditOutcome>
+            outcomeMapper
+    ) {
+        UUID validatedOperatorId =
+            Objects.requireNonNull(
+                operatorId,
+                "operatorId must not be null"
+            );
+
+        UUID validatedRecordId =
+            Objects.requireNonNull(
+                recordId,
+                "recordId must not be null"
+            );
+
+        KafkaDeadLetterCommandType
+            validatedCommandType =
+            Objects.requireNonNull(
+                commandType,
+                "commandType must not be null"
+            );
+
+        Supplier<R> validatedCommandAction =
+            Objects.requireNonNull(
+                commandAction,
+                "commandAction must not be null"
+            );
+
+        Function<
+            R,
+            KafkaDeadLetterCommandAuditOutcome
+            > validatedOutcomeMapper =
+            Objects.requireNonNull(
+                outcomeMapper,
+                "outcomeMapper must not be null"
+            );
+
+        UUID commandId = appendAttempted(
+            validatedOperatorId,
+            validatedRecordId,
+            validatedCommandType
+        );
+
+        R result;
+
+        try {
+            result =
+                Objects.requireNonNull(
+                    validatedCommandAction.get(),
+                    "command result must not be null"
+                );
+        } catch (RuntimeException exception) {
+            throw internalFailure(
+                commandId,
+                validatedOperatorId,
+                validatedRecordId,
+                validatedCommandType,
+                exception
+            );
+        }
+
+        KafkaDeadLetterCommandAuditOutcome outcome;
+
+        try {
+            outcome =
+                Objects.requireNonNull(
+                    validatedOutcomeMapper.apply(result),
+                    "audit outcome must not be null"
+                );
+        } catch (RuntimeException exception) {
+            throw internalFailure(
+                commandId,
+                validatedOperatorId,
+                validatedRecordId,
+                validatedCommandType,
+                exception
+            );
+        }
+
+        appendCompleted(
+            commandId,
+            validatedOperatorId,
+            validatedRecordId,
+            validatedCommandType,
+            outcome
+        );
+
+        return result;
+    }
+
+    private UUID appendAttempted(
+        UUID operatorId,
+        UUID recordId,
+        KafkaDeadLetterCommandType commandType
+    ) {
+        try {
+            UUID commandId = nextId();
+
+            auditPort.append(
+                KafkaDeadLetterCommandAudit.attempted(
+                    nextId(),
+                    commandId,
+                    operatorId,
+                    recordId,
+                    commandType,
+                    clock.instant()
+                )
+            );
+
+            return commandId;
+        } catch (RuntimeException exception) {
+            throw KafkaDeadLetterCommandAuditException
+                .attemptPersistenceFailed(exception);
+        }
+    }
+
+    private void appendCompleted(
+        UUID commandId,
+        UUID operatorId,
+        UUID recordId,
+        KafkaDeadLetterCommandType commandType,
+        KafkaDeadLetterCommandAuditOutcome outcome
+    ) {
+        try {
+            auditPort.append(
+                KafkaDeadLetterCommandAudit.completed(
+                    nextId(),
+                    commandId,
+                    operatorId,
+                    recordId,
+                    commandType,
+                    outcome,
+                    clock.instant()
+                )
+            );
+        } catch (RuntimeException exception) {
+            throw KafkaDeadLetterCommandAuditException
+                .completionPersistenceFailed(exception);
+        }
+    }
+
+    private KafkaDeadLetterCommandAuditException
+    internalFailure(
+        UUID commandId,
+        UUID operatorId,
+        UUID recordId,
+        KafkaDeadLetterCommandType commandType,
+        RuntimeException commandFailure
+    ) {
+        try {
+            auditPort.append(
+                KafkaDeadLetterCommandAudit.completed(
+                    nextId(),
+                    commandId,
+                    operatorId,
+                    recordId,
+                    commandType,
+                    KafkaDeadLetterCommandAuditOutcome
+                        .INTERNAL_FAILURE,
+                    clock.instant()
+                )
+            );
+        } catch (RuntimeException auditFailure) {
+            KafkaDeadLetterCommandAuditException
+                failure =
+                KafkaDeadLetterCommandAuditException
+                    .completionPersistenceFailed(
+                        auditFailure
+                    );
+
+            failure.addSuppressed(commandFailure);
+            return failure;
+        }
+
+        return KafkaDeadLetterCommandAuditException
+            .commandInternalFailure(commandFailure);
+    }
+
+    private UUID nextId() {
+        return Objects.requireNonNull(
+            idSupplier.get(),
+            "idSupplier must not return null"
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/KafkaDeadLetterCommandAuditOutcomeMapper.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/KafkaDeadLetterCommandAuditOutcomeMapper.java
@@ -1,0 +1,77 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import java.util.Objects;
+
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAuditOutcome;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordResult;
+
+final class KafkaDeadLetterCommandAuditOutcomeMapper {
+
+    private KafkaDeadLetterCommandAuditOutcomeMapper() {
+    }
+
+    static KafkaDeadLetterCommandAuditOutcome
+    fromReplay(
+        ReplayKafkaDeadLetterRecordResult result
+    ) {
+        ReplayKafkaDeadLetterRecordResult
+            validatedResult =
+            Objects.requireNonNull(
+                result,
+                "result must not be null"
+            );
+
+        return switch (validatedResult.outcome()) {
+            case REPLAYED ->
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAYED;
+
+            case NOT_FOUND ->
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_NOT_FOUND;
+
+            case NOT_CLAIMABLE ->
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_NOT_CLAIMABLE;
+
+            case REPLAY_FAILED ->
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_FAILED;
+
+            case UNRESOLVED ->
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_UNRESOLVED;
+        };
+    }
+
+    static KafkaDeadLetterCommandAuditOutcome
+    fromDiscard(
+        DiscardKafkaDeadLetterRecordResult result
+    ) {
+        DiscardKafkaDeadLetterRecordResult
+            validatedResult =
+            Objects.requireNonNull(
+                result,
+                "result must not be null"
+            );
+
+        return switch (validatedResult.outcome()) {
+            case DISCARDED ->
+                KafkaDeadLetterCommandAuditOutcome
+                    .DISCARDED;
+
+            case ALREADY_DISCARDED ->
+                KafkaDeadLetterCommandAuditOutcome
+                    .ALREADY_DISCARDED;
+
+            case NOT_FOUND ->
+                KafkaDeadLetterCommandAuditOutcome
+                    .DISCARD_NOT_FOUND;
+
+            case NOT_DISCARDABLE ->
+                KafkaDeadLetterCommandAuditOutcome
+                    .DISCARD_NOT_DISCARDABLE;
+        };
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/OperatorDiscardKafkaDeadLetterRecordService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/OperatorDiscardKafkaDeadLetterRecordService.java
@@ -1,0 +1,67 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import java.time.Clock;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandType;
+import com.nursena.payflow.eventprocessing.application.model.OperatorDiscardKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.port.in.DiscardKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.in.OperatorDiscardKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterCommandAuditPort;
+
+public class OperatorDiscardKafkaDeadLetterRecordService
+    extends AbstractOperatorKafkaDeadLetterCommandService
+    implements OperatorDiscardKafkaDeadLetterRecordUseCase {
+
+    private final DiscardKafkaDeadLetterRecordUseCase
+        discardUseCase;
+
+    public OperatorDiscardKafkaDeadLetterRecordService(
+        DiscardKafkaDeadLetterRecordUseCase discardUseCase,
+        KafkaDeadLetterCommandAuditPort auditPort,
+        Clock clock,
+        Supplier<UUID> idSupplier
+    ) {
+        super(
+            auditPort,
+            clock,
+            idSupplier
+        );
+
+        this.discardUseCase =
+            Objects.requireNonNull(
+                discardUseCase,
+                "discardUseCase must not be null"
+            );
+    }
+
+    @Override
+    public DiscardKafkaDeadLetterRecordResult discard(
+        OperatorDiscardKafkaDeadLetterRecordCommand
+            command
+    ) {
+        OperatorDiscardKafkaDeadLetterRecordCommand
+            validatedCommand =
+            Objects.requireNonNull(
+                command,
+                "command must not be null"
+            );
+
+        return executeAudited(
+            validatedCommand.operatorId(),
+            validatedCommand.recordId(),
+            KafkaDeadLetterCommandType.DISCARD,
+            () -> discardUseCase.discard(
+                new DiscardKafkaDeadLetterRecordCommand(
+                    validatedCommand.recordId()
+                )
+            ),
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                ::fromDiscard
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/application/service/OperatorReplayKafkaDeadLetterRecordService.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/application/service/OperatorReplayKafkaDeadLetterRecordService.java
@@ -1,0 +1,67 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import java.time.Clock;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandType;
+import com.nursena.payflow.eventprocessing.application.model.OperatorReplayKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.in.OperatorReplayKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.in.ReplayKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterCommandAuditPort;
+
+public class OperatorReplayKafkaDeadLetterRecordService
+    extends AbstractOperatorKafkaDeadLetterCommandService
+    implements OperatorReplayKafkaDeadLetterRecordUseCase {
+
+    private final ReplayKafkaDeadLetterRecordUseCase
+        replayUseCase;
+
+    public OperatorReplayKafkaDeadLetterRecordService(
+        ReplayKafkaDeadLetterRecordUseCase replayUseCase,
+        KafkaDeadLetterCommandAuditPort auditPort,
+        Clock clock,
+        Supplier<UUID> idSupplier
+    ) {
+        super(
+            auditPort,
+            clock,
+            idSupplier
+        );
+
+        this.replayUseCase =
+            Objects.requireNonNull(
+                replayUseCase,
+                "replayUseCase must not be null"
+            );
+    }
+
+    @Override
+    public ReplayKafkaDeadLetterRecordResult replay(
+        OperatorReplayKafkaDeadLetterRecordCommand
+            command
+    ) {
+        OperatorReplayKafkaDeadLetterRecordCommand
+            validatedCommand =
+            Objects.requireNonNull(
+                command,
+                "command must not be null"
+            );
+
+        return executeAudited(
+            validatedCommand.operatorId(),
+            validatedCommand.recordId(),
+            KafkaDeadLetterCommandType.REPLAY,
+            () -> replayUseCase.replay(
+                new ReplayKafkaDeadLetterRecordCommand(
+                    validatedCommand.recordId()
+                )
+            ),
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                ::fromReplay
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterCommandAuditConfiguration.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/configuration/KafkaDeadLetterCommandAuditConfiguration.java
@@ -1,0 +1,51 @@
+package com.nursena.payflow.eventprocessing.configuration;
+
+import java.time.Clock;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.port.in.DiscardKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.in.OperatorDiscardKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.in.OperatorReplayKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.in.ReplayKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterCommandAuditPort;
+import com.nursena.payflow.eventprocessing.application.service.OperatorDiscardKafkaDeadLetterRecordService;
+import com.nursena.payflow.eventprocessing.application.service.OperatorReplayKafkaDeadLetterRecordService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class KafkaDeadLetterCommandAuditConfiguration {
+
+    @Bean
+    OperatorReplayKafkaDeadLetterRecordUseCase
+    operatorReplayKafkaDeadLetterRecordUseCase(
+        ReplayKafkaDeadLetterRecordUseCase replayUseCase,
+        KafkaDeadLetterCommandAuditPort auditPort,
+        Clock clock
+    ) {
+        return new
+            OperatorReplayKafkaDeadLetterRecordService(
+            replayUseCase,
+            auditPort,
+            clock,
+            UUID::randomUUID
+        );
+    }
+
+    @Bean
+    OperatorDiscardKafkaDeadLetterRecordUseCase
+    operatorDiscardKafkaDeadLetterRecordUseCase(
+        DiscardKafkaDeadLetterRecordUseCase
+            discardUseCase,
+        KafkaDeadLetterCommandAuditPort auditPort,
+        Clock clock
+    ) {
+        return new
+            OperatorDiscardKafkaDeadLetterRecordService(
+            discardUseCase,
+            auditPort,
+            clock,
+            UUID::randomUUID
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/eventprocessing/domain/exception/KafkaDeadLetterCommandAuditException.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/domain/exception/KafkaDeadLetterCommandAuditException.java
@@ -1,0 +1,76 @@
+package com.nursena.payflow.eventprocessing.domain.exception;
+
+import java.util.Objects;
+
+public final class KafkaDeadLetterCommandAuditException
+    extends RuntimeException {
+
+    private final Reason reason;
+
+    private KafkaDeadLetterCommandAuditException(
+        Reason reason,
+        String message,
+        RuntimeException cause
+    ) {
+        super(
+            message,
+            Objects.requireNonNull(
+                cause,
+                "cause must not be null"
+            )
+        );
+
+        this.reason =
+            Objects.requireNonNull(
+                reason,
+                "reason must not be null"
+            );
+    }
+
+    public static KafkaDeadLetterCommandAuditException
+    attemptPersistenceFailed(
+        RuntimeException cause
+    ) {
+        return new KafkaDeadLetterCommandAuditException(
+            Reason.ATTEMPT_PERSISTENCE_FAILED,
+            "Kafka dead-letter command audit "
+                + "attempt could not be persisted.",
+            cause
+        );
+    }
+
+    public static KafkaDeadLetterCommandAuditException
+    completionPersistenceFailed(
+        RuntimeException cause
+    ) {
+        return new KafkaDeadLetterCommandAuditException(
+            Reason.COMPLETION_PERSISTENCE_FAILED,
+            "Kafka dead-letter command completion "
+                + "could not be audited safely.",
+            cause
+        );
+    }
+
+    public static KafkaDeadLetterCommandAuditException
+    commandInternalFailure(
+        RuntimeException cause
+    ) {
+        return new KafkaDeadLetterCommandAuditException(
+            Reason.COMMAND_INTERNAL_FAILURE,
+            "Kafka dead-letter command failed "
+                + "unexpectedly.",
+            cause
+        );
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+
+    public enum Reason {
+
+        ATTEMPT_PERSISTENCE_FAILED,
+        COMPLETION_PERSISTENCE_FAILED,
+        COMMAND_INTERNAL_FAILURE
+    }
+}

--- a/src/main/resources/db/migration/V12__create_kafka_dead_letter_command_audits.sql
+++ b/src/main/resources/db/migration/V12__create_kafka_dead_letter_command_audits.sql
@@ -1,0 +1,202 @@
+CREATE TABLE kafka_dead_letter_command_audits (
+    id UUID PRIMARY KEY,
+    command_id UUID NOT NULL,
+    stage VARCHAR(20) NOT NULL,
+    operator_id UUID NOT NULL,
+    dead_letter_record_id UUID NOT NULL,
+    command_type VARCHAR(20) NOT NULL,
+    outcome VARCHAR(40),
+    error_code VARCHAR(100),
+    occurred_at TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT uq_kafka_dead_letter_command_audits_command_stage
+        UNIQUE (
+            command_id,
+            stage
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_command_audits_stage
+        CHECK (
+            stage IN (
+                'ATTEMPTED',
+                'COMPLETED'
+            )
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_command_audits_type
+        CHECK (
+            command_type IN (
+                'REPLAY',
+                'DISCARD'
+            )
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_command_audits_outcome
+        CHECK (
+            outcome IS NULL
+            OR outcome IN (
+                'REPLAYED',
+                'REPLAY_NOT_FOUND',
+                'REPLAY_NOT_CLAIMABLE',
+                'REPLAY_FAILED',
+                'REPLAY_UNRESOLVED',
+                'DISCARDED',
+                'ALREADY_DISCARDED',
+                'DISCARD_NOT_FOUND',
+                'DISCARD_NOT_DISCARDABLE',
+                'INTERNAL_FAILURE'
+            )
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_command_audits_error_code
+        CHECK (
+            error_code IS NULL
+            OR error_code IN (
+                'KAFKA_DEAD_LETTER_RECORD_NOT_FOUND',
+                'KAFKA_DEAD_LETTER_RECORD_NOT_CLAIMABLE',
+                'KAFKA_DEAD_LETTER_REPLAY_FAILED',
+                'KAFKA_DEAD_LETTER_REPLAY_UNRESOLVED',
+                'KAFKA_DEAD_LETTER_RECORD_NOT_DISCARDABLE',
+                'KAFKA_DEAD_LETTER_COMMAND_INTERNAL_FAILURE'
+            )
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_command_audits_stage_state
+        CHECK (
+            (
+                stage = 'ATTEMPTED'
+                AND outcome IS NULL
+                AND error_code IS NULL
+            )
+            OR
+            (
+                stage = 'COMPLETED'
+                AND outcome IS NOT NULL
+            )
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_command_audits_command_outcome
+        CHECK (
+            outcome IS NULL
+            OR
+            (
+                command_type = 'REPLAY'
+                AND outcome IN (
+                    'REPLAYED',
+                    'REPLAY_NOT_FOUND',
+                    'REPLAY_NOT_CLAIMABLE',
+                    'REPLAY_FAILED',
+                    'REPLAY_UNRESOLVED',
+                    'INTERNAL_FAILURE'
+                )
+            )
+            OR
+            (
+                command_type = 'DISCARD'
+                AND outcome IN (
+                    'DISCARDED',
+                    'ALREADY_DISCARDED',
+                    'DISCARD_NOT_FOUND',
+                    'DISCARD_NOT_DISCARDABLE',
+                    'INTERNAL_FAILURE'
+                )
+            )
+        ),
+
+    CONSTRAINT chk_kafka_dead_letter_command_audits_outcome_error
+        CHECK (
+            (
+                outcome IS NULL
+                AND error_code IS NULL
+            )
+            OR
+            (
+                outcome IN (
+                    'REPLAYED',
+                    'DISCARDED',
+                    'ALREADY_DISCARDED'
+                )
+                AND error_code IS NULL
+            )
+            OR
+            (
+                outcome IN (
+                    'REPLAY_NOT_FOUND',
+                    'DISCARD_NOT_FOUND'
+                )
+                AND error_code =
+                    'KAFKA_DEAD_LETTER_RECORD_NOT_FOUND'
+            )
+            OR
+            (
+                outcome = 'REPLAY_NOT_CLAIMABLE'
+                AND error_code =
+                    'KAFKA_DEAD_LETTER_RECORD_NOT_CLAIMABLE'
+            )
+            OR
+            (
+                outcome = 'REPLAY_FAILED'
+                AND error_code =
+                    'KAFKA_DEAD_LETTER_REPLAY_FAILED'
+            )
+            OR
+            (
+                outcome = 'REPLAY_UNRESOLVED'
+                AND error_code =
+                    'KAFKA_DEAD_LETTER_REPLAY_UNRESOLVED'
+            )
+            OR
+            (
+                outcome = 'DISCARD_NOT_DISCARDABLE'
+                AND error_code =
+                    'KAFKA_DEAD_LETTER_RECORD_NOT_DISCARDABLE'
+            )
+            OR
+            (
+                outcome = 'INTERNAL_FAILURE'
+                AND error_code =
+                    'KAFKA_DEAD_LETTER_COMMAND_INTERNAL_FAILURE'
+            )
+        )
+);
+
+CREATE INDEX idx_kafka_dead_letter_command_audits_operator_time
+    ON kafka_dead_letter_command_audits (
+        operator_id,
+        occurred_at DESC
+    );
+
+CREATE INDEX idx_kafka_dead_letter_command_audits_record_time
+    ON kafka_dead_letter_command_audits (
+        dead_letter_record_id,
+        occurred_at DESC
+    );
+
+CREATE INDEX idx_kafka_dead_letter_command_audits_type_time
+    ON kafka_dead_letter_command_audits (
+        command_type,
+        occurred_at DESC
+    );
+
+CREATE INDEX idx_kafka_dead_letter_command_audits_occurred_at
+    ON kafka_dead_letter_command_audits (
+        occurred_at DESC
+    );
+
+CREATE FUNCTION reject_kafka_dead_letter_command_audit_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION
+        'kafka_dead_letter_command_audits is append-only'
+        USING ERRCODE = '55000';
+END;
+$$;
+
+CREATE TRIGGER trg_kafka_dead_letter_command_audits_append_only
+    BEFORE UPDATE OR DELETE
+    ON kafka_dead_letter_command_audits
+    FOR EACH ROW
+    EXECUTE FUNCTION
+        reject_kafka_dead_letter_command_audit_mutation();

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -398,6 +398,7 @@ class OpenApiJsonContractIntegrationTest {
                 "403",
                 "404",
                 "409",
+                "500",
                 "502",
                 "503"
             }
@@ -423,7 +424,9 @@ class OpenApiJsonContractIntegrationTest {
                 "401",
                 "403",
                 "404",
-                "409"
+                "409",
+                "500",
+                "503"
             }
         );
 

--- a/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandControllerTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandControllerTest.java
@@ -21,17 +21,19 @@ import com.nursena.payflow.configuration
 import com.nursena.payflow.configuration.security
     .OperationsAuthorities;
 import com.nursena.payflow.eventprocessing.application.model
-    .DiscardKafkaDeadLetterRecordCommand;
+    .OperatorDiscardKafkaDeadLetterRecordCommand;
 import com.nursena.payflow.eventprocessing.application.model
     .DiscardKafkaDeadLetterRecordResult;
 import com.nursena.payflow.eventprocessing.application.model
-    .ReplayKafkaDeadLetterRecordCommand;
+    .OperatorReplayKafkaDeadLetterRecordCommand;
 import com.nursena.payflow.eventprocessing.application.model
     .ReplayKafkaDeadLetterRecordResult;
 import com.nursena.payflow.eventprocessing.application.port.in
-    .DiscardKafkaDeadLetterRecordUseCase;
+    .OperatorDiscardKafkaDeadLetterRecordUseCase;
 import com.nursena.payflow.eventprocessing.application.port.in
-    .ReplayKafkaDeadLetterRecordUseCase;
+    .OperatorReplayKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.domain.exception
+    .KafkaDeadLetterCommandAuditException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet
@@ -55,6 +57,11 @@ import org.springframework.test.web.servlet.request
 })
 class KafkaDeadLetterCommandControllerTest {
 
+    private static final UUID OPERATOR_ID =
+        UUID.fromString(
+            "70000000-0000-0000-0000-000000002401"
+        );
+
     private static final UUID RECORD_ID =
         UUID.fromString(
             "80000000-0000-0000-0000-000000002401"
@@ -73,11 +80,11 @@ class KafkaDeadLetterCommandControllerTest {
     private MockMvc mockMvc;
 
     @MockitoBean
-    private ReplayKafkaDeadLetterRecordUseCase
+    private OperatorReplayKafkaDeadLetterRecordUseCase
         replayUseCase;
 
     @MockitoBean
-    private DiscardKafkaDeadLetterRecordUseCase
+    private OperatorDiscardKafkaDeadLetterRecordUseCase
         discardUseCase;
 
     @MockitoBean
@@ -87,8 +94,9 @@ class KafkaDeadLetterCommandControllerTest {
     void shouldReplayRecordForAuthorizedOperator()
         throws Exception {
 
-        ReplayKafkaDeadLetterRecordCommand command =
-            new ReplayKafkaDeadLetterRecordCommand(
+        OperatorReplayKafkaDeadLetterRecordCommand command =
+            new OperatorReplayKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
                 RECORD_ID
             );
 
@@ -135,8 +143,9 @@ class KafkaDeadLetterCommandControllerTest {
     void shouldReturnNotFoundWhenReplayRecordIsMissing()
         throws Exception {
 
-        ReplayKafkaDeadLetterRecordCommand command =
-            new ReplayKafkaDeadLetterRecordCommand(
+        OperatorReplayKafkaDeadLetterRecordCommand command =
+            new OperatorReplayKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
                 RECORD_ID
             );
 
@@ -185,8 +194,9 @@ class KafkaDeadLetterCommandControllerTest {
     void shouldReturnConflictWhenRecordCannotBeReplayed()
         throws Exception {
 
-        ReplayKafkaDeadLetterRecordCommand command =
-            new ReplayKafkaDeadLetterRecordCommand(
+        OperatorReplayKafkaDeadLetterRecordCommand command =
+            new OperatorReplayKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
                 RECORD_ID
             );
 
@@ -236,8 +246,9 @@ class KafkaDeadLetterCommandControllerTest {
     void shouldReturnBadGatewayWhenReplayPublicationFails()
         throws Exception {
 
-        ReplayKafkaDeadLetterRecordCommand command =
-            new ReplayKafkaDeadLetterRecordCommand(
+        OperatorReplayKafkaDeadLetterRecordCommand command =
+            new OperatorReplayKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
                 RECORD_ID
             );
 
@@ -286,8 +297,9 @@ class KafkaDeadLetterCommandControllerTest {
     void shouldReturnServiceUnavailableForUnresolvedReplay()
         throws Exception {
 
-        ReplayKafkaDeadLetterRecordCommand command =
-            new ReplayKafkaDeadLetterRecordCommand(
+        OperatorReplayKafkaDeadLetterRecordCommand command =
+            new OperatorReplayKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
                 RECORD_ID
             );
 
@@ -339,8 +351,9 @@ class KafkaDeadLetterCommandControllerTest {
     void shouldDiscardRecordForAuthorizedOperator()
         throws Exception {
 
-        DiscardKafkaDeadLetterRecordCommand command =
-            new DiscardKafkaDeadLetterRecordCommand(
+        OperatorDiscardKafkaDeadLetterRecordCommand command =
+            new OperatorDiscardKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
                 RECORD_ID
             );
 
@@ -368,8 +381,9 @@ class KafkaDeadLetterCommandControllerTest {
     void shouldTreatRepeatedDiscardAsSuccessful()
         throws Exception {
 
-        DiscardKafkaDeadLetterRecordCommand command =
-            new DiscardKafkaDeadLetterRecordCommand(
+        OperatorDiscardKafkaDeadLetterRecordCommand command =
+            new OperatorDiscardKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
                 RECORD_ID
             );
 
@@ -397,8 +411,9 @@ class KafkaDeadLetterCommandControllerTest {
     void shouldReturnNotFoundWhenDiscardRecordIsMissing()
         throws Exception {
 
-        DiscardKafkaDeadLetterRecordCommand command =
-            new DiscardKafkaDeadLetterRecordCommand(
+        OperatorDiscardKafkaDeadLetterRecordCommand command =
+            new OperatorDiscardKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
                 RECORD_ID
             );
 
@@ -440,8 +455,9 @@ class KafkaDeadLetterCommandControllerTest {
     void shouldReturnConflictWhenRecordCannotBeDiscarded()
         throws Exception {
 
-        DiscardKafkaDeadLetterRecordCommand command =
-            new DiscardKafkaDeadLetterRecordCommand(
+        OperatorDiscardKafkaDeadLetterRecordCommand command =
+            new OperatorDiscardKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
                 RECORD_ID
             );
 
@@ -550,6 +566,217 @@ class KafkaDeadLetterCommandControllerTest {
     }
 
     @Test
+    void shouldRejectMalformedOperatorIdentity()
+        throws Exception {
+
+        mockMvc.perform(
+                post(REPLAY_PATH)
+                    .with(malformedOperatorJwt())
+            )
+            .andExpect(status().isUnauthorized())
+            .andExpect(
+                jsonPath("$.status")
+                    .value(401)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "KAFKA_DEAD_LETTER_OPERATOR_"
+                            + "IDENTITY_INVALID"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Authenticated operator "
+                            + "identity is invalid."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(REPLAY_PATH)
+            );
+
+        verifyNoInteractions(
+            replayUseCase,
+            discardUseCase
+        );
+    }
+
+    @Test
+    void shouldReturnServiceUnavailableWhenAuditAttemptFails()
+        throws Exception {
+
+        OperatorReplayKafkaDeadLetterRecordCommand command =
+            new OperatorReplayKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
+                RECORD_ID
+            );
+
+        when(
+            replayUseCase.replay(command)
+        ).thenThrow(
+            KafkaDeadLetterCommandAuditException
+                .attemptPersistenceFailed(
+                    new IllegalStateException(
+                        "sensitive database detail"
+                    )
+                )
+        );
+
+        mockMvc.perform(
+                post(REPLAY_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(
+                status().isServiceUnavailable()
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value(503)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "KAFKA_DEAD_LETTER_COMMAND_"
+                            + "AUDIT_UNAVAILABLE"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Kafka dead-letter command "
+                            + "audit attempt could not "
+                            + "be persisted."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(REPLAY_PATH)
+            );
+
+        verify(replayUseCase)
+            .replay(command);
+
+        verifyNoInteractions(discardUseCase);
+    }
+
+    @Test
+    void shouldReturnServiceUnavailableWhenCompletionAuditFails()
+        throws Exception {
+
+        OperatorDiscardKafkaDeadLetterRecordCommand command =
+            new OperatorDiscardKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
+                RECORD_ID
+            );
+
+        when(
+            discardUseCase.discard(command)
+        ).thenThrow(
+            KafkaDeadLetterCommandAuditException
+                .completionPersistenceFailed(
+                    new IllegalStateException(
+                        "sensitive database detail"
+                    )
+                )
+        );
+
+        mockMvc.perform(
+                post(DISCARD_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(
+                status().isServiceUnavailable()
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value(503)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "KAFKA_DEAD_LETTER_COMMAND_"
+                            + "AUDIT_COMPLETION_UNAVAILABLE"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Kafka dead-letter command "
+                            + "completion could not be "
+                            + "audited safely."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(DISCARD_PATH)
+            );
+
+        verify(discardUseCase)
+            .discard(command);
+
+        verifyNoInteractions(replayUseCase);
+    }
+
+    @Test
+    void shouldReturnInternalServerErrorForUnexpectedCommandFailure()
+        throws Exception {
+
+        OperatorReplayKafkaDeadLetterRecordCommand command =
+            new OperatorReplayKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
+                RECORD_ID
+            );
+
+        when(
+            replayUseCase.replay(command)
+        ).thenThrow(
+            KafkaDeadLetterCommandAuditException
+                .commandInternalFailure(
+                    new IllegalStateException(
+                        "sensitive command detail"
+                    )
+                )
+        );
+
+        mockMvc.perform(
+                post(REPLAY_PATH)
+                    .with(operatorJwt())
+            )
+            .andExpect(
+                status().isInternalServerError()
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value(500)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "KAFKA_DEAD_LETTER_COMMAND_"
+                            + "INTERNAL_FAILURE"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Kafka dead-letter command "
+                            + "failed unexpectedly."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(REPLAY_PATH)
+            );
+
+        verify(replayUseCase)
+            .replay(command);
+
+        verifyNoInteractions(discardUseCase);
+    }
+
+    @Test
     void shouldRejectMalformedReplayRecordIdentifier()
         throws Exception {
 
@@ -620,6 +847,11 @@ class KafkaDeadLetterCommandControllerTest {
     private static RequestPostProcessor
     operatorJwt() {
         return jwt()
+            .jwt(
+                builder -> builder.subject(
+                    OPERATOR_ID.toString()
+                )
+            )
             .authorities(
                 new SimpleGrantedAuthority(
                     OperationsAuthorities.OPERATIONS
@@ -630,9 +862,29 @@ class KafkaDeadLetterCommandControllerTest {
     private static RequestPostProcessor
     nonOperatorJwt() {
         return jwt()
+            .jwt(
+                builder -> builder.subject(
+                    OPERATOR_ID.toString()
+                )
+            )
             .authorities(
                 new SimpleGrantedAuthority(
                     "PAYFLOW_CUSTOMER"
+                )
+            );
+    }
+
+    private static RequestPostProcessor
+    malformedOperatorJwt() {
+        return jwt()
+            .jwt(
+                builder -> builder.subject(
+                    "not-a-uuid"
+                )
+            )
+            .authorities(
+                new SimpleGrantedAuthority(
+                    OperationsAuthorities.OPERATIONS
                 )
             );
     }

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterCommandAuditOutcomeTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterCommandAuditOutcomeTest.java
@@ -1,0 +1,91 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class KafkaDeadLetterCommandAuditOutcomeTest {
+
+    @Test
+    void shouldExposeSafeErrorCodes() {
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcome
+                .REPLAYED.safeErrorCode()
+        )
+            .isNull();
+
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcome
+                .REPLAY_NOT_CLAIMABLE
+                .safeErrorCode()
+        )
+            .isEqualTo(
+                "KAFKA_DEAD_LETTER_RECORD_"
+                    + "NOT_CLAIMABLE"
+            );
+
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcome
+                .INTERNAL_FAILURE
+                .safeErrorCode()
+        )
+            .isEqualTo(
+                "KAFKA_DEAD_LETTER_COMMAND_"
+                    + "INTERNAL_FAILURE"
+            );
+    }
+
+    @Test
+    void shouldEnforceCommandCompatibility() {
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcome
+                .REPLAYED.supports(
+                    KafkaDeadLetterCommandType
+                        .REPLAY
+                )
+        )
+            .isTrue();
+
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcome
+                .REPLAYED.supports(
+                    KafkaDeadLetterCommandType
+                        .DISCARD
+                )
+        )
+            .isFalse();
+
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcome
+                .INTERNAL_FAILURE.supports(
+                    KafkaDeadLetterCommandType
+                        .REPLAY
+                )
+        )
+            .isTrue();
+
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcome
+                .INTERNAL_FAILURE.supports(
+                    KafkaDeadLetterCommandType
+                        .DISCARD
+                )
+        )
+            .isTrue();
+    }
+
+    @Test
+    void shouldRequireCandidateCommandType() {
+        assertThatThrownBy(() ->
+            KafkaDeadLetterCommandAuditOutcome
+                .REPLAYED.supports(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "candidate must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterCommandAuditTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/KafkaDeadLetterCommandAuditTest.java
@@ -1,0 +1,314 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class KafkaDeadLetterCommandAuditTest {
+
+    private static final UUID AUDIT_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002001"
+        );
+
+    private static final UUID COMMAND_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002002"
+        );
+
+    private static final UUID OPERATOR_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002003"
+        );
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002004"
+        );
+
+    private static final Instant OCCURRED_AT =
+        Instant.parse(
+            "2026-07-23T13:45:20.123456789Z"
+        );
+
+    @Test
+    void shouldCreateAttemptedAudit() {
+        KafkaDeadLetterCommandAudit audit =
+            KafkaDeadLetterCommandAudit.attempted(
+                AUDIT_ID,
+                COMMAND_ID,
+                OPERATOR_ID,
+                RECORD_ID,
+                KafkaDeadLetterCommandType.REPLAY,
+                OCCURRED_AT
+            );
+
+        assertThat(audit.id())
+            .isEqualTo(AUDIT_ID);
+
+        assertThat(audit.commandId())
+            .isEqualTo(COMMAND_ID);
+
+        assertThat(audit.stage())
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditStage
+                    .ATTEMPTED
+            );
+
+        assertThat(audit.operatorId())
+            .isEqualTo(OPERATOR_ID);
+
+        assertThat(audit.deadLetterRecordId())
+            .isEqualTo(RECORD_ID);
+
+        assertThat(audit.commandType())
+            .isEqualTo(
+                KafkaDeadLetterCommandType.REPLAY
+            );
+
+        assertThat(audit.outcome())
+            .isNull();
+
+        assertThat(audit.errorCode())
+            .isNull();
+
+        assertThat(audit.occurredAt())
+            .isEqualTo(
+                Instant.parse(
+                    "2026-07-23T13:45:20.123456Z"
+                )
+            );
+    }
+
+    @Test
+    void shouldCreateSuccessfulCompletedAudit() {
+        KafkaDeadLetterCommandAudit audit =
+            KafkaDeadLetterCommandAudit.completed(
+                AUDIT_ID,
+                COMMAND_ID,
+                OPERATOR_ID,
+                RECORD_ID,
+                KafkaDeadLetterCommandType
+                    .DISCARD,
+                KafkaDeadLetterCommandAuditOutcome
+                    .DISCARDED,
+                OCCURRED_AT
+            );
+
+        assertThat(audit.stage())
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditStage
+                    .COMPLETED
+            );
+
+        assertThat(audit.outcome())
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditOutcome
+                    .DISCARDED
+            );
+
+        assertThat(audit.errorCode())
+            .isNull();
+    }
+
+    @Test
+    void shouldDeriveSafeErrorCode() {
+        KafkaDeadLetterCommandAudit audit =
+            KafkaDeadLetterCommandAudit.completed(
+                AUDIT_ID,
+                COMMAND_ID,
+                OPERATOR_ID,
+                RECORD_ID,
+                KafkaDeadLetterCommandType.REPLAY,
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_FAILED,
+                OCCURRED_AT
+            );
+
+        assertThat(audit.errorCode())
+            .isEqualTo(
+                "KAFKA_DEAD_LETTER_REPLAY_FAILED"
+            );
+    }
+
+    @Test
+    void shouldAllowInternalFailureForBothCommands() {
+        KafkaDeadLetterCommandAudit replayAudit =
+            completedInternalFailure(
+                KafkaDeadLetterCommandType.REPLAY
+            );
+
+        KafkaDeadLetterCommandAudit discardAudit =
+            completedInternalFailure(
+                KafkaDeadLetterCommandType.DISCARD
+            );
+
+        assertThat(replayAudit.errorCode())
+            .isEqualTo(
+                "KAFKA_DEAD_LETTER_COMMAND_"
+                    + "INTERNAL_FAILURE"
+            );
+
+        assertThat(discardAudit.errorCode())
+            .isEqualTo(replayAudit.errorCode());
+    }
+
+    @Test
+    void shouldRejectOutcomeForAttemptedAudit() {
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterCommandAudit(
+                AUDIT_ID,
+                COMMAND_ID,
+                KafkaDeadLetterCommandAuditStage
+                    .ATTEMPTED,
+                OPERATOR_ID,
+                RECORD_ID,
+                KafkaDeadLetterCommandType.REPLAY,
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAYED,
+                null,
+                OCCURRED_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "ATTEMPTED audit must not have "
+                    + "an outcome or errorCode."
+            );
+    }
+
+    @Test
+    void shouldRequireOutcomeForCompletedAudit() {
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterCommandAudit(
+                AUDIT_ID,
+                COMMAND_ID,
+                KafkaDeadLetterCommandAuditStage
+                    .COMPLETED,
+                OPERATOR_ID,
+                RECORD_ID,
+                KafkaDeadLetterCommandType.REPLAY,
+                null,
+                null,
+                OCCURRED_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "COMPLETED audit must have an outcome."
+            );
+    }
+
+    @Test
+    void shouldRejectOutcomeForDifferentCommand() {
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterCommandAudit(
+                AUDIT_ID,
+                COMMAND_ID,
+                KafkaDeadLetterCommandAuditStage
+                    .COMPLETED,
+                OPERATOR_ID,
+                RECORD_ID,
+                KafkaDeadLetterCommandType.DISCARD,
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAYED,
+                null,
+                OCCURRED_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "outcome must be compatible "
+                    + "with commandType."
+            );
+    }
+
+    @Test
+    void shouldRejectInconsistentErrorCode() {
+        assertThatThrownBy(() ->
+            new KafkaDeadLetterCommandAudit(
+                AUDIT_ID,
+                COMMAND_ID,
+                KafkaDeadLetterCommandAuditStage
+                    .COMPLETED,
+                OPERATOR_ID,
+                RECORD_ID,
+                KafkaDeadLetterCommandType.REPLAY,
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_FAILED,
+                "SENSITIVE_EXCEPTION_DETAIL",
+                OCCURRED_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "errorCode must match the "
+                    + "selected outcome."
+            );
+    }
+
+    @Test
+    void shouldRequireIdentifiersAndTimestamp() {
+        assertThatThrownBy(() ->
+            KafkaDeadLetterCommandAudit.attempted(
+                null,
+                COMMAND_ID,
+                OPERATOR_ID,
+                RECORD_ID,
+                KafkaDeadLetterCommandType.REPLAY,
+                OCCURRED_AT
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "id must not be null"
+            );
+
+        assertThatThrownBy(() ->
+            KafkaDeadLetterCommandAudit.attempted(
+                AUDIT_ID,
+                COMMAND_ID,
+                OPERATOR_ID,
+                RECORD_ID,
+                KafkaDeadLetterCommandType.REPLAY,
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "occurredAt must not be null"
+            );
+    }
+
+    private static KafkaDeadLetterCommandAudit
+    completedInternalFailure(
+        KafkaDeadLetterCommandType commandType
+    ) {
+        return KafkaDeadLetterCommandAudit.completed(
+            AUDIT_ID,
+            COMMAND_ID,
+            OPERATOR_ID,
+            RECORD_ID,
+            commandType,
+            KafkaDeadLetterCommandAuditOutcome
+                .INTERNAL_FAILURE,
+            OCCURRED_AT
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/OperatorDiscardKafkaDeadLetterRecordCommandTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/OperatorDiscardKafkaDeadLetterRecordCommandTest.java
@@ -1,0 +1,66 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class OperatorDiscardKafkaDeadLetterRecordCommandTest {
+
+    private static final UUID OPERATOR_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002201"
+        );
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002202"
+        );
+
+    @Test
+    void shouldCreateCommand() {
+        OperatorDiscardKafkaDeadLetterRecordCommand
+            command =
+            new OperatorDiscardKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
+                RECORD_ID
+            );
+
+        assertThat(command.operatorId())
+            .isEqualTo(OPERATOR_ID);
+
+        assertThat(command.recordId())
+            .isEqualTo(RECORD_ID);
+    }
+
+    @Test
+    void shouldRequireIdentifiers() {
+        assertThatThrownBy(() ->
+            new OperatorDiscardKafkaDeadLetterRecordCommand(
+                null,
+                RECORD_ID
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "operatorId must not be null"
+            );
+
+        assertThatThrownBy(() ->
+            new OperatorDiscardKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "recordId must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/model/OperatorReplayKafkaDeadLetterRecordCommandTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/model/OperatorReplayKafkaDeadLetterRecordCommandTest.java
@@ -1,0 +1,66 @@
+package com.nursena.payflow.eventprocessing.application.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class OperatorReplayKafkaDeadLetterRecordCommandTest {
+
+    private static final UUID OPERATOR_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002101"
+        );
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000002102"
+        );
+
+    @Test
+    void shouldCreateCommand() {
+        OperatorReplayKafkaDeadLetterRecordCommand
+            command =
+            new OperatorReplayKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
+                RECORD_ID
+            );
+
+        assertThat(command.operatorId())
+            .isEqualTo(OPERATOR_ID);
+
+        assertThat(command.recordId())
+            .isEqualTo(RECORD_ID);
+    }
+
+    @Test
+    void shouldRequireIdentifiers() {
+        assertThatThrownBy(() ->
+            new OperatorReplayKafkaDeadLetterRecordCommand(
+                null,
+                RECORD_ID
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "operatorId must not be null"
+            );
+
+        assertThatThrownBy(() ->
+            new OperatorReplayKafkaDeadLetterRecordCommand(
+                OPERATOR_ID,
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "recordId must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/KafkaDeadLetterCommandAuditOutcomeMapperTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/KafkaDeadLetterCommandAuditOutcomeMapperTest.java
@@ -1,0 +1,154 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAuditOutcome;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordResult;
+import org.junit.jupiter.api.Test;
+
+class KafkaDeadLetterCommandAuditOutcomeMapperTest {
+
+    @Test
+    void shouldMapReplayOutcomes() {
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                .fromReplay(
+                    ReplayKafkaDeadLetterRecordResult
+                        .replayed()
+                )
+        )
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAYED
+            );
+
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                .fromReplay(
+                    ReplayKafkaDeadLetterRecordResult
+                        .notFound()
+                )
+        )
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_NOT_FOUND
+            );
+
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                .fromReplay(
+                    ReplayKafkaDeadLetterRecordResult
+                        .notClaimable()
+                )
+        )
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_NOT_CLAIMABLE
+            );
+
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                .fromReplay(
+                    ReplayKafkaDeadLetterRecordResult
+                        .replayFailed()
+                )
+        )
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_FAILED
+            );
+
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                .fromReplay(
+                    ReplayKafkaDeadLetterRecordResult
+                        .unresolved()
+                )
+        )
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_UNRESOLVED
+            );
+    }
+
+    @Test
+    void shouldMapDiscardOutcomes() {
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                .fromDiscard(
+                    DiscardKafkaDeadLetterRecordResult
+                        .discarded()
+                )
+        )
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditOutcome
+                    .DISCARDED
+            );
+
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                .fromDiscard(
+                    DiscardKafkaDeadLetterRecordResult
+                        .alreadyDiscarded()
+                )
+        )
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditOutcome
+                    .ALREADY_DISCARDED
+            );
+
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                .fromDiscard(
+                    DiscardKafkaDeadLetterRecordResult
+                        .notFound()
+                )
+        )
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditOutcome
+                    .DISCARD_NOT_FOUND
+            );
+
+        assertThat(
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                .fromDiscard(
+                    DiscardKafkaDeadLetterRecordResult
+                        .notDiscardable()
+                )
+        )
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditOutcome
+                    .DISCARD_NOT_DISCARDABLE
+            );
+    }
+
+    @Test
+    void shouldRequireReplayResult() {
+        assertThatThrownBy(() ->
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                .fromReplay(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "result must not be null"
+            );
+    }
+
+    @Test
+    void shouldRequireDiscardResult() {
+        assertThatThrownBy(() ->
+            KafkaDeadLetterCommandAuditOutcomeMapper
+                .fromDiscard(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "result must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/OperatorDiscardKafkaDeadLetterRecordServiceTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/OperatorDiscardKafkaDeadLetterRecordServiceTest.java
@@ -1,0 +1,396 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.DiscardKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAudit;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAuditOutcome;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAuditStage;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandType;
+import com.nursena.payflow.eventprocessing.application.model.OperatorDiscardKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.port.in.DiscardKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterCommandAuditPort;
+import com.nursena.payflow.eventprocessing.domain.exception.KafkaDeadLetterCommandAuditException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OperatorDiscardKafkaDeadLetterRecordServiceTest {
+
+    private static final UUID OPERATOR_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000003101"
+        );
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000003102"
+        );
+
+    private static final UUID COMMAND_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000003103"
+        );
+
+    private static final UUID ATTEMPT_AUDIT_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000003104"
+        );
+
+    private static final UUID COMPLETION_AUDIT_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000003105"
+        );
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-23T14:35:00.987654321Z"
+        );
+
+    private static final Instant EXPECTED_TIME =
+        Instant.parse(
+            "2026-07-23T14:35:00.987654Z"
+        );
+
+    private static final OperatorDiscardKafkaDeadLetterRecordCommand
+        COMMAND =
+        new OperatorDiscardKafkaDeadLetterRecordCommand(
+            OPERATOR_ID,
+            RECORD_ID
+        );
+
+    @Mock
+    private DiscardKafkaDeadLetterRecordUseCase
+        discardUseCase;
+
+    @Mock
+    private KafkaDeadLetterCommandAuditPort
+        auditPort;
+
+    private OperatorDiscardKafkaDeadLetterRecordService
+        service;
+
+    @BeforeEach
+    void setUp() {
+        service = newService(idSupplier());
+    }
+
+    @ParameterizedTest
+    @MethodSource("discardOutcomes")
+    void shouldAuditDiscardOutcome(
+        DiscardKafkaDeadLetterRecordResult delegateResult,
+        KafkaDeadLetterCommandAuditOutcome
+            expectedOutcome
+    ) {
+        when(
+            discardUseCase.discard(
+                new DiscardKafkaDeadLetterRecordCommand(
+                    RECORD_ID
+                )
+            )
+        ).thenReturn(delegateResult);
+
+        DiscardKafkaDeadLetterRecordResult result =
+            service.discard(COMMAND);
+
+        assertThat(result)
+            .isSameAs(delegateResult);
+
+        ArgumentCaptor<KafkaDeadLetterCommandAudit>
+            auditCaptor =
+            ArgumentCaptor.forClass(
+                KafkaDeadLetterCommandAudit.class
+            );
+
+        verify(auditPort, times(2))
+            .append(auditCaptor.capture());
+
+        List<KafkaDeadLetterCommandAudit> audits =
+            auditCaptor.getAllValues();
+
+        assertAttempted(audits.get(0));
+        assertCompleted(
+            audits.get(1),
+            expectedOutcome
+        );
+
+        InOrder ordered =
+            inOrder(
+                auditPort,
+                discardUseCase
+            );
+
+        ordered.verify(auditPort)
+            .append(any());
+        ordered.verify(discardUseCase)
+            .discard(
+                new DiscardKafkaDeadLetterRecordCommand(
+                    RECORD_ID
+                )
+            );
+        ordered.verify(auditPort)
+            .append(any());
+    }
+
+    @Test
+    void shouldAuditUnexpectedDiscardFailure() {
+        IllegalStateException commandFailure =
+            new IllegalStateException(
+                "sensitive database detail"
+            );
+
+        when(discardUseCase.discard(any()))
+            .thenThrow(commandFailure);
+
+        assertThatThrownBy(
+            () -> service.discard(COMMAND)
+        )
+            .isInstanceOf(
+                KafkaDeadLetterCommandAuditException
+                    .class
+            )
+            .hasCause(commandFailure)
+            .satisfies(exception ->
+                assertThat(
+                    ((KafkaDeadLetterCommandAuditException)
+                        exception).getReason()
+                ).isEqualTo(
+                    KafkaDeadLetterCommandAuditException
+                        .Reason
+                        .COMMAND_INTERNAL_FAILURE
+                )
+            );
+
+        ArgumentCaptor<KafkaDeadLetterCommandAudit>
+            auditCaptor =
+            ArgumentCaptor.forClass(
+                KafkaDeadLetterCommandAudit.class
+            );
+
+        verify(auditPort, times(2))
+            .append(auditCaptor.capture());
+
+        KafkaDeadLetterCommandAudit completed =
+            auditCaptor.getAllValues().get(1);
+
+        assertCompleted(
+            completed,
+            KafkaDeadLetterCommandAuditOutcome
+                .INTERNAL_FAILURE
+        );
+        assertThat(completed.errorCode())
+            .doesNotContain(
+                commandFailure.getMessage()
+            );
+    }
+
+    @Test
+    void shouldFailClosedBeforeDiscardWhenAttemptFails() {
+        IllegalStateException persistenceFailure =
+            new IllegalStateException(
+                "database detail"
+            );
+
+        doThrow(persistenceFailure)
+            .when(auditPort)
+            .append(any());
+
+        assertThatThrownBy(
+            () -> service.discard(COMMAND)
+        )
+            .isInstanceOf(
+                KafkaDeadLetterCommandAuditException
+                    .class
+            )
+            .hasCause(persistenceFailure)
+            .satisfies(exception ->
+                assertThat(
+                    ((KafkaDeadLetterCommandAuditException)
+                        exception).getReason()
+                ).isEqualTo(
+                    KafkaDeadLetterCommandAuditException
+                        .Reason
+                        .ATTEMPT_PERSISTENCE_FAILED
+                )
+            );
+
+        verifyNoInteractions(discardUseCase);
+    }
+
+    @Test
+    void shouldRequireCommand() {
+        assertThatThrownBy(
+            () -> service.discard(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "command must not be null"
+            );
+
+        verifyNoInteractions(
+            auditPort,
+            discardUseCase
+        );
+    }
+
+    @Test
+    void shouldRequireDiscardUseCase() {
+        assertThatThrownBy(
+            () -> new OperatorDiscardKafkaDeadLetterRecordService(
+                null,
+                auditPort,
+                fixedClock(),
+                idSupplier()
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "discardUseCase must not be null"
+            );
+    }
+
+    private OperatorDiscardKafkaDeadLetterRecordService
+    newService(Supplier<UUID> supplier) {
+        return new
+            OperatorDiscardKafkaDeadLetterRecordService(
+            discardUseCase,
+            auditPort,
+            fixedClock(),
+            supplier
+        );
+    }
+
+    private static Clock fixedClock() {
+        return Clock.fixed(
+            NOW,
+            ZoneOffset.UTC
+        );
+    }
+
+    private static Supplier<UUID> idSupplier() {
+        Queue<UUID> identifiers =
+            new ArrayDeque<>(
+                List.of(
+                    COMMAND_ID,
+                    ATTEMPT_AUDIT_ID,
+                    COMPLETION_AUDIT_ID
+                )
+            );
+
+        return identifiers::remove;
+    }
+
+    private static void assertAttempted(
+        KafkaDeadLetterCommandAudit audit
+    ) {
+        assertThat(audit.id())
+            .isEqualTo(ATTEMPT_AUDIT_ID);
+        assertThat(audit.commandId())
+            .isEqualTo(COMMAND_ID);
+        assertThat(audit.stage())
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditStage
+                    .ATTEMPTED
+            );
+        assertCommonAuditFields(audit);
+        assertThat(audit.outcome())
+            .isNull();
+        assertThat(audit.errorCode())
+            .isNull();
+    }
+
+    private static void assertCompleted(
+        KafkaDeadLetterCommandAudit audit,
+        KafkaDeadLetterCommandAuditOutcome outcome
+    ) {
+        assertThat(audit.id())
+            .isEqualTo(COMPLETION_AUDIT_ID);
+        assertThat(audit.commandId())
+            .isEqualTo(COMMAND_ID);
+        assertThat(audit.stage())
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditStage
+                    .COMPLETED
+            );
+        assertCommonAuditFields(audit);
+        assertThat(audit.outcome())
+            .isEqualTo(outcome);
+        assertThat(audit.errorCode())
+            .isEqualTo(outcome.safeErrorCode());
+    }
+
+    private static void assertCommonAuditFields(
+        KafkaDeadLetterCommandAudit audit
+    ) {
+        assertThat(audit.operatorId())
+            .isEqualTo(OPERATOR_ID);
+        assertThat(audit.deadLetterRecordId())
+            .isEqualTo(RECORD_ID);
+        assertThat(audit.commandType())
+            .isEqualTo(
+                KafkaDeadLetterCommandType.DISCARD
+            );
+        assertThat(audit.occurredAt())
+            .isEqualTo(EXPECTED_TIME);
+    }
+
+    private static Stream<Arguments> discardOutcomes() {
+        return Stream.of(
+            Arguments.of(
+                DiscardKafkaDeadLetterRecordResult
+                    .discarded(),
+                KafkaDeadLetterCommandAuditOutcome
+                    .DISCARDED
+            ),
+            Arguments.of(
+                DiscardKafkaDeadLetterRecordResult
+                    .alreadyDiscarded(),
+                KafkaDeadLetterCommandAuditOutcome
+                    .ALREADY_DISCARDED
+            ),
+            Arguments.of(
+                DiscardKafkaDeadLetterRecordResult
+                    .notFound(),
+                KafkaDeadLetterCommandAuditOutcome
+                    .DISCARD_NOT_FOUND
+            ),
+            Arguments.of(
+                DiscardKafkaDeadLetterRecordResult
+                    .notDiscardable(),
+                KafkaDeadLetterCommandAuditOutcome
+                    .DISCARD_NOT_DISCARDABLE
+            )
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/application/service/OperatorReplayKafkaDeadLetterRecordServiceTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/application/service/OperatorReplayKafkaDeadLetterRecordServiceTest.java
@@ -1,0 +1,577 @@
+package com.nursena.payflow.eventprocessing.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAudit;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAuditOutcome;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAuditStage;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandType;
+import com.nursena.payflow.eventprocessing.application.model.OperatorReplayKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model.ReplayKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.in.ReplayKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterCommandAuditPort;
+import com.nursena.payflow.eventprocessing.domain.exception.KafkaDeadLetterCommandAuditException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OperatorReplayKafkaDeadLetterRecordServiceTest {
+
+    private static final UUID OPERATOR_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000003001"
+        );
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000003002"
+        );
+
+    private static final UUID COMMAND_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000003003"
+        );
+
+    private static final UUID ATTEMPT_AUDIT_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000003004"
+        );
+
+    private static final UUID COMPLETION_AUDIT_ID =
+        UUID.fromString(
+            "80000000-0000-0000-0000-000000003005"
+        );
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-23T14:30:00.123456789Z"
+        );
+
+    private static final Instant EXPECTED_TIME =
+        Instant.parse(
+            "2026-07-23T14:30:00.123456Z"
+        );
+
+    private static final OperatorReplayKafkaDeadLetterRecordCommand
+        COMMAND =
+        new OperatorReplayKafkaDeadLetterRecordCommand(
+            OPERATOR_ID,
+            RECORD_ID
+        );
+
+    @Mock
+    private ReplayKafkaDeadLetterRecordUseCase
+        replayUseCase;
+
+    @Mock
+    private KafkaDeadLetterCommandAuditPort
+        auditPort;
+
+    private OperatorReplayKafkaDeadLetterRecordService
+        service;
+
+    @BeforeEach
+    void setUp() {
+        service = newService(idSupplier());
+    }
+
+    @ParameterizedTest
+    @MethodSource("replayOutcomes")
+    void shouldAuditReplayOutcome(
+        ReplayKafkaDeadLetterRecordResult delegateResult,
+        KafkaDeadLetterCommandAuditOutcome
+            expectedOutcome
+    ) {
+        when(
+            replayUseCase.replay(
+                new ReplayKafkaDeadLetterRecordCommand(
+                    RECORD_ID
+                )
+            )
+        ).thenReturn(delegateResult);
+
+        ReplayKafkaDeadLetterRecordResult result =
+            service.replay(COMMAND);
+
+        assertThat(result)
+            .isSameAs(delegateResult);
+
+        ArgumentCaptor<KafkaDeadLetterCommandAudit>
+            auditCaptor =
+            ArgumentCaptor.forClass(
+                KafkaDeadLetterCommandAudit.class
+            );
+
+        verify(auditPort, times(2))
+            .append(auditCaptor.capture());
+
+        List<KafkaDeadLetterCommandAudit> audits =
+            auditCaptor.getAllValues();
+
+        assertAttempted(audits.get(0));
+        assertCompleted(
+            audits.get(1),
+            expectedOutcome
+        );
+
+        InOrder ordered =
+            inOrder(
+                auditPort,
+                replayUseCase
+            );
+
+        ordered.verify(auditPort)
+            .append(any());
+        ordered.verify(replayUseCase)
+            .replay(
+                new ReplayKafkaDeadLetterRecordCommand(
+                    RECORD_ID
+                )
+            );
+        ordered.verify(auditPort)
+            .append(any());
+    }
+
+    @Test
+    void shouldFailClosedWhenAttemptCannotBePersisted() {
+        IllegalStateException persistenceFailure =
+            new IllegalStateException(
+                "database detail"
+            );
+
+        doThrow(persistenceFailure)
+            .when(auditPort)
+            .append(any());
+
+        assertThatThrownBy(
+            () -> service.replay(COMMAND)
+        )
+            .isInstanceOf(
+                KafkaDeadLetterCommandAuditException
+                    .class
+            )
+            .hasMessage(
+                "Kafka dead-letter command audit "
+                    + "attempt could not be persisted."
+            )
+            .hasCause(persistenceFailure)
+            .satisfies(exception ->
+                assertThat(
+                    ((KafkaDeadLetterCommandAuditException)
+                        exception).getReason()
+                ).isEqualTo(
+                    KafkaDeadLetterCommandAuditException
+                        .Reason
+                        .ATTEMPT_PERSISTENCE_FAILED
+                )
+            );
+
+        verify(auditPort)
+            .append(any());
+        verifyNoInteractions(replayUseCase);
+    }
+
+    @Test
+    void shouldSurfaceAmbiguousCompletionWhenFinalAuditFails() {
+        ReplayKafkaDeadLetterRecordResult delegateResult =
+            ReplayKafkaDeadLetterRecordResult
+                .replayed();
+
+        when(replayUseCase.replay(any()))
+            .thenReturn(delegateResult);
+
+        IllegalStateException persistenceFailure =
+            new IllegalStateException(
+                "database detail"
+            );
+
+        doNothing()
+            .doThrow(persistenceFailure)
+            .when(auditPort)
+            .append(any());
+
+        assertThatThrownBy(
+            () -> service.replay(COMMAND)
+        )
+            .isInstanceOf(
+                KafkaDeadLetterCommandAuditException
+                    .class
+            )
+            .hasMessage(
+                "Kafka dead-letter command completion "
+                    + "could not be audited safely."
+            )
+            .hasCause(persistenceFailure)
+            .satisfies(exception ->
+                assertThat(
+                    ((KafkaDeadLetterCommandAuditException)
+                        exception).getReason()
+                ).isEqualTo(
+                    KafkaDeadLetterCommandAuditException
+                        .Reason
+                        .COMPLETION_PERSISTENCE_FAILED
+                )
+            );
+
+        verify(replayUseCase)
+            .replay(
+                new ReplayKafkaDeadLetterRecordCommand(
+                    RECORD_ID
+                )
+            );
+        verify(auditPort, times(2))
+            .append(any());
+    }
+
+    @Test
+    void shouldAuditUnexpectedReplayFailureWithoutDetails() {
+        IllegalStateException commandFailure =
+            new IllegalStateException(
+                "payload and broker detail"
+            );
+
+        when(replayUseCase.replay(any()))
+            .thenThrow(commandFailure);
+
+        assertThatThrownBy(
+            () -> service.replay(COMMAND)
+        )
+            .isInstanceOf(
+                KafkaDeadLetterCommandAuditException
+                    .class
+            )
+            .hasMessage(
+                "Kafka dead-letter command failed "
+                    + "unexpectedly."
+            )
+            .hasCause(commandFailure)
+            .satisfies(exception ->
+                assertThat(
+                    ((KafkaDeadLetterCommandAuditException)
+                        exception).getReason()
+                ).isEqualTo(
+                    KafkaDeadLetterCommandAuditException
+                        .Reason
+                        .COMMAND_INTERNAL_FAILURE
+                )
+            );
+
+        ArgumentCaptor<KafkaDeadLetterCommandAudit>
+            auditCaptor =
+            ArgumentCaptor.forClass(
+                KafkaDeadLetterCommandAudit.class
+            );
+
+        verify(auditPort, times(2))
+            .append(auditCaptor.capture());
+
+        KafkaDeadLetterCommandAudit completed =
+            auditCaptor.getAllValues().get(1);
+
+        assertCompleted(
+            completed,
+            KafkaDeadLetterCommandAuditOutcome
+                .INTERNAL_FAILURE
+        );
+        assertThat(completed.errorCode())
+            .isEqualTo(
+                "KAFKA_DEAD_LETTER_COMMAND_INTERNAL_FAILURE"
+            )
+            .doesNotContain(
+                commandFailure.getMessage()
+            );
+    }
+
+    @Test
+    void shouldPreferCompletionAuditFailureWhenInternalFailureCannotBeAudited() {
+        IllegalStateException commandFailure =
+            new IllegalStateException(
+                "command detail"
+            );
+
+        when(replayUseCase.replay(any()))
+            .thenThrow(commandFailure);
+
+        IllegalStateException auditFailure =
+            new IllegalStateException(
+                "audit detail"
+            );
+
+        doNothing()
+            .doThrow(auditFailure)
+            .when(auditPort)
+            .append(any());
+
+        assertThatThrownBy(
+            () -> service.replay(COMMAND)
+        )
+            .isInstanceOf(
+                KafkaDeadLetterCommandAuditException
+                    .class
+            )
+            .hasCause(auditFailure)
+            .satisfies(exception -> {
+                KafkaDeadLetterCommandAuditException
+                    auditException =
+                    (KafkaDeadLetterCommandAuditException)
+                        exception;
+
+                assertThat(auditException.getReason())
+                    .isEqualTo(
+                        KafkaDeadLetterCommandAuditException
+                            .Reason
+                            .COMPLETION_PERSISTENCE_FAILED
+                    );
+                assertThat(
+                    auditException.getSuppressed()
+                ).containsExactly(commandFailure);
+            });
+    }
+
+    @Test
+    void shouldTreatNullDelegateResultAsInternalFailure() {
+        when(replayUseCase.replay(any()))
+            .thenReturn(null);
+
+        assertThatThrownBy(
+            () -> service.replay(COMMAND)
+        )
+            .isInstanceOf(
+                KafkaDeadLetterCommandAuditException
+                    .class
+            )
+            .hasCauseInstanceOf(
+                NullPointerException.class
+            )
+            .satisfies(exception ->
+                assertThat(
+                    ((KafkaDeadLetterCommandAuditException)
+                        exception).getReason()
+                ).isEqualTo(
+                    KafkaDeadLetterCommandAuditException
+                        .Reason
+                        .COMMAND_INTERNAL_FAILURE
+                )
+            );
+
+        verify(auditPort, times(2))
+            .append(any());
+    }
+
+    @Test
+    void shouldRequireCommand() {
+        assertThatThrownBy(
+            () -> service.replay(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "command must not be null"
+            );
+
+        verifyNoInteractions(
+            auditPort,
+            replayUseCase
+        );
+    }
+
+    @Test
+    void shouldRequireReplayUseCase() {
+        assertThatThrownBy(
+            () -> new OperatorReplayKafkaDeadLetterRecordService(
+                null,
+                auditPort,
+                fixedClock(),
+                idSupplier()
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "replayUseCase must not be null"
+            );
+    }
+
+    @Test
+    void shouldFailClosedWhenIdentifierSupplierReturnsNull() {
+        OperatorReplayKafkaDeadLetterRecordService
+            invalidService =
+            newService(() -> null);
+
+        assertThatThrownBy(
+            () -> invalidService.replay(COMMAND)
+        )
+            .isInstanceOf(
+                KafkaDeadLetterCommandAuditException
+                    .class
+            )
+            .hasCauseInstanceOf(
+                NullPointerException.class
+            )
+            .satisfies(exception ->
+                assertThat(
+                    ((KafkaDeadLetterCommandAuditException)
+                        exception).getReason()
+                ).isEqualTo(
+                    KafkaDeadLetterCommandAuditException
+                        .Reason
+                        .ATTEMPT_PERSISTENCE_FAILED
+                )
+            );
+
+        verify(auditPort, never())
+            .append(any());
+        verifyNoInteractions(replayUseCase);
+    }
+
+    private OperatorReplayKafkaDeadLetterRecordService
+    newService(Supplier<UUID> supplier) {
+        return new
+            OperatorReplayKafkaDeadLetterRecordService(
+            replayUseCase,
+            auditPort,
+            fixedClock(),
+            supplier
+        );
+    }
+
+    private static Clock fixedClock() {
+        return Clock.fixed(
+            NOW,
+            ZoneOffset.UTC
+        );
+    }
+
+    private static Supplier<UUID> idSupplier() {
+        Queue<UUID> identifiers =
+            new ArrayDeque<>(
+                List.of(
+                    COMMAND_ID,
+                    ATTEMPT_AUDIT_ID,
+                    COMPLETION_AUDIT_ID
+                )
+            );
+
+        return identifiers::remove;
+    }
+
+    private static void assertAttempted(
+        KafkaDeadLetterCommandAudit audit
+    ) {
+        assertThat(audit.id())
+            .isEqualTo(ATTEMPT_AUDIT_ID);
+        assertThat(audit.commandId())
+            .isEqualTo(COMMAND_ID);
+        assertThat(audit.stage())
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditStage
+                    .ATTEMPTED
+            );
+        assertCommonAuditFields(audit);
+        assertThat(audit.outcome())
+            .isNull();
+        assertThat(audit.errorCode())
+            .isNull();
+    }
+
+    private static void assertCompleted(
+        KafkaDeadLetterCommandAudit audit,
+        KafkaDeadLetterCommandAuditOutcome outcome
+    ) {
+        assertThat(audit.id())
+            .isEqualTo(COMPLETION_AUDIT_ID);
+        assertThat(audit.commandId())
+            .isEqualTo(COMMAND_ID);
+        assertThat(audit.stage())
+            .isEqualTo(
+                KafkaDeadLetterCommandAuditStage
+                    .COMPLETED
+            );
+        assertCommonAuditFields(audit);
+        assertThat(audit.outcome())
+            .isEqualTo(outcome);
+        assertThat(audit.errorCode())
+            .isEqualTo(outcome.safeErrorCode());
+    }
+
+    private static void assertCommonAuditFields(
+        KafkaDeadLetterCommandAudit audit
+    ) {
+        assertThat(audit.operatorId())
+            .isEqualTo(OPERATOR_ID);
+        assertThat(audit.deadLetterRecordId())
+            .isEqualTo(RECORD_ID);
+        assertThat(audit.commandType())
+            .isEqualTo(
+                KafkaDeadLetterCommandType.REPLAY
+            );
+        assertThat(audit.occurredAt())
+            .isEqualTo(EXPECTED_TIME);
+    }
+
+    private static Stream<Arguments> replayOutcomes() {
+        return Stream.of(
+            Arguments.of(
+                ReplayKafkaDeadLetterRecordResult
+                    .replayed(),
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAYED
+            ),
+            Arguments.of(
+                ReplayKafkaDeadLetterRecordResult
+                    .notFound(),
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_NOT_FOUND
+            ),
+            Arguments.of(
+                ReplayKafkaDeadLetterRecordResult
+                    .notClaimable(),
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_NOT_CLAIMABLE
+            ),
+            Arguments.of(
+                ReplayKafkaDeadLetterRecordResult
+                    .replayFailed(),
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_FAILED
+            ),
+            Arguments.of(
+                ReplayKafkaDeadLetterRecordResult
+                    .unresolved(),
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_UNRESOLVED
+            )
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterCommandAuditPersistenceIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterCommandAuditPersistenceIntegrationTest.java
@@ -1,0 +1,202 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAudit;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAuditOutcome;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandType;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterCommandAuditPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class KafkaDeadLetterCommandAuditPersistenceIntegrationTest {
+
+    private static final UUID COMMAND_ID =
+        UUID.fromString(
+            "90000000-0000-0000-0000-000000000101"
+        );
+
+    private static final UUID OPERATOR_ID =
+        UUID.fromString(
+            "91000000-0000-0000-0000-000000000101"
+        );
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "92000000-0000-0000-0000-000000000101"
+        );
+
+    private static final Instant OCCURRED_AT =
+        Instant.parse(
+            "2026-07-23T13:00:00.123456789Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private KafkaDeadLetterCommandAuditPort
+        auditPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.execute(
+            "TRUNCATE TABLE "
+                + "kafka_dead_letter_command_audits"
+        );
+    }
+
+    @Test
+    void shouldPersistAttemptedAudit() {
+        UUID auditId =
+            UUID.fromString(
+                "93000000-0000-0000-0000-000000000101"
+            );
+
+        auditPort.append(
+            KafkaDeadLetterCommandAudit.attempted(
+                auditId,
+                COMMAND_ID,
+                OPERATOR_ID,
+                RECORD_ID,
+                KafkaDeadLetterCommandType.REPLAY,
+                OCCURRED_AT
+            )
+        );
+
+        Map<String, Object> stored =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT
+                    command_id,
+                    stage,
+                    operator_id,
+                    dead_letter_record_id,
+                    command_type,
+                    outcome,
+                    error_code,
+                    occurred_at
+                FROM kafka_dead_letter_command_audits
+                WHERE id = ?
+                """,
+                auditId
+            );
+
+        assertThat(stored.get("command_id"))
+            .isEqualTo(COMMAND_ID);
+
+        assertThat(stored.get("stage"))
+            .isEqualTo("ATTEMPTED");
+
+        assertThat(stored.get("operator_id"))
+            .isEqualTo(OPERATOR_ID);
+
+        assertThat(
+            stored.get("dead_letter_record_id")
+        )
+            .isEqualTo(RECORD_ID);
+
+        assertThat(stored.get("command_type"))
+            .isEqualTo("REPLAY");
+
+        assertThat(stored.get("outcome"))
+            .isNull();
+
+        assertThat(stored.get("error_code"))
+            .isNull();
+
+        assertThat(stored.get("occurred_at"))
+            .isEqualTo(
+                Timestamp.from(
+                    Instant.parse(
+                        "2026-07-23T13:00:00.123456Z"
+                    )
+                )
+            );
+    }
+
+    @Test
+    void shouldPersistCompletedAuditWithSafeErrorCode() {
+        auditPort.append(
+            KafkaDeadLetterCommandAudit.attempted(
+                UUID.fromString(
+                    "93000000-0000-0000-0000-000000000102"
+                ),
+                COMMAND_ID,
+                OPERATOR_ID,
+                RECORD_ID,
+                KafkaDeadLetterCommandType.REPLAY,
+                OCCURRED_AT
+            )
+        );
+
+        UUID completedAuditId =
+            UUID.fromString(
+                "93000000-0000-0000-0000-000000000103"
+            );
+
+        auditPort.append(
+            KafkaDeadLetterCommandAudit.completed(
+                completedAuditId,
+                COMMAND_ID,
+                OPERATOR_ID,
+                RECORD_ID,
+                KafkaDeadLetterCommandType.REPLAY,
+                KafkaDeadLetterCommandAuditOutcome
+                    .REPLAY_NOT_CLAIMABLE,
+                OCCURRED_AT.plusSeconds(1)
+            )
+        );
+
+        Map<String, Object> stored =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT
+                    stage,
+                    command_type,
+                    outcome,
+                    error_code
+                FROM kafka_dead_letter_command_audits
+                WHERE id = ?
+                """,
+                completedAuditId
+            );
+
+        assertThat(stored.get("stage"))
+            .isEqualTo("COMPLETED");
+
+        assertThat(stored.get("command_type"))
+            .isEqualTo("REPLAY");
+
+        assertThat(stored.get("outcome"))
+            .isEqualTo(
+                "REPLAY_NOT_CLAIMABLE"
+            );
+
+        assertThat(stored.get("error_code"))
+            .isEqualTo(
+                "KAFKA_DEAD_LETTER_RECORD_NOT_CLAIMABLE"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterCommandAuditSchemaIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterCommandAuditSchemaIntegrationTest.java
@@ -1,0 +1,396 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class KafkaDeadLetterCommandAuditSchemaIntegrationTest {
+
+    private static final UUID AUDIT_ID =
+        UUID.fromString(
+            "93000000-0000-0000-0000-000000000201"
+        );
+
+    private static final UUID COMMAND_ID =
+        UUID.fromString(
+            "90000000-0000-0000-0000-000000000201"
+        );
+
+    private static final UUID OPERATOR_ID =
+        UUID.fromString(
+            "91000000-0000-0000-0000-000000000201"
+        );
+
+    private static final UUID RECORD_ID =
+        UUID.fromString(
+            "92000000-0000-0000-0000-000000000201"
+        );
+
+    private static final Instant OCCURRED_AT =
+        Instant.parse(
+            "2026-07-23T13:00:00Z"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.execute(
+            "TRUNCATE TABLE "
+                + "kafka_dead_letter_command_audits"
+        );
+    }
+
+    @Test
+    void shouldPersistValidAttemptedAudit() {
+        insertAudit(
+            AUDIT_ID,
+            COMMAND_ID,
+            "ATTEMPTED",
+            "REPLAY",
+            null,
+            null
+        );
+
+        assertThat(countByAuditId(AUDIT_ID))
+            .isEqualTo(1);
+    }
+
+    @Test
+    void shouldPersistValidCompletedAudit() {
+        insertAudit(
+            AUDIT_ID,
+            COMMAND_ID,
+            "COMPLETED",
+            "DISCARD",
+            "DISCARDED",
+            null
+        );
+
+        assertThat(countByAuditId(AUDIT_ID))
+            .isEqualTo(1);
+    }
+
+    @Test
+    void shouldRejectDuplicateCommandStage() {
+        insertAudit(
+            AUDIT_ID,
+            COMMAND_ID,
+            "ATTEMPTED",
+            "REPLAY",
+            null,
+            null
+        );
+
+        assertConstraintViolation(
+            () -> insertAudit(
+                UUID.fromString(
+                    "93000000-0000-0000-0000-000000000202"
+                ),
+                COMMAND_ID,
+                "ATTEMPTED",
+                "REPLAY",
+                null,
+                null
+            ),
+            "uq_kafka_dead_letter_command_audits_command_stage"
+        );
+    }
+
+    @Test
+    void shouldRejectUnsupportedStage() {
+        assertDataIntegrityViolation(
+            () -> insertAudit(
+                AUDIT_ID,
+                COMMAND_ID,
+                "STARTED",
+                "REPLAY",
+                null,
+                null
+            )
+        );
+    }
+
+    @Test
+    void shouldRejectUnsupportedCommandType() {
+        assertConstraintViolation(
+            () -> insertAudit(
+                AUDIT_ID,
+                COMMAND_ID,
+                "ATTEMPTED",
+                "RETRY",
+                null,
+                null
+            ),
+            "chk_kafka_dead_letter_command_audits_type"
+        );
+    }
+
+    @Test
+    void shouldRejectUnsupportedOutcome() {
+        assertDataIntegrityViolation(
+            () -> insertAudit(
+                AUDIT_ID,
+                COMMAND_ID,
+                "COMPLETED",
+                "REPLAY",
+                "REPLAY_REJECTED",
+                null
+            )
+        );
+    }
+
+    @Test
+    void shouldRejectUnsupportedErrorCode() {
+        assertDataIntegrityViolation(
+            () -> insertAudit(
+                AUDIT_ID,
+                COMMAND_ID,
+                "COMPLETED",
+                "REPLAY",
+                "REPLAY_FAILED",
+                "RAW_EXCEPTION_MESSAGE"
+            )
+        );
+    }
+
+    @Test
+    void shouldRejectOutcomeOnAttemptedAudit() {
+        assertConstraintViolation(
+            () -> insertAudit(
+                AUDIT_ID,
+                COMMAND_ID,
+                "ATTEMPTED",
+                "REPLAY",
+                "REPLAYED",
+                null
+            ),
+            "chk_kafka_dead_letter_command_audits_stage_state"
+        );
+    }
+
+    @Test
+    void shouldRejectMissingOutcomeOnCompletedAudit() {
+        assertConstraintViolation(
+            () -> insertAudit(
+                AUDIT_ID,
+                COMMAND_ID,
+                "COMPLETED",
+                "REPLAY",
+                null,
+                null
+            ),
+            "chk_kafka_dead_letter_command_audits_stage_state"
+        );
+    }
+
+    @Test
+    void shouldRejectOutcomeForDifferentCommandType() {
+        assertConstraintViolation(
+            () -> insertAudit(
+                AUDIT_ID,
+                COMMAND_ID,
+                "COMPLETED",
+                "DISCARD",
+                "REPLAYED",
+                null
+            ),
+            "chk_kafka_dead_letter_command_audits_command_outcome"
+        );
+    }
+
+    @Test
+    void shouldRejectErrorCodeInconsistentWithOutcome() {
+        assertConstraintViolation(
+            () -> insertAudit(
+                AUDIT_ID,
+                COMMAND_ID,
+                "COMPLETED",
+                "REPLAY",
+                "REPLAY_FAILED",
+                "KAFKA_DEAD_LETTER_REPLAY_UNRESOLVED"
+            ),
+            "chk_kafka_dead_letter_command_audits_outcome_error"
+        );
+    }
+
+    @Test
+    void shouldRejectUpdate() {
+        insertAudit(
+            AUDIT_ID,
+            COMMAND_ID,
+            "ATTEMPTED",
+            "REPLAY",
+            null,
+            null
+        );
+
+        assertAppendOnlyViolation(
+            () -> jdbcTemplate.update(
+                """
+                UPDATE kafka_dead_letter_command_audits
+                SET operator_id = ?
+                WHERE id = ?
+                """,
+                UUID.fromString(
+                    "91000000-0000-0000-0000-000000000202"
+                ),
+                AUDIT_ID
+            )
+        );
+    }
+
+    @Test
+    void shouldRejectDelete() {
+        insertAudit(
+            AUDIT_ID,
+            COMMAND_ID,
+            "ATTEMPTED",
+            "REPLAY",
+            null,
+            null
+        );
+
+        assertAppendOnlyViolation(
+            () -> jdbcTemplate.update(
+                """
+                DELETE FROM kafka_dead_letter_command_audits
+                WHERE id = ?
+                """,
+                AUDIT_ID
+            )
+        );
+    }
+
+    private Integer countByAuditId(
+        UUID auditId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM kafka_dead_letter_command_audits
+            WHERE id = ?
+            """,
+            Integer.class,
+            auditId
+        );
+    }
+
+    private void insertAudit(
+        UUID auditId,
+        UUID commandId,
+        String stage,
+        String commandType,
+        String outcome,
+        String errorCode
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO kafka_dead_letter_command_audits (
+                id,
+                command_id,
+                stage,
+                operator_id,
+                dead_letter_record_id,
+                command_type,
+                outcome,
+                error_code,
+                occurred_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            auditId,
+            commandId,
+            stage,
+            OPERATOR_ID,
+            RECORD_ID,
+            commandType,
+            outcome,
+            errorCode,
+            Timestamp.from(OCCURRED_AT)
+        );
+    }
+
+    private static void assertConstraintViolation(
+        ThrowingCallable operation,
+        String constraintName
+    ) {
+        Throwable thrown = catchThrowable(
+            operation
+        );
+
+        assertThat(thrown)
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+
+        assertThat(rootCauseOf(thrown).getMessage())
+            .contains(constraintName);
+    }
+
+    private static void assertDataIntegrityViolation(
+        ThrowingCallable operation
+    ) {
+        assertThat(catchThrowable(operation))
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    private static void assertAppendOnlyViolation(
+        ThrowingCallable operation
+    ) {
+        Throwable thrown = catchThrowable(
+            operation
+        );
+
+        assertThat(thrown)
+            .isInstanceOf(
+                DataAccessException.class
+            );
+
+        assertThat(rootCauseOf(thrown).getMessage())
+            .contains(
+                "kafka_dead_letter_command_audits "
+                    + "is append-only"
+            );
+    }
+
+    private static Throwable rootCauseOf(
+        Throwable throwable
+    ) {
+        Throwable current = throwable;
+
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+
+        return current;
+    }
+}

--- a/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterCommandAuditTransactionIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/integration/KafkaDeadLetterCommandAuditTransactionIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.nursena.payflow.eventprocessing.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandAudit;
+import com.nursena.payflow.eventprocessing.application.model.KafkaDeadLetterCommandType;
+import com.nursena.payflow.eventprocessing.application.port.out.KafkaDeadLetterCommandAuditPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class KafkaDeadLetterCommandAuditTransactionIntegrationTest {
+
+    private static final UUID AUDIT_ID =
+        UUID.fromString(
+            "93000000-0000-0000-0000-000000000301"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private KafkaDeadLetterCommandAuditPort
+        auditPort;
+
+    @Autowired
+    private PlatformTransactionManager
+        transactionManager;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.execute(
+            "TRUNCATE TABLE "
+                + "kafka_dead_letter_command_audits"
+        );
+    }
+
+    @Test
+    void shouldCommitAuditWhenOuterTransactionRollsBack() {
+        TransactionTemplate outerTransaction =
+            new TransactionTemplate(
+                transactionManager
+            );
+
+        assertThatThrownBy(
+            () -> outerTransaction.executeWithoutResult(
+                status -> {
+                    auditPort.append(
+                        attemptedAudit()
+                    );
+
+                    throw new OuterTransactionFailure();
+                }
+            )
+        )
+            .isInstanceOf(
+                OuterTransactionFailure.class
+            );
+
+        Integer count = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM kafka_dead_letter_command_audits
+            WHERE id = ?
+            """,
+            Integer.class,
+            AUDIT_ID
+        );
+
+        assertThat(count)
+            .isEqualTo(1);
+    }
+
+    private static KafkaDeadLetterCommandAudit
+    attemptedAudit() {
+        return KafkaDeadLetterCommandAudit.attempted(
+            AUDIT_ID,
+            UUID.fromString(
+                "90000000-0000-0000-0000-000000000301"
+            ),
+            UUID.fromString(
+                "91000000-0000-0000-0000-000000000301"
+            ),
+            UUID.fromString(
+                "92000000-0000-0000-0000-000000000301"
+            ),
+            KafkaDeadLetterCommandType.REPLAY,
+            Instant.parse(
+                "2026-07-23T13:00:00Z"
+            )
+        );
+    }
+
+    private static final class
+    OuterTransactionFailure extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an append-only PostgreSQL audit trail for authorized Kafka dead-letter replay and discard commands.
- Records correlated ATTEMPTED and COMPLETED entries with explicit safe outcomes.
- Derives the operator UUID exclusively from the authenticated JWT subject.
- Preserves the existing replay/discard lifecycle and HTTP contracts.
- Fails closed when the initial audit record cannot be persisted.
- Exposes only fixed safe error codes for audit and command failures.

## Architecture

- Documents the decision in ADR 0007.
- Separates HTTP, application orchestration, and JDBC persistence responsibilities.
- Uses a dedicated REQUIRES_NEW persistence adapter for independent audit commits.
- Does not wrap Kafka replay publication in a long PostgreSQL transaction.
- Enforces append-only behavior and audit invariants with PostgreSQL constraints and a mutation-rejection trigger.

## Security

The audit trail does not store or expose:

- Kafka payloads
- Kafka record keys
- JWTs or access tokens
- operator email addresses
- exception messages or stack traces
- replay lease owners

Anonymous and unauthorized requests are rejected before the audited use cases are invoked.

## Verification

- `.\mvnw.cmd clean verify`
- 591 tests executed
- 0 failures
- 0 errors
- PostgreSQL migration, schema, persistence, and transaction integration tests
- application orchestration unit tests
- MockMvc security and HTTP contract tests
- OpenAPI contract tests
- branch whitespace and conflict-marker checks
- sensitive-field scans

Refs #53
