### PR TITLE
chore: release v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This keeps domain rules independent from Spring and infrastructure while avoidin
 
 ## Current status
 
-The repository foundation, identity flow, wallet management, transactional transfer processing, Kafka delivery pipeline, and secure dead-letter operations control plane are implemented.
+The repository foundation, identity flow, wallet management, transactional transfer processing, Kafka delivery pipeline, secure dead-letter operations control plane, and durable refresh-session persistence foundation are implemented.
 
 Completed capabilities include:
 
@@ -56,6 +56,12 @@ Completed capabilities include:
 - user registration with normalized email addresses
 - BCrypt password hashing
 - user login with RSA-signed JWT access tokens
+- refresh-session architecture and threat model with explicit rotation and reuse-detection boundaries
+- refresh-token family and record domain/application contracts
+- PostgreSQL refresh-session persistence with SHA-256 digest-only token storage
+- constrained refresh-token lineage, expiration, consumption, and family revocation semantics
+- pessimistic row locking for concurrent refresh-session mutation
+- clean-install and V13-to-V14 refresh-session migration coverage
 - authenticated current-user profile
 - authenticated wallet creation and current-wallet retrieval
 - one-wallet-per-user enforcement at application and database levels
@@ -92,7 +98,7 @@ Completed capabilities include:
 - operator-only, paginated command-audit queries and chronological command timelines
 - Prometheus metrics, Grafana dashboards, and alert rules for Kafka consumer failures
 
-OpenAPI documentation and the executable Postman collection cover the implemented API. PayFlow v0.6.0 extends the operations control plane with secured command-audit investigation workflows and modernizes the GitHub Actions JavaScript runtimes. See the [roadmap](docs/roadmap.md).
+OpenAPI documentation and the executable Postman collection cover the implemented API. PayFlow v0.7.0 establishes the architecture, domain contracts, and PostgreSQL persistence foundation for secure refresh-token rotation. Public refresh-token issuance, rotation, and revocation endpoints are intentionally deferred to a later release. See the [roadmap](docs/roadmap.md).
 
 ## Implemented API
 
@@ -374,11 +380,17 @@ docker compose --profile app up --build
 
 ## Database model
 
-Flyway migrations define users, wallets, payment transactions, immutable ledger entries, transactional outbox records, processed Kafka events, Kafka dead-letter records, and append-only operator command audits.
+Flyway migrations define users, refresh-token families and records, wallets, payment transactions, immutable ledger entries, transactional outbox records, processed Kafka events, Kafka dead-letter records, and append-only operator command audits.
 
 Important database guarantees include:
 
 - unique normalized user email addresses
+- fixed-length and globally unique refresh-token digests
+- plaintext refresh tokens excluded from the persistence schema
+- same-family refresh-token successor lineage
+- paired token-consumption and successor metadata
+- paired family-revocation timestamp and reason metadata
+- token expiration bounded by family expiration
 - one wallet per user
 - non-negative wallet balances
 - optimistic-lock wallet versions
@@ -408,7 +420,7 @@ Transfers and ledger writes require strong relational constraints, transactional
 
 ### Why Redis?
 
-Redis will support bounded, explicitly expiring concerns such as login rate limiting, short-lived wallet summaries, refresh-token metadata, and selected idempotency lookups. PostgreSQL remains the source of truth.
+Redis will support bounded, explicitly expiring concerns such as login rate limiting, short-lived wallet summaries, and selected idempotency lookups. PostgreSQL remains the source of truth for durable financial and refresh-session lifecycle state.
 
 ### Why Kafka?
 

--- a/docs/adr/0009-refresh-session-architecture.md
+++ b/docs/adr/0009-refresh-session-architecture.md
@@ -1,0 +1,791 @@
+# ADR 0009: Use opaque rotating refresh sessions
+
+- Status: Accepted
+- Date: 2026-07-26
+
+## Context
+
+PayFlow currently authenticates users through:
+
+```text
+POST /api/v1/auth/login
+```
+
+A successful login returns one RSA-signed JWT access token. The token:
+
+- uses the configured PayFlow issuer
+- uses the authenticated user UUID as the `sub` claim
+- carries the user's email address and domain role
+- expires after the configured short lifetime
+- is validated by Spring Security resource-server support
+- is not persisted or placed on a server-side denylist
+
+The HTTP security boundary is stateless and deny-by-default. Registration and
+login are public, while customer and operations endpoints require a verified
+access token.
+
+This design avoids durable session state, but it requires users to submit their
+credentials again after access-token expiration. Increasing the access-token
+lifetime would reduce login frequency while increasing the useful lifetime of a
+stolen bearer credential.
+
+PayFlow v0.7.0 requires revocable sessions without turning access tokens into
+long-lived credentials. The design must provide:
+
+- short-lived JWT access tokens
+- opaque refresh tokens
+- single-use refresh-token rotation
+- token-family reuse detection
+- current-session logout
+- all-session logout
+- deterministic concurrent-refresh behavior
+- durable PostgreSQL correctness
+- safe errors, logs, metrics, and diagnostic events
+
+Refresh tokens are credentials. Plaintext refresh tokens must not be persisted,
+logged, measured, traced, audited, or exposed through administrative APIs.
+
+## Decision
+
+PayFlow will introduce server-side refresh sessions based on opaque,
+single-use refresh tokens and durable PostgreSQL state.
+
+The design uses two related concepts:
+
+- a refresh-token family representing one authenticated client session
+- refresh-token records representing every token issued in that family
+
+One successful login creates one family and one initial token record.
+
+Each successful refresh consumes one active token and creates exactly one
+successor token in the same family.
+
+PostgreSQL is the authoritative source of refresh-session lifecycle state.
+
+Redis is not part of refresh-token correctness, rotation, reuse detection, or
+revocation.
+
+## Credential responsibilities
+
+### Access tokens
+
+Access tokens remain RSA-signed JWT bearer tokens.
+
+They are used only to authorize protected API requests.
+
+Access tokens:
+
+- remain short-lived
+- are not persisted in PostgreSQL
+- are not placed on a server-side denylist
+- are verified through signature, issuer, and expiration validation
+- derive authenticated identity from the verified `sub` claim
+- carry the PayFlow role required for authority mapping
+
+Revoking a refresh-token family does not immediately invalidate access tokens
+that were already issued. Those access tokens may remain usable until their
+normal expiration.
+
+This residual validity window is accepted for v0.7.0.
+
+Access-token denylisting and online token introspection are outside this
+decision.
+
+### Refresh tokens
+
+Refresh tokens are opaque random credentials.
+
+A refresh token:
+
+- is not a JWT
+- contains no user, role, family, or expiration claims
+- is not accepted as a Bearer credential for business endpoints
+- is returned only by successful login and refresh operations
+- is submitted only to refresh-session endpoints
+- is single-use for rotation
+- is never persisted in plaintext
+- is never logged, measured, traced, or exposed operationally
+
+The initial API transport uses JSON request and response bodies.
+
+Browser-cookie transport is not defined by this ADR. Cookie transport would
+require a separate decision covering CSRF, SameSite, Secure, domain, and path
+rules.
+
+## Token generation and hashing
+
+Each refresh token contains at least 256 bits of entropy produced by a
+cryptographically secure random generator.
+
+Its external representation uses canonical Base64 URL encoding without
+padding.
+
+When PayFlow receives a refresh token, it:
+
+1. validates the encoded shape
+2. decodes it using strict Base64 URL rules
+3. verifies the expected decoded byte length
+4. calculates SHA-256 over the decoded random bytes
+5. uses only the digest for persistence lookup
+
+PostgreSQL stores the fixed-length binary digest, not the encoded token.
+
+A deterministic SHA-256 digest is appropriate because refresh tokens have
+machine-generated 256-bit entropy. Password hashing algorithms such as BCrypt
+and Argon2 are not used for token lookup because their salted outputs prevent
+indexed equality lookup.
+
+Refresh-token digests remain sensitive internal credential verifiers. They must
+not appear in logs, responses, metrics, traces, audit records, or operational
+APIs.
+
+## Refresh-session data model
+
+### Token family
+
+A refresh-token family represents one authenticated client session.
+
+The durable family record contains at least:
+
+- family UUID
+- user UUID
+- creation timestamp
+- absolute expiration timestamp
+- optional revocation timestamp
+- optional fixed revocation reason
+
+Initial revocation reasons are:
+
+- `CURRENT_SESSION_LOGOUT`
+- `ALL_SESSIONS_LOGOUT`
+- `REUSE_DETECTED`
+- `USER_ACCOUNT_UNAVAILABLE`
+- `ADMINISTRATIVE_REVOCATION`
+
+Administrative revocation is reserved for future trusted internal use. This ADR
+does not introduce a public administrative session endpoint.
+
+A family is active only when:
+
+- it has not been revoked
+- its absolute expiration is later than the shared clock time
+- the owning user remains eligible to authenticate
+
+Expiration is time-derived and does not require a scheduled database update.
+
+### Token record
+
+Each issued refresh token has one durable token record.
+
+The record contains at least:
+
+- token-record UUID
+- family UUID
+- unique SHA-256 digest
+- issuance timestamp
+- expiration timestamp
+- optional consumption timestamp
+- optional successor token-record UUID
+
+A token record is active only when:
+
+- its family is active
+- its expiration is later than the shared clock time
+- it has not been consumed
+- it does not identify a successor
+
+A successfully rotated token records both:
+
+- the time at which it was consumed
+- the exact successor token-record identifier
+
+Token state is derived from timestamps, successor linkage, and family state. A
+mutable free-form status column is not required.
+
+PostgreSQL constraints must prevent:
+
+- duplicate token digests
+- a token replacing itself
+- a consumed token without a successor
+- a successor without a consumption timestamp
+- more than one successor for one predecessor
+- cross-family predecessor and successor linkage
+- token expiration after family expiration
+- token issuance before family creation
+- unsupported revocation reasons
+
+The persistence issue may introduce triggers or additional constraints when a
+plain check constraint or foreign key cannot express an invariant.
+
+## Expiration policy
+
+Refresh-session durations are configuration values.
+
+The implementation defines:
+
+- an individual refresh-token lifetime
+- an absolute token-family lifetime
+
+A successor expires at the earlier of:
+
+- its issuance time plus the configured token lifetime
+- the family's absolute expiration time
+
+Rotation never extends a session beyond the absolute family lifetime.
+
+All expiration decisions use the shared UTC `Clock`.
+
+Application and persistence tests use fixed or controlled clocks. Refresh
+session code does not call `Instant.now()` directly.
+
+## Application boundaries
+
+Refresh-session orchestration remains inside the user module.
+
+The application layer defines focused ports instead of depending directly on:
+
+- Spring Security
+- HTTP types
+- JDBC or JPA
+- secure-random APIs
+- cryptographic hashing APIs
+- persistence framework entities
+
+Planned responsibilities include ports for:
+
+- access-token generation
+- secure refresh-token generation
+- refresh-token digest calculation
+- refresh-session persistence
+- atomic token consumption or row locking
+- shared clock access
+
+The existing `TokenGenerationPort` represents access-token generation.
+Implementation may rename it to `AccessTokenGenerationPort` before introducing
+refresh-token generation so the two credential types cannot be confused.
+
+Plaintext refresh-token material may exist transiently in application memory
+only long enough to:
+
+- calculate its digest
+- persist the digest and lifecycle metadata
+- return the plaintext token to the successful caller
+
+Persistence adapters receive only digests and safe lifecycle metadata.
+
+## Login behavior
+
+The existing credential validation order remains:
+
+1. normalize and resolve the email address
+2. reject an unknown account with the existing invalid-credentials outcome
+3. verify the password
+4. reject an incorrect password with the same invalid-credentials outcome
+5. verify that the account is active
+
+After successful validation, login:
+
+1. creates a new refresh-token family
+2. generates an initial opaque refresh token
+3. persists its digest and initial token record
+4. generates a short-lived access token
+5. returns the access and refresh credential pair
+
+The response eventually contains at least:
+
+- access token
+- access-token type
+- access-token expiration
+- refresh token
+- refresh-token expiration
+
+Family and initial-token persistence occur in one database transaction.
+
+If access-token generation or refresh-session persistence fails, login does not
+return a partial credential pair.
+
+The current login use case is read-only. Its implementation will move to the
+smallest required write transaction when refresh-session persistence is added.
+
+## Refresh behavior
+
+PayFlow will introduce:
+
+```text
+POST /api/v1/auth/refresh
+```
+
+The route is public at the Spring Security layer because the refresh credential
+authorizes the operation.
+
+The refresh application flow:
+
+1. validates the request shape
+2. strictly decodes and hashes the presented token
+3. starts one database transaction
+4. locates and locks the matching token record and family
+5. evaluates token, family, user, and expiration state
+6. consumes the active predecessor token
+7. creates exactly one successor token record
+8. generates a new short-lived access token
+9. commits the complete rotation
+10. returns the new credential pair
+
+Predecessor consumption and successor creation are atomic.
+
+If access-token generation fails before commit, the transaction rolls back. The
+predecessor remains active and no successor remains persisted.
+
+## Concurrent refresh requests
+
+Rotation uses strict single-use semantics.
+
+The persistence implementation serializes competing requests for the same token
+through a PostgreSQL row lock or an equivalent atomic conditional update.
+
+For two concurrent requests presenting the same active refresh token:
+
+1. one request consumes the token and creates the successor
+2. the other request observes that the predecessor is already consumed
+3. the second observation is classified as token reuse
+4. the complete family is revoked
+
+The successor returned by the first request may therefore become unusable after
+the second request confirms reuse.
+
+This fail-closed result is intentional.
+
+PayFlow does not introduce a concurrent-refresh grace period in v0.7.0.
+Clients must serialize refresh operations.
+
+## Reuse detection
+
+Presenting a previously consumed token is evidence that more than one party may
+possess credentials belonging to the family.
+
+When reuse is confirmed, PayFlow atomically:
+
+- revokes the complete family
+- records `REUSE_DETECTED` as the internal revocation reason
+- denies issuance of another credential pair
+- increments a safe aggregate security metric
+- emits a safe structured security event
+
+The external response does not reveal whether the presented token was:
+
+- unknown
+- expired
+- revoked
+- already consumed
+- associated with a family revoked for reuse
+
+These cases share one safe refresh rejection contract.
+
+Raw tokens, token digests, access tokens, passwords, email addresses, and
+exception details are excluded from metrics and security events.
+
+## Current-session logout
+
+PayFlow will introduce:
+
+```text
+POST /api/v1/auth/logout
+```
+
+Current-session logout is authorized by possession of a refresh token.
+
+For a syntactically valid request, the use case:
+
+1. hashes the presented token
+2. locates its family when one exists
+3. revokes the complete family with `CURRENT_SESSION_LOGOUT`
+4. returns HTTP 204
+
+Logout is idempotent.
+
+A syntactically valid token that is unknown, expired, consumed, or already
+revoked also returns HTTP 204. The response does not act as a token-existence
+oracle.
+
+Normal JSON and field validation failures continue to use the HTTP 400
+validation contract.
+
+Historical token digests remain available for reuse detection and may identify
+the family when an older rotated token is presented to logout.
+
+## All-session logout
+
+PayFlow will introduce:
+
+```text
+POST /api/v1/auth/logout-all
+```
+
+This endpoint requires a valid access token.
+
+The authenticated user UUID comes from the verified JWT `sub` claim. The
+request does not accept a user ID, email address, or family ID.
+
+The application operation revokes every active family owned by the user with
+`ALL_SESSIONS_LOGOUT`.
+
+The endpoint returns HTTP 204 and is idempotent when no active family exists.
+
+Already issued access tokens remain valid until normal expiration.
+
+## User-account state
+
+Possession of a refresh token does not bypass user-account status.
+
+Before issuing a rotated credential pair, PayFlow verifies that the owning user
+remains active.
+
+When the account is unavailable:
+
+- no successor is created
+- the family is revoked with `USER_ACCOUNT_UNAVAILABLE`
+- the safe account-unavailable contract may be returned
+- no internal account, family, or token state is exposed
+
+Login retains its existing invalid-credentials and account-unavailable
+behavior.
+
+## Public error contracts
+
+Refresh-session APIs use the existing `ApiError` response structure.
+
+Planned stable outcomes are:
+
+| Situation | HTTP status | Safe code |
+|---|---:|---|
+| Invalid request body | 400 | `VALIDATION_FAILED` |
+| Unknown, expired, revoked, or reused refresh token | 401 | `REFRESH_TOKEN_INVALID` |
+| User account unavailable | 403 | `USER_ACCOUNT_UNAVAILABLE` |
+| Unexpected refresh-session infrastructure failure | 503 | `REFRESH_SESSION_UNAVAILABLE` |
+
+Reuse is classified internally but is not exposed through a distinct public
+error code.
+
+Current-session and all-session logout return HTTP 204 for successful and
+already-completed revocation outcomes.
+
+Responses never include SQL text, database details, token state, token digests,
+exception messages, or stack traces.
+
+## Transaction boundaries
+
+The following operations use independent and explicit PostgreSQL transactions:
+
+- login family and initial-token creation
+- refresh predecessor consumption and successor creation
+- reuse detection and family revocation
+- current-session family revocation
+- all-session revocation for one authenticated user
+
+No refresh-session transaction includes:
+
+- Redis
+- Kafka
+- email delivery
+- another remote system
+
+PostgreSQL commit success is required before login or refresh returns newly
+generated refresh credentials.
+
+## Trust boundaries
+
+### Client boundary
+
+The client receives and submits plaintext refresh tokens.
+
+PayFlow cannot guarantee how client software stores credentials. Storage
+guidance will be documented in OpenAPI, Postman, and release documentation.
+
+### HTTP boundary
+
+HTTP adapters:
+
+- validate request shapes
+- do not log credential-bearing request bodies
+- derive trusted user identity from verified JWTs where required
+- construct application commands
+- map application outcomes to fixed public contracts
+
+Controllers do not implement hashing, row locking, rotation, or revocation
+rules.
+
+### Application boundary
+
+Application services own refresh-session orchestration and lifecycle decisions.
+
+They depend on application ports and domain models rather than infrastructure
+types.
+
+### PostgreSQL boundary
+
+PostgreSQL stores only:
+
+- token digests
+- family and token-record identifiers
+- user identifiers
+- lifecycle timestamps
+- successor linkage
+- fixed revocation reasons
+
+It is the durable source of truth for rotation and revocation.
+
+### Redis boundary
+
+Redis is reserved for bounded login-attempt protection in a later v0.7.0
+increment.
+
+Redis loss, restart, eviction, or unavailability must not:
+
+- reactivate a consumed token
+- lose a family revocation
+- permit a second successor
+- disable reuse detection
+- change durable refresh-session correctness
+
+## Logging, metrics, and tracing
+
+The following are forbidden in logs, metrics, traces, audit rows, and
+administrative responses:
+
+- plaintext refresh tokens
+- refresh-token digests
+- access tokens
+- authorization headers
+- passwords
+- credential-bearing request bodies
+
+Safe structured diagnostics may contain:
+
+- fixed event type
+- fixed outcome or rejection category
+- family UUID
+- token-record UUID
+- user UUID when required for trusted diagnostics
+- request correlation identifier
+
+Email addresses are not included.
+
+Metrics use low-cardinality labels only. Permitted labels include fixed values
+such as:
+
+- operation
+- outcome
+- rejection category
+
+User, family, token-record, digest, email, and correlation identifiers must not
+be metric labels.
+
+## Threat model
+
+### Assets
+
+Protected assets include:
+
+- passwords
+- plaintext refresh tokens
+- access tokens
+- refresh-token digests
+- refresh-session lifecycle state
+- user and family identifiers
+- the ability to issue new access tokens
+- the ability to revoke active sessions
+
+### Trust boundaries
+
+Relevant trust boundaries are:
+
+- client to HTTP API
+- HTTP adapter to application core
+- application core to PostgreSQL
+- JWT verification to protected endpoints
+- application process to logs, metrics, and traces
+
+### Threats and mitigations
+
+| Threat | Mitigation | Residual risk |
+|---|---|---|
+| Database disclosure | Store only digests of 256-bit random tokens | Family and user metadata remain visible |
+| Refresh-token theft | Short token lifetime, absolute family lifetime, single-use rotation | A stolen active token may be used first |
+| Replay after rotation | Persist consumption and revoke the family on reuse | Legitimate concurrent refresh may revoke the family |
+| Concurrent refresh | PostgreSQL serialization and one-successor constraints | A returned successor may later be revoked |
+| Token guessing | At least 256 bits of secure randomness and strict decoding | Denial-of-service attempts remain possible |
+| Telemetry leakage | Explicit field denylist and safe allowlists | External infrastructure must also protect bodies |
+| Credential role confusion | Separate types, ports, routes, and tests | Implementation defects remain possible |
+| Incomplete revocation | Durable family-level revocation | Existing access JWTs remain valid until expiry |
+| Account enumeration | Generic login and refresh rejection contracts | Account-unavailable login remains distinct |
+| Clock inconsistency | Shared injected UTC clock | Host clock accuracy remains operationally important |
+| Redis loss | Exclude Redis from session correctness | Login protection may degrade separately |
+| Exception disclosure | Fixed safe errors without exception text | Internal diagnostic access still requires protection |
+
+## Security invariants
+
+The implementation preserves all of the following:
+
+1. No plaintext refresh token is persisted.
+2. No token digest is returned through an API.
+3. One token record belongs to exactly one family.
+4. One active token creates at most one successor.
+5. A consumed token never becomes active again.
+6. A revoked family never issues another successor.
+7. Every successor expires no later than its family.
+8. Reuse of a consumed token revokes the complete family.
+9. Logout is idempotent.
+10. All-session logout derives identity from a verified JWT subject.
+11. Redis is not required to evaluate durable token validity.
+12. Public responses do not reveal internal token state.
+13. Metrics contain no user or credential identifiers.
+14. Lifecycle rules remain independent from HTTP and persistence frameworks.
+
+## Consequences
+
+### Positive
+
+- access tokens can remain short-lived
+- refresh credentials can be revoked durably
+- database disclosure does not reveal plaintext refresh tokens
+- single-use rotation limits repeated use of a stolen token
+- reuse detection provides a family-wide response boundary
+- current-session and all-session logout become possible
+- PostgreSQL constraints reinforce application invariants
+- concurrency behavior is explicit and testable
+- Redis failure cannot corrupt session correctness
+- application boundaries remain aligned with the modular monolith
+
+### Negative
+
+- login changes from a read-only operation to a write transaction
+- every login creates durable session state
+- successful refresh operations create additional writes
+- historical token records require a future retention strategy
+- strict concurrent-refresh handling can revoke a legitimate session
+- logout does not immediately invalidate access JWTs
+- credential-bearing request and response DTOs require special care
+- schema constraints and concurrency tests increase complexity
+- PostgreSQL availability becomes required for login and refresh issuance
+
+## Alternatives considered
+
+### Use long-lived access tokens
+
+Rejected because stolen bearer tokens would remain useful longer and could not
+be revoked through the planned session model.
+
+### Use JWT refresh tokens
+
+Rejected because self-contained refresh credentials make single-use rotation,
+durable family revocation, and reuse detection harder to enforce.
+
+### Store plaintext refresh tokens
+
+Rejected because database disclosure would reveal immediately usable
+credentials.
+
+### Store refresh tokens with BCrypt or Argon2
+
+Rejected because salted password hashes are not suitable for unique indexed
+token lookup.
+
+Machine-generated 256-bit tokens already resist offline guessing when stored as
+deterministic SHA-256 digests.
+
+### Use Redis as the refresh-session source of truth
+
+Rejected because eviction, restart, memory pressure, and degraded availability
+must not lose rotation or revocation facts.
+
+### Add an access-token denylist
+
+Rejected for v0.7.0 because it would add online state to every protected API
+request and significantly change the stateless resource-server design.
+
+### Allow a concurrent-refresh grace window
+
+Rejected because reusing a successor would require retaining plaintext
+successor material, while creating another successor would weaken single-use
+rotation.
+
+### Rotate without token families
+
+Rejected because descendants of a compromised token could not be revoked as one
+security boundary.
+
+### Delete consumed token records immediately
+
+Rejected because consumed records are required to detect replay of older
+tokens.
+
+### Return different errors for expired, revoked, and reused tokens
+
+Rejected because detailed errors would expose internal token state.
+
+### Accept user or family identifiers in logout-all requests
+
+Rejected because authorization identity must come from the verified JWT
+subject, not request-controlled input.
+
+## Verification
+
+Implementation is verified through:
+
+- refresh-session domain invariant tests
+- secure-token generation and digest tests
+- tests proving at least 256 bits of token entropy
+- token-shape and strict-decoding tests
+- login orchestration tests
+- refresh rotation tests
+- PostgreSQL mapping and constraint tests
+- row-lock or atomic-consumption integration tests
+- controlled concurrent-refresh tests
+- reuse-detection and family-revocation tests
+- current-session logout tests
+- all-session logout tests
+- account-unavailable refresh tests
+- MockMvc validation and safe-error tests
+- tests proving tokens and digests are absent from logs and responses
+- tests proving metric labels remain low-cardinality and safe
+- OpenAPI JSON contract tests
+- Postman authentication-workflow checks
+- complete Maven clean verification
+
+The persistence work uses a new additive Flyway migration after `V13`.
+Released migrations are not edited.
+
+## Ordered implementation follow-ups
+
+This decision is implemented through separate reviewable issues:
+
+1. define refresh-session domain and application contracts
+2. add PostgreSQL family and token-record persistence
+3. add secure token-generation and digest adapters
+4. extend login to issue access and refresh credentials
+5. add atomic refresh rotation
+6. add reuse detection and current-session logout
+7. add all-session logout
+8. add safe metrics and diagnostics
+9. update OpenAPI, Postman, architecture, and release documentation
+10. complete end-to-end, concurrency, migration, and regression verification
+
+## Out of scope
+
+This ADR does not introduce:
+
+- external OAuth or OpenID Connect providers
+- social login
+- multi-factor authentication
+- password reset
+- email verification
+- browser-cookie transport
+- device fingerprinting
+- user-visible session listing
+- trusted-device management
+- access-token introspection
+- access-token denylisting
+- production KMS or HSM integration
+- refresh-session retention jobs
+- administrative session-management APIs
+- Redis-backed login-rate-limiting implementation

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,233 @@
+# PayFlow v0.7.0
+
+Release date: 2026-07-27
+
+## Overview
+
+PayFlow v0.7.0 establishes the durable security and persistence foundation
+required for future refresh-token issuance, rotation, reuse detection, and
+family revocation workflows.
+
+The release defines the refresh-session architecture and threat model,
+introduces explicit domain and application contracts, and adds PostgreSQL
+persistence for refresh-token families and individual token records.
+
+Refresh-token HTTP endpoints and runtime rotation orchestration are not
+included in this release. The public API remains unchanged.
+
+## Highlights
+
+### Refresh-session architecture and threat model
+
+The identity-security roadmap now defines refresh sessions as explicit token
+families rather than isolated bearer credentials.
+
+The architecture establishes boundaries for:
+
+- single-use refresh-token semantics
+- token rotation lineage
+- family-level revocation
+- replay and reuse detection
+- user-wide session revocation
+- transaction ownership
+- concurrent refresh-session mutation
+- plaintext-token exclusion from durable storage
+
+The design keeps security-sensitive lifecycle rules in the domain and
+application layers while persistence remains an outbound adapter.
+
+### Domain and application contracts
+
+The release introduces explicit domain types for:
+
+- refresh-token family identifiers
+- refresh-token record identifiers
+- fixed-length token digests
+- family revocation reasons
+- token consumption and successor lineage
+- family and token expiration
+- refresh-session lifecycle state
+
+Repository ports define the persistence operations required by future
+application use cases.
+
+The contracts do not depend on JPA, Spring Data, HTTP, or a particular token
+encoding.
+
+### PostgreSQL refresh-session persistence
+
+Flyway migration V14 adds:
+
+- `refresh_token_families`
+- `refresh_token_records`
+
+The persistence model stores only fixed-length token digests. It contains no
+column for a plaintext refresh token.
+
+Token digests are constrained to exactly 32 bytes and are globally unique.
+
+### Database lifecycle guarantees
+
+PostgreSQL enforces the core refresh-session invariants.
+
+Family revocation timestamps and reasons must either both be present or both
+be absent.
+
+Token consumption timestamps and successor identifiers must also appear as a
+pair.
+
+Successor lineage is constrained so that:
+
+- a successor belongs to the same refresh-token family
+- one token can have at most one successor
+- one successor cannot be assigned to multiple predecessors
+- lineage can be persisted safely within a transaction
+
+Token expiration cannot exceed family expiration.
+
+A database trigger also prevents family expiration from being shortened below
+the expiration of an existing token record.
+
+### Persistence adapters
+
+The release adds JPA persistence adapters for refresh-token families and token
+records.
+
+The adapters provide:
+
+- family persistence and retrieval
+- token-record persistence and retrieval
+- lookup by token digest
+- bulk revocation of active families for one user
+- pessimistic row locking for security-sensitive mutation
+- domain-to-persistence mapping
+- defensive copying of digest byte arrays
+
+Transaction boundaries remain owned by the application layer so pessimistic
+locks remain active for the complete use-case transaction.
+
+### Concurrency control
+
+Family lookup by identifier and token lookup by digest use
+`PESSIMISTIC_WRITE` locking.
+
+Integration tests verify real PostgreSQL lock waiting with controlled
+concurrent transactions.
+
+The tests ensure that a competing transaction cannot mutate the same
+refresh-session state before the lock owner completes.
+
+### Migration verification
+
+The V14 migration is verified in both supported paths:
+
+- a clean database installation from V1 through V14
+- an upgrade from V13 to V14
+
+Upgrade verification confirms that existing user data remains intact while
+the new refresh-session schema is introduced.
+
+### Security and privacy
+
+The persistence boundary is intentionally digest-only.
+
+The release verifies that:
+
+- plaintext refresh tokens are not represented in the schema
+- digest values have a fixed 32-byte length
+- digest values are defensively copied at domain boundaries
+- digest lookup uses bound persistence parameters
+- lifecycle mutations execute under explicit transaction ownership
+- concurrent mutation paths acquire PostgreSQL row locks
+
+Applications built on these contracts must still keep plaintext refresh
+tokens out of logs, metrics, traces, exception messages, and durable queues.
+
+## Public API
+
+PayFlow v0.7.0 does not add or change a public HTTP endpoint.
+
+Registration, login, user, wallet, transfer, transaction-history, and Kafka
+operations APIs remain compatible with v0.6.0.
+
+The current login endpoint continues to issue only the existing RSA-signed
+JWT access token.
+
+## Database changes
+
+### V14 - refresh-token sessions
+
+Migration V14 creates the refresh-token family and token-record persistence
+model with:
+
+- UUID primary keys
+- user-to-family ownership
+- digest-only token lookup
+- explicit expiration timestamps
+- family revocation metadata
+- token consumption metadata
+- successor lineage
+- lifecycle constraints
+- query and locking indexes
+- cross-row expiration protection
+
+Flyway applies the migration automatically during application startup.
+
+## Included work
+
+- Identity-security roadmap - PR #71
+- Refresh-session architecture and threat model - PR #73
+- Refresh-session domain and application contracts - PR #75
+- PostgreSQL refresh-session persistence - PR #77
+
+## Verification
+
+The release candidate was verified with:
+
+- `.\mvnw.cmd clean verify`
+- 689 automated tests
+- zero test failures
+- zero test errors
+- zero skipped tests
+- 147 Surefire XML reports
+- PostgreSQL Testcontainers integration tests
+- clean V1-to-V14 migration verification
+- V13-to-V14 upgrade verification
+- schema-constraint verification
+- persistence-mapping verification
+- defensive-copy verification
+- real PostgreSQL pessimistic-lock verification
+- pull-request CI verification
+- whitespace and conflict-marker checks
+- committed-secret and token-material scans
+
+## Compatibility
+
+The v0.7.0 database change is additive.
+
+No existing public endpoint is removed, renamed, or behaviorally replaced.
+
+Existing PostgreSQL installations upgrade from V13 to V14 through Flyway.
+
+No Redis data migration is required.
+
+This release establishes the persistence foundation but does not yet issue,
+rotate, revoke, or exchange refresh tokens through the public API.
+
+## Upgrade notes
+
+1. Back up PostgreSQL according to the deployment environment's normal
+   operational procedure.
+2. Deploy the application with Flyway enabled so migration V14 is applied.
+3. Verify that the application database user can create the V14 tables,
+   indexes, constraints, foreign keys, and trigger.
+4. Keep plaintext refresh tokens out of logs, traces, metrics, queues, and
+   source-controlled configuration.
+5. Do not enable client-side refresh-token workflows until a later release
+   exposes and documents the complete issuance and rotation boundary.
+6. No existing API client or Postman workflow change is required for v0.7.0.
+
+## Disclaimer
+
+PayFlow is an educational portfolio project. It is not certified for banking,
+payment processing, custody, or production financial use.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,82 +2,199 @@
 
 ## Current delivery focus
 
-The repository foundation, identity flow, wallet management, wallet-to-wallet transfer processing, double-entry ledger persistence, authenticated transaction history, OpenAPI documentation, executable Postman collection, and the `v0.2.0` release are complete.
+PayFlow v0.6.0 is published and the active development line uses
+`0.7.0-SNAPSHOT`.
 
-The current delivery increment focuses on transactional outbox persistence and Kafka-based post-transfer processing.
+The v0.7.0 increment focuses on identity and session security. The goal is to
+extend the existing RSA-signed access-token authentication with revocable,
+rotating refresh-token sessions and bounded Redis-backed login protection.
 
-## Milestone 0 — Repository foundation
+The project remains a modular monolith. PostgreSQL remains the system of record,
+Redis is used only for explicitly bounded and expiring concerns, and public API
+changes must preserve stable security and error contracts.
+
+## Delivered baseline through v0.6.0
+
+### Repository and architecture
 
 - [x] Java 21 and Spring Boot 3.5 baseline
 - [x] Modular-monolith package convention
+- [x] Inward-facing domain, application, and adapter dependencies
 - [x] PostgreSQL, Redis, and Kafka local infrastructure
-- [x] Flyway baseline migration
+- [x] Flyway-managed database schema
 - [x] CI, Dependabot, pull request, and issue templates
-- [x] Wallet domain aggregate and unit tests
+- [x] Conventional Commits and protected pull-request workflow
+- [x] Tagged GitHub releases with executable JAR and SHA-256 assets
 
-## Milestone 1 — Identity and authentication
+### Identity and authorization
 
-- [x] User registration
-- [x] Password hashing with BCrypt
+- [x] User registration with normalized email addresses
+- [x] BCrypt password hashing
 - [x] User login
-- [x] RSA-signed JWT access token
+- [x] RSA-signed JWT access tokens
 - [x] Authenticated current-user profile
-- [x] Authentication integration tests
-- [ ] Rotating refresh token and revocation
-- [ ] ADMIN authorization
-- [ ] Login rate limiting with Redis
+- [x] Stable authentication and authorization error handling
+- [x] ADMIN-derived `PAYFLOW_OPERATIONS` authorization boundary
+- [x] Authentication and operations-security integration tests
 
-## Milestone 2 — Wallet management
+### Wallets, transfers, and ledger
 
-- [x] Open wallet for authenticated user
-- [x] Enforce one wallet per user
-- [x] Return a stable `409 Conflict` response for duplicate wallet creation
-- [x] PostgreSQL persistence and integration tests with Testcontainers
-- [x] Retrieve the authenticated user's wallet summary
-- [x] Return a stable `WALLET_NOT_FOUND` response
-- [x] Simulated top-up
-- [x] Verify optimistic locking behavior with PostgreSQL concurrency tests
-
-## Milestone 3 — Transfers and ledger
-
-- [x] Transfer domain model and lifecycle
-- [x] Payment-transaction persistence
-- [x] `PENDING` to `COMPLETED` state transition
-- [x] Authenticated transfer use case
-- [x] Source wallet derived from JWT identity
-- [x] `Idempotency-Key` HTTP contract
-- [x] Source-wallet-scoped database uniqueness
-- [x] Completed-request replay
-- [x] Conflicting-payload detection
-- [x] In-progress request conflict behavior
-- [x] Atomic source-wallet debit and target-wallet credit
-- [x] Double-entry ledger domain model
-- [x] Immutable `DEBIT` and `CREDIT` persistence
-- [x] Database constraints for transfer and ledger invariants
-- [x] Rollback verification when ledger persistence fails
+- [x] One wallet per authenticated user
+- [x] Current-wallet retrieval
+- [x] Simulated wallet top-up
+- [x] Optimistic locking and PostgreSQL concurrency verification
+- [x] Authenticated wallet-to-wallet transfers
+- [x] Source identity derived from the JWT subject
+- [x] Source-wallet-scoped idempotency
+- [x] Atomic source debit and target credit
+- [x] Immutable double-entry ledger persistence
+- [x] Transaction rollback verification
 - [x] Concurrent duplicate-transfer verification
-- [x] Authenticated endpoint-to-database integration test
-- [x] Transaction history
-- [x] Filtering by direction, status, and date range
-- [x] Pagination and deterministic sorting
+- [x] Paginated and filterable transaction history
+- [x] Deterministic transaction ordering
+- [x] Endpoint-to-database integration tests
 
-## Milestone 4 — Event-driven processing
+### Event-driven delivery and operations
 
-- [ ] Transactional outbox
-- [ ] Versioned `wallet.transfer.completed` event
-- [ ] Kafka publisher
-- [ ] Notification and audit consumers
-- [ ] Consumer idempotency
-- [ ] Kafka integration tests
+- [x] Transactional outbox persistence
+- [x] Versioned `wallet.transfer.completed` event
+- [x] Leased and retryable Kafka publication
+- [x] Idempotent event consumption
+- [x] Kafka integration tests
+- [x] Durable dead-letter intake
+- [x] Replay lineage and controlled replay lifecycle
+- [x] Explicit discard lifecycle
+- [x] Operator-only dead-letter query and command APIs
+- [x] Append-only replay and discard command auditing
+- [x] Paginated audit investigation queries
+- [x] Chronological command timelines
+- [x] Safe-field response allowlists
 
-## Milestone 5 — Production readiness
+### Documentation and observability
 
