### PR TITLE
feat: add PostgreSQL refresh-session persistence

### DIFF
--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenFamilyJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenFamilyJpaEntity.java
@@ -1,0 +1,96 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "refresh_token_families")
+class RefreshTokenFamilyJpaEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(
+        name = "user_id",
+        nullable = false,
+        updatable = false
+    )
+    private UUID userId;
+
+    @Column(
+        name = "created_at",
+        nullable = false,
+        updatable = false
+    )
+    private Instant createdAt;
+
+    @Column(
+        name = "expires_at",
+        nullable = false
+    )
+    private Instant expiresAt;
+
+    @Column(name = "revoked_at")
+    private Instant revokedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+        name = "revocation_reason",
+        length = 40
+    )
+    private RefreshTokenFamilyRevocationReason
+        revocationReason;
+
+    protected RefreshTokenFamilyJpaEntity() {
+    }
+
+    RefreshTokenFamilyJpaEntity(
+        UUID id,
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt,
+        Instant revokedAt,
+        RefreshTokenFamilyRevocationReason
+            revocationReason
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.createdAt = createdAt;
+        this.expiresAt = expiresAt;
+        this.revokedAt = revokedAt;
+        this.revocationReason = revocationReason;
+    }
+
+    UUID getId() {
+        return id;
+    }
+
+    UUID getUserId() {
+        return userId;
+    }
+
+    Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    Instant getRevokedAt() {
+        return revokedAt;
+    }
+
+    RefreshTokenFamilyRevocationReason
+    getRevocationReason() {
+        return revocationReason;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenFamilyPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenFamilyPersistenceAdapter.java
@@ -1,0 +1,69 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import org.springframework.stereotype.Component;
+
+@Component
+class RefreshTokenFamilyPersistenceAdapter
+    implements RefreshTokenFamilyRepositoryPort {
+
+    private final SpringDataRefreshTokenFamilyRepository
+        repository;
+
+    RefreshTokenFamilyPersistenceAdapter(
+        SpringDataRefreshTokenFamilyRepository
+            repository
+    ) {
+        this.repository = repository;
+    }
+
+    @Override
+    public RefreshTokenFamily save(
+        RefreshTokenFamily family
+    ) {
+        RefreshTokenFamilyJpaEntity saved =
+            repository.saveAndFlush(
+                RefreshTokenPersistenceMapper
+                    .toFamilyEntity(family)
+            );
+
+        return RefreshTokenPersistenceMapper
+            .toFamilyDomain(saved);
+    }
+
+    @Override
+    public Optional<RefreshTokenFamily>
+    findByIdForUpdate(
+        RefreshTokenFamilyId familyId
+    ) {
+        return repository
+            .findByIdForUpdate(
+                familyId.value()
+            )
+            .map(
+                RefreshTokenPersistenceMapper
+                    ::toFamilyDomain
+            );
+    }
+
+    @Override
+    public int revokeAllActiveByUserId(
+        UUID userId,
+        Instant revokedAt,
+        RefreshTokenFamilyRevocationReason reason
+    ) {
+        return repository
+            .revokeAllActiveByUserId(
+                userId,
+                revokedAt,
+                reason
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenPersistenceMapper.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenPersistenceMapper.java
@@ -1,0 +1,91 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+
+final class RefreshTokenPersistenceMapper {
+
+    private RefreshTokenPersistenceMapper() {
+    }
+
+    static RefreshTokenFamilyJpaEntity
+    toFamilyEntity(
+        RefreshTokenFamily family
+    ) {
+        return new RefreshTokenFamilyJpaEntity(
+            family.id().value(),
+            family.userId(),
+            family.createdAt(),
+            family.expiresAt(),
+            family.revokedAt(),
+            family.revocationReason()
+        );
+    }
+
+    static RefreshTokenFamily toFamilyDomain(
+        RefreshTokenFamilyJpaEntity entity
+    ) {
+        return RefreshTokenFamily.rehydrate(
+            RefreshTokenFamilyId.of(
+                entity.getId()
+            ),
+            entity.getUserId(),
+            entity.getCreatedAt(),
+            entity.getExpiresAt(),
+            entity.getRevokedAt(),
+            entity.getRevocationReason()
+        );
+    }
+
+    static RefreshTokenRecordJpaEntity
+    toRecordEntity(
+        RefreshTokenRecord record
+    ) {
+        RefreshTokenRecordId successorId =
+            record.successorId();
+
+        return new RefreshTokenRecordJpaEntity(
+            record.id().value(),
+            record.familyId().value(),
+            record.digest().value(),
+            record.issuedAt(),
+            record.expiresAt(),
+            record.consumedAt(),
+            successorId == null
+                ? null
+                : successorId.value()
+        );
+    }
+
+    static RefreshTokenRecord toRecordDomain(
+        RefreshTokenRecordJpaEntity entity,
+        RefreshTokenFamily family
+    ) {
+        RefreshTokenRecordId successorId =
+            entity.getSuccessorId() == null
+                ? null
+                : RefreshTokenRecordId.of(
+                    entity.getSuccessorId()
+                );
+
+        return RefreshTokenRecord.rehydrate(
+            RefreshTokenRecordId.of(
+                entity.getId()
+            ),
+            RefreshTokenFamilyId.of(
+                entity.getFamilyId()
+            ),
+            RefreshTokenDigest.of(
+                entity.getTokenDigest()
+            ),
+            entity.getIssuedAt(),
+            entity.getExpiresAt(),
+            entity.getConsumedAt(),
+            successorId,
+            family
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenRecordJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenRecordJpaEntity.java
@@ -1,0 +1,115 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "refresh_token_records")
+class RefreshTokenRecordJpaEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(
+        name = "family_id",
+        nullable = false,
+        updatable = false
+    )
+    private UUID familyId;
+
+    @Column(
+        name = "token_digest",
+        nullable = false,
+        updatable = false
+    )
+    private byte[] tokenDigest;
+
+    @Column(
+        name = "issued_at",
+        nullable = false,
+        updatable = false
+    )
+    private Instant issuedAt;
+
+    @Column(
+        name = "expires_at",
+        nullable = false,
+        updatable = false
+    )
+    private Instant expiresAt;
+
+    @Column(name = "consumed_at")
+    private Instant consumedAt;
+
+    @Column(name = "successor_id")
+    private UUID successorId;
+
+    protected RefreshTokenRecordJpaEntity() {
+    }
+
+    RefreshTokenRecordJpaEntity(
+        UUID id,
+        UUID familyId,
+        byte[] tokenDigest,
+        Instant issuedAt,
+        Instant expiresAt,
+        Instant consumedAt,
+        UUID successorId
+    ) {
+        this.id = id;
+        this.familyId = familyId;
+        this.tokenDigest =
+            copyDigest(tokenDigest);
+        this.issuedAt = issuedAt;
+        this.expiresAt = expiresAt;
+        this.consumedAt = consumedAt;
+        this.successorId = successorId;
+    }
+
+    UUID getId() {
+        return id;
+    }
+
+    UUID getFamilyId() {
+        return familyId;
+    }
+
+    byte[] getTokenDigest() {
+        return copyDigest(tokenDigest);
+    }
+
+    Instant getIssuedAt() {
+        return issuedAt;
+    }
+
+    Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    Instant getConsumedAt() {
+        return consumedAt;
+    }
+
+    UUID getSuccessorId() {
+        return successorId;
+    }
+
+    private static byte[] copyDigest(
+        byte[] source
+    ) {
+        if (source == null) {
+            return null;
+        }
+
+        return Arrays.copyOf(
+            source,
+            source.length
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenRecordPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenRecordPersistenceAdapter.java
@@ -1,0 +1,109 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import org.springframework.stereotype.Component;
+
+@Component
+class RefreshTokenRecordPersistenceAdapter
+    implements RefreshTokenRecordRepositoryPort {
+
+    private final SpringDataRefreshTokenRecordRepository
+        recordRepository;
+
+    private final SpringDataRefreshTokenFamilyRepository
+        familyRepository;
+
+    RefreshTokenRecordPersistenceAdapter(
+        SpringDataRefreshTokenRecordRepository
+            recordRepository,
+        SpringDataRefreshTokenFamilyRepository
+            familyRepository
+    ) {
+        this.recordRepository = recordRepository;
+        this.familyRepository = familyRepository;
+    }
+
+    @Override
+    public RefreshTokenRecord save(
+        RefreshTokenRecord record
+    ) {
+        RefreshTokenRecordJpaEntity saved =
+            recordRepository.saveAndFlush(
+                RefreshTokenPersistenceMapper
+                    .toRecordEntity(record)
+            );
+
+        return toDomain(saved);
+    }
+
+    @Override
+    public Optional<RefreshTokenRecord>
+    findByDigestForUpdate(
+        RefreshTokenDigest digest
+    ) {
+        return recordRepository
+            .findByDigestForUpdate(
+                digest.value()
+            )
+            .map(this::toDomain);
+    }
+
+    @Override
+    public Optional<RefreshTokenRecord> findById(
+        RefreshTokenRecordId recordId
+    ) {
+        return recordRepository
+            .findById(
+                recordId.value()
+            )
+            .map(this::toDomain);
+    }
+
+    private RefreshTokenRecord toDomain(
+        RefreshTokenRecordJpaEntity entity
+    ) {
+        RefreshTokenFamily family =
+            familyRepository
+                .findById(
+                    entity.getFamilyId()
+                )
+                .map(
+                    RefreshTokenPersistenceMapper
+                        ::toFamilyDomain
+                )
+                .orElseThrow(
+                    () -> missingFamily(entity)
+                );
+
+        return RefreshTokenPersistenceMapper
+            .toRecordDomain(
+                entity,
+                family
+            );
+    }
+
+    private static IllegalStateException
+    missingFamily(
+        RefreshTokenRecordJpaEntity entity
+    ) {
+        UUID familyId =
+            entity.getFamilyId();
+
+        UUID recordId =
+            entity.getId();
+
+        return new IllegalStateException(
+            "refresh token family "
+                + familyId
+                + " was not found for record "
+                + recordId
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataRefreshTokenFamilyRepository.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataRefreshTokenFamilyRepository.java
@@ -1,0 +1,55 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+interface SpringDataRefreshTokenFamilyRepository
+    extends JpaRepository<
+        RefreshTokenFamilyJpaEntity,
+        UUID
+    > {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT family
+        FROM RefreshTokenFamilyJpaEntity family
+        WHERE family.id = :familyId
+        """)
+    Optional<RefreshTokenFamilyJpaEntity>
+    findByIdForUpdate(
+        @Param("familyId")
+        UUID familyId
+    );
+
+    @Modifying(
+        flushAutomatically = true,
+        clearAutomatically = true
+    )
+    @Query("""
+        UPDATE RefreshTokenFamilyJpaEntity family
+        SET family.revokedAt = :revokedAt,
+            family.revocationReason = :reason
+        WHERE family.userId = :userId
+          AND family.revokedAt IS NULL
+          AND family.revocationReason IS NULL
+          AND family.createdAt <= :revokedAt
+          AND family.expiresAt > :revokedAt
+        """)
+    int revokeAllActiveByUserId(
+        @Param("userId")
+        UUID userId,
+        @Param("revokedAt")
+        Instant revokedAt,
+        @Param("reason")
+        RefreshTokenFamilyRevocationReason reason
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataRefreshTokenRecordRepository.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataRefreshTokenRecordRepository.java
@@ -1,0 +1,29 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+interface SpringDataRefreshTokenRecordRepository
+    extends JpaRepository<
+        RefreshTokenRecordJpaEntity,
+        UUID
+    > {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT record
+        FROM RefreshTokenRecordJpaEntity record
+        WHERE record.tokenDigest = :digest
+        """)
+    Optional<RefreshTokenRecordJpaEntity>
+    findByDigestForUpdate(
+        @Param("digest")
+        byte[] digest
+    );
+}

--- a/src/main/resources/db/migration/V14__create_refresh_token_sessions.sql
+++ b/src/main/resources/db/migration/V14__create_refresh_token_sessions.sql
@@ -1,0 +1,219 @@
+CREATE TABLE refresh_token_families (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    revoked_at TIMESTAMPTZ,
+    revocation_reason VARCHAR(40),
+
+    CONSTRAINT fk_refresh_token_families_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT chk_refresh_token_families_lifetime
+        CHECK (
+            expires_at > created_at
+        ),
+
+    CONSTRAINT chk_refresh_token_families_revocation_state
+        CHECK (
+            (
+                revoked_at IS NULL
+                AND revocation_reason IS NULL
+            )
+            OR
+            (
+                revoked_at IS NOT NULL
+                AND revocation_reason IS NOT NULL
+            )
+        ),
+
+    CONSTRAINT chk_refresh_token_families_revocation_time
+        CHECK (
+            revoked_at IS NULL
+            OR revoked_at >= created_at
+        ),
+
+    CONSTRAINT chk_refresh_token_families_revocation_reason
+        CHECK (
+            revocation_reason IS NULL
+            OR revocation_reason IN (
+                'CURRENT_SESSION_LOGOUT',
+                'ALL_SESSIONS_LOGOUT',
+                'REUSE_DETECTED',
+                'USER_ACCOUNT_UNAVAILABLE',
+                'ADMINISTRATIVE_REVOCATION'
+            )
+        )
+);
+
+CREATE TABLE refresh_token_records (
+    id UUID PRIMARY KEY,
+    family_id UUID NOT NULL,
+    token_digest BYTEA NOT NULL,
+    issued_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    consumed_at TIMESTAMPTZ,
+    successor_id UUID,
+
+    CONSTRAINT uq_refresh_token_records_id_family
+        UNIQUE (
+            id,
+            family_id
+        ),
+
+    CONSTRAINT uq_refresh_token_records_digest
+        UNIQUE (
+            token_digest
+        ),
+
+    CONSTRAINT uq_refresh_token_records_successor
+        UNIQUE (
+            successor_id
+        ),
+
+    CONSTRAINT fk_refresh_token_records_family
+        FOREIGN KEY (family_id)
+        REFERENCES refresh_token_families(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT chk_refresh_token_records_digest_length
+        CHECK (
+            octet_length(token_digest) = 32
+        ),
+
+    CONSTRAINT chk_refresh_token_records_lifetime
+        CHECK (
+            expires_at > issued_at
+        ),
+
+    CONSTRAINT chk_refresh_token_records_consumption_state
+        CHECK (
+            (
+                consumed_at IS NULL
+                AND successor_id IS NULL
+            )
+            OR
+            (
+                consumed_at IS NOT NULL
+                AND successor_id IS NOT NULL
+            )
+        ),
+
+    CONSTRAINT chk_refresh_token_records_consumption_time
+        CHECK (
+            consumed_at IS NULL
+            OR (
+                consumed_at >= issued_at
+                AND consumed_at < expires_at
+            )
+        ),
+
+    CONSTRAINT chk_refresh_token_records_not_self_successor
+        CHECK (
+            successor_id IS NULL
+            OR successor_id <> id
+        )
+);
+
+ALTER TABLE refresh_token_records
+    ADD CONSTRAINT fk_refresh_token_records_successor_family
+    FOREIGN KEY (
+        successor_id,
+        family_id
+    )
+    REFERENCES refresh_token_records (
+        id,
+        family_id
+    )
+    DEFERRABLE INITIALLY DEFERRED;
+
+CREATE FUNCTION enforce_refresh_token_record_family_expiration()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    family_expiration TIMESTAMPTZ;
+BEGIN
+    SELECT family.expires_at
+    INTO family_expiration
+    FROM refresh_token_families family
+    WHERE family.id = NEW.family_id;
+
+    IF NOT FOUND THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.expires_at > family_expiration THEN
+        RAISE EXCEPTION
+            'refresh token expiration exceeds family expiration'
+            USING
+                ERRCODE = '23514',
+                CONSTRAINT =
+                    'chk_refresh_token_records_family_expiration';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_refresh_token_records_family_expiration
+    BEFORE INSERT OR UPDATE OF family_id, expires_at
+    ON refresh_token_records
+    FOR EACH ROW
+    EXECUTE FUNCTION
+        enforce_refresh_token_record_family_expiration();
+
+CREATE FUNCTION enforce_refresh_token_family_expiration_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM refresh_token_records record
+        WHERE record.family_id = NEW.id
+          AND record.expires_at > NEW.expires_at
+    ) THEN
+        RAISE EXCEPTION
+            'family expiration precedes token expiration'
+            USING
+                ERRCODE = '23514',
+                CONSTRAINT =
+                    'chk_refresh_token_records_family_expiration';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_refresh_token_families_expiration_update
+    BEFORE UPDATE OF expires_at
+    ON refresh_token_families
+    FOR EACH ROW
+    EXECUTE FUNCTION
+        enforce_refresh_token_family_expiration_update();
+
+CREATE INDEX idx_refresh_token_families_user_active
+    ON refresh_token_families (
+        user_id,
+        expires_at
+    )
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX idx_refresh_token_families_expires_at
+    ON refresh_token_families (
+        expires_at
+    );
+
+CREATE INDEX idx_refresh_token_records_family_issued_at
+    ON refresh_token_records (
+        family_id,
+        issued_at DESC
+    );
+
+CREATE INDEX idx_refresh_token_records_expires_at
+    ON refresh_token_records (
+        expires_at
+    );

--- a/src/test/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenPersistenceAdapterIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenPersistenceAdapterIntegrationTest.java
@@ -1,0 +1,715 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class RefreshTokenPersistenceAdapterIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    @Autowired
+    private RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PlatformTransactionManager
+        transactionManager;
+
+    private TransactionTemplate
+        transactionTemplate;
+
+    @BeforeEach
+    void setUp() {
+        transactionTemplate =
+            new TransactionTemplate(
+                transactionManager
+            );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldRoundTripActiveFamilyAndRecord() {
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant familyExpiresAt =
+            createdAt.plusSeconds(
+                86_400
+            );
+
+        RefreshTokenFamily family =
+            RefreshTokenFamily.create(
+                RefreshTokenFamilyId.of(
+                    UUID.randomUUID()
+                ),
+                userId,
+                createdAt,
+                familyExpiresAt
+            );
+
+        RefreshTokenFamily savedFamily =
+            familyRepository.save(family);
+
+        assertThat(savedFamily.id())
+            .isEqualTo(family.id());
+
+        assertThat(savedFamily.userId())
+            .isEqualTo(userId);
+
+        assertThat(savedFamily.createdAt())
+            .isEqualTo(createdAt);
+
+        assertThat(savedFamily.expiresAt())
+            .isEqualTo(familyExpiresAt);
+
+        assertThat(savedFamily.isRevoked())
+            .isFalse();
+
+        RefreshTokenDigest digest =
+            digest(1);
+
+        RefreshTokenRecord record =
+            RefreshTokenRecord.issue(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                ),
+                savedFamily,
+                digest,
+                createdAt.plusSeconds(60),
+                familyExpiresAt
+            );
+
+        RefreshTokenRecord savedRecord =
+            recordRepository.save(record);
+
+        Optional<RefreshTokenRecord> reloaded =
+            recordRepository.findById(
+                savedRecord.id()
+            );
+
+        assertThat(reloaded)
+            .isPresent();
+
+        RefreshTokenRecord persistedRecord =
+            reloaded.orElseThrow();
+
+        assertThat(persistedRecord.id())
+            .isEqualTo(record.id());
+
+        assertThat(persistedRecord.familyId())
+            .isEqualTo(family.id());
+
+        assertThat(persistedRecord.digest())
+            .isEqualTo(digest);
+
+        assertThat(persistedRecord.issuedAt())
+            .isEqualTo(
+                createdAt.plusSeconds(60)
+            );
+
+        assertThat(persistedRecord.expiresAt())
+            .isEqualTo(familyExpiresAt);
+
+        assertThat(persistedRecord.isConsumed())
+            .isFalse();
+
+        assertThat(persistedRecord.successorId())
+            .isNull();
+    }
+
+    @Test
+    void shouldRoundTripRevokedFamily() {
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(
+                86_400
+            );
+
+        Instant revokedAt =
+            createdAt.plusSeconds(
+                3_600
+            );
+
+        RefreshTokenFamily revokedFamily =
+            RefreshTokenFamily.create(
+                RefreshTokenFamilyId.of(
+                    UUID.randomUUID()
+                ),
+                userId,
+                createdAt,
+                expiresAt
+            ).revoke(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT,
+                revokedAt
+            );
+
+        familyRepository.save(
+            revokedFamily
+        );
+
+        RefreshTokenFamily reloaded =
+            findFamilyForUpdate(
+                revokedFamily.id()
+            ).orElseThrow();
+
+        assertThat(reloaded.isRevoked())
+            .isTrue();
+
+        assertThat(reloaded.revokedAt())
+            .isEqualTo(revokedAt);
+
+        assertThat(reloaded.revocationReason())
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT
+            );
+    }
+
+    @Test
+    void shouldRoundTripConsumedRecordLineage() {
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(
+                86_400
+            );
+
+        Instant consumedAt =
+            createdAt.plusSeconds(
+                3_600
+            );
+
+        RefreshTokenFamily family =
+            familyRepository.save(
+                RefreshTokenFamily.create(
+                    RefreshTokenFamilyId.of(
+                        UUID.randomUUID()
+                    ),
+                    userId,
+                    createdAt,
+                    expiresAt
+                )
+            );
+
+        RefreshTokenRecord successor =
+            RefreshTokenRecord.issue(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                ),
+                family,
+                digest(2),
+                consumedAt,
+                expiresAt
+            );
+
+        recordRepository.save(successor);
+
+        RefreshTokenRecord predecessor =
+            RefreshTokenRecord.issue(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                ),
+                family,
+                digest(3),
+                createdAt.plusSeconds(60),
+                expiresAt
+            ).consume(
+                successor.id(),
+                consumedAt,
+                family
+            );
+
+        recordRepository.save(
+            predecessor
+        );
+
+        RefreshTokenRecord reloaded =
+            recordRepository.findById(
+                predecessor.id()
+            ).orElseThrow();
+
+        assertThat(reloaded.isConsumed())
+            .isTrue();
+
+        assertThat(reloaded.consumedAt())
+            .isEqualTo(consumedAt);
+
+        assertThat(reloaded.successorId())
+            .isEqualTo(successor.id());
+    }
+
+    @Test
+    void shouldPreserveDigestDefensiveCopiesAcrossPersistenceBoundary() {
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(
+                86_400
+            );
+
+        RefreshTokenFamily family =
+            familyRepository.save(
+                RefreshTokenFamily.create(
+                    RefreshTokenFamilyId.of(
+                        UUID.randomUUID()
+                    ),
+                    userId,
+                    createdAt,
+                    expiresAt
+                )
+            );
+
+        byte[] sourceDigest =
+            digestBytes(4);
+
+        RefreshTokenDigest digest =
+            RefreshTokenDigest.of(
+                sourceDigest
+            );
+
+        RefreshTokenRecord saved =
+            recordRepository.save(
+                RefreshTokenRecord.issue(
+                    RefreshTokenRecordId.of(
+                        UUID.randomUUID()
+                    ),
+                    family,
+                    digest,
+                    createdAt.plusSeconds(60),
+                    expiresAt
+                )
+            );
+
+        Arrays.fill(
+            sourceDigest,
+            (byte) 99
+        );
+
+        byte[] exposedDigest =
+            saved.digest().value();
+
+        Arrays.fill(
+            exposedDigest,
+            (byte) 88
+        );
+
+        RefreshTokenRecord reloaded =
+            recordRepository.findById(
+                saved.id()
+            ).orElseThrow();
+
+        assertThat(
+            reloaded.digest().value()
+        )
+            .containsOnly((byte) 4);
+    }
+
+    @Test
+    void shouldRevokeOnlyActiveFamiliesForUser() {
+        UUID targetUserId =
+            insertUser();
+
+        UUID otherUserId =
+            insertUser();
+
+        Instant now =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        RefreshTokenFamily active =
+            familyRepository.save(
+                newFamily(
+                    targetUserId,
+                    now.minusSeconds(3_600),
+                    now.plusSeconds(86_400)
+                )
+            );
+
+        RefreshTokenFamily expired =
+            familyRepository.save(
+                newFamily(
+                    targetUserId,
+                    now.minusSeconds(86_400),
+                    now.minusSeconds(1)
+                )
+            );
+
+        RefreshTokenFamily future =
+            familyRepository.save(
+                newFamily(
+                    targetUserId,
+                    now.plusSeconds(60),
+                    now.plusSeconds(86_400)
+                )
+            );
+
+        RefreshTokenFamily alreadyRevoked =
+            familyRepository.save(
+                newFamily(
+                    targetUserId,
+                    now.minusSeconds(7_200),
+                    now.plusSeconds(86_400)
+                ).revoke(
+                    RefreshTokenFamilyRevocationReason
+                        .ADMINISTRATIVE_REVOCATION,
+                    now.minusSeconds(3_600)
+                )
+            );
+
+        RefreshTokenFamily otherUserActive =
+            familyRepository.save(
+                newFamily(
+                    otherUserId,
+                    now.minusSeconds(3_600),
+                    now.plusSeconds(86_400)
+                )
+            );
+
+        Integer revokedCount =
+            transactionTemplate.execute(
+                status ->
+                    familyRepository
+                        .revokeAllActiveByUserId(
+                            targetUserId,
+                            now,
+                            RefreshTokenFamilyRevocationReason
+                                .ALL_SESSIONS_LOGOUT
+                        )
+            );
+
+        assertThat(revokedCount)
+            .isEqualTo(1);
+
+        RefreshTokenFamily reloadedActive =
+            findFamilyForUpdate(
+                active.id()
+            ).orElseThrow();
+
+        assertThat(reloadedActive.isRevoked())
+            .isTrue();
+
+        assertThat(reloadedActive.revokedAt())
+            .isEqualTo(now);
+
+        assertThat(
+            reloadedActive.revocationReason()
+        )
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .ALL_SESSIONS_LOGOUT
+            );
+
+        assertThat(
+            findFamilyForUpdate(
+                expired.id()
+            ).orElseThrow().isRevoked()
+        )
+            .isFalse();
+
+        assertThat(
+            findFamilyForUpdate(
+                future.id()
+            ).orElseThrow().isRevoked()
+        )
+            .isFalse();
+
+        RefreshTokenFamily reloadedPreviouslyRevoked =
+            findFamilyForUpdate(
+                alreadyRevoked.id()
+            ).orElseThrow();
+
+        assertThat(
+            reloadedPreviouslyRevoked
+                .revocationReason()
+        )
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .ADMINISTRATIVE_REVOCATION
+            );
+
+        assertThat(
+            findFamilyForUpdate(
+                otherUserActive.id()
+            ).orElseThrow().isRevoked()
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldFindRecordByDigestForUpdateInsideTransaction() {
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(
+                86_400
+            );
+
+        RefreshTokenFamily family =
+            familyRepository.save(
+                RefreshTokenFamily.create(
+                    RefreshTokenFamilyId.of(
+                        UUID.randomUUID()
+                    ),
+                    userId,
+                    createdAt,
+                    expiresAt
+                )
+            );
+
+        RefreshTokenDigest digest =
+            digest(5);
+
+        RefreshTokenRecord saved =
+            recordRepository.save(
+                RefreshTokenRecord.issue(
+                    RefreshTokenRecordId.of(
+                        UUID.randomUUID()
+                    ),
+                    family,
+                    digest,
+                    createdAt.plusSeconds(60),
+                    expiresAt
+                )
+            );
+
+        Optional<RefreshTokenRecord> found =
+            findRecordByDigestForUpdate(
+                digest
+            );
+
+        assertThat(found)
+            .isPresent();
+
+        assertThat(found.orElseThrow().id())
+            .isEqualTo(saved.id());
+    }
+
+    @Test
+    void shouldReturnEmptyForUnknownIdentifiers() {
+        Optional<RefreshTokenFamily>
+            missingFamily =
+            findFamilyForUpdate(
+                RefreshTokenFamilyId.of(
+                    UUID.randomUUID()
+                )
+            );
+
+        Optional<RefreshTokenRecord>
+            missingRecord =
+            recordRepository.findById(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                )
+            );
+
+        Optional<RefreshTokenRecord>
+            missingDigest =
+            findRecordByDigestForUpdate(
+                digest(6)
+            );
+
+        assertThat(missingFamily)
+            .isEmpty();
+
+        assertThat(missingRecord)
+            .isEmpty();
+
+        assertThat(missingDigest)
+            .isEmpty();
+    }
+
+    private Optional<RefreshTokenFamily>
+    findFamilyForUpdate(
+        RefreshTokenFamilyId familyId
+    ) {
+        Optional<RefreshTokenFamily> result =
+            transactionTemplate.execute(
+                status ->
+                    familyRepository
+                        .findByIdForUpdate(
+                            familyId
+                        )
+            );
+
+        return result == null
+            ? Optional.empty()
+            : result;
+    }
+
+    private Optional<RefreshTokenRecord>
+    findRecordByDigestForUpdate(
+        RefreshTokenDigest digest
+    ) {
+        Optional<RefreshTokenRecord> result =
+            transactionTemplate.execute(
+                status ->
+                    recordRepository
+                        .findByDigestForUpdate(
+                            digest
+                        )
+            );
+
+        return result == null
+            ? Optional.empty()
+            : result;
+    }
+
+    private static RefreshTokenFamily
+    newFamily(
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt
+    ) {
+        return RefreshTokenFamily.create(
+            RefreshTokenFamilyId.of(
+                UUID.randomUUID()
+            ),
+            userId,
+            createdAt,
+            expiresAt
+        );
+    }
+
+    private UUID insertUser() {
+        UUID userId =
+            UUID.randomUUID();
+
+        Instant now =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Timestamp timestamp =
+            Timestamp.from(now);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, 'USER', 'ACTIVE', ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            "test-password-hash",
+            timestamp,
+            timestamp
+        );
+
+        return userId;
+    }
+
+    private static RefreshTokenDigest
+    digest(
+        int marker
+    ) {
+        return RefreshTokenDigest.of(
+            digestBytes(marker)
+        );
+    }
+
+    private static byte[] digestBytes(
+        int marker
+    ) {
+        byte[] digest =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            digest,
+            (byte) marker
+        );
+
+        return digest;
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenPersistenceLockIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenPersistenceLockIntegrationTest.java
@@ -1,0 +1,462 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class RefreshTokenPersistenceLockIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    @Autowired
+    private RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    @Autowired
+    private PlatformTransactionManager
+        transactionManager;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldBlockConcurrentFamilyLockUntilFirstTransactionCompletes()
+        throws Exception {
+
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        RefreshTokenFamily family =
+            familyRepository.save(
+                RefreshTokenFamily.create(
+                    RefreshTokenFamilyId.of(
+                        UUID.randomUUID()
+                    ),
+                    userId,
+                    createdAt,
+                    createdAt.plusSeconds(
+                        86_400
+                    )
+                )
+            );
+
+        assertSecondTransactionWaits(
+            () ->
+                familyRepository
+                    .findByIdForUpdate(
+                        family.id()
+                    )
+                    .orElseThrow()
+        );
+    }
+
+    @Test
+    void shouldBlockConcurrentDigestLockUntilFirstTransactionCompletes()
+        throws Exception {
+
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(
+                86_400
+            );
+
+        RefreshTokenFamily family =
+            familyRepository.save(
+                RefreshTokenFamily.create(
+                    RefreshTokenFamilyId.of(
+                        UUID.randomUUID()
+                    ),
+                    userId,
+                    createdAt,
+                    expiresAt
+                )
+            );
+
+        RefreshTokenDigest digest =
+            digest(1);
+
+        recordRepository.save(
+            RefreshTokenRecord.issue(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                ),
+                family,
+                digest,
+                createdAt.plusSeconds(60),
+                expiresAt
+            )
+        );
+
+        assertSecondTransactionWaits(
+            () ->
+                recordRepository
+                    .findByDigestForUpdate(
+                        digest
+                    )
+                    .orElseThrow()
+        );
+    }
+
+    private void assertSecondTransactionWaits(
+        Runnable lockOperation
+    ) throws Exception {
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(2);
+
+        CountDownLatch holderHasLock =
+            new CountDownLatch(1);
+
+        CountDownLatch releaseHolder =
+            new CountDownLatch(1);
+
+        String identifier =
+            UUID.randomUUID()
+                .toString()
+                .replace("-", "");
+
+        String holderApplicationName =
+            "refresh-lock-holder-"
+                + identifier;
+
+        String contenderApplicationName =
+            "refresh-lock-contender-"
+                + identifier;
+
+        Future<?> holderFuture =
+            null;
+
+        Future<?> contenderFuture =
+            null;
+
+        try {
+            holderFuture =
+                executor.submit(
+                    () ->
+                        executeInTransaction(
+                            () -> {
+                                setApplicationName(
+                                    holderApplicationName
+                                );
+
+                                lockOperation.run();
+
+                                holderHasLock.countDown();
+
+                                await(
+                                    releaseHolder
+                                );
+                            }
+                        )
+                );
+
+            assertThat(
+                holderHasLock.await(
+                    10,
+                    SECONDS
+                )
+            )
+                .as(
+                    "first transaction should acquire the lock"
+                )
+                .isTrue();
+
+            contenderFuture =
+                executor.submit(
+                    () ->
+                        executeInTransaction(
+                            () -> {
+                                setApplicationName(
+                                    contenderApplicationName
+                                );
+
+                                lockOperation.run();
+                            }
+                        )
+                );
+
+            assertThat(
+                waitUntilLockWaitVisible(
+                    contenderApplicationName,
+                    Duration.ofSeconds(10)
+                )
+            )
+                .as(
+                    "second transaction should wait on a PostgreSQL lock"
+                )
+                .isTrue();
+
+            assertThat(
+                contenderFuture.isDone()
+            )
+                .as(
+                    "second transaction must remain blocked before release"
+                )
+                .isFalse();
+
+            releaseHolder.countDown();
+
+            holderFuture.get(
+                10,
+                SECONDS
+            );
+
+            contenderFuture.get(
+                10,
+                SECONDS
+            );
+
+            assertThat(
+                contenderFuture.isDone()
+            )
+                .isTrue();
+        } finally {
+            releaseHolder.countDown();
+
+            if (holderFuture != null) {
+                holderFuture.cancel(true);
+            }
+
+            if (contenderFuture != null) {
+                contenderFuture.cancel(true);
+            }
+
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    SECONDS
+                )
+            )
+                .as(
+                    "executor should terminate cleanly"
+                )
+                .isTrue();
+        }
+    }
+
+    private void executeInTransaction(
+        Runnable action
+    ) {
+        TransactionTemplate template =
+            new TransactionTemplate(
+                transactionManager
+            );
+
+        template.executeWithoutResult(
+            status -> action.run()
+        );
+    }
+
+    private void setApplicationName(
+        String applicationName
+    ) {
+        jdbcTemplate.queryForObject(
+            """
+            SELECT set_config(
+                'application_name',
+                ?,
+                TRUE
+            )
+            """,
+            String.class,
+            applicationName
+        );
+    }
+
+    private boolean waitUntilLockWaitVisible(
+        String applicationName,
+        Duration timeout
+    ) {
+        Instant deadline =
+            Instant.now().plus(timeout);
+
+        while (
+            Instant.now()
+                .isBefore(deadline)
+        ) {
+            Boolean waiting =
+                jdbcTemplate.queryForObject(
+                    """
+                    SELECT EXISTS (
+                        SELECT 1
+                        FROM pg_stat_activity
+                        WHERE application_name = ?
+                          AND wait_event_type = 'Lock'
+                    )
+                    """,
+                    Boolean.class,
+                    applicationName
+                );
+
+            if (Boolean.TRUE.equals(waiting)) {
+                return true;
+            }
+
+            sleepBriefly();
+        }
+
+        return false;
+    }
+
+    private static void await(
+        CountDownLatch latch
+    ) {
+        try {
+            boolean released =
+                latch.await(
+                    15,
+                    SECONDS
+                );
+
+            if (!released) {
+                throw new IllegalStateException(
+                    "lock holder was not released"
+                );
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread()
+                .interrupt();
+
+            throw new IllegalStateException(
+                "lock wait was interrupted",
+                exception
+            );
+        }
+    }
+
+    private static void sleepBriefly() {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException exception) {
+            Thread.currentThread()
+                .interrupt();
+
+            throw new IllegalStateException(
+                "lock polling was interrupted",
+                exception
+            );
+        }
+    }
+
+    private UUID insertUser() {
+        UUID userId =
+            UUID.randomUUID();
+
+        Instant now =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Timestamp timestamp =
+            Timestamp.from(now);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, 'USER', 'ACTIVE', ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            "test-password-hash",
+            timestamp,
+            timestamp
+        );
+
+        return userId;
+    }
+
+    private static RefreshTokenDigest digest(
+        int marker
+    ) {
+        byte[] value =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            value,
+            (byte) marker
+        );
+
+        return RefreshTokenDigest.of(
+            value
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RefreshSessionMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RefreshSessionMigrationIntegrationTest.java
@@ -1,0 +1,251 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class RefreshSessionMigrationIntegrationTest {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    private static JdbcTemplate jdbcTemplate;
+
+    @BeforeAll
+    static void configureJdbcTemplate() {
+        DriverManagerDataSource dataSource =
+            new DriverManagerDataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            );
+
+        jdbcTemplate =
+            new JdbcTemplate(dataSource);
+    }
+
+    @Test
+    void shouldUpgradeV13ToV14AndPreserveExistingUserData() {
+        migrateToVersion("13");
+
+        assertThat(currentSchemaVersion())
+            .isEqualTo("13");
+
+        assertThat(migrationApplied("14"))
+            .isFalse();
+
+        assertThat(
+            tableExists(
+                "refresh_token_families"
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            tableExists(
+                "refresh_token_records"
+            )
+        )
+            .isFalse();
+
+        UUID existingUserId =
+            UUID.randomUUID();
+
+        insertUser(existingUserId);
+
+        assertThat(userCount(existingUserId))
+            .isEqualTo(1);
+
+        migrateToLatestVersion();
+
+        assertThat(currentSchemaVersion())
+            .isEqualTo("14");
+
+        assertThat(migrationApplied("13"))
+            .isTrue();
+
+        assertThat(migrationApplied("14"))
+            .isTrue();
+
+        assertThat(
+            tableExists(
+                "refresh_token_families"
+            )
+        )
+            .isTrue();
+
+        assertThat(
+            tableExists(
+                "refresh_token_records"
+            )
+        )
+            .isTrue();
+
+        assertThat(userCount(existingUserId))
+            .isEqualTo(1);
+
+        assertThat(failedMigrationCount())
+            .isZero();
+    }
+
+    private static void migrateToVersion(
+        String targetVersion
+    ) {
+        Flyway.configure()
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .target(targetVersion)
+            .load()
+            .migrate();
+    }
+
+    private static void migrateToLatestVersion() {
+        Flyway.configure()
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .load()
+            .migrate();
+    }
+
+    private static String currentSchemaVersion() {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT version
+            FROM flyway_schema_history
+            WHERE success = TRUE
+              AND version IS NOT NULL
+            ORDER BY installed_rank DESC
+            LIMIT 1
+            """,
+            String.class
+        );
+    }
+
+    private static boolean migrationApplied(
+        String version
+    ) {
+        Boolean applied =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM flyway_schema_history
+                    WHERE version = ?
+                      AND success = TRUE
+                )
+                """,
+                Boolean.class,
+                version
+            );
+
+        return Boolean.TRUE.equals(applied);
+    }
+
+    private static boolean tableExists(
+        String tableName
+    ) {
+        Boolean exists =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM information_schema.tables
+                    WHERE table_schema = 'public'
+                      AND table_name = ?
+                )
+                """,
+                Boolean.class,
+                tableName
+            );
+
+        return Boolean.TRUE.equals(exists);
+    }
+
+    private static int failedMigrationCount() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM flyway_schema_history
+                WHERE success = FALSE
+                """,
+                Integer.class
+            );
+
+        return count == null
+            ? 0
+            : count;
+    }
+
+    private static void insertUser(
+        UUID userId
+    ) {
+        Instant now =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Timestamp timestamp =
+            Timestamp.from(now);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, 'USER', 'ACTIVE', ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            "test-password-hash",
+            timestamp,
+            timestamp
+        );
+    }
+
+    private static int userCount(
+        UUID userId
+    ) {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM users
+                WHERE id = ?
+                """,
+                Integer.class,
+                userId
+            );
+
+        return count == null
+            ? 0
+            : count;
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RefreshSessionSchemaIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RefreshSessionSchemaIntegrationTest.java
@@ -1,0 +1,756 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class RefreshSessionSchemaIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldPersistValidRotationLineage() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+        UUID predecessorId = UUID.randomUUID();
+        UUID successorId = UUID.randomUUID();
+
+        Instant familyCreatedAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant familyExpiresAt =
+            Instant.parse(
+                "2026-08-25T18:00:00Z"
+            );
+
+        Instant successorIssuedAt =
+            Instant.parse(
+                "2026-07-26T19:00:00Z"
+            );
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            familyCreatedAt,
+            familyExpiresAt
+        );
+
+        insertToken(
+            successorId,
+            familyId,
+            digest(2),
+            successorIssuedAt,
+            familyExpiresAt,
+            null,
+            null
+        );
+
+        insertToken(
+            predecessorId,
+            familyId,
+            digest(1),
+            familyCreatedAt.plusSeconds(60),
+            familyExpiresAt,
+            successorIssuedAt,
+            successorId
+        );
+
+        Integer familyCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                WHERE id = ?
+                """,
+                Integer.class,
+                familyId
+            );
+
+        Integer tokenCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                WHERE family_id = ?
+                """,
+                Integer.class,
+                familyId
+            );
+
+        UUID persistedSuccessor =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT successor_id
+                FROM refresh_token_records
+                WHERE id = ?
+                """,
+                UUID.class,
+                predecessorId
+            );
+
+        assertThat(familyCount)
+            .isEqualTo(1);
+
+        assertThat(tokenCount)
+            .isEqualTo(2);
+
+        assertThat(persistedSuccessor)
+            .isEqualTo(successorId);
+    }
+
+    @Test
+    void shouldRejectDigestThatIsNotSha256Length() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                familyId,
+                new byte[31],
+                createdAt.plusSeconds(60),
+                expiresAt,
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectDuplicateDigest() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        byte[] digest = digest(3);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        insertToken(
+            UUID.randomUUID(),
+            familyId,
+            digest,
+            createdAt.plusSeconds(60),
+            expiresAt,
+            null,
+            null
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                familyId,
+                digest,
+                createdAt.plusSeconds(120),
+                expiresAt,
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectPartialFamilyRevocationState() {
+        UUID userId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        assertThatThrownBy(
+            () -> jdbcTemplate.update(
+                """
+                INSERT INTO refresh_token_families (
+                    id,
+                    user_id,
+                    created_at,
+                    expires_at,
+                    revoked_at,
+                    revocation_reason
+                )
+                VALUES (?, ?, ?, ?, ?, NULL)
+                """,
+                UUID.randomUUID(),
+                userId,
+                timestamp(createdAt),
+                timestamp(expiresAt),
+                timestamp(
+                    createdAt.plusSeconds(60)
+                )
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+
+        assertThatThrownBy(
+            () -> jdbcTemplate.update(
+                """
+                INSERT INTO refresh_token_families (
+                    id,
+                    user_id,
+                    created_at,
+                    expires_at,
+                    revoked_at,
+                    revocation_reason
+                )
+                VALUES (?, ?, ?, ?, NULL, ?)
+                """,
+                UUID.randomUUID(),
+                userId,
+                timestamp(createdAt),
+                timestamp(expiresAt),
+                "CURRENT_SESSION_LOGOUT"
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectPartialTokenConsumptionState() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+        UUID successorId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        insertToken(
+            successorId,
+            familyId,
+            digest(4),
+            createdAt.plusSeconds(3_600),
+            expiresAt,
+            null,
+            null
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                familyId,
+                digest(5),
+                createdAt.plusSeconds(60),
+                expiresAt,
+                createdAt.plusSeconds(3_600),
+                null
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                familyId,
+                digest(6),
+                createdAt.plusSeconds(120),
+                expiresAt,
+                null,
+                successorId
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectSelfSuccessor() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+        UUID tokenId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                tokenId,
+                familyId,
+                digest(7),
+                createdAt.plusSeconds(60),
+                expiresAt,
+                createdAt.plusSeconds(3_600),
+                tokenId
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectCrossFamilySuccessor() {
+        UUID userId = UUID.randomUUID();
+        UUID firstFamilyId = UUID.randomUUID();
+        UUID secondFamilyId = UUID.randomUUID();
+        UUID successorId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        insertFamily(
+            firstFamilyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        insertFamily(
+            secondFamilyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        insertToken(
+            successorId,
+            secondFamilyId,
+            digest(8),
+            createdAt.plusSeconds(3_600),
+            expiresAt,
+            null,
+            null
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                firstFamilyId,
+                digest(9),
+                createdAt.plusSeconds(60),
+                expiresAt,
+                createdAt.plusSeconds(3_600),
+                successorId
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectSuccessorUsedByMultipleTokens() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+        UUID successorId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        Instant consumedAt =
+            createdAt.plusSeconds(3_600);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        insertToken(
+            successorId,
+            familyId,
+            digest(10),
+            consumedAt,
+            expiresAt,
+            null,
+            null
+        );
+
+        insertToken(
+            UUID.randomUUID(),
+            familyId,
+            digest(11),
+            createdAt.plusSeconds(60),
+            expiresAt,
+            consumedAt,
+            successorId
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                familyId,
+                digest(12),
+                createdAt.plusSeconds(120),
+                expiresAt,
+                consumedAt,
+                successorId
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectTokenExpirationAfterFamilyExpiration() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant familyExpiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            familyExpiresAt
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                familyId,
+                digest(13),
+                createdAt.plusSeconds(60),
+                familyExpiresAt.plusSeconds(1),
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectFamilyExpirationBeforeExistingTokenExpiration() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant familyExpiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            familyExpiresAt
+        );
+
+        insertToken(
+            UUID.randomUUID(),
+            familyId,
+            digest(14),
+            createdAt.plusSeconds(60),
+            familyExpiresAt,
+            null,
+            null
+        );
+
+        assertThatThrownBy(
+            () -> jdbcTemplate.update(
+                """
+                UPDATE refresh_token_families
+                SET expires_at = ?
+                WHERE id = ?
+                """,
+                timestamp(
+                    familyExpiresAt.minusSeconds(1)
+                ),
+                familyId
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldExposeOnlyDigestBasedCredentialColumns() {
+        assertThat(
+            columnsOf("refresh_token_families")
+        )
+            .containsExactly(
+                "id",
+                "user_id",
+                "created_at",
+                "expires_at",
+                "revoked_at",
+                "revocation_reason"
+            );
+
+        assertThat(
+            columnsOf("refresh_token_records")
+        )
+            .containsExactly(
+                "id",
+                "family_id",
+                "token_digest",
+                "issued_at",
+                "expires_at",
+                "consumed_at",
+                "successor_id"
+            );
+    }
+
+    private void insertUser(UUID userId) {
+        Instant now =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, 'USER', 'ACTIVE', ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            "test-password-hash",
+            timestamp(now),
+            timestamp(now)
+        );
+    }
+
+    private void insertFamily(
+        UUID familyId,
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO refresh_token_families (
+                id,
+                user_id,
+                created_at,
+                expires_at,
+                revoked_at,
+                revocation_reason
+            )
+            VALUES (?, ?, ?, ?, NULL, NULL)
+            """,
+            familyId,
+            userId,
+            timestamp(createdAt),
+            timestamp(expiresAt)
+        );
+    }
+
+    private void insertToken(
+        UUID tokenId,
+        UUID familyId,
+        byte[] tokenDigest,
+        Instant issuedAt,
+        Instant expiresAt,
+        Instant consumedAt,
+        UUID successorId
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO refresh_token_records (
+                id,
+                family_id,
+                token_digest,
+                issued_at,
+                expires_at,
+                consumed_at,
+                successor_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            tokenId,
+            familyId,
+            tokenDigest,
+            timestamp(issuedAt),
+            timestamp(expiresAt),
+            timestamp(consumedAt),
+            successorId
+        );
+    }
+
+    private static Timestamp timestamp(
+        Instant value
+    ) {
+        return value == null
+            ? null
+            : Timestamp.from(value);
+    }
+
+    private List<String> columnsOf(
+        String tableName
+    ) {
+        return jdbcTemplate.queryForList(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = ?
+            ORDER BY ordinal_position
+            """,
+            String.class,
+            tableName
+        );
+    }
+
+    private static byte[] digest(int marker) {
+        byte[] digest = new byte[32];
+
+        Arrays.fill(
+            digest,
+            (byte) marker
+        );
+
+        return digest;
+    }
+}


### PR DESCRIPTION
## Summary

- add Flyway V14 schema for refresh-token families and token records
- persist only unique, fixed-length SHA-256 refresh-token digests
- enforce family, token lifetime, revocation and successor-lineage invariants
- implement JPA entities, mappers and repository adapters
- add pessimistic row locking for family and digest lookups
- support bulk revocation of active user refresh-token families
- verify clean migration and V13-to-V14 database upgrades

## Database guarantees

- plaintext refresh tokens are never persisted
- token digests are exactly 32 bytes and globally unique
- consumed tokens and successor identifiers are stored together
- successor lineage cannot cross refresh-token families
- token expiration cannot exceed family expiration
- family expiration cannot be shortened below an existing token expiration

## Verification

- 689 tests
- 0 failures
- 0 errors
- 0 skipped
- 147 Surefire reports
- PostgreSQL row-lock concurrency behavior verified
- full Maven clean verification successful
- UTF-8 without BOM
- LF line endings

Refs #76

Issue #76 will be closed after post-merge verification because this PR targets the develop branch.