### PR TITLE
chore: start v0.8.0 development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0-SNAPSHOT</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 


### PR DESCRIPTION
## Summary

Start the PayFlow v0.8.0 development cycle.

## Change

- update the Maven project version from .7.0 to .8.0-SNAPSHOT
- preserve UTF-8 no-BOM and LF formatting
- keep the implementation scope limited to pom.xml

## Baseline

- develop: $expectedDevelop
- v0.7.0 main release: $expectedMain

## Verification

- Maven resolves project.version as .8.0-SNAPSHOT
- pom.xml remains valid XML
- whitespace validation passes
- no source or documentation file is changed

Closes #80.
