### PR TITLE
chore: start v0.7.0 development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 


### PR DESCRIPTION
## Summary

Starts the PayFlow v0.7.0 development cycle.

## Changes

- changes the Maven version from `0.6.0` to `0.7.0-SNAPSHOT`
- preserves application behavior
- introduces no API, database, dependency, or CI changes

## Verification

- `.\mvnw.cmd clean verify`
- 640 tests
- 0 failures
- 0 errors
- executable `payflow-0.7.0-SNAPSHOT.jar` generated
- working tree clean
- branch synchronized with remote

Refs #
