### PR TITLE
feat: define refresh-session domain and application contracts

### DIFF
--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/JwtAccessTokenGenerationAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/JwtAccessTokenGenerationAdapter.java
@@ -4,7 +4,7 @@ import java.time.Clock;
 import java.time.Instant;
 
 import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
-import com.nursena.payflow.user.application.port.out.TokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
 import com.nursena.payflow.user.domain.model.User;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
@@ -13,14 +13,14 @@ import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.stereotype.Component;
 
 @Component
-class JwtTokenGenerationAdapter
-    implements TokenGenerationPort {
+class JwtAccessTokenGenerationAdapter
+    implements AccessTokenGenerationPort {
 
     private final JwtEncoder jwtEncoder;
     private final JwtProperties properties;
     private final Clock clock;
 
-    JwtTokenGenerationAdapter(
+    JwtAccessTokenGenerationAdapter(
         JwtEncoder jwtEncoder,
         JwtProperties properties,
         Clock clock

--- a/src/main/java/com/nursena/payflow/user/application/port/out/AccessTokenGenerationPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/AccessTokenGenerationPort.java
@@ -2,7 +2,7 @@ package com.nursena.payflow.user.application.port.out;
 
 import com.nursena.payflow.user.domain.model.User;
 
-public interface TokenGenerationPort {
+public interface AccessTokenGenerationPort {
 
     GeneratedAccessToken generate(User user);
 }

--- a/src/main/java/com/nursena/payflow/user/application/port/out/GeneratedRefreshToken.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/GeneratedRefreshToken.java
@@ -1,0 +1,26 @@
+package com.nursena.payflow.user.application.port.out;
+
+import java.util.Objects;
+
+public record GeneratedRefreshToken(
+    String value
+) {
+
+    public GeneratedRefreshToken {
+        Objects.requireNonNull(
+            value,
+            "value must not be null"
+        );
+
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(
+                "value must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "GeneratedRefreshToken[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenDigestPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenDigestPort.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.user.application.port.out;
+
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+
+public interface RefreshTokenDigestPort {
+
+    RefreshTokenDigest digest(
+        String refreshToken
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenFamilyRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenFamilyRepositoryPort.java
@@ -1,0 +1,27 @@
+package com.nursena.payflow.user.application.port.out;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+
+public interface RefreshTokenFamilyRepositoryPort {
+
+    RefreshTokenFamily save(
+        RefreshTokenFamily family
+    );
+
+    Optional<RefreshTokenFamily>
+    findByIdForUpdate(
+        RefreshTokenFamilyId familyId
+    );
+
+    int revokeAllActiveByUserId(
+        UUID userId,
+        Instant revokedAt,
+        RefreshTokenFamilyRevocationReason reason
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenGenerationPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenGenerationPort.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.user.application.port.out;
+
+public interface RefreshTokenGenerationPort {
+
+    GeneratedRefreshToken generate();
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenRecordRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenRecordRepositoryPort.java
@@ -1,0 +1,23 @@
+package com.nursena.payflow.user.application.port.out;
+
+import java.util.Optional;
+
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+
+public interface RefreshTokenRecordRepositoryPort {
+
+    RefreshTokenRecord save(
+        RefreshTokenRecord record
+    );
+
+    Optional<RefreshTokenRecord>
+    findByDigestForUpdate(
+        RefreshTokenDigest digest
+    );
+
+    Optional<RefreshTokenRecord> findById(
+        RefreshTokenRecordId recordId
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/AuthenticateUserService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/AuthenticateUserService.java
@@ -5,7 +5,7 @@ import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserUseCase;
 import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
 import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
-import com.nursena.payflow.user.application.port.out.TokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
 import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
 import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
@@ -22,16 +22,16 @@ public class AuthenticateUserService
 
     private final UserRepositoryPort userRepository;
     private final PasswordVerificationPort passwordVerification;
-    private final TokenGenerationPort tokenGeneration;
+    private final AccessTokenGenerationPort accessTokenGeneration;
 
     public AuthenticateUserService(
         UserRepositoryPort userRepository,
         PasswordVerificationPort passwordVerification,
-        TokenGenerationPort tokenGeneration
+        AccessTokenGenerationPort accessTokenGeneration
     ) {
         this.userRepository = userRepository;
         this.passwordVerification = passwordVerification;
-        this.tokenGeneration = tokenGeneration;
+        this.accessTokenGeneration = accessTokenGeneration;
     }
 
     @Override
@@ -57,7 +57,7 @@ public class AuthenticateUserService
             throw new UserAccountUnavailableException();
         }
 
-        GeneratedAccessToken token = tokenGeneration.generate(user);
+        GeneratedAccessToken token = accessTokenGeneration.generate(user);
 
         return new AuthenticateUserResult(
             token.value(),

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenDigest.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenDigest.java
@@ -1,0 +1,85 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public final class RefreshTokenDigest {
+
+    public static final int SHA_256_LENGTH_BYTES = 32;
+
+    private final byte[] value;
+
+    private RefreshTokenDigest(
+        byte[] value
+    ) {
+        Objects.requireNonNull(
+            value,
+            "value must not be null"
+        );
+
+        if (
+            value.length
+                != SHA_256_LENGTH_BYTES
+        ) {
+            throw new IllegalArgumentException(
+                "value must contain exactly "
+                    + SHA_256_LENGTH_BYTES
+                    + " bytes"
+            );
+        }
+
+        this.value =
+            Arrays.copyOf(
+                value,
+                value.length
+            );
+    }
+
+    public static RefreshTokenDigest of(
+        byte[] value
+    ) {
+        return new RefreshTokenDigest(value);
+    }
+
+    public byte[] value() {
+        return Arrays.copyOf(
+            value,
+            value.length
+        );
+    }
+
+    @Override
+    public boolean equals(
+        Object candidate
+    ) {
+        if (this == candidate) {
+            return true;
+        }
+
+        if (
+            candidate == null
+                || getClass()
+                != candidate.getClass()
+        ) {
+            return false;
+        }
+
+        RefreshTokenDigest other =
+            (RefreshTokenDigest) candidate;
+
+        return Arrays.equals(
+            value,
+            other.value
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return "RefreshTokenDigest[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamily.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamily.java
@@ -1,0 +1,218 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class RefreshTokenFamily {
+
+    private final RefreshTokenFamilyId id;
+    private final UUID userId;
+    private final Instant createdAt;
+    private final Instant expiresAt;
+    private final Instant revokedAt;
+    private final RefreshTokenFamilyRevocationReason
+        revocationReason;
+
+    private RefreshTokenFamily(
+        RefreshTokenFamilyId id,
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt,
+        Instant revokedAt,
+        RefreshTokenFamilyRevocationReason
+            revocationReason
+    ) {
+        this.id =
+            Objects.requireNonNull(
+                id,
+                "id must not be null"
+            );
+
+        this.userId =
+            Objects.requireNonNull(
+                userId,
+                "userId must not be null"
+            );
+
+        this.createdAt =
+            Objects.requireNonNull(
+                createdAt,
+                "createdAt must not be null"
+            );
+
+        this.expiresAt =
+            Objects.requireNonNull(
+                expiresAt,
+                "expiresAt must not be null"
+            );
+
+        this.revokedAt = revokedAt;
+        this.revocationReason =
+            revocationReason;
+
+        validateLifetime();
+        validateRevocationState();
+    }
+
+    public static RefreshTokenFamily create(
+        RefreshTokenFamilyId id,
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt
+    ) {
+        return new RefreshTokenFamily(
+            id,
+            userId,
+            createdAt,
+            expiresAt,
+            null,
+            null
+        );
+    }
+
+    public static RefreshTokenFamily rehydrate(
+        RefreshTokenFamilyId id,
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt,
+        Instant revokedAt,
+        RefreshTokenFamilyRevocationReason
+            revocationReason
+    ) {
+        return new RefreshTokenFamily(
+            id,
+            userId,
+            createdAt,
+            expiresAt,
+            revokedAt,
+            revocationReason
+        );
+    }
+
+    public boolean isRevoked() {
+        return revokedAt != null;
+    }
+
+    public boolean isExpiredAt(
+        Instant now
+    ) {
+        Instant checkedAt =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        return !expiresAt.isAfter(checkedAt);
+    }
+
+    public boolean isActiveAt(
+        Instant now
+    ) {
+        Instant checkedAt =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        return !checkedAt.isBefore(createdAt)
+            && !isRevoked()
+            && !isExpiredAt(checkedAt);
+    }
+
+    public RefreshTokenFamily revoke(
+        RefreshTokenFamilyRevocationReason reason,
+        Instant now
+    ) {
+        RefreshTokenFamilyRevocationReason
+            checkedReason =
+            Objects.requireNonNull(
+                reason,
+                "reason must not be null"
+            );
+
+        Instant checkedAt =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        if (checkedAt.isBefore(createdAt)) {
+            throw new IllegalArgumentException(
+                "revokedAt must not be before "
+                    + "createdAt"
+            );
+        }
+
+        if (isRevoked()) {
+            return this;
+        }
+
+        return new RefreshTokenFamily(
+            id,
+            userId,
+            createdAt,
+            expiresAt,
+            checkedAt,
+            checkedReason
+        );
+    }
+
+    private void validateLifetime() {
+        if (!expiresAt.isAfter(createdAt)) {
+            throw new IllegalArgumentException(
+                "expiresAt must be after createdAt"
+            );
+        }
+    }
+
+    private void validateRevocationState() {
+        boolean hasRevokedAt =
+            revokedAt != null;
+
+        boolean hasReason =
+            revocationReason != null;
+
+        if (hasRevokedAt != hasReason) {
+            throw new IllegalArgumentException(
+                "revokedAt and revocationReason "
+                    + "must appear together"
+            );
+        }
+
+        if (
+            revokedAt != null
+                && revokedAt.isBefore(createdAt)
+        ) {
+            throw new IllegalArgumentException(
+                "revokedAt must not be before "
+                    + "createdAt"
+            );
+        }
+    }
+
+    public RefreshTokenFamilyId id() {
+        return id;
+    }
+
+    public UUID userId() {
+        return userId;
+    }
+
+    public Instant createdAt() {
+        return createdAt;
+    }
+
+    public Instant expiresAt() {
+        return expiresAt;
+    }
+
+    public Instant revokedAt() {
+        return revokedAt;
+    }
+
+    public RefreshTokenFamilyRevocationReason
+    revocationReason() {
+        return revocationReason;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyId.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyId.java
@@ -1,0 +1,22 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record RefreshTokenFamilyId(
+    UUID value
+) {
+
+    public RefreshTokenFamilyId {
+        Objects.requireNonNull(
+            value,
+            "value must not be null"
+        );
+    }
+
+    public static RefreshTokenFamilyId of(
+        UUID value
+    ) {
+        return new RefreshTokenFamilyId(value);
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyRevocationReason.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyRevocationReason.java
@@ -1,0 +1,9 @@
+package com.nursena.payflow.user.domain.model;
+
+public enum RefreshTokenFamilyRevocationReason {
+    CURRENT_SESSION_LOGOUT,
+    ALL_SESSIONS_LOGOUT,
+    REUSE_DETECTED,
+    USER_ACCOUNT_UNAVAILABLE,
+    ADMINISTRATIVE_REVOCATION
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenRecord.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenRecord.java
@@ -1,0 +1,410 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public final class RefreshTokenRecord {
+
+    private final RefreshTokenRecordId id;
+    private final RefreshTokenFamilyId familyId;
+    private final RefreshTokenDigest digest;
+    private final Instant issuedAt;
+    private final Instant expiresAt;
+    private final Instant consumedAt;
+    private final RefreshTokenRecordId successorId;
+
+    private RefreshTokenRecord(
+        RefreshTokenRecordId id,
+        RefreshTokenFamilyId familyId,
+        RefreshTokenDigest digest,
+        Instant issuedAt,
+        Instant expiresAt,
+        Instant consumedAt,
+        RefreshTokenRecordId successorId
+    ) {
+        this.id =
+            Objects.requireNonNull(
+                id,
+                "id must not be null"
+            );
+
+        this.familyId =
+            Objects.requireNonNull(
+                familyId,
+                "familyId must not be null"
+            );
+
+        this.digest =
+            Objects.requireNonNull(
+                digest,
+                "digest must not be null"
+            );
+
+        this.issuedAt =
+            Objects.requireNonNull(
+                issuedAt,
+                "issuedAt must not be null"
+            );
+
+        this.expiresAt =
+            Objects.requireNonNull(
+                expiresAt,
+                "expiresAt must not be null"
+            );
+
+        this.consumedAt = consumedAt;
+        this.successorId = successorId;
+
+        validateLocalState();
+    }
+
+    public static RefreshTokenRecord issue(
+        RefreshTokenRecordId id,
+        RefreshTokenFamily family,
+        RefreshTokenDigest digest,
+        Instant issuedAt,
+        Instant expiresAt
+    ) {
+        RefreshTokenFamily checkedFamily =
+            Objects.requireNonNull(
+                family,
+                "family must not be null"
+            );
+
+        Instant checkedIssuedAt =
+            Objects.requireNonNull(
+                issuedAt,
+                "issuedAt must not be null"
+            );
+
+        if (
+            checkedIssuedAt.isBefore(
+                checkedFamily.createdAt()
+            )
+        ) {
+            throw new IllegalArgumentException(
+                "issuedAt must not be before "
+                    + "family createdAt"
+            );
+        }
+
+        if (
+            checkedIssuedAt.isBefore(
+                checkedFamily.createdAt()
+            )
+        ) {
+            throw new IllegalArgumentException(
+                "issuedAt must not be before "
+                    + "family createdAt"
+            );
+        }
+
+        if (
+            !checkedFamily.isActiveAt(
+                checkedIssuedAt
+            )
+        ) {
+            throw new IllegalStateException(
+                "family must be active when "
+                    + "a token is issued"
+            );
+        }
+
+        RefreshTokenRecord record =
+            new RefreshTokenRecord(
+                id,
+                checkedFamily.id(),
+                digest,
+                checkedIssuedAt,
+                expiresAt,
+                null,
+                null
+            );
+
+        record.validateFamilyState(
+            checkedFamily
+        );
+
+        return record;
+    }
+
+    public static RefreshTokenRecord rehydrate(
+        RefreshTokenRecordId id,
+        RefreshTokenFamilyId familyId,
+        RefreshTokenDigest digest,
+        Instant issuedAt,
+        Instant expiresAt,
+        Instant consumedAt,
+        RefreshTokenRecordId successorId,
+        RefreshTokenFamily family
+    ) {
+        RefreshTokenRecord record =
+            new RefreshTokenRecord(
+                id,
+                familyId,
+                digest,
+                issuedAt,
+                expiresAt,
+                consumedAt,
+                successorId
+            );
+
+        record.validateFamilyState(
+            Objects.requireNonNull(
+                family,
+                "family must not be null"
+            )
+        );
+
+        return record;
+    }
+
+    public RefreshTokenRecord consume(
+        RefreshTokenRecordId successorId,
+        Instant consumedAt,
+        RefreshTokenFamily family
+    ) {
+        RefreshTokenRecordId checkedSuccessorId =
+            Objects.requireNonNull(
+                successorId,
+                "successorId must not be null"
+            );
+
+        Instant checkedConsumedAt =
+            Objects.requireNonNull(
+                consumedAt,
+                "consumedAt must not be null"
+            );
+
+        RefreshTokenFamily checkedFamily =
+            Objects.requireNonNull(
+                family,
+                "family must not be null"
+            );
+
+        validateFamilyIdentity(
+            checkedFamily
+        );
+
+        if (id.equals(checkedSuccessorId)) {
+            throw new IllegalArgumentException(
+                "a token must not replace itself"
+            );
+        }
+
+        if (isConsumed()) {
+            throw new IllegalStateException(
+                "refresh token is already consumed"
+            );
+        }
+
+        if (checkedConsumedAt.isBefore(issuedAt)) {
+            throw new IllegalArgumentException(
+                "consumedAt must not be before "
+                    + "issuedAt"
+            );
+        }
+
+        if (
+            !checkedFamily.isActiveAt(
+                checkedConsumedAt
+            )
+        ) {
+            throw new IllegalStateException(
+                "family must be active when "
+                    + "a token is consumed"
+            );
+        }
+
+        if (!expiresAt.isAfter(checkedConsumedAt)) {
+            throw new IllegalStateException(
+                "refresh token must not be expired"
+            );
+        }
+
+        return new RefreshTokenRecord(
+            id,
+            familyId,
+            digest,
+            issuedAt,
+            expiresAt,
+            checkedConsumedAt,
+            checkedSuccessorId
+        );
+    }
+
+    public boolean isConsumed() {
+        return consumedAt != null;
+    }
+
+    public boolean isExpiredAt(
+        Instant now
+    ) {
+        Instant checkedAt =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        return !expiresAt.isAfter(checkedAt);
+    }
+
+    public boolean isActiveAt(
+        RefreshTokenFamily family,
+        Instant now
+    ) {
+        RefreshTokenFamily checkedFamily =
+            Objects.requireNonNull(
+                family,
+                "family must not be null"
+            );
+
+        Instant checkedAt =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        validateFamilyIdentity(
+            checkedFamily
+        );
+
+        return !checkedAt.isBefore(issuedAt)
+            && !isConsumed()
+            && !isExpiredAt(checkedAt)
+            && checkedFamily.isActiveAt(checkedAt);
+    }
+
+    private void validateLocalState() {
+        if (!expiresAt.isAfter(issuedAt)) {
+            throw new IllegalArgumentException(
+                "expiresAt must be after issuedAt"
+            );
+        }
+
+        boolean hasConsumedAt =
+            consumedAt != null;
+
+        boolean hasSuccessor =
+            successorId != null;
+
+        if (hasConsumedAt != hasSuccessor) {
+            throw new IllegalArgumentException(
+                "consumedAt and successorId "
+                    + "must appear together"
+            );
+        }
+
+        if (
+            successorId != null
+                && id.equals(successorId)
+        ) {
+            throw new IllegalArgumentException(
+                "a token must not replace itself"
+            );
+        }
+
+        if (
+            consumedAt != null
+                && consumedAt.isBefore(issuedAt)
+        ) {
+            throw new IllegalArgumentException(
+                "consumedAt must not be before "
+                    + "issuedAt"
+            );
+        }
+
+        if (
+            consumedAt != null
+                && !expiresAt.isAfter(consumedAt)
+        ) {
+            throw new IllegalArgumentException(
+                "consumedAt must be before "
+                    + "expiresAt"
+            );
+        }
+    }
+
+    private void validateFamilyState(
+        RefreshTokenFamily family
+    ) {
+        validateFamilyIdentity(family);
+
+        if (issuedAt.isBefore(family.createdAt())) {
+            throw new IllegalArgumentException(
+                "issuedAt must not be before "
+                    + "family createdAt"
+            );
+        }
+
+        if (expiresAt.isAfter(family.expiresAt())) {
+            throw new IllegalArgumentException(
+                "token expiresAt must not be after "
+                    + "family expiresAt"
+            );
+        }
+
+        if (
+            family.revokedAt() != null
+                && !issuedAt.isBefore(
+                family.revokedAt()
+            )
+        ) {
+            throw new IllegalArgumentException(
+                "issuedAt must be before "
+                    + "family revokedAt"
+            );
+        }
+
+        if (
+            consumedAt != null
+                && family.revokedAt() != null
+                && consumedAt.isAfter(
+                family.revokedAt()
+            )
+        ) {
+            throw new IllegalArgumentException(
+                "consumedAt must not be after "
+                    + "family revokedAt"
+            );
+        }
+    }
+
+    private void validateFamilyIdentity(
+        RefreshTokenFamily family
+    ) {
+        if (!familyId.equals(family.id())) {
+            throw new IllegalArgumentException(
+                "token familyId must match family id"
+            );
+        }
+    }
+
+    public RefreshTokenRecordId id() {
+        return id;
+    }
+
+    public RefreshTokenFamilyId familyId() {
+        return familyId;
+    }
+
+    public RefreshTokenDigest digest() {
+        return digest;
+    }
+
+    public Instant issuedAt() {
+        return issuedAt;
+    }
+
+    public Instant expiresAt() {
+        return expiresAt;
+    }
+
+    public Instant consumedAt() {
+        return consumedAt;
+    }
+
+    public RefreshTokenRecordId successorId() {
+        return successorId;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenRecordId.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenRecordId.java
@@ -1,0 +1,22 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record RefreshTokenRecordId(
+    UUID value
+) {
+
+    public RefreshTokenRecordId {
+        Objects.requireNonNull(
+            value,
+            "value must not be null"
+        );
+    }
+
+    public static RefreshTokenRecordId of(
+        UUID value
+    ) {
+        return new RefreshTokenRecordId(value);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/JwtAccessTokenGenerationAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/JwtAccessTokenGenerationAdapterTest.java
@@ -21,7 +21,7 @@ import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 
-class JwtTokenGenerationAdapterTest {
+class JwtAccessTokenGenerationAdapterTest {
 
     private static final Instant NOW =
         Instant.parse("2026-07-14T12:00:00Z");
@@ -47,8 +47,8 @@ class JwtTokenGenerationAdapterTest {
             ZoneOffset.UTC
         );
 
-        JwtTokenGenerationAdapter adapter =
-            new JwtTokenGenerationAdapter(
+        JwtAccessTokenGenerationAdapter adapter =
+            new JwtAccessTokenGenerationAdapter(
                 jwtEncoder,
                 properties,
                 clock

--- a/src/test/java/com/nursena/payflow/user/application/port/out/GeneratedRefreshTokenTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/out/GeneratedRefreshTokenTest.java
@@ -1,0 +1,53 @@
+package com.nursena.payflow.user.application.port.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class GeneratedRefreshTokenTest {
+
+    @Test
+    void shouldCreateGeneratedRefreshToken() {
+        GeneratedRefreshToken token =
+            new GeneratedRefreshToken(
+                "opaque-refresh-token"
+            );
+
+        assertThat(token.value())
+            .isEqualTo(
+                "opaque-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRedactTokenFromStringRepresentation() {
+        GeneratedRefreshToken token =
+            new GeneratedRefreshToken(
+                "secret-refresh-token"
+            );
+
+        assertThat(token.toString())
+            .isEqualTo(
+                "GeneratedRefreshToken[redacted]"
+            );
+
+        assertThat(token.toString())
+            .doesNotContain(
+                "secret-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankGeneratedRefreshToken() {
+        assertThatThrownBy(() ->
+            new GeneratedRefreshToken(" ")
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "value must not be blank"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/AuthenticateUserServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/AuthenticateUserServiceTest.java
@@ -15,7 +15,7 @@ import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
 import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
 import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
-import com.nursena.payflow.user.application.port.out.TokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
 import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
 import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
@@ -59,7 +59,7 @@ class AuthenticateUserServiceTest {
     private PasswordVerificationPort passwordVerification;
 
     @Mock
-    private TokenGenerationPort tokenGeneration;
+    private AccessTokenGenerationPort accessTokenGeneration;
 
     private AuthenticateUserService authenticateUserService;
 
@@ -68,7 +68,7 @@ class AuthenticateUserServiceTest {
         authenticateUserService = new AuthenticateUserService(
             userRepository,
             passwordVerification,
-            tokenGeneration
+            accessTokenGeneration
         );
     }
 
@@ -85,7 +85,7 @@ class AuthenticateUserServiceTest {
             RAW_PASSWORD,
             PASSWORD_HASH
         )).thenReturn(true);
-        when(tokenGeneration.generate(user))
+        when(accessTokenGeneration.generate(user))
             .thenReturn(new GeneratedAccessToken(
                 ACCESS_TOKEN,
                 EXPIRES_AT
@@ -109,7 +109,7 @@ class AuthenticateUserServiceTest {
             RAW_PASSWORD,
             PASSWORD_HASH
         );
-        verify(tokenGeneration).generate(user);
+        verify(accessTokenGeneration).generate(user);
     }
 
     @Test
@@ -133,7 +133,7 @@ class AuthenticateUserServiceTest {
         verify(userRepository).findByEmail(email);
         verifyNoInteractions(
             passwordVerification,
-            tokenGeneration
+            accessTokenGeneration
         );
     }
 
@@ -161,7 +161,7 @@ class AuthenticateUserServiceTest {
             .isInstanceOf(InvalidCredentialsException.class)
             .hasMessage("Email or password is incorrect.");
 
-        verify(tokenGeneration, never()).generate(user);
+        verify(accessTokenGeneration, never()).generate(user);
     }
 
     @Test
@@ -192,7 +192,7 @@ class AuthenticateUserServiceTest {
                 "User account is not available for authentication."
             );
 
-        verify(tokenGeneration, never()).generate(user);
+        verify(accessTokenGeneration, never()).generate(user);
     }
 
     private static User activeUser(EmailAddress email) {

--- a/src/test/java/com/nursena/payflow/user/domain/model/RefreshTokenDigestTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/RefreshTokenDigestTest.java
@@ -1,0 +1,107 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenDigestTest {
+
+    @Test
+    void shouldDefensivelyCopyDigestBytes() {
+        byte[] source = digestBytes((byte) 7);
+
+        RefreshTokenDigest digest =
+            RefreshTokenDigest.of(source);
+
+        source[0] = 99;
+
+        byte[] exposed = digest.value();
+        exposed[1] = 88;
+
+        assertThat(digest.value())
+            .containsOnly((byte) 7);
+    }
+
+    @Test
+    void shouldCompareByDigestContent() {
+        RefreshTokenDigest first =
+            RefreshTokenDigest.of(
+                digestBytes((byte) 4)
+            );
+
+        RefreshTokenDigest second =
+            RefreshTokenDigest.of(
+                digestBytes((byte) 4)
+            );
+
+        assertThat(first)
+            .isEqualTo(second);
+
+        assertThat(first.hashCode())
+            .isEqualTo(second.hashCode());
+    }
+
+    @Test
+    void shouldRequireSha256Length() {
+        assertThatThrownBy(() ->
+            RefreshTokenDigest.of(
+                new byte[31]
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "value must contain exactly 32 bytes"
+            );
+
+        assertThatThrownBy(() ->
+            RefreshTokenDigest.of(
+                new byte[33]
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "value must contain exactly 32 bytes"
+            );
+    }
+
+    @Test
+    void shouldRedactDigestFromStringRepresentation() {
+        RefreshTokenDigest digest =
+            RefreshTokenDigest.of(
+                digestBytes((byte) 12)
+            );
+
+        assertThat(digest.toString())
+            .isEqualTo(
+                "RefreshTokenDigest[redacted]"
+            );
+
+        assertThat(digest.toString())
+            .doesNotContain(
+                Arrays.toString(
+                    digest.value()
+                )
+            );
+    }
+
+    private static byte[] digestBytes(
+        byte value
+    ) {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(bytes, value);
+
+        return bytes;
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyTest.java
@@ -1,0 +1,249 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenFamilyTest {
+
+    private static final RefreshTokenFamilyId
+        FAMILY_ID =
+        RefreshTokenFamilyId.of(
+            UUID.fromString(
+                "70000000-0000-0000-0000-000000000001"
+            )
+        );
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "70000000-0000-0000-0000-000000000002"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-26T13:00:00Z"
+        );
+
+    private static final Instant EXPIRES_AT =
+        CREATED_AT.plusSeconds(86_400);
+
+    @Test
+    void shouldCreateActiveFamily() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        assertThat(family.id())
+            .isEqualTo(FAMILY_ID);
+
+        assertThat(family.userId())
+            .isEqualTo(USER_ID);
+
+        assertThat(family.createdAt())
+            .isEqualTo(CREATED_AT);
+
+        assertThat(family.expiresAt())
+            .isEqualTo(EXPIRES_AT);
+
+        assertThat(family.isRevoked())
+            .isFalse();
+
+        assertThat(
+            family.isActiveAt(
+                CREATED_AT
+            )
+        )
+            .isTrue();
+    }
+
+    @Test
+    void shouldNotBeActiveBeforeCreation() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        assertThat(
+            family.isActiveAt(
+                CREATED_AT.minusNanos(1)
+            )
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldTreatExpirationBoundaryAsInactive() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        assertThat(
+            family.isActiveAt(
+                EXPIRES_AT.minusNanos(1)
+            )
+        )
+            .isTrue();
+
+        assertThat(
+            family.isActiveAt(
+                EXPIRES_AT
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            family.isExpiredAt(
+                EXPIRES_AT
+            )
+        )
+            .isTrue();
+    }
+
+    @Test
+    void shouldRevokeWithoutMutatingOriginal() {
+        RefreshTokenFamily original =
+            activeFamily();
+
+        Instant revokedAt =
+            CREATED_AT.plusSeconds(60);
+
+        RefreshTokenFamily revoked =
+            original.revoke(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT,
+                revokedAt
+            );
+
+        assertThat(original.isRevoked())
+            .isFalse();
+
+        assertThat(revoked.isRevoked())
+            .isTrue();
+
+        assertThat(revoked.revokedAt())
+            .isEqualTo(revokedAt);
+
+        assertThat(revoked.revocationReason())
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT
+            );
+
+        assertThat(
+            revoked.isActiveAt(
+                revokedAt
+            )
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldKeepFirstRevocationIdempotently() {
+        RefreshTokenFamily revoked =
+            activeFamily().revoke(
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED,
+                CREATED_AT.plusSeconds(30)
+            );
+
+        RefreshTokenFamily repeated =
+            revoked.revoke(
+                RefreshTokenFamilyRevocationReason
+                    .ALL_SESSIONS_LOGOUT,
+                CREATED_AT.plusSeconds(60)
+            );
+
+        assertThat(repeated)
+            .isSameAs(revoked);
+
+        assertThat(repeated.revocationReason())
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED
+            );
+    }
+
+    @Test
+    void shouldRejectInvalidLifetime() {
+        assertThatThrownBy(() ->
+            RefreshTokenFamily.create(
+                FAMILY_ID,
+                USER_ID,
+                CREATED_AT,
+                CREATED_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "expiresAt must be after createdAt"
+            );
+    }
+
+    @Test
+    void shouldRejectIncompleteRevocationState() {
+        assertThatThrownBy(() ->
+            RefreshTokenFamily.rehydrate(
+                FAMILY_ID,
+                USER_ID,
+                CREATED_AT,
+                EXPIRES_AT,
+                CREATED_AT.plusSeconds(10),
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "revokedAt and revocationReason "
+                    + "must appear together"
+            );
+
+        assertThatThrownBy(() ->
+            RefreshTokenFamily.rehydrate(
+                FAMILY_ID,
+                USER_ID,
+                CREATED_AT,
+                EXPIRES_AT,
+                null,
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "revokedAt and revocationReason "
+                    + "must appear together"
+            );
+    }
+
+    @Test
+    void shouldRejectRevocationBeforeCreation() {
+        assertThatThrownBy(() ->
+            activeFamily().revoke(
+                RefreshTokenFamilyRevocationReason
+                    .ADMINISTRATIVE_REVOCATION,
+                CREATED_AT.minusSeconds(1)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "revokedAt must not be before createdAt"
+            );
+    }
+
+    private static RefreshTokenFamily activeFamily() {
+        return RefreshTokenFamily.create(
+            FAMILY_ID,
+            USER_ID,
+            CREATED_AT,
+            EXPIRES_AT
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/domain/model/RefreshTokenRecordTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/RefreshTokenRecordTest.java
@@ -1,0 +1,436 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenRecordTest {
+
+    private static final RefreshTokenFamilyId
+        FAMILY_ID =
+        RefreshTokenFamilyId.of(
+            UUID.fromString(
+                "71000000-0000-0000-0000-000000000001"
+            )
+        );
+
+    private static final RefreshTokenFamilyId
+        OTHER_FAMILY_ID =
+        RefreshTokenFamilyId.of(
+            UUID.fromString(
+                "71000000-0000-0000-0000-000000000002"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        TOKEN_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "71000000-0000-0000-0000-000000000003"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        SUCCESSOR_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "71000000-0000-0000-0000-000000000004"
+            )
+        );
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "71000000-0000-0000-0000-000000000005"
+        );
+
+    private static final Instant FAMILY_CREATED_AT =
+        Instant.parse(
+            "2026-07-26T13:00:00Z"
+        );
+
+    private static final Instant FAMILY_EXPIRES_AT =
+        FAMILY_CREATED_AT.plusSeconds(86_400);
+
+    private static final Instant TOKEN_EXPIRES_AT =
+        FAMILY_CREATED_AT.plusSeconds(3_600);
+
+    @Test
+    void shouldIssueActiveToken() {
+        RefreshTokenRecord token =
+            activeToken();
+
+        assertThat(token.id())
+            .isEqualTo(TOKEN_ID);
+
+        assertThat(token.familyId())
+            .isEqualTo(FAMILY_ID);
+
+        assertThat(token.isConsumed())
+            .isFalse();
+
+        assertThat(
+            token.isActiveAt(
+                activeFamily(),
+                FAMILY_CREATED_AT
+            )
+        )
+            .isTrue();
+    }
+
+    @Test
+    void shouldNotBeActiveBeforeIssuance() {
+        RefreshTokenRecord token =
+            activeToken();
+
+        assertThat(
+            token.isActiveAt(
+                activeFamily(),
+                FAMILY_CREATED_AT.minusNanos(1)
+            )
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldRejectIssuanceBeforeFamilyCreation() {
+        assertThatThrownBy(() ->
+            RefreshTokenRecord.issue(
+                TOKEN_ID,
+                activeFamily(),
+                digest((byte) 1),
+                FAMILY_CREATED_AT.minusSeconds(1),
+                TOKEN_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "issuedAt must not be before "
+                    + "family createdAt"
+            );
+    }
+
+    @Test
+    void shouldRejectExpirationAfterFamilyExpiration() {
+        assertThatThrownBy(() ->
+            RefreshTokenRecord.issue(
+                TOKEN_ID,
+                activeFamily(),
+                digest((byte) 1),
+                FAMILY_CREATED_AT,
+                FAMILY_EXPIRES_AT.plusSeconds(1)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "token expiresAt must not be after "
+                    + "family expiresAt"
+            );
+    }
+
+    @Test
+    void shouldRejectIssuanceForRevokedFamily() {
+        RefreshTokenFamily revoked =
+            activeFamily().revoke(
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED,
+                FAMILY_CREATED_AT.plusSeconds(30)
+            );
+
+        assertThatThrownBy(() ->
+            RefreshTokenRecord.issue(
+                TOKEN_ID,
+                revoked,
+                digest((byte) 1),
+                FAMILY_CREATED_AT.plusSeconds(60),
+                TOKEN_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "family must be active when "
+                    + "a token is issued"
+            );
+    }
+
+    @Test
+    void shouldConsumeWithoutMutatingOriginal() {
+        RefreshTokenRecord original =
+            activeToken();
+
+        Instant consumedAt =
+            FAMILY_CREATED_AT.plusSeconds(600);
+
+        RefreshTokenRecord consumed =
+            original.consume(
+                SUCCESSOR_ID,
+                consumedAt,
+                activeFamily()
+            );
+
+        assertThat(original.isConsumed())
+            .isFalse();
+
+        assertThat(consumed.isConsumed())
+            .isTrue();
+
+        assertThat(consumed.consumedAt())
+            .isEqualTo(consumedAt);
+
+        assertThat(consumed.successorId())
+            .isEqualTo(SUCCESSOR_ID);
+
+        assertThat(
+            consumed.isActiveAt(
+                activeFamily(),
+                consumedAt
+            )
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldRejectSelfSuccessor() {
+        assertThatThrownBy(() ->
+            activeToken().consume(
+                TOKEN_ID,
+                FAMILY_CREATED_AT.plusSeconds(10),
+                activeFamily()
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "a token must not replace itself"
+            );
+    }
+
+    @Test
+    void shouldRejectSecondConsumption() {
+        RefreshTokenRecord consumed =
+            activeToken().consume(
+                SUCCESSOR_ID,
+                FAMILY_CREATED_AT.plusSeconds(10),
+                activeFamily()
+            );
+
+        assertThatThrownBy(() ->
+            consumed.consume(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                ),
+                FAMILY_CREATED_AT.plusSeconds(20),
+                activeFamily()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "refresh token is already consumed"
+            );
+    }
+
+    @Test
+    void shouldRejectExpiredTokenConsumption() {
+        assertThatThrownBy(() ->
+            activeToken().consume(
+                SUCCESSOR_ID,
+                TOKEN_EXPIRES_AT,
+                activeFamily()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "refresh token must not be expired"
+            );
+    }
+
+    @Test
+    void shouldRejectConsumptionForRevokedFamily() {
+        Instant revokedAt =
+            FAMILY_CREATED_AT.plusSeconds(300);
+
+        RefreshTokenFamily revoked =
+            activeFamily().revoke(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT,
+                revokedAt
+            );
+
+        assertThatThrownBy(() ->
+            activeToken().consume(
+                SUCCESSOR_ID,
+                revokedAt.plusSeconds(1),
+                revoked
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "family must be active when "
+                    + "a token is consumed"
+            );
+    }
+
+    @Test
+    void shouldRejectConsumptionForDifferentFamily() {
+        RefreshTokenFamily otherFamily =
+            RefreshTokenFamily.create(
+                OTHER_FAMILY_ID,
+                USER_ID,
+                FAMILY_CREATED_AT,
+                FAMILY_EXPIRES_AT
+            );
+
+        assertThatThrownBy(() ->
+            activeToken().consume(
+                SUCCESSOR_ID,
+                FAMILY_CREATED_AT.plusSeconds(10),
+                otherFamily
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "token familyId must match family id"
+            );
+    }
+
+    @Test
+    void shouldRejectIncompleteConsumedState() {
+        assertThatThrownBy(() ->
+            RefreshTokenRecord.rehydrate(
+                TOKEN_ID,
+                FAMILY_ID,
+                digest((byte) 1),
+                FAMILY_CREATED_AT,
+                TOKEN_EXPIRES_AT,
+                FAMILY_CREATED_AT.plusSeconds(10),
+                null,
+                activeFamily()
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "consumedAt and successorId "
+                    + "must appear together"
+            );
+
+        assertThatThrownBy(() ->
+            RefreshTokenRecord.rehydrate(
+                TOKEN_ID,
+                FAMILY_ID,
+                digest((byte) 1),
+                FAMILY_CREATED_AT,
+                TOKEN_EXPIRES_AT,
+                null,
+                SUCCESSOR_ID,
+                activeFamily()
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "consumedAt and successorId "
+                    + "must appear together"
+            );
+    }
+
+    @Test
+    void shouldRehydrateConsumedTokenInRevokedFamily() {
+        Instant consumedAt =
+            FAMILY_CREATED_AT.plusSeconds(300);
+
+        Instant revokedAt =
+            consumedAt.plusSeconds(300);
+
+        RefreshTokenFamily revoked =
+            RefreshTokenFamily.rehydrate(
+                FAMILY_ID,
+                USER_ID,
+                FAMILY_CREATED_AT,
+                FAMILY_EXPIRES_AT,
+                revokedAt,
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED
+            );
+
+        RefreshTokenRecord token =
+            RefreshTokenRecord.rehydrate(
+                TOKEN_ID,
+                FAMILY_ID,
+                digest((byte) 1),
+                FAMILY_CREATED_AT,
+                TOKEN_EXPIRES_AT,
+                consumedAt,
+                SUCCESSOR_ID,
+                revoked
+            );
+
+        assertThat(token.isConsumed())
+            .isTrue();
+
+        assertThat(token.successorId())
+            .isEqualTo(SUCCESSOR_ID);
+
+        assertThat(
+            token.isActiveAt(
+                revoked,
+                consumedAt
+            )
+        )
+            .isFalse();
+    }
+
+    private static RefreshTokenFamily activeFamily() {
+        return RefreshTokenFamily.create(
+            FAMILY_ID,
+            USER_ID,
+            FAMILY_CREATED_AT,
+            FAMILY_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenRecord activeToken() {
+        return RefreshTokenRecord.issue(
+            TOKEN_ID,
+            activeFamily(),
+            digest((byte) 1),
+            FAMILY_CREATED_AT,
+            TOKEN_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenDigest digest(
+        byte value
+    ) {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(bytes, value);
+
+        return RefreshTokenDigest.of(bytes);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the framework-independent refresh-session domain model and
application contracts defined by ADR 0009.

## Changes

- add typed refresh-token family and record identifiers
- add defensive SHA-256 digest value object
- add immutable family lifecycle and revocation model
- add immutable token issuance, consumption, and successor model
- add refresh-token generation and digest ports
- add family and token-record persistence contracts
- rename access-token generation contracts explicitly
- redact generated refresh tokens from string representations
- add lifecycle, boundary, validation, and defensive-copy tests

## Security invariants

- plaintext refresh tokens are not part of persisted domain models
- token digests are immutable and redacted
- revoked or expired families cannot issue successors
- consumed tokens cannot become active again
- tokens cannot replace themselves
- token expiration cannot exceed family expiration
- lifecycle decisions use supplied time values
- domain and application contracts contain no framework dependencies

## Scope

This PR does not add:

- Flyway migrations
- persistence adapters
- REST endpoints
- login response changes
- cryptographic implementations
- Redis integration
- OpenAPI or Postman changes

## Verification

- 668 tests
- 0 failures
- 0 errors
- 0 skipped tests
- full Maven clean verification successful
- staged UTF-8 blobs verified without BOM
- LF repository line endings verified
- whitespace checks passed
- no stale access-token contract names
- working tree clean

Closes #74