### PR TITLE
chore: modernize GitHub Actions runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
@@ -29,7 +29,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports
           path: |


### PR DESCRIPTION
## Summary

Modernizes the JavaScript runtimes used by PayFlow CI GitHub Actions.

## Changes

- upgrades `actions/checkout` from `v4` to `v6`
- upgrades `actions/setup-java` from `v4` to `v5`
- upgrades `actions/upload-artifact` from `v4` to `v7`

## Preserved behavior

- Java 21 with Eclipse Temurin
- Maven dependency caching
- Maven Wrapper execution
- `clean verify`
- Testcontainers and Docker availability
- Surefire and JaCoCo artifact upload
- workflow triggers
- job timeout
- `contents: read` permission

## Scope

- one workflow file
- three action-reference updates
- no application source changes
- no dependency or Maven plugin changes
- no database migration changes
- no secrets or credentials

## Verification

- `.\mvnw.cmd clean verify`
- 640 tests executed
- 0 failures
- 0 errors
- snapshot JAR generated successfully
- staged diff contains one workflow file
- working tree clean
- branch synchronized with remote

## CI acceptance

The pull-request run must:

- complete successfully
- preserve Java 21 setup and Maven caching
- upload the configured test artifacts
- contain no deprecated Node.js 20 action-runtime warning

Refs #62
