### PR TITLE
chore: start v0.6.0 development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0-SNAPSHOT</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 


### PR DESCRIPTION
## Summary

Starts the PayFlow v0.6.0 development cycle from the synchronized `develop` branch.

## Changes

- Changes the Maven project version from `0.5.0` to `0.6.0-SNAPSHOT`.
- Preserves the published v0.5.0 release state on `main`.
- Establishes the version baseline for subsequent v0.6.0 feature work.
- Introduces no product or runtime behavior changes.

## Verification

- `.\mvnw.cmd clean verify`
- 591 tests executed
- 0 failures
- 0 errors
- Snapshot artifact generated as `target/payflow-0.6.0-SNAPSHOT.jar`
- Working tree clean
- Branch synchronized with its remote

Refs #58