-- [ ] Refresh-token storage and key-rotation strategy
-- [ ] Cache strategy and invalidation tests
-- [ ] Structured logging and correlation IDs
-- [ ] Prometheus metrics and Grafana dashboard
-- [ ] API security hardening
-- [ ] Performance test scenarios
-- [ ] Architecture and ER diagram exports
-- [x] OpenAPI examples and Postman collection
-- [x] Release workflow and tagged release
+- [x] OpenAPI contracts and examples
+- [x] Executable Postman collection
+- [x] Prometheus metrics for Kafka delivery failures
+- [x] Provisioned Grafana dashboards
+- [x] Operational alert rules
+- [x] Architecture and ER diagram sources
+- [x] Release notes and upgrade guidance
+
+## v0.7.0 — Identity and Session Security
+
+### Product outcome
+
+Authenticated users can maintain revocable sessions without receiving
+long-lived bearer access tokens. Refresh-token rotation limits replay windows,
+token-family reuse detection provides an incident response boundary, and login
+rate limiting reduces automated credential attacks.
+
+No plaintext refresh token, password, JWT, authorization header, or equivalent
+credential may be persisted, logged, returned through administrative APIs, or
+included in metrics.
+
+### Increment 1 — Architecture and security contracts
+
+- [ ] Record the refresh-session architecture and threat model in an ADR
+- [ ] Define access-token and refresh-token responsibilities
+- [ ] Define token-family lifecycle states and invariants
+- [ ] Define expiration, rotation, revocation, and reuse-detection semantics
+- [ ] Define stable public error codes and HTTP outcomes
+- [ ] Define safe logging, metric, and audit-field allowlists
+- [ ] Define clock and token-generation ports for deterministic tests
+
+### Increment 2 — Durable refresh-session persistence
+
+- [ ] Add a Flyway migration for refresh-token families and token records
+- [ ] Persist only cryptographic token hashes
+- [ ] Store family, user, creation, expiration, replacement, and revocation metadata
+- [ ] Enforce database constraints for family and rotation invariants
+- [ ] Add indexes for active-token lookup and user-session revocation
+- [ ] Add PostgreSQL repository integration tests
+- [ ] Verify that plaintext credentials never enter persistence
+
+### Increment 3 — Token issuance and atomic rotation
+
+- [ ] Extend successful login with an access and refresh token pair
+- [ ] Add a refresh endpoint with an explicit request contract
+- [ ] Rotate refresh tokens exactly once
+- [ ] Replace the consumed token atomically
+- [ ] Reject expired, revoked, malformed, and unknown tokens deterministically
+- [ ] Handle concurrent refresh requests without issuing multiple valid successors
+- [ ] Add endpoint-to-database integration and concurrency tests
+
+### Increment 4 — Reuse detection and session revocation
+
+- [ ] Detect reuse of an already rotated refresh token
+- [ ] Revoke the complete token family after confirmed reuse
+- [ ] Add current-session logout
+- [ ] Add all-session logout for the authenticated user
+- [ ] Keep logout behavior idempotent
+- [ ] Add safe security metrics for rotation, rejection, reuse, and revocation
+- [ ] Verify that operational data exposes no token material
+
+### Increment 5 — Redis-backed login protection
+
+- [ ] Define a bounded login-attempt policy
+- [ ] Apply limits using normalized login identity and trusted client context
+- [ ] Use atomic Redis operations with explicit expiration
+- [ ] Return a stable `429 Too Many Requests` contract
+- [ ] Avoid revealing whether an account exists
+- [ ] Define safe behavior when Redis is unavailable
+- [ ] Add Redis integration, expiration, and concurrency tests
+
+### Increment 6 — Public contracts and release readiness
+
+- [ ] Update OpenAPI authentication contracts and examples
+- [ ] Update the executable Postman authentication workflow
+- [ ] Document refresh, logout, reuse, and rate-limit behavior
+- [ ] Add regression tests for existing access-token-only endpoints
+- [ ] Verify authentication responses exclude credential internals
+- [ ] Run full Maven, security, migration, and API-contract verification
+- [ ] Publish v0.7.0 release notes, JAR, and SHA-256 checksum
+
+## Explicit v0.7.0 non-goals
+
+The following work is valuable but is not part of the v0.7.0 commitment:
+
+- external OAuth or OpenID Connect identity providers
+- social login
+- multi-factor authentication
+- password-reset and email-verification workflows
+- browser or mobile user interfaces
+- device fingerprinting
+- generalized API-wide rate limiting
+- production KMS or HSM integration
+- microservice extraction
+- wallet-summary caching
+- unrelated dependency modernization
+
+These items require separate milestones and threat models rather than being
+silently added to the session-security increment.
+
+## v0.7.0 release exit criteria
+
+The release is ready only when:
+
+- [ ] all committed v0.7.0 issues are closed
+- [ ] database migrations are backward-safe and verified with PostgreSQL
+- [ ] refresh-token rotation is atomic under concurrent requests
+- [ ] confirmed token reuse revokes the complete family
+- [ ] current-session and all-session logout behavior is verified
+- [ ] login rate limiting is verified against Redis
+- [ ] no plaintext refresh token or other credential is persisted or logged
+- [ ] OpenAPI and Postman contracts match the implementation
+- [ ] all automated tests and pull-request checks pass
+- [ ] release documentation, executable JAR, and SHA-256 checksum are published
+
+## Future candidates
+
+Potential increments after v0.7.0 include:
+
+- signing-key rotation and external key-management integration
+- structured JSON logging and request correlation
+- performance and load-test scenarios
+- cache strategy and invalidation verification
+- password recovery and verified-email workflows
+- multi-factor authentication
+- broader operational-security dashboards

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.7.0</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenFamilyJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenFamilyJpaEntity.java
@@ -1,0 +1,96 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "refresh_token_families")
+class RefreshTokenFamilyJpaEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(
+        name = "user_id",
+        nullable = false,
+        updatable = false
+    )
+    private UUID userId;
+
+    @Column(
+        name = "created_at",
+        nullable = false,
+        updatable = false
+    )
+    private Instant createdAt;
+
+    @Column(
+        name = "expires_at",
+        nullable = false
+    )
+    private Instant expiresAt;
+
+    @Column(name = "revoked_at")
+    private Instant revokedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+        name = "revocation_reason",
+        length = 40
+    )
+    private RefreshTokenFamilyRevocationReason
+        revocationReason;
+
+    protected RefreshTokenFamilyJpaEntity() {
+    }
+
+    RefreshTokenFamilyJpaEntity(
+        UUID id,
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt,
+        Instant revokedAt,
+        RefreshTokenFamilyRevocationReason
+            revocationReason
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.createdAt = createdAt;
+        this.expiresAt = expiresAt;
+        this.revokedAt = revokedAt;
+        this.revocationReason = revocationReason;
+    }
+
+    UUID getId() {
+        return id;
+    }
+
+    UUID getUserId() {
+        return userId;
+    }
+
+    Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    Instant getRevokedAt() {
+        return revokedAt;
+    }
+
+    RefreshTokenFamilyRevocationReason
+    getRevocationReason() {
+        return revocationReason;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenFamilyPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenFamilyPersistenceAdapter.java
@@ -1,0 +1,69 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import org.springframework.stereotype.Component;
+
+@Component
+class RefreshTokenFamilyPersistenceAdapter
+    implements RefreshTokenFamilyRepositoryPort {
+
+    private final SpringDataRefreshTokenFamilyRepository
+        repository;
+
+    RefreshTokenFamilyPersistenceAdapter(
+        SpringDataRefreshTokenFamilyRepository
+            repository
+    ) {
+        this.repository = repository;
+    }
+
+    @Override
+    public RefreshTokenFamily save(
+        RefreshTokenFamily family
+    ) {
+        RefreshTokenFamilyJpaEntity saved =
+            repository.saveAndFlush(
+                RefreshTokenPersistenceMapper
+                    .toFamilyEntity(family)
+            );
+
+        return RefreshTokenPersistenceMapper
+            .toFamilyDomain(saved);
+    }
+
+    @Override
+    public Optional<RefreshTokenFamily>
+    findByIdForUpdate(
+        RefreshTokenFamilyId familyId
+    ) {
+        return repository
+            .findByIdForUpdate(
+                familyId.value()
+            )
+            .map(
+                RefreshTokenPersistenceMapper
+                    ::toFamilyDomain
+            );
+    }
+
+    @Override
+    public int revokeAllActiveByUserId(
+        UUID userId,
+        Instant revokedAt,
+        RefreshTokenFamilyRevocationReason reason
+    ) {
+        return repository
+            .revokeAllActiveByUserId(
+                userId,
+                revokedAt,
+                reason
+            );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenPersistenceMapper.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenPersistenceMapper.java
@@ -1,0 +1,91 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+
+final class RefreshTokenPersistenceMapper {
+
+    private RefreshTokenPersistenceMapper() {
+    }
+
+    static RefreshTokenFamilyJpaEntity
+    toFamilyEntity(
+        RefreshTokenFamily family
+    ) {
+        return new RefreshTokenFamilyJpaEntity(
+            family.id().value(),
+            family.userId(),
+            family.createdAt(),
+            family.expiresAt(),
+            family.revokedAt(),
+            family.revocationReason()
+        );
+    }
+
+    static RefreshTokenFamily toFamilyDomain(
+        RefreshTokenFamilyJpaEntity entity
+    ) {
+        return RefreshTokenFamily.rehydrate(
+            RefreshTokenFamilyId.of(
+                entity.getId()
+            ),
+            entity.getUserId(),
+            entity.getCreatedAt(),
+            entity.getExpiresAt(),
+            entity.getRevokedAt(),
+            entity.getRevocationReason()
+        );
+    }
+
+    static RefreshTokenRecordJpaEntity
+    toRecordEntity(
+        RefreshTokenRecord record
+    ) {
+        RefreshTokenRecordId successorId =
+            record.successorId();
+
+        return new RefreshTokenRecordJpaEntity(
+            record.id().value(),
+            record.familyId().value(),
+            record.digest().value(),
+            record.issuedAt(),
+            record.expiresAt(),
+            record.consumedAt(),
+            successorId == null
+                ? null
+                : successorId.value()
+        );
+    }
+
+    static RefreshTokenRecord toRecordDomain(
+        RefreshTokenRecordJpaEntity entity,
+        RefreshTokenFamily family
+    ) {
+        RefreshTokenRecordId successorId =
+            entity.getSuccessorId() == null
+                ? null
+                : RefreshTokenRecordId.of(
+                    entity.getSuccessorId()
+                );
+
+        return RefreshTokenRecord.rehydrate(
+            RefreshTokenRecordId.of(
+                entity.getId()
+            ),
+            RefreshTokenFamilyId.of(
+                entity.getFamilyId()
+            ),
+            RefreshTokenDigest.of(
+                entity.getTokenDigest()
+            ),
+            entity.getIssuedAt(),
+            entity.getExpiresAt(),
+            entity.getConsumedAt(),
+            successorId,
+            family
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenRecordJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenRecordJpaEntity.java
@@ -1,0 +1,115 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "refresh_token_records")
+class RefreshTokenRecordJpaEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(
+        name = "family_id",
+        nullable = false,
+        updatable = false
+    )
+    private UUID familyId;
+
+    @Column(
+        name = "token_digest",
+        nullable = false,
+        updatable = false
+    )
+    private byte[] tokenDigest;
+
+    @Column(
+        name = "issued_at",
+        nullable = false,
+        updatable = false
+    )
+    private Instant issuedAt;
+
+    @Column(
+        name = "expires_at",
+        nullable = false,
+        updatable = false
+    )
+    private Instant expiresAt;
+
+    @Column(name = "consumed_at")
+    private Instant consumedAt;
+
+    @Column(name = "successor_id")
+    private UUID successorId;
+
+    protected RefreshTokenRecordJpaEntity() {
+    }
+
+    RefreshTokenRecordJpaEntity(
+        UUID id,
+        UUID familyId,
+        byte[] tokenDigest,
+        Instant issuedAt,
+        Instant expiresAt,
+        Instant consumedAt,
+        UUID successorId
+    ) {
+        this.id = id;
+        this.familyId = familyId;
+        this.tokenDigest =
+            copyDigest(tokenDigest);
+        this.issuedAt = issuedAt;
+        this.expiresAt = expiresAt;
+        this.consumedAt = consumedAt;
+        this.successorId = successorId;
+    }
+
+    UUID getId() {
+        return id;
+    }
+
+    UUID getFamilyId() {
+        return familyId;
+    }
+
+    byte[] getTokenDigest() {
+        return copyDigest(tokenDigest);
+    }
+
+    Instant getIssuedAt() {
+        return issuedAt;
+    }
+
+    Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    Instant getConsumedAt() {
+        return consumedAt;
+    }
+
+    UUID getSuccessorId() {
+        return successorId;
+    }
+
+    private static byte[] copyDigest(
+        byte[] source
+    ) {
+        if (source == null) {
+            return null;
+        }
+
+        return Arrays.copyOf(
+            source,
+            source.length
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenRecordPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenRecordPersistenceAdapter.java
@@ -1,0 +1,109 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import org.springframework.stereotype.Component;
+
+@Component
+class RefreshTokenRecordPersistenceAdapter
+    implements RefreshTokenRecordRepositoryPort {
+
+    private final SpringDataRefreshTokenRecordRepository
+        recordRepository;
+
+    private final SpringDataRefreshTokenFamilyRepository
+        familyRepository;
+
+    RefreshTokenRecordPersistenceAdapter(
+        SpringDataRefreshTokenRecordRepository
+            recordRepository,
+        SpringDataRefreshTokenFamilyRepository
+            familyRepository
+    ) {
+        this.recordRepository = recordRepository;
+        this.familyRepository = familyRepository;
+    }
+
+    @Override
+    public RefreshTokenRecord save(
+        RefreshTokenRecord record
+    ) {
+        RefreshTokenRecordJpaEntity saved =
+            recordRepository.saveAndFlush(
+                RefreshTokenPersistenceMapper
+                    .toRecordEntity(record)
+            );
+
+        return toDomain(saved);
+    }
+
+    @Override
+    public Optional<RefreshTokenRecord>
+    findByDigestForUpdate(
+        RefreshTokenDigest digest
+    ) {
+        return recordRepository
+            .findByDigestForUpdate(
+                digest.value()
+            )
+            .map(this::toDomain);
+    }
+
+    @Override
+    public Optional<RefreshTokenRecord> findById(
+        RefreshTokenRecordId recordId
+    ) {
+        return recordRepository
+            .findById(
+                recordId.value()
+            )
+            .map(this::toDomain);
+    }
+
+    private RefreshTokenRecord toDomain(
+        RefreshTokenRecordJpaEntity entity
+    ) {
+        RefreshTokenFamily family =
+            familyRepository
+                .findById(
+                    entity.getFamilyId()
+                )
+                .map(
+                    RefreshTokenPersistenceMapper
+                        ::toFamilyDomain
+                )
+                .orElseThrow(
+                    () -> missingFamily(entity)
+                );
+
+        return RefreshTokenPersistenceMapper
+            .toRecordDomain(
+                entity,
+                family
+            );
+    }
+
+    private static IllegalStateException
+    missingFamily(
+        RefreshTokenRecordJpaEntity entity
+    ) {
+        UUID familyId =
+            entity.getFamilyId();
+
+        UUID recordId =
+            entity.getId();
+
+        return new IllegalStateException(
+            "refresh token family "
+                + familyId
+                + " was not found for record "
+                + recordId
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataRefreshTokenFamilyRepository.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataRefreshTokenFamilyRepository.java
@@ -1,0 +1,55 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+interface SpringDataRefreshTokenFamilyRepository
+    extends JpaRepository<
+        RefreshTokenFamilyJpaEntity,
+        UUID
+    > {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT family
+        FROM RefreshTokenFamilyJpaEntity family
+        WHERE family.id = :familyId
+        """)
+    Optional<RefreshTokenFamilyJpaEntity>
+    findByIdForUpdate(
+        @Param("familyId")
+        UUID familyId
+    );
+
+    @Modifying(
+        flushAutomatically = true,
+        clearAutomatically = true
+    )
+    @Query("""
+        UPDATE RefreshTokenFamilyJpaEntity family
+        SET family.revokedAt = :revokedAt,
+            family.revocationReason = :reason
+        WHERE family.userId = :userId
+          AND family.revokedAt IS NULL
+          AND family.revocationReason IS NULL
+          AND family.createdAt <= :revokedAt
+          AND family.expiresAt > :revokedAt
+        """)
+    int revokeAllActiveByUserId(
+        @Param("userId")
+        UUID userId,
+        @Param("revokedAt")
+        Instant revokedAt,
+        @Param("reason")
+        RefreshTokenFamilyRevocationReason reason
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataRefreshTokenRecordRepository.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataRefreshTokenRecordRepository.java
@@ -1,0 +1,29 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+interface SpringDataRefreshTokenRecordRepository
+    extends JpaRepository<
+        RefreshTokenRecordJpaEntity,
+        UUID
+    > {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT record
+        FROM RefreshTokenRecordJpaEntity record
+        WHERE record.tokenDigest = :digest
+        """)
+    Optional<RefreshTokenRecordJpaEntity>
+    findByDigestForUpdate(
+        @Param("digest")
+        byte[] digest
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/JwtAccessTokenGenerationAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/JwtAccessTokenGenerationAdapter.java
@@ -4,7 +4,7 @@ import java.time.Clock;
 import java.time.Instant;
 
 import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
-import com.nursena.payflow.user.application.port.out.TokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
 import com.nursena.payflow.user.domain.model.User;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
@@ -13,14 +13,14 @@ import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.stereotype.Component;
 
 @Component
-class JwtTokenGenerationAdapter
-    implements TokenGenerationPort {
+class JwtAccessTokenGenerationAdapter
+    implements AccessTokenGenerationPort {
 
     private final JwtEncoder jwtEncoder;
     private final JwtProperties properties;
     private final Clock clock;
 
-    JwtTokenGenerationAdapter(
+    JwtAccessTokenGenerationAdapter(
         JwtEncoder jwtEncoder,
         JwtProperties properties,
         Clock clock

--- a/src/main/java/com/nursena/payflow/user/application/port/out/AccessTokenGenerationPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/AccessTokenGenerationPort.java
@@ -2,7 +2,7 @@ package com.nursena.payflow.user.application.port.out;
 
 import com.nursena.payflow.user.domain.model.User;
 
-public interface TokenGenerationPort {
+public interface AccessTokenGenerationPort {
 
     GeneratedAccessToken generate(User user);
 }

--- a/src/main/java/com/nursena/payflow/user/application/port/out/GeneratedRefreshToken.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/GeneratedRefreshToken.java
@@ -1,0 +1,26 @@
+package com.nursena.payflow.user.application.port.out;
+
+import java.util.Objects;
+
+public record GeneratedRefreshToken(
+    String value
+) {
+
+    public GeneratedRefreshToken {
+        Objects.requireNonNull(
+            value,
+            "value must not be null"
+        );
+
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(
+                "value must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "GeneratedRefreshToken[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenDigestPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenDigestPort.java
@@ -1,0 +1,10 @@
+package com.nursena.payflow.user.application.port.out;
+
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+
+public interface RefreshTokenDigestPort {
+
+    RefreshTokenDigest digest(
+        String refreshToken
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenFamilyRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenFamilyRepositoryPort.java
@@ -1,0 +1,27 @@
+package com.nursena.payflow.user.application.port.out;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+
+public interface RefreshTokenFamilyRepositoryPort {
+
+    RefreshTokenFamily save(
+        RefreshTokenFamily family
+    );
+
+    Optional<RefreshTokenFamily>
+    findByIdForUpdate(
+        RefreshTokenFamilyId familyId
+    );
+
+    int revokeAllActiveByUserId(
+        UUID userId,
+        Instant revokedAt,
+        RefreshTokenFamilyRevocationReason reason
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenGenerationPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenGenerationPort.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.user.application.port.out;
+
+public interface RefreshTokenGenerationPort {
+
+    GeneratedRefreshToken generate();
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenRecordRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/RefreshTokenRecordRepositoryPort.java
@@ -1,0 +1,23 @@
+package com.nursena.payflow.user.application.port.out;
+
+import java.util.Optional;
+
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+
+public interface RefreshTokenRecordRepositoryPort {
+
+    RefreshTokenRecord save(
+        RefreshTokenRecord record
+    );
+
+    Optional<RefreshTokenRecord>
+    findByDigestForUpdate(
+        RefreshTokenDigest digest
+    );
+
+    Optional<RefreshTokenRecord> findById(
+        RefreshTokenRecordId recordId
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/AuthenticateUserService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/AuthenticateUserService.java
@@ -5,7 +5,7 @@ import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserUseCase;
 import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
 import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
-import com.nursena.payflow.user.application.port.out.TokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
 import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
 import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
@@ -22,16 +22,16 @@ public class AuthenticateUserService
 
     private final UserRepositoryPort userRepository;
     private final PasswordVerificationPort passwordVerification;
-    private final TokenGenerationPort tokenGeneration;
+    private final AccessTokenGenerationPort accessTokenGeneration;
 
     public AuthenticateUserService(
         UserRepositoryPort userRepository,
         PasswordVerificationPort passwordVerification,
-        TokenGenerationPort tokenGeneration
+        AccessTokenGenerationPort accessTokenGeneration
     ) {
         this.userRepository = userRepository;
         this.passwordVerification = passwordVerification;
-        this.tokenGeneration = tokenGeneration;
+        this.accessTokenGeneration = accessTokenGeneration;
     }
 
     @Override
@@ -57,7 +57,7 @@ public class AuthenticateUserService
             throw new UserAccountUnavailableException();
         }
 
-        GeneratedAccessToken token = tokenGeneration.generate(user);
+        GeneratedAccessToken token = accessTokenGeneration.generate(user);
 
         return new AuthenticateUserResult(
             token.value(),

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenDigest.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenDigest.java
@@ -1,0 +1,85 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public final class RefreshTokenDigest {
+
+    public static final int SHA_256_LENGTH_BYTES = 32;
+
+    private final byte[] value;
+
+    private RefreshTokenDigest(
+        byte[] value
+    ) {
+        Objects.requireNonNull(
+            value,
+            "value must not be null"
+        );
+
+        if (
+            value.length
+                != SHA_256_LENGTH_BYTES
+        ) {
+            throw new IllegalArgumentException(
+                "value must contain exactly "
+                    + SHA_256_LENGTH_BYTES
+                    + " bytes"
+            );
+        }
+
+        this.value =
+            Arrays.copyOf(
+                value,
+                value.length
+            );
+    }
+
+    public static RefreshTokenDigest of(
+        byte[] value
+    ) {
+        return new RefreshTokenDigest(value);
+    }
+
+    public byte[] value() {
+        return Arrays.copyOf(
+            value,
+            value.length
+        );
+    }
+
+    @Override
+    public boolean equals(
+        Object candidate
+    ) {
+        if (this == candidate) {
+            return true;
+        }
+
+        if (
+            candidate == null
+                || getClass()
+                != candidate.getClass()
+        ) {
+            return false;
+        }
+
+        RefreshTokenDigest other =
+            (RefreshTokenDigest) candidate;
+
+        return Arrays.equals(
+            value,
+            other.value
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return "RefreshTokenDigest[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamily.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamily.java
@@ -1,0 +1,218 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class RefreshTokenFamily {
+
+    private final RefreshTokenFamilyId id;
+    private final UUID userId;
+    private final Instant createdAt;
+    private final Instant expiresAt;
+    private final Instant revokedAt;
+    private final RefreshTokenFamilyRevocationReason
+        revocationReason;
+
+    private RefreshTokenFamily(
+        RefreshTokenFamilyId id,
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt,
+        Instant revokedAt,
+        RefreshTokenFamilyRevocationReason
+            revocationReason
+    ) {
+        this.id =
+            Objects.requireNonNull(
+                id,
+                "id must not be null"
+            );
+
+        this.userId =
+            Objects.requireNonNull(
+                userId,
+                "userId must not be null"
+            );
+
+        this.createdAt =
+            Objects.requireNonNull(
+                createdAt,
+                "createdAt must not be null"
+            );
+
+        this.expiresAt =
+            Objects.requireNonNull(
+                expiresAt,
+                "expiresAt must not be null"
+            );
+
+        this.revokedAt = revokedAt;
+        this.revocationReason =
+            revocationReason;
+
+        validateLifetime();
+        validateRevocationState();
+    }
+
+    public static RefreshTokenFamily create(
+        RefreshTokenFamilyId id,
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt
+    ) {
+        return new RefreshTokenFamily(
+            id,
+            userId,
+            createdAt,
+            expiresAt,
+            null,
+            null
+        );
+    }
+
+    public static RefreshTokenFamily rehydrate(
+        RefreshTokenFamilyId id,
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt,
+        Instant revokedAt,
+        RefreshTokenFamilyRevocationReason
+            revocationReason
+    ) {
+        return new RefreshTokenFamily(
+            id,
+            userId,
+            createdAt,
+            expiresAt,
+            revokedAt,
+            revocationReason
+        );
+    }
+
+    public boolean isRevoked() {
+        return revokedAt != null;
+    }
+
+    public boolean isExpiredAt(
+        Instant now
+    ) {
+        Instant checkedAt =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        return !expiresAt.isAfter(checkedAt);
+    }
+
+    public boolean isActiveAt(
+        Instant now
+    ) {
+        Instant checkedAt =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        return !checkedAt.isBefore(createdAt)
+            && !isRevoked()
+            && !isExpiredAt(checkedAt);
+    }
+
+    public RefreshTokenFamily revoke(
+        RefreshTokenFamilyRevocationReason reason,
+        Instant now
+    ) {
+        RefreshTokenFamilyRevocationReason
+            checkedReason =
+            Objects.requireNonNull(
+                reason,
+                "reason must not be null"
+            );
+
+        Instant checkedAt =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        if (checkedAt.isBefore(createdAt)) {
+            throw new IllegalArgumentException(
+                "revokedAt must not be before "
+                    + "createdAt"
+            );
+        }
+
+        if (isRevoked()) {
+            return this;
+        }
+
+        return new RefreshTokenFamily(
+            id,
+            userId,
+            createdAt,
+            expiresAt,
+            checkedAt,
+            checkedReason
+        );
+    }
+
+    private void validateLifetime() {
+        if (!expiresAt.isAfter(createdAt)) {
+            throw new IllegalArgumentException(
+                "expiresAt must be after createdAt"
+            );
+        }
+    }
+
+    private void validateRevocationState() {
+        boolean hasRevokedAt =
+            revokedAt != null;
+
+        boolean hasReason =
+            revocationReason != null;
+
+        if (hasRevokedAt != hasReason) {
+            throw new IllegalArgumentException(
+                "revokedAt and revocationReason "
+                    + "must appear together"
+            );
+        }
+
+        if (
+            revokedAt != null
+                && revokedAt.isBefore(createdAt)
+        ) {
+            throw new IllegalArgumentException(
+                "revokedAt must not be before "
+                    + "createdAt"
+            );
+        }
+    }
+
+    public RefreshTokenFamilyId id() {
+        return id;
+    }
+
+    public UUID userId() {
+        return userId;
+    }
+
+    public Instant createdAt() {
+        return createdAt;
+    }
+
+    public Instant expiresAt() {
+        return expiresAt;
+    }
+
+    public Instant revokedAt() {
+        return revokedAt;
+    }
+
+    public RefreshTokenFamilyRevocationReason
+    revocationReason() {
+        return revocationReason;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyId.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyId.java
@@ -1,0 +1,22 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record RefreshTokenFamilyId(
+    UUID value
+) {
+
+    public RefreshTokenFamilyId {
+        Objects.requireNonNull(
+            value,
+            "value must not be null"
+        );
+    }
+
+    public static RefreshTokenFamilyId of(
+        UUID value
+    ) {
+        return new RefreshTokenFamilyId(value);
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyRevocationReason.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyRevocationReason.java
@@ -1,0 +1,9 @@
+package com.nursena.payflow.user.domain.model;
+
+public enum RefreshTokenFamilyRevocationReason {
+    CURRENT_SESSION_LOGOUT,
+    ALL_SESSIONS_LOGOUT,
+    REUSE_DETECTED,
+    USER_ACCOUNT_UNAVAILABLE,
+    ADMINISTRATIVE_REVOCATION
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenRecord.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenRecord.java
@@ -1,0 +1,410 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public final class RefreshTokenRecord {
+
+    private final RefreshTokenRecordId id;
+    private final RefreshTokenFamilyId familyId;
+    private final RefreshTokenDigest digest;
+    private final Instant issuedAt;
+    private final Instant expiresAt;
+    private final Instant consumedAt;
+    private final RefreshTokenRecordId successorId;
+
+    private RefreshTokenRecord(
+        RefreshTokenRecordId id,
+        RefreshTokenFamilyId familyId,
+        RefreshTokenDigest digest,
+        Instant issuedAt,
+        Instant expiresAt,
+        Instant consumedAt,
+        RefreshTokenRecordId successorId
+    ) {
+        this.id =
+            Objects.requireNonNull(
+                id,
+                "id must not be null"
+            );
+
+        this.familyId =
+            Objects.requireNonNull(
+                familyId,
+                "familyId must not be null"
+            );
+
+        this.digest =
+            Objects.requireNonNull(
+                digest,
+                "digest must not be null"
+            );
+
+        this.issuedAt =
+            Objects.requireNonNull(
+                issuedAt,
+                "issuedAt must not be null"
+            );
+
+        this.expiresAt =
+            Objects.requireNonNull(
+                expiresAt,
+                "expiresAt must not be null"
+            );
+
+        this.consumedAt = consumedAt;
+        this.successorId = successorId;
+
+        validateLocalState();
+    }
+
+    public static RefreshTokenRecord issue(
+        RefreshTokenRecordId id,
+        RefreshTokenFamily family,
+        RefreshTokenDigest digest,
+        Instant issuedAt,
+        Instant expiresAt
+    ) {
+        RefreshTokenFamily checkedFamily =
+            Objects.requireNonNull(
+                family,
+                "family must not be null"
+            );
+
+        Instant checkedIssuedAt =
+            Objects.requireNonNull(
+                issuedAt,
+                "issuedAt must not be null"
+            );
+
+        if (
+            checkedIssuedAt.isBefore(
+                checkedFamily.createdAt()
+            )
+        ) {
+            throw new IllegalArgumentException(
+                "issuedAt must not be before "
+                    + "family createdAt"
+            );
+        }
+
+        if (
+            checkedIssuedAt.isBefore(
+                checkedFamily.createdAt()
+            )
+        ) {
+            throw new IllegalArgumentException(
+                "issuedAt must not be before "
+                    + "family createdAt"
+            );
+        }
+
+        if (
+            !checkedFamily.isActiveAt(
+                checkedIssuedAt
+            )
+        ) {
+            throw new IllegalStateException(
+                "family must be active when "
+                    + "a token is issued"
+            );
+        }
+
+        RefreshTokenRecord record =
+            new RefreshTokenRecord(
+                id,
+                checkedFamily.id(),
+                digest,
+                checkedIssuedAt,
+                expiresAt,
+                null,
+                null
+            );
+
+        record.validateFamilyState(
+            checkedFamily
+        );
+
+        return record;
+    }
+
+    public static RefreshTokenRecord rehydrate(
+        RefreshTokenRecordId id,
+        RefreshTokenFamilyId familyId,
+        RefreshTokenDigest digest,
+        Instant issuedAt,
+        Instant expiresAt,
+        Instant consumedAt,
+        RefreshTokenRecordId successorId,
+        RefreshTokenFamily family
+    ) {
+        RefreshTokenRecord record =
+            new RefreshTokenRecord(
+                id,
+                familyId,
+                digest,
+                issuedAt,
+                expiresAt,
+                consumedAt,
+                successorId
+            );
+
+        record.validateFamilyState(
+            Objects.requireNonNull(
+                family,
+                "family must not be null"
+            )
+        );
+
+        return record;
+    }
+
+    public RefreshTokenRecord consume(
+        RefreshTokenRecordId successorId,
+        Instant consumedAt,
+        RefreshTokenFamily family
+    ) {
+        RefreshTokenRecordId checkedSuccessorId =
+            Objects.requireNonNull(
+                successorId,
+                "successorId must not be null"
+            );
+
+        Instant checkedConsumedAt =
+            Objects.requireNonNull(
+                consumedAt,
+                "consumedAt must not be null"
+            );
+
+        RefreshTokenFamily checkedFamily =
+            Objects.requireNonNull(
+                family,
+                "family must not be null"
+            );
+
+        validateFamilyIdentity(
+            checkedFamily
+        );
+
+        if (id.equals(checkedSuccessorId)) {
+            throw new IllegalArgumentException(
+                "a token must not replace itself"
+            );
+        }
+
+        if (isConsumed()) {
+            throw new IllegalStateException(
+                "refresh token is already consumed"
+            );
+        }
+
+        if (checkedConsumedAt.isBefore(issuedAt)) {
+            throw new IllegalArgumentException(
+                "consumedAt must not be before "
+                    + "issuedAt"
+            );
+        }
+
+        if (
+            !checkedFamily.isActiveAt(
+                checkedConsumedAt
+            )
+        ) {
+            throw new IllegalStateException(
+                "family must be active when "
+                    + "a token is consumed"
+            );
+        }
+
+        if (!expiresAt.isAfter(checkedConsumedAt)) {
+            throw new IllegalStateException(
+                "refresh token must not be expired"
+            );
+        }
+
+        return new RefreshTokenRecord(
+            id,
+            familyId,
+            digest,
+            issuedAt,
+            expiresAt,
+            checkedConsumedAt,
+            checkedSuccessorId
+        );
+    }
+
+    public boolean isConsumed() {
+        return consumedAt != null;
+    }
+
+    public boolean isExpiredAt(
+        Instant now
+    ) {
+        Instant checkedAt =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        return !expiresAt.isAfter(checkedAt);
+    }
+
+    public boolean isActiveAt(
+        RefreshTokenFamily family,
+        Instant now
+    ) {
+        RefreshTokenFamily checkedFamily =
+            Objects.requireNonNull(
+                family,
+                "family must not be null"
+            );
+
+        Instant checkedAt =
+            Objects.requireNonNull(
+                now,
+                "now must not be null"
+            );
+
+        validateFamilyIdentity(
+            checkedFamily
+        );
+
+        return !checkedAt.isBefore(issuedAt)
+            && !isConsumed()
+            && !isExpiredAt(checkedAt)
+            && checkedFamily.isActiveAt(checkedAt);
+    }
+
+    private void validateLocalState() {
+        if (!expiresAt.isAfter(issuedAt)) {
+            throw new IllegalArgumentException(
+                "expiresAt must be after issuedAt"
+            );
+        }
+
+        boolean hasConsumedAt =
+            consumedAt != null;
+
+        boolean hasSuccessor =
+            successorId != null;
+
+        if (hasConsumedAt != hasSuccessor) {
+            throw new IllegalArgumentException(
+                "consumedAt and successorId "
+                    + "must appear together"
+            );
+        }
+
+        if (
+            successorId != null
+                && id.equals(successorId)
+        ) {
+            throw new IllegalArgumentException(
+                "a token must not replace itself"
+            );
+        }
+
+        if (
+            consumedAt != null
+                && consumedAt.isBefore(issuedAt)
+        ) {
+            throw new IllegalArgumentException(
+                "consumedAt must not be before "
+                    + "issuedAt"
+            );
+        }
+
+        if (
+            consumedAt != null
+                && !expiresAt.isAfter(consumedAt)
+        ) {
+            throw new IllegalArgumentException(
+                "consumedAt must be before "
+                    + "expiresAt"
+            );
+        }
+    }
+
+    private void validateFamilyState(
+        RefreshTokenFamily family
+    ) {
+        validateFamilyIdentity(family);
+
+        if (issuedAt.isBefore(family.createdAt())) {
+            throw new IllegalArgumentException(
+                "issuedAt must not be before "
+                    + "family createdAt"
+            );
+        }
+
+        if (expiresAt.isAfter(family.expiresAt())) {
+            throw new IllegalArgumentException(
+                "token expiresAt must not be after "
+                    + "family expiresAt"
+            );
+        }
+
+        if (
+            family.revokedAt() != null
+                && !issuedAt.isBefore(
+                family.revokedAt()
+            )
+        ) {
+            throw new IllegalArgumentException(
+                "issuedAt must be before "
+                    + "family revokedAt"
+            );
+        }
+
+        if (
+            consumedAt != null
+                && family.revokedAt() != null
+                && consumedAt.isAfter(
+                family.revokedAt()
+            )
+        ) {
+            throw new IllegalArgumentException(
+                "consumedAt must not be after "
+                    + "family revokedAt"
+            );
+        }
+    }
+
+    private void validateFamilyIdentity(
+        RefreshTokenFamily family
+    ) {
+        if (!familyId.equals(family.id())) {
+            throw new IllegalArgumentException(
+                "token familyId must match family id"
+            );
+        }
+    }
+
+    public RefreshTokenRecordId id() {
+        return id;
+    }
+
+    public RefreshTokenFamilyId familyId() {
+        return familyId;
+    }
+
+    public RefreshTokenDigest digest() {
+        return digest;
+    }
+
+    public Instant issuedAt() {
+        return issuedAt;
+    }
+
+    public Instant expiresAt() {
+        return expiresAt;
+    }
+
+    public Instant consumedAt() {
+        return consumedAt;
+    }
+
+    public RefreshTokenRecordId successorId() {
+        return successorId;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenRecordId.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenRecordId.java
@@ -1,0 +1,22 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record RefreshTokenRecordId(
+    UUID value
+) {
+
+    public RefreshTokenRecordId {
+        Objects.requireNonNull(
+            value,
+            "value must not be null"
+        );
+    }
+
+    public static RefreshTokenRecordId of(
+        UUID value
+    ) {
+        return new RefreshTokenRecordId(value);
+    }
+}

--- a/src/main/resources/db/migration/V14__create_refresh_token_sessions.sql
+++ b/src/main/resources/db/migration/V14__create_refresh_token_sessions.sql
@@ -1,0 +1,219 @@
+CREATE TABLE refresh_token_families (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    revoked_at TIMESTAMPTZ,
+    revocation_reason VARCHAR(40),
+
+    CONSTRAINT fk_refresh_token_families_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT chk_refresh_token_families_lifetime
+        CHECK (
+            expires_at > created_at
+        ),
+
+    CONSTRAINT chk_refresh_token_families_revocation_state
+        CHECK (
+            (
+                revoked_at IS NULL
+                AND revocation_reason IS NULL
+            )
+            OR
+            (
+                revoked_at IS NOT NULL
+                AND revocation_reason IS NOT NULL
+            )
+        ),
+
+    CONSTRAINT chk_refresh_token_families_revocation_time
+        CHECK (
+            revoked_at IS NULL
+            OR revoked_at >= created_at
+        ),
+
+    CONSTRAINT chk_refresh_token_families_revocation_reason
+        CHECK (
+            revocation_reason IS NULL
+            OR revocation_reason IN (
+                'CURRENT_SESSION_LOGOUT',
+                'ALL_SESSIONS_LOGOUT',
+                'REUSE_DETECTED',
+                'USER_ACCOUNT_UNAVAILABLE',
+                'ADMINISTRATIVE_REVOCATION'
+            )
+        )
+);
+
+CREATE TABLE refresh_token_records (
+    id UUID PRIMARY KEY,
+    family_id UUID NOT NULL,
+    token_digest BYTEA NOT NULL,
+    issued_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    consumed_at TIMESTAMPTZ,
+    successor_id UUID,
+
+    CONSTRAINT uq_refresh_token_records_id_family
+        UNIQUE (
+            id,
+            family_id
+        ),
+
+    CONSTRAINT uq_refresh_token_records_digest
+        UNIQUE (
+            token_digest
+        ),
+
+    CONSTRAINT uq_refresh_token_records_successor
+        UNIQUE (
+            successor_id
+        ),
+
+    CONSTRAINT fk_refresh_token_records_family
+        FOREIGN KEY (family_id)
+        REFERENCES refresh_token_families(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT chk_refresh_token_records_digest_length
+        CHECK (
+            octet_length(token_digest) = 32
+        ),
+
+    CONSTRAINT chk_refresh_token_records_lifetime
+        CHECK (
+            expires_at > issued_at
+        ),
+
+    CONSTRAINT chk_refresh_token_records_consumption_state
+        CHECK (
+            (
+                consumed_at IS NULL
+                AND successor_id IS NULL
+            )
+            OR
+            (
+                consumed_at IS NOT NULL
+                AND successor_id IS NOT NULL
+            )
+        ),
+
+    CONSTRAINT chk_refresh_token_records_consumption_time
+        CHECK (
+            consumed_at IS NULL
+            OR (
+                consumed_at >= issued_at
+                AND consumed_at < expires_at
+            )
+        ),
+
+    CONSTRAINT chk_refresh_token_records_not_self_successor
+        CHECK (
+            successor_id IS NULL
+            OR successor_id <> id
+        )
+);
+
+ALTER TABLE refresh_token_records
+    ADD CONSTRAINT fk_refresh_token_records_successor_family
+    FOREIGN KEY (
+        successor_id,
+        family_id
+    )
+    REFERENCES refresh_token_records (
+        id,
+        family_id
+    )
+    DEFERRABLE INITIALLY DEFERRED;
+
+CREATE FUNCTION enforce_refresh_token_record_family_expiration()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    family_expiration TIMESTAMPTZ;
+BEGIN
+    SELECT family.expires_at
+    INTO family_expiration
+    FROM refresh_token_families family
+    WHERE family.id = NEW.family_id;
+
+    IF NOT FOUND THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.expires_at > family_expiration THEN
+        RAISE EXCEPTION
+            'refresh token expiration exceeds family expiration'
+            USING
+                ERRCODE = '23514',
+                CONSTRAINT =
+                    'chk_refresh_token_records_family_expiration';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_refresh_token_records_family_expiration
+    BEFORE INSERT OR UPDATE OF family_id, expires_at
+    ON refresh_token_records
+    FOR EACH ROW
+    EXECUTE FUNCTION
+        enforce_refresh_token_record_family_expiration();
+
+CREATE FUNCTION enforce_refresh_token_family_expiration_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM refresh_token_records record
+        WHERE record.family_id = NEW.id
+          AND record.expires_at > NEW.expires_at
+    ) THEN
+        RAISE EXCEPTION
+            'family expiration precedes token expiration'
+            USING
+                ERRCODE = '23514',
+                CONSTRAINT =
+                    'chk_refresh_token_records_family_expiration';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_refresh_token_families_expiration_update
+    BEFORE UPDATE OF expires_at
+    ON refresh_token_families
+    FOR EACH ROW
+    EXECUTE FUNCTION
+        enforce_refresh_token_family_expiration_update();
+
+CREATE INDEX idx_refresh_token_families_user_active
+    ON refresh_token_families (
+        user_id,
+        expires_at
+    )
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX idx_refresh_token_families_expires_at
+    ON refresh_token_families (
+        expires_at
+    );
+
+CREATE INDEX idx_refresh_token_records_family_issued_at
+    ON refresh_token_records (
+        family_id,
+        issued_at DESC
+    );
+
+CREATE INDEX idx_refresh_token_records_expires_at
+    ON refresh_token_records (
+        expires_at
+    );

--- a/src/test/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenPersistenceAdapterIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenPersistenceAdapterIntegrationTest.java
@@ -1,0 +1,715 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class RefreshTokenPersistenceAdapterIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    @Autowired
+    private RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PlatformTransactionManager
+        transactionManager;
+
+    private TransactionTemplate
+        transactionTemplate;
+
+    @BeforeEach
+    void setUp() {
+        transactionTemplate =
+            new TransactionTemplate(
+                transactionManager
+            );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldRoundTripActiveFamilyAndRecord() {
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant familyExpiresAt =
+            createdAt.plusSeconds(
+                86_400
+            );
+
+        RefreshTokenFamily family =
+            RefreshTokenFamily.create(
+                RefreshTokenFamilyId.of(
+                    UUID.randomUUID()
+                ),
+                userId,
+                createdAt,
+                familyExpiresAt
+            );
+
+        RefreshTokenFamily savedFamily =
+            familyRepository.save(family);
+
+        assertThat(savedFamily.id())
+            .isEqualTo(family.id());
+
+        assertThat(savedFamily.userId())
+            .isEqualTo(userId);
+
+        assertThat(savedFamily.createdAt())
+            .isEqualTo(createdAt);
+
+        assertThat(savedFamily.expiresAt())
+            .isEqualTo(familyExpiresAt);
+
+        assertThat(savedFamily.isRevoked())
+            .isFalse();
+
+        RefreshTokenDigest digest =
+            digest(1);
+
+        RefreshTokenRecord record =
+            RefreshTokenRecord.issue(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                ),
+                savedFamily,
+                digest,
+                createdAt.plusSeconds(60),
+                familyExpiresAt
+            );
+
+        RefreshTokenRecord savedRecord =
+            recordRepository.save(record);
+
+        Optional<RefreshTokenRecord> reloaded =
+            recordRepository.findById(
+                savedRecord.id()
+            );
+
+        assertThat(reloaded)
+            .isPresent();
+
+        RefreshTokenRecord persistedRecord =
+            reloaded.orElseThrow();
+
+        assertThat(persistedRecord.id())
+            .isEqualTo(record.id());
+
+        assertThat(persistedRecord.familyId())
+            .isEqualTo(family.id());
+
+        assertThat(persistedRecord.digest())
+            .isEqualTo(digest);
+
+        assertThat(persistedRecord.issuedAt())
+            .isEqualTo(
+                createdAt.plusSeconds(60)
+            );
+
+        assertThat(persistedRecord.expiresAt())
+            .isEqualTo(familyExpiresAt);
+
+        assertThat(persistedRecord.isConsumed())
+            .isFalse();
+
+        assertThat(persistedRecord.successorId())
+            .isNull();
+    }
+
+    @Test
+    void shouldRoundTripRevokedFamily() {
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(
+                86_400
+            );
+
+        Instant revokedAt =
+            createdAt.plusSeconds(
+                3_600
+            );
+
+        RefreshTokenFamily revokedFamily =
+            RefreshTokenFamily.create(
+                RefreshTokenFamilyId.of(
+                    UUID.randomUUID()
+                ),
+                userId,
+                createdAt,
+                expiresAt
+            ).revoke(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT,
+                revokedAt
+            );
+
+        familyRepository.save(
+            revokedFamily
+        );
+
+        RefreshTokenFamily reloaded =
+            findFamilyForUpdate(
+                revokedFamily.id()
+            ).orElseThrow();
+
+        assertThat(reloaded.isRevoked())
+            .isTrue();
+
+        assertThat(reloaded.revokedAt())
+            .isEqualTo(revokedAt);
+
+        assertThat(reloaded.revocationReason())
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT
+            );
+    }
+
+    @Test
+    void shouldRoundTripConsumedRecordLineage() {
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(
+                86_400
+            );
+
+        Instant consumedAt =
+            createdAt.plusSeconds(
+                3_600
+            );
+
+        RefreshTokenFamily family =
+            familyRepository.save(
+                RefreshTokenFamily.create(
+                    RefreshTokenFamilyId.of(
+                        UUID.randomUUID()
+                    ),
+                    userId,
+                    createdAt,
+                    expiresAt
+                )
+            );
+
+        RefreshTokenRecord successor =
+            RefreshTokenRecord.issue(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                ),
+                family,
+                digest(2),
+                consumedAt,
+                expiresAt
+            );
+
+        recordRepository.save(successor);
+
+        RefreshTokenRecord predecessor =
+            RefreshTokenRecord.issue(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                ),
+                family,
+                digest(3),
+                createdAt.plusSeconds(60),
+                expiresAt
+            ).consume(
+                successor.id(),
+                consumedAt,
+                family
+            );
+
+        recordRepository.save(
+            predecessor
+        );
+
+        RefreshTokenRecord reloaded =
+            recordRepository.findById(
+                predecessor.id()
+            ).orElseThrow();
+
+        assertThat(reloaded.isConsumed())
+            .isTrue();
+
+        assertThat(reloaded.consumedAt())
+            .isEqualTo(consumedAt);
+
+        assertThat(reloaded.successorId())
+            .isEqualTo(successor.id());
+    }
+
+    @Test
+    void shouldPreserveDigestDefensiveCopiesAcrossPersistenceBoundary() {
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(
+                86_400
+            );
+
+        RefreshTokenFamily family =
+            familyRepository.save(
+                RefreshTokenFamily.create(
+                    RefreshTokenFamilyId.of(
+                        UUID.randomUUID()
+                    ),
+                    userId,
+                    createdAt,
+                    expiresAt
+                )
+            );
+
+        byte[] sourceDigest =
+            digestBytes(4);
+
+        RefreshTokenDigest digest =
+            RefreshTokenDigest.of(
+                sourceDigest
+            );
+
+        RefreshTokenRecord saved =
+            recordRepository.save(
+                RefreshTokenRecord.issue(
+                    RefreshTokenRecordId.of(
+                        UUID.randomUUID()
+                    ),
+                    family,
+                    digest,
+                    createdAt.plusSeconds(60),
+                    expiresAt
+                )
+            );
+
+        Arrays.fill(
+            sourceDigest,
+            (byte) 99
+        );
+
+        byte[] exposedDigest =
+            saved.digest().value();
+
+        Arrays.fill(
+            exposedDigest,
+            (byte) 88
+        );
+
+        RefreshTokenRecord reloaded =
+            recordRepository.findById(
+                saved.id()
+            ).orElseThrow();
+
+        assertThat(
+            reloaded.digest().value()
+        )
+            .containsOnly((byte) 4);
+    }
+
+    @Test
+    void shouldRevokeOnlyActiveFamiliesForUser() {
+        UUID targetUserId =
+            insertUser();
+
+        UUID otherUserId =
+            insertUser();
+
+        Instant now =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        RefreshTokenFamily active =
+            familyRepository.save(
+                newFamily(
+                    targetUserId,
+                    now.minusSeconds(3_600),
+                    now.plusSeconds(86_400)
+                )
+            );
+
+        RefreshTokenFamily expired =
+            familyRepository.save(
+                newFamily(
+                    targetUserId,
+                    now.minusSeconds(86_400),
+                    now.minusSeconds(1)
+                )
+            );
+
+        RefreshTokenFamily future =
+            familyRepository.save(
+                newFamily(
+                    targetUserId,
+                    now.plusSeconds(60),
+                    now.plusSeconds(86_400)
+                )
+            );
+
+        RefreshTokenFamily alreadyRevoked =
+            familyRepository.save(
+                newFamily(
+                    targetUserId,
+                    now.minusSeconds(7_200),
+                    now.plusSeconds(86_400)
+                ).revoke(
+                    RefreshTokenFamilyRevocationReason
+                        .ADMINISTRATIVE_REVOCATION,
+                    now.minusSeconds(3_600)
+                )
+            );
+
+        RefreshTokenFamily otherUserActive =
+            familyRepository.save(
+                newFamily(
+                    otherUserId,
+                    now.minusSeconds(3_600),
+                    now.plusSeconds(86_400)
+                )
+            );
+
+        Integer revokedCount =
+            transactionTemplate.execute(
+                status ->
+                    familyRepository
+                        .revokeAllActiveByUserId(
+                            targetUserId,
+                            now,
+                            RefreshTokenFamilyRevocationReason
+                                .ALL_SESSIONS_LOGOUT
+                        )
+            );
+
+        assertThat(revokedCount)
+            .isEqualTo(1);
+
+        RefreshTokenFamily reloadedActive =
+            findFamilyForUpdate(
+                active.id()
+            ).orElseThrow();
+
+        assertThat(reloadedActive.isRevoked())
+            .isTrue();
+
+        assertThat(reloadedActive.revokedAt())
+            .isEqualTo(now);
+
+        assertThat(
+            reloadedActive.revocationReason()
+        )
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .ALL_SESSIONS_LOGOUT
+            );
+
+        assertThat(
+            findFamilyForUpdate(
+                expired.id()
+            ).orElseThrow().isRevoked()
+        )
+            .isFalse();
+
+        assertThat(
+            findFamilyForUpdate(
+                future.id()
+            ).orElseThrow().isRevoked()
+        )
+            .isFalse();
+
+        RefreshTokenFamily reloadedPreviouslyRevoked =
+            findFamilyForUpdate(
+                alreadyRevoked.id()
+            ).orElseThrow();
+
+        assertThat(
+            reloadedPreviouslyRevoked
+                .revocationReason()
+        )
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .ADMINISTRATIVE_REVOCATION
+            );
+
+        assertThat(
+            findFamilyForUpdate(
+                otherUserActive.id()
+            ).orElseThrow().isRevoked()
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldFindRecordByDigestForUpdateInsideTransaction() {
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(
+                86_400
+            );
+
+        RefreshTokenFamily family =
+            familyRepository.save(
+                RefreshTokenFamily.create(
+                    RefreshTokenFamilyId.of(
+                        UUID.randomUUID()
+                    ),
+                    userId,
+                    createdAt,
+                    expiresAt
+                )
+            );
+
+        RefreshTokenDigest digest =
+            digest(5);
+
+        RefreshTokenRecord saved =
+            recordRepository.save(
+                RefreshTokenRecord.issue(
+                    RefreshTokenRecordId.of(
+                        UUID.randomUUID()
+                    ),
+                    family,
+                    digest,
+                    createdAt.plusSeconds(60),
+                    expiresAt
+                )
+            );
+
+        Optional<RefreshTokenRecord> found =
+            findRecordByDigestForUpdate(
+                digest
+            );
+
+        assertThat(found)
+            .isPresent();
+
+        assertThat(found.orElseThrow().id())
+            .isEqualTo(saved.id());
+    }
+
+    @Test
+    void shouldReturnEmptyForUnknownIdentifiers() {
+        Optional<RefreshTokenFamily>
+            missingFamily =
+            findFamilyForUpdate(
+                RefreshTokenFamilyId.of(
+                    UUID.randomUUID()
+                )
+            );
+
+        Optional<RefreshTokenRecord>
+            missingRecord =
+            recordRepository.findById(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                )
+            );
+
+        Optional<RefreshTokenRecord>
+            missingDigest =
+            findRecordByDigestForUpdate(
+                digest(6)
+            );
+
+        assertThat(missingFamily)
+            .isEmpty();
+
+        assertThat(missingRecord)
+            .isEmpty();
+
+        assertThat(missingDigest)
+            .isEmpty();
+    }
+
+    private Optional<RefreshTokenFamily>
+    findFamilyForUpdate(
+        RefreshTokenFamilyId familyId
+    ) {
+        Optional<RefreshTokenFamily> result =
+            transactionTemplate.execute(
+                status ->
+                    familyRepository
+                        .findByIdForUpdate(
+                            familyId
+                        )
+            );
+
+        return result == null
+            ? Optional.empty()
+            : result;
+    }
+
+    private Optional<RefreshTokenRecord>
+    findRecordByDigestForUpdate(
+        RefreshTokenDigest digest
+    ) {
+        Optional<RefreshTokenRecord> result =
+            transactionTemplate.execute(
+                status ->
+                    recordRepository
+                        .findByDigestForUpdate(
+                            digest
+                        )
+            );
+
+        return result == null
+            ? Optional.empty()
+            : result;
+    }
+
+    private static RefreshTokenFamily
+    newFamily(
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt
+    ) {
+        return RefreshTokenFamily.create(
+            RefreshTokenFamilyId.of(
+                UUID.randomUUID()
+            ),
+            userId,
+            createdAt,
+            expiresAt
+        );
+    }
+
+    private UUID insertUser() {
+        UUID userId =
+            UUID.randomUUID();
+
+        Instant now =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Timestamp timestamp =
+            Timestamp.from(now);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, 'USER', 'ACTIVE', ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            "test-password-hash",
+            timestamp,
+            timestamp
+        );
+
+        return userId;
+    }
+
+    private static RefreshTokenDigest
+    digest(
+        int marker
+    ) {
+        return RefreshTokenDigest.of(
+            digestBytes(marker)
+        );
+    }
+
+    private static byte[] digestBytes(
+        int marker
+    ) {
+        byte[] digest =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            digest,
+            (byte) marker
+        );
+
+        return digest;
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenPersistenceLockIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/persistence/RefreshTokenPersistenceLockIntegrationTest.java
@@ -1,0 +1,462 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class RefreshTokenPersistenceLockIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    @Autowired
+    private RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    @Autowired
+    private PlatformTransactionManager
+        transactionManager;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldBlockConcurrentFamilyLockUntilFirstTransactionCompletes()
+        throws Exception {
+
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        RefreshTokenFamily family =
+            familyRepository.save(
+                RefreshTokenFamily.create(
+                    RefreshTokenFamilyId.of(
+                        UUID.randomUUID()
+                    ),
+                    userId,
+                    createdAt,
+                    createdAt.plusSeconds(
+                        86_400
+                    )
+                )
+            );
+
+        assertSecondTransactionWaits(
+            () ->
+                familyRepository
+                    .findByIdForUpdate(
+                        family.id()
+                    )
+                    .orElseThrow()
+        );
+    }
+
+    @Test
+    void shouldBlockConcurrentDigestLockUntilFirstTransactionCompletes()
+        throws Exception {
+
+        UUID userId =
+            insertUser();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(
+                86_400
+            );
+
+        RefreshTokenFamily family =
+            familyRepository.save(
+                RefreshTokenFamily.create(
+                    RefreshTokenFamilyId.of(
+                        UUID.randomUUID()
+                    ),
+                    userId,
+                    createdAt,
+                    expiresAt
+                )
+            );
+
+        RefreshTokenDigest digest =
+            digest(1);
+
+        recordRepository.save(
+            RefreshTokenRecord.issue(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                ),
+                family,
+                digest,
+                createdAt.plusSeconds(60),
+                expiresAt
+            )
+        );
+
+        assertSecondTransactionWaits(
+            () ->
+                recordRepository
+                    .findByDigestForUpdate(
+                        digest
+                    )
+                    .orElseThrow()
+        );
+    }
+
+    private void assertSecondTransactionWaits(
+        Runnable lockOperation
+    ) throws Exception {
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(2);
+
+        CountDownLatch holderHasLock =
+            new CountDownLatch(1);
+
+        CountDownLatch releaseHolder =
+            new CountDownLatch(1);
+
+        String identifier =
+            UUID.randomUUID()
+                .toString()
+                .replace("-", "");
+
+        String holderApplicationName =
+            "refresh-lock-holder-"
+                + identifier;
+
+        String contenderApplicationName =
+            "refresh-lock-contender-"
+                + identifier;
+
+        Future<?> holderFuture =
+            null;
+
+        Future<?> contenderFuture =
+            null;
+
+        try {
+            holderFuture =
+                executor.submit(
+                    () ->
+                        executeInTransaction(
+                            () -> {
+                                setApplicationName(
+                                    holderApplicationName
+                                );
+
+                                lockOperation.run();
+
+                                holderHasLock.countDown();
+
+                                await(
+                                    releaseHolder
+                                );
+                            }
+                        )
+                );
+
+            assertThat(
+                holderHasLock.await(
+                    10,
+                    SECONDS
+                )
+            )
+                .as(
+                    "first transaction should acquire the lock"
+                )
+                .isTrue();
+
+            contenderFuture =
+                executor.submit(
+                    () ->
+                        executeInTransaction(
+                            () -> {
+                                setApplicationName(
+                                    contenderApplicationName
+                                );
+
+                                lockOperation.run();
+                            }
+                        )
+                );
+
+            assertThat(
+                waitUntilLockWaitVisible(
+                    contenderApplicationName,
+                    Duration.ofSeconds(10)
+                )
+            )
+                .as(
+                    "second transaction should wait on a PostgreSQL lock"
+                )
+                .isTrue();
+
+            assertThat(
+                contenderFuture.isDone()
+            )
+                .as(
+                    "second transaction must remain blocked before release"
+                )
+                .isFalse();
+
+            releaseHolder.countDown();
+
+            holderFuture.get(
+                10,
+                SECONDS
+            );
+
+            contenderFuture.get(
+                10,
+                SECONDS
+            );
+
+            assertThat(
+                contenderFuture.isDone()
+            )
+                .isTrue();
+        } finally {
+            releaseHolder.countDown();
+
+            if (holderFuture != null) {
+                holderFuture.cancel(true);
+            }
+
+            if (contenderFuture != null) {
+                contenderFuture.cancel(true);
+            }
+
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    SECONDS
+                )
+            )
+                .as(
+                    "executor should terminate cleanly"
+                )
+                .isTrue();
+        }
+    }
+
+    private void executeInTransaction(
+        Runnable action
+    ) {
+        TransactionTemplate template =
+            new TransactionTemplate(
+                transactionManager
+            );
+
+        template.executeWithoutResult(
+            status -> action.run()
+        );
+    }
+
+    private void setApplicationName(
+        String applicationName
+    ) {
+        jdbcTemplate.queryForObject(
+            """
+            SELECT set_config(
+                'application_name',
+                ?,
+                TRUE
+            )
+            """,
+            String.class,
+            applicationName
+        );
+    }
+
+    private boolean waitUntilLockWaitVisible(
+        String applicationName,
+        Duration timeout
+    ) {
+        Instant deadline =
+            Instant.now().plus(timeout);
+
+        while (
+            Instant.now()
+                .isBefore(deadline)
+        ) {
+            Boolean waiting =
+                jdbcTemplate.queryForObject(
+                    """
+                    SELECT EXISTS (
+                        SELECT 1
+                        FROM pg_stat_activity
+                        WHERE application_name = ?
+                          AND wait_event_type = 'Lock'
+                    )
+                    """,
+                    Boolean.class,
+                    applicationName
+                );
+
+            if (Boolean.TRUE.equals(waiting)) {
+                return true;
+            }
+
+            sleepBriefly();
+        }
+
+        return false;
+    }
+
+    private static void await(
+        CountDownLatch latch
+    ) {
+        try {
+            boolean released =
+                latch.await(
+                    15,
+                    SECONDS
+                );
+
+            if (!released) {
+                throw new IllegalStateException(
+                    "lock holder was not released"
+                );
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread()
+                .interrupt();
+
+            throw new IllegalStateException(
+                "lock wait was interrupted",
+                exception
+            );
+        }
+    }
+
+    private static void sleepBriefly() {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException exception) {
+            Thread.currentThread()
+                .interrupt();
+
+            throw new IllegalStateException(
+                "lock polling was interrupted",
+                exception
+            );
+        }
+    }
+
+    private UUID insertUser() {
+        UUID userId =
+            UUID.randomUUID();
+
+        Instant now =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Timestamp timestamp =
+            Timestamp.from(now);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, 'USER', 'ACTIVE', ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            "test-password-hash",
+            timestamp,
+            timestamp
+        );
+
+        return userId;
+    }
+
+    private static RefreshTokenDigest digest(
+        int marker
+    ) {
+        byte[] value =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            value,
+            (byte) marker
+        );
+
+        return RefreshTokenDigest.of(
+            value
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/JwtAccessTokenGenerationAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/JwtAccessTokenGenerationAdapterTest.java
@@ -21,7 +21,7 @@ import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 
-class JwtTokenGenerationAdapterTest {
+class JwtAccessTokenGenerationAdapterTest {
 
     private static final Instant NOW =
         Instant.parse("2026-07-14T12:00:00Z");
@@ -47,8 +47,8 @@ class JwtTokenGenerationAdapterTest {
             ZoneOffset.UTC
         );
 
-        JwtTokenGenerationAdapter adapter =
-            new JwtTokenGenerationAdapter(
+        JwtAccessTokenGenerationAdapter adapter =
+            new JwtAccessTokenGenerationAdapter(
                 jwtEncoder,
                 properties,
                 clock

--- a/src/test/java/com/nursena/payflow/user/application/port/out/GeneratedRefreshTokenTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/out/GeneratedRefreshTokenTest.java
@@ -1,0 +1,53 @@
+package com.nursena.payflow.user.application.port.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class GeneratedRefreshTokenTest {
+
+    @Test
+    void shouldCreateGeneratedRefreshToken() {
+        GeneratedRefreshToken token =
+            new GeneratedRefreshToken(
+                "opaque-refresh-token"
+            );
+
+        assertThat(token.value())
+            .isEqualTo(
+                "opaque-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRedactTokenFromStringRepresentation() {
+        GeneratedRefreshToken token =
+            new GeneratedRefreshToken(
+                "secret-refresh-token"
+            );
+
+        assertThat(token.toString())
+            .isEqualTo(
+                "GeneratedRefreshToken[redacted]"
+            );
+
+        assertThat(token.toString())
+            .doesNotContain(
+                "secret-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankGeneratedRefreshToken() {
+        assertThatThrownBy(() ->
+            new GeneratedRefreshToken(" ")
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "value must not be blank"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/AuthenticateUserServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/AuthenticateUserServiceTest.java
@@ -15,7 +15,7 @@ import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
 import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
 import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
-import com.nursena.payflow.user.application.port.out.TokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
 import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
 import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
@@ -59,7 +59,7 @@ class AuthenticateUserServiceTest {
     private PasswordVerificationPort passwordVerification;
 
     @Mock
-    private TokenGenerationPort tokenGeneration;
+    private AccessTokenGenerationPort accessTokenGeneration;
 
     private AuthenticateUserService authenticateUserService;
 
@@ -68,7 +68,7 @@ class AuthenticateUserServiceTest {
         authenticateUserService = new AuthenticateUserService(
             userRepository,
             passwordVerification,
-            tokenGeneration
+            accessTokenGeneration
         );
     }
 
@@ -85,7 +85,7 @@ class AuthenticateUserServiceTest {
             RAW_PASSWORD,
             PASSWORD_HASH
         )).thenReturn(true);
-        when(tokenGeneration.generate(user))
+        when(accessTokenGeneration.generate(user))
             .thenReturn(new GeneratedAccessToken(
                 ACCESS_TOKEN,
                 EXPIRES_AT
@@ -109,7 +109,7 @@ class AuthenticateUserServiceTest {
             RAW_PASSWORD,
             PASSWORD_HASH
         );
-        verify(tokenGeneration).generate(user);
+        verify(accessTokenGeneration).generate(user);
     }
 
     @Test
@@ -133,7 +133,7 @@ class AuthenticateUserServiceTest {
         verify(userRepository).findByEmail(email);
         verifyNoInteractions(
             passwordVerification,
-            tokenGeneration
+            accessTokenGeneration
         );
     }
 
@@ -161,7 +161,7 @@ class AuthenticateUserServiceTest {
             .isInstanceOf(InvalidCredentialsException.class)
             .hasMessage("Email or password is incorrect.");
 
-        verify(tokenGeneration, never()).generate(user);
+        verify(accessTokenGeneration, never()).generate(user);
     }
 
     @Test
@@ -192,7 +192,7 @@ class AuthenticateUserServiceTest {
                 "User account is not available for authentication."
             );
 
-        verify(tokenGeneration, never()).generate(user);
+        verify(accessTokenGeneration, never()).generate(user);
     }
 
     private static User activeUser(EmailAddress email) {

--- a/src/test/java/com/nursena/payflow/user/domain/model/RefreshTokenDigestTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/RefreshTokenDigestTest.java
@@ -1,0 +1,107 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenDigestTest {
+
+    @Test
+    void shouldDefensivelyCopyDigestBytes() {
+        byte[] source = digestBytes((byte) 7);
+
+        RefreshTokenDigest digest =
+            RefreshTokenDigest.of(source);
+
+        source[0] = 99;
+
+        byte[] exposed = digest.value();
+        exposed[1] = 88;
+
+        assertThat(digest.value())
+            .containsOnly((byte) 7);
+    }
+
+    @Test
+    void shouldCompareByDigestContent() {
+        RefreshTokenDigest first =
+            RefreshTokenDigest.of(
+                digestBytes((byte) 4)
+            );
+
+        RefreshTokenDigest second =
+            RefreshTokenDigest.of(
+                digestBytes((byte) 4)
+            );
+
+        assertThat(first)
+            .isEqualTo(second);
+
+        assertThat(first.hashCode())
+            .isEqualTo(second.hashCode());
+    }
+
+    @Test
+    void shouldRequireSha256Length() {
+        assertThatThrownBy(() ->
+            RefreshTokenDigest.of(
+                new byte[31]
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "value must contain exactly 32 bytes"
+            );
+
+        assertThatThrownBy(() ->
+            RefreshTokenDigest.of(
+                new byte[33]
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "value must contain exactly 32 bytes"
+            );
+    }
+
+    @Test
+    void shouldRedactDigestFromStringRepresentation() {
+        RefreshTokenDigest digest =
+            RefreshTokenDigest.of(
+                digestBytes((byte) 12)
+            );
+
+        assertThat(digest.toString())
+            .isEqualTo(
+                "RefreshTokenDigest[redacted]"
+            );
+
+        assertThat(digest.toString())
+            .doesNotContain(
+                Arrays.toString(
+                    digest.value()
+                )
+            );
+    }
+
+    private static byte[] digestBytes(
+        byte value
+    ) {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(bytes, value);
+
+        return bytes;
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyTest.java
@@ -1,0 +1,249 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenFamilyTest {
+
+    private static final RefreshTokenFamilyId
+        FAMILY_ID =
+        RefreshTokenFamilyId.of(
+            UUID.fromString(
+                "70000000-0000-0000-0000-000000000001"
+            )
+        );
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "70000000-0000-0000-0000-000000000002"
+        );
+
+    private static final Instant CREATED_AT =
+        Instant.parse(
+            "2026-07-26T13:00:00Z"
+        );
+
+    private static final Instant EXPIRES_AT =
+        CREATED_AT.plusSeconds(86_400);
+
+    @Test
+    void shouldCreateActiveFamily() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        assertThat(family.id())
+            .isEqualTo(FAMILY_ID);
+
+        assertThat(family.userId())
+            .isEqualTo(USER_ID);
+
+        assertThat(family.createdAt())
+            .isEqualTo(CREATED_AT);
+
+        assertThat(family.expiresAt())
+            .isEqualTo(EXPIRES_AT);
+
+        assertThat(family.isRevoked())
+            .isFalse();
+
+        assertThat(
+            family.isActiveAt(
+                CREATED_AT
+            )
+        )
+            .isTrue();
+    }
+
+    @Test
+    void shouldNotBeActiveBeforeCreation() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        assertThat(
+            family.isActiveAt(
+                CREATED_AT.minusNanos(1)
+            )
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldTreatExpirationBoundaryAsInactive() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        assertThat(
+            family.isActiveAt(
+                EXPIRES_AT.minusNanos(1)
+            )
+        )
+            .isTrue();
+
+        assertThat(
+            family.isActiveAt(
+                EXPIRES_AT
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            family.isExpiredAt(
+                EXPIRES_AT
+            )
+        )
+            .isTrue();
+    }
+
+    @Test
+    void shouldRevokeWithoutMutatingOriginal() {
+        RefreshTokenFamily original =
+            activeFamily();
+
+        Instant revokedAt =
+            CREATED_AT.plusSeconds(60);
+
+        RefreshTokenFamily revoked =
+            original.revoke(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT,
+                revokedAt
+            );
+
+        assertThat(original.isRevoked())
+            .isFalse();
+
+        assertThat(revoked.isRevoked())
+            .isTrue();
+
+        assertThat(revoked.revokedAt())
+            .isEqualTo(revokedAt);
+
+        assertThat(revoked.revocationReason())
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT
+            );
+
+        assertThat(
+            revoked.isActiveAt(
+                revokedAt
+            )
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldKeepFirstRevocationIdempotently() {
+        RefreshTokenFamily revoked =
+            activeFamily().revoke(
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED,
+                CREATED_AT.plusSeconds(30)
+            );
+
+        RefreshTokenFamily repeated =
+            revoked.revoke(
+                RefreshTokenFamilyRevocationReason
+                    .ALL_SESSIONS_LOGOUT,
+                CREATED_AT.plusSeconds(60)
+            );
+
+        assertThat(repeated)
+            .isSameAs(revoked);
+
+        assertThat(repeated.revocationReason())
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED
+            );
+    }
+
+    @Test
+    void shouldRejectInvalidLifetime() {
+        assertThatThrownBy(() ->
+            RefreshTokenFamily.create(
+                FAMILY_ID,
+                USER_ID,
+                CREATED_AT,
+                CREATED_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "expiresAt must be after createdAt"
+            );
+    }
+
+    @Test
+    void shouldRejectIncompleteRevocationState() {
+        assertThatThrownBy(() ->
+            RefreshTokenFamily.rehydrate(
+                FAMILY_ID,
+                USER_ID,
+                CREATED_AT,
+                EXPIRES_AT,
+                CREATED_AT.plusSeconds(10),
+                null
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "revokedAt and revocationReason "
+                    + "must appear together"
+            );
+
+        assertThatThrownBy(() ->
+            RefreshTokenFamily.rehydrate(
+                FAMILY_ID,
+                USER_ID,
+                CREATED_AT,
+                EXPIRES_AT,
+                null,
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "revokedAt and revocationReason "
+                    + "must appear together"
+            );
+    }
+
+    @Test
+    void shouldRejectRevocationBeforeCreation() {
+        assertThatThrownBy(() ->
+            activeFamily().revoke(
+                RefreshTokenFamilyRevocationReason
+                    .ADMINISTRATIVE_REVOCATION,
+                CREATED_AT.minusSeconds(1)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "revokedAt must not be before createdAt"
+            );
+    }
+
+    private static RefreshTokenFamily activeFamily() {
+        return RefreshTokenFamily.create(
+            FAMILY_ID,
+            USER_ID,
+            CREATED_AT,
+            EXPIRES_AT
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/domain/model/RefreshTokenRecordTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/RefreshTokenRecordTest.java
@@ -1,0 +1,436 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenRecordTest {
+
+    private static final RefreshTokenFamilyId
+        FAMILY_ID =
+        RefreshTokenFamilyId.of(
+            UUID.fromString(
+                "71000000-0000-0000-0000-000000000001"
+            )
+        );
+
+    private static final RefreshTokenFamilyId
+        OTHER_FAMILY_ID =
+        RefreshTokenFamilyId.of(
+            UUID.fromString(
+                "71000000-0000-0000-0000-000000000002"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        TOKEN_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "71000000-0000-0000-0000-000000000003"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        SUCCESSOR_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "71000000-0000-0000-0000-000000000004"
+            )
+        );
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "71000000-0000-0000-0000-000000000005"
+        );
+
+    private static final Instant FAMILY_CREATED_AT =
+        Instant.parse(
+            "2026-07-26T13:00:00Z"
+        );
+
+    private static final Instant FAMILY_EXPIRES_AT =
+        FAMILY_CREATED_AT.plusSeconds(86_400);
+
+    private static final Instant TOKEN_EXPIRES_AT =
+        FAMILY_CREATED_AT.plusSeconds(3_600);
+
+    @Test
+    void shouldIssueActiveToken() {
+        RefreshTokenRecord token =
+            activeToken();
+
+        assertThat(token.id())
+            .isEqualTo(TOKEN_ID);
+
+        assertThat(token.familyId())
+            .isEqualTo(FAMILY_ID);
+
+        assertThat(token.isConsumed())
+            .isFalse();
+
+        assertThat(
+            token.isActiveAt(
+                activeFamily(),
+                FAMILY_CREATED_AT
+            )
+        )
+            .isTrue();
+    }
+
+    @Test
+    void shouldNotBeActiveBeforeIssuance() {
+        RefreshTokenRecord token =
+            activeToken();
+
+        assertThat(
+            token.isActiveAt(
+                activeFamily(),
+                FAMILY_CREATED_AT.minusNanos(1)
+            )
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldRejectIssuanceBeforeFamilyCreation() {
+        assertThatThrownBy(() ->
+            RefreshTokenRecord.issue(
+                TOKEN_ID,
+                activeFamily(),
+                digest((byte) 1),
+                FAMILY_CREATED_AT.minusSeconds(1),
+                TOKEN_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "issuedAt must not be before "
+                    + "family createdAt"
+            );
+    }
+
+    @Test
+    void shouldRejectExpirationAfterFamilyExpiration() {
+        assertThatThrownBy(() ->
+            RefreshTokenRecord.issue(
+                TOKEN_ID,
+                activeFamily(),
+                digest((byte) 1),
+                FAMILY_CREATED_AT,
+                FAMILY_EXPIRES_AT.plusSeconds(1)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "token expiresAt must not be after "
+                    + "family expiresAt"
+            );
+    }
+
+    @Test
+    void shouldRejectIssuanceForRevokedFamily() {
+        RefreshTokenFamily revoked =
+            activeFamily().revoke(
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED,
+                FAMILY_CREATED_AT.plusSeconds(30)
+            );
+
+        assertThatThrownBy(() ->
+            RefreshTokenRecord.issue(
+                TOKEN_ID,
+                revoked,
+                digest((byte) 1),
+                FAMILY_CREATED_AT.plusSeconds(60),
+                TOKEN_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "family must be active when "
+                    + "a token is issued"
+            );
+    }
+
+    @Test
+    void shouldConsumeWithoutMutatingOriginal() {
+        RefreshTokenRecord original =
+            activeToken();
+
+        Instant consumedAt =
+            FAMILY_CREATED_AT.plusSeconds(600);
+
+        RefreshTokenRecord consumed =
+            original.consume(
+                SUCCESSOR_ID,
+                consumedAt,
+                activeFamily()
+            );
+
+        assertThat(original.isConsumed())
+            .isFalse();
+
+        assertThat(consumed.isConsumed())
+            .isTrue();
+
+        assertThat(consumed.consumedAt())
+            .isEqualTo(consumedAt);
+
+        assertThat(consumed.successorId())
+            .isEqualTo(SUCCESSOR_ID);
+
+        assertThat(
+            consumed.isActiveAt(
+                activeFamily(),
+                consumedAt
+            )
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldRejectSelfSuccessor() {
+        assertThatThrownBy(() ->
+            activeToken().consume(
+                TOKEN_ID,
+                FAMILY_CREATED_AT.plusSeconds(10),
+                activeFamily()
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "a token must not replace itself"
+            );
+    }
+
+    @Test
+    void shouldRejectSecondConsumption() {
+        RefreshTokenRecord consumed =
+            activeToken().consume(
+                SUCCESSOR_ID,
+                FAMILY_CREATED_AT.plusSeconds(10),
+                activeFamily()
+            );
+
+        assertThatThrownBy(() ->
+            consumed.consume(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                ),
+                FAMILY_CREATED_AT.plusSeconds(20),
+                activeFamily()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "refresh token is already consumed"
+            );
+    }
+
+    @Test
+    void shouldRejectExpiredTokenConsumption() {
+        assertThatThrownBy(() ->
+            activeToken().consume(
+                SUCCESSOR_ID,
+                TOKEN_EXPIRES_AT,
+                activeFamily()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "refresh token must not be expired"
+            );
+    }
+
+    @Test
+    void shouldRejectConsumptionForRevokedFamily() {
+        Instant revokedAt =
+            FAMILY_CREATED_AT.plusSeconds(300);
+
+        RefreshTokenFamily revoked =
+            activeFamily().revoke(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT,
+                revokedAt
+            );
+
+        assertThatThrownBy(() ->
+            activeToken().consume(
+                SUCCESSOR_ID,
+                revokedAt.plusSeconds(1),
+                revoked
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "family must be active when "
+                    + "a token is consumed"
+            );
+    }
+
+    @Test
+    void shouldRejectConsumptionForDifferentFamily() {
+        RefreshTokenFamily otherFamily =
+            RefreshTokenFamily.create(
+                OTHER_FAMILY_ID,
+                USER_ID,
+                FAMILY_CREATED_AT,
+                FAMILY_EXPIRES_AT
+            );
+
+        assertThatThrownBy(() ->
+            activeToken().consume(
+                SUCCESSOR_ID,
+                FAMILY_CREATED_AT.plusSeconds(10),
+                otherFamily
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "token familyId must match family id"
+            );
+    }
+
+    @Test
+    void shouldRejectIncompleteConsumedState() {
+        assertThatThrownBy(() ->
+            RefreshTokenRecord.rehydrate(
+                TOKEN_ID,
+                FAMILY_ID,
+                digest((byte) 1),
+                FAMILY_CREATED_AT,
+                TOKEN_EXPIRES_AT,
+                FAMILY_CREATED_AT.plusSeconds(10),
+                null,
+                activeFamily()
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "consumedAt and successorId "
+                    + "must appear together"
+            );
+
+        assertThatThrownBy(() ->
+            RefreshTokenRecord.rehydrate(
+                TOKEN_ID,
+                FAMILY_ID,
+                digest((byte) 1),
+                FAMILY_CREATED_AT,
+                TOKEN_EXPIRES_AT,
+                null,
+                SUCCESSOR_ID,
+                activeFamily()
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "consumedAt and successorId "
+                    + "must appear together"
+            );
+    }
+
+    @Test
+    void shouldRehydrateConsumedTokenInRevokedFamily() {
+        Instant consumedAt =
+            FAMILY_CREATED_AT.plusSeconds(300);
+
+        Instant revokedAt =
+            consumedAt.plusSeconds(300);
+
+        RefreshTokenFamily revoked =
+            RefreshTokenFamily.rehydrate(
+                FAMILY_ID,
+                USER_ID,
+                FAMILY_CREATED_AT,
+                FAMILY_EXPIRES_AT,
+                revokedAt,
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED
+            );
+
+        RefreshTokenRecord token =
+            RefreshTokenRecord.rehydrate(
+                TOKEN_ID,
+                FAMILY_ID,
+                digest((byte) 1),
+                FAMILY_CREATED_AT,
+                TOKEN_EXPIRES_AT,
+                consumedAt,
+                SUCCESSOR_ID,
+                revoked
+            );
+
+        assertThat(token.isConsumed())
+            .isTrue();
+
+        assertThat(token.successorId())
+            .isEqualTo(SUCCESSOR_ID);
+
+        assertThat(
+            token.isActiveAt(
+                revoked,
+                consumedAt
+            )
+        )
+            .isFalse();
+    }
+
+    private static RefreshTokenFamily activeFamily() {
+        return RefreshTokenFamily.create(
+            FAMILY_ID,
+            USER_ID,
+            FAMILY_CREATED_AT,
+            FAMILY_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenRecord activeToken() {
+        return RefreshTokenRecord.issue(
+            TOKEN_ID,
+            activeFamily(),
+            digest((byte) 1),
+            FAMILY_CREATED_AT,
+            TOKEN_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenDigest digest(
+        byte value
+    ) {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(bytes, value);
+
+        return RefreshTokenDigest.of(bytes);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RefreshSessionMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RefreshSessionMigrationIntegrationTest.java
@@ -1,0 +1,251 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class RefreshSessionMigrationIntegrationTest {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    private static JdbcTemplate jdbcTemplate;
+
+    @BeforeAll
+    static void configureJdbcTemplate() {
+        DriverManagerDataSource dataSource =
+            new DriverManagerDataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            );
+
+        jdbcTemplate =
+            new JdbcTemplate(dataSource);
+    }
+
+    @Test
+    void shouldUpgradeV13ToV14AndPreserveExistingUserData() {
+        migrateToVersion("13");
+
+        assertThat(currentSchemaVersion())
+            .isEqualTo("13");
+
+        assertThat(migrationApplied("14"))
+            .isFalse();
+
+        assertThat(
+            tableExists(
+                "refresh_token_families"
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            tableExists(
+                "refresh_token_records"
+            )
+        )
+            .isFalse();
+
+        UUID existingUserId =
+            UUID.randomUUID();
+
+        insertUser(existingUserId);
+
+        assertThat(userCount(existingUserId))
+            .isEqualTo(1);
+
+        migrateToLatestVersion();
+
+        assertThat(currentSchemaVersion())
+            .isEqualTo("14");
+
+        assertThat(migrationApplied("13"))
+            .isTrue();
+
+        assertThat(migrationApplied("14"))
+            .isTrue();
+
+        assertThat(
+            tableExists(
+                "refresh_token_families"
+            )
+        )
+            .isTrue();
+
+        assertThat(
+            tableExists(
+                "refresh_token_records"
+            )
+        )
+            .isTrue();
+
+        assertThat(userCount(existingUserId))
+            .isEqualTo(1);
+
+        assertThat(failedMigrationCount())
+            .isZero();
+    }
+
+    private static void migrateToVersion(
+        String targetVersion
+    ) {
+        Flyway.configure()
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .target(targetVersion)
+            .load()
+            .migrate();
+    }
+
+    private static void migrateToLatestVersion() {
+        Flyway.configure()
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .load()
+            .migrate();
+    }
+
+    private static String currentSchemaVersion() {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT version
+            FROM flyway_schema_history
+            WHERE success = TRUE
+              AND version IS NOT NULL
+            ORDER BY installed_rank DESC
+            LIMIT 1
+            """,
+            String.class
+        );
+    }
+
+    private static boolean migrationApplied(
+        String version
+    ) {
+        Boolean applied =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM flyway_schema_history
+                    WHERE version = ?
+                      AND success = TRUE
+                )
+                """,
+                Boolean.class,
+                version
+            );
+
+        return Boolean.TRUE.equals(applied);
+    }
+
+    private static boolean tableExists(
+        String tableName
+    ) {
+        Boolean exists =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM information_schema.tables
+                    WHERE table_schema = 'public'
+                      AND table_name = ?
+                )
+                """,
+                Boolean.class,
+                tableName
+            );
+
+        return Boolean.TRUE.equals(exists);
+    }
+
+    private static int failedMigrationCount() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM flyway_schema_history
+                WHERE success = FALSE
+                """,
+                Integer.class
+            );
+
+        return count == null
+            ? 0
+            : count;
+    }
+
+    private static void insertUser(
+        UUID userId
+    ) {
+        Instant now =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Timestamp timestamp =
+            Timestamp.from(now);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, 'USER', 'ACTIVE', ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            "test-password-hash",
+            timestamp,
+            timestamp
+        );
+    }
+
+    private static int userCount(
+        UUID userId
+    ) {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM users
+                WHERE id = ?
+                """,
+                Integer.class,
+                userId
+            );
+
+        return count == null
+            ? 0
+            : count;
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RefreshSessionSchemaIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RefreshSessionSchemaIntegrationTest.java
@@ -1,0 +1,756 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class RefreshSessionSchemaIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldPersistValidRotationLineage() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+        UUID predecessorId = UUID.randomUUID();
+        UUID successorId = UUID.randomUUID();
+
+        Instant familyCreatedAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant familyExpiresAt =
+            Instant.parse(
+                "2026-08-25T18:00:00Z"
+            );
+
+        Instant successorIssuedAt =
+            Instant.parse(
+                "2026-07-26T19:00:00Z"
+            );
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            familyCreatedAt,
+            familyExpiresAt
+        );
+
+        insertToken(
+            successorId,
+            familyId,
+            digest(2),
+            successorIssuedAt,
+            familyExpiresAt,
+            null,
+            null
+        );
+
+        insertToken(
+            predecessorId,
+            familyId,
+            digest(1),
+            familyCreatedAt.plusSeconds(60),
+            familyExpiresAt,
+            successorIssuedAt,
+            successorId
+        );
+
+        Integer familyCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                WHERE id = ?
+                """,
+                Integer.class,
+                familyId
+            );
+
+        Integer tokenCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                WHERE family_id = ?
+                """,
+                Integer.class,
+                familyId
+            );
+
+        UUID persistedSuccessor =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT successor_id
+                FROM refresh_token_records
+                WHERE id = ?
+                """,
+                UUID.class,
+                predecessorId
+            );
+
+        assertThat(familyCount)
+            .isEqualTo(1);
+
+        assertThat(tokenCount)
+            .isEqualTo(2);
+
+        assertThat(persistedSuccessor)
+            .isEqualTo(successorId);
+    }
+
+    @Test
+    void shouldRejectDigestThatIsNotSha256Length() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                familyId,
+                new byte[31],
+                createdAt.plusSeconds(60),
+                expiresAt,
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectDuplicateDigest() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        byte[] digest = digest(3);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        insertToken(
+            UUID.randomUUID(),
+            familyId,
+            digest,
+            createdAt.plusSeconds(60),
+            expiresAt,
+            null,
+            null
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                familyId,
+                digest,
+                createdAt.plusSeconds(120),
+                expiresAt,
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectPartialFamilyRevocationState() {
+        UUID userId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        assertThatThrownBy(
+            () -> jdbcTemplate.update(
+                """
+                INSERT INTO refresh_token_families (
+                    id,
+                    user_id,
+                    created_at,
+                    expires_at,
+                    revoked_at,
+                    revocation_reason
+                )
+                VALUES (?, ?, ?, ?, ?, NULL)
+                """,
+                UUID.randomUUID(),
+                userId,
+                timestamp(createdAt),
+                timestamp(expiresAt),
+                timestamp(
+                    createdAt.plusSeconds(60)
+                )
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+
+        assertThatThrownBy(
+            () -> jdbcTemplate.update(
+                """
+                INSERT INTO refresh_token_families (
+                    id,
+                    user_id,
+                    created_at,
+                    expires_at,
+                    revoked_at,
+                    revocation_reason
+                )
+                VALUES (?, ?, ?, ?, NULL, ?)
+                """,
+                UUID.randomUUID(),
+                userId,
+                timestamp(createdAt),
+                timestamp(expiresAt),
+                "CURRENT_SESSION_LOGOUT"
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectPartialTokenConsumptionState() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+        UUID successorId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        insertToken(
+            successorId,
+            familyId,
+            digest(4),
+            createdAt.plusSeconds(3_600),
+            expiresAt,
+            null,
+            null
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                familyId,
+                digest(5),
+                createdAt.plusSeconds(60),
+                expiresAt,
+                createdAt.plusSeconds(3_600),
+                null
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                familyId,
+                digest(6),
+                createdAt.plusSeconds(120),
+                expiresAt,
+                null,
+                successorId
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectSelfSuccessor() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+        UUID tokenId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                tokenId,
+                familyId,
+                digest(7),
+                createdAt.plusSeconds(60),
+                expiresAt,
+                createdAt.plusSeconds(3_600),
+                tokenId
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectCrossFamilySuccessor() {
+        UUID userId = UUID.randomUUID();
+        UUID firstFamilyId = UUID.randomUUID();
+        UUID secondFamilyId = UUID.randomUUID();
+        UUID successorId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        insertFamily(
+            firstFamilyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        insertFamily(
+            secondFamilyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        insertToken(
+            successorId,
+            secondFamilyId,
+            digest(8),
+            createdAt.plusSeconds(3_600),
+            expiresAt,
+            null,
+            null
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                firstFamilyId,
+                digest(9),
+                createdAt.plusSeconds(60),
+                expiresAt,
+                createdAt.plusSeconds(3_600),
+                successorId
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectSuccessorUsedByMultipleTokens() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+        UUID successorId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant expiresAt =
+            createdAt.plusSeconds(86_400);
+
+        Instant consumedAt =
+            createdAt.plusSeconds(3_600);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            expiresAt
+        );
+
+        insertToken(
+            successorId,
+            familyId,
+            digest(10),
+            consumedAt,
+            expiresAt,
+            null,
+            null
+        );
+
+        insertToken(
+            UUID.randomUUID(),
+            familyId,
+            digest(11),
+            createdAt.plusSeconds(60),
+            expiresAt,
+            consumedAt,
+            successorId
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                familyId,
+                digest(12),
+                createdAt.plusSeconds(120),
+                expiresAt,
+                consumedAt,
+                successorId
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectTokenExpirationAfterFamilyExpiration() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant familyExpiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            familyExpiresAt
+        );
+
+        assertThatThrownBy(
+            () -> insertToken(
+                UUID.randomUUID(),
+                familyId,
+                digest(13),
+                createdAt.plusSeconds(60),
+                familyExpiresAt.plusSeconds(1),
+                null,
+                null
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldRejectFamilyExpirationBeforeExistingTokenExpiration() {
+        UUID userId = UUID.randomUUID();
+        UUID familyId = UUID.randomUUID();
+
+        Instant createdAt =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        Instant familyExpiresAt =
+            createdAt.plusSeconds(86_400);
+
+        insertUser(userId);
+
+        insertFamily(
+            familyId,
+            userId,
+            createdAt,
+            familyExpiresAt
+        );
+
+        insertToken(
+            UUID.randomUUID(),
+            familyId,
+            digest(14),
+            createdAt.plusSeconds(60),
+            familyExpiresAt,
+            null,
+            null
+        );
+
+        assertThatThrownBy(
+            () -> jdbcTemplate.update(
+                """
+                UPDATE refresh_token_families
+                SET expires_at = ?
+                WHERE id = ?
+                """,
+                timestamp(
+                    familyExpiresAt.minusSeconds(1)
+                ),
+                familyId
+            )
+        )
+            .isInstanceOf(
+                DataIntegrityViolationException.class
+            );
+    }
+
+    @Test
+    void shouldExposeOnlyDigestBasedCredentialColumns() {
+        assertThat(
+            columnsOf("refresh_token_families")
+        )
+            .containsExactly(
+                "id",
+                "user_id",
+                "created_at",
+                "expires_at",
+                "revoked_at",
+                "revocation_reason"
+            );
+
+        assertThat(
+            columnsOf("refresh_token_records")
+        )
+            .containsExactly(
+                "id",
+                "family_id",
+                "token_digest",
+                "issued_at",
+                "expires_at",
+                "consumed_at",
+                "successor_id"
+            );
+    }
+
+    private void insertUser(UUID userId) {
+        Instant now =
+            Instant.parse(
+                "2026-07-26T18:00:00Z"
+            );
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, 'USER', 'ACTIVE', ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            "test-password-hash",
+            timestamp(now),
+            timestamp(now)
+        );
+    }
+
+    private void insertFamily(
+        UUID familyId,
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO refresh_token_families (
+                id,
+                user_id,
+                created_at,
+                expires_at,
+                revoked_at,
+                revocation_reason
+            )
+            VALUES (?, ?, ?, ?, NULL, NULL)
+            """,
+            familyId,
+            userId,
+            timestamp(createdAt),
+            timestamp(expiresAt)
+        );
+    }
+
+    private void insertToken(
+        UUID tokenId,
+        UUID familyId,
+        byte[] tokenDigest,
+        Instant issuedAt,
+        Instant expiresAt,
+        Instant consumedAt,
+        UUID successorId
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO refresh_token_records (
+                id,
+                family_id,
+                token_digest,
+                issued_at,
+                expires_at,
+                consumed_at,
+                successor_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            tokenId,
+            familyId,
+            tokenDigest,
+            timestamp(issuedAt),
+            timestamp(expiresAt),
+            timestamp(consumedAt),
+            successorId
+        );
+    }
+
+    private static Timestamp timestamp(
+        Instant value
+    ) {
+        return value == null
+            ? null
+            : Timestamp.from(value);
+    }
+
+    private List<String> columnsOf(
+        String tableName
+    ) {
+        return jdbcTemplate.queryForList(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = ?
+            ORDER BY ordinal_position
+            """,
+            String.class,
+            tableName
+        );
+    }
+
+    private static byte[] digest(int marker) {
+        byte[] digest = new byte[32];
+
+        Arrays.fill(
+            digest,
+            (byte) marker
+        );
+
+        return digest;
+    }
+}


### PR DESCRIPTION
## Summary

Release PayFlow v0.7.0 from the verified release candidate.

This release establishes the architecture, domain contracts and durable
PostgreSQL persistence foundation required for future refresh-token issuance,
rotation, reuse detection and family revocation.

The public HTTP API remains unchanged.

## Included work

- identity-security roadmap — PR #71
- refresh-session architecture and threat model — PR #73
- refresh-session domain and application contracts — PR #75
- PostgreSQL refresh-session persistence — PR #77
- v0.7.0 release documentation
- Maven release version finalization

## Release baseline

- develop baseline: `cc2dcc96b79c3ec9e1d59f4a856aefc4e9f55a67`
- documentation commit: `a6eccbdad536aa34c7edd51a2d2abe74e1ce77a5`
- release candidate: `dc413d09aeb361c1630f6bab667d4361ab25c40c`
- project version: `0.7.0`
- Flyway migration range: V1-V14

## Verification

- `.\mvnw.cmd clean verify`
- 689 automated tests
- zero failures
- zero errors
- zero skipped tests
- PostgreSQL Testcontainers integration tests
- clean V1-to-V14 migration verification
- V13-to-V14 upgrade verification
- real PostgreSQL pessimistic-lock verification
- release JAR: `target/payflow-0.7.0.jar`
- release JAR SHA-256: `0EE1EBBD85567F60CB832BBFF02FA8F1A06349B370DAFE366B3BE1B15B87EA71`

## Release process

Tracks #78.

Issue #78 and the v0.7.0 milestone must remain open until the annotated tag
and GitHub Release have been published and verified.

This release PR must be merged into `main` with a merge commit. It must not be
squash-merged or rebase-merged.
