### PR TITLE
feat(auth): add secure refresh-token cryptography adapters

### DIFF
--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/RefreshTokenCryptographyConfiguration.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/RefreshTokenCryptographyConfiguration.java
@@ -1,0 +1,28 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import java.security.SecureRandom;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+class RefreshTokenCryptographyConfiguration {
+
+    @Bean
+    RefreshTokenGenerationPort
+    refreshTokenGenerationPort() {
+        return new
+            SecureRandomRefreshTokenGenerationAdapter(
+            new SecureRandom()
+        );
+    }
+
+    @Bean
+    RefreshTokenDigestPort
+    refreshTokenDigestPort() {
+        return new
+            Sha256RefreshTokenDigestAdapter();
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/SecureRandomRefreshTokenGenerationAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/SecureRandomRefreshTokenGenerationAdapter.java
@@ -1,0 +1,66 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+
+final class SecureRandomRefreshTokenGenerationAdapter
+    implements RefreshTokenGenerationPort {
+
+    static final int ENTROPY_LENGTH_BYTES = 32;
+    static final int ENCODED_TOKEN_LENGTH = 43;
+
+    private static final Base64.Encoder TOKEN_ENCODER =
+        Base64.getUrlEncoder()
+            .withoutPadding();
+
+    private final SecureRandom secureRandom;
+
+    SecureRandomRefreshTokenGenerationAdapter(
+        SecureRandom secureRandom
+    ) {
+        this.secureRandom =
+            Objects.requireNonNull(
+                secureRandom,
+                "secureRandom must not be null"
+            );
+    }
+
+    @Override
+    public GeneratedRefreshToken generate() {
+        byte[] randomBytes =
+            new byte[ENTROPY_LENGTH_BYTES];
+
+        try {
+            secureRandom.nextBytes(randomBytes);
+
+            String encodedToken =
+                TOKEN_ENCODER.encodeToString(
+                    randomBytes
+                );
+
+            if (
+                encodedToken.length()
+                    != ENCODED_TOKEN_LENGTH
+            ) {
+                throw new IllegalStateException(
+                    "Generated refresh token has "
+                        + "an unexpected encoded length."
+                );
+            }
+
+            return new GeneratedRefreshToken(
+                encodedToken
+            );
+        } finally {
+            Arrays.fill(
+                randomBytes,
+                (byte) 0
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/Sha256RefreshTokenDigestAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/Sha256RefreshTokenDigestAdapter.java
@@ -1,0 +1,151 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+
+final class Sha256RefreshTokenDigestAdapter
+    implements RefreshTokenDigestPort {
+
+    static final int TOKEN_LENGTH_BYTES = 32;
+    static final int ENCODED_TOKEN_LENGTH = 43;
+
+    private static final String SHA_256 =
+        "SHA-256";
+
+    private static final Base64.Decoder TOKEN_DECODER =
+        Base64.getUrlDecoder();
+
+    private static final Base64.Encoder TOKEN_ENCODER =
+        Base64.getUrlEncoder()
+            .withoutPadding();
+
+    @Override
+    public RefreshTokenDigest digest(
+        String refreshToken
+    ) {
+        byte[] decodedToken =
+            decodeCanonicalToken(
+                refreshToken
+            );
+
+        try {
+            byte[] digestBytes =
+                messageDigest().digest(
+                    decodedToken
+                );
+
+            return RefreshTokenDigest.of(
+                digestBytes
+            );
+        } finally {
+            Arrays.fill(
+                decodedToken,
+                (byte) 0
+            );
+        }
+    }
+
+    private static byte[] decodeCanonicalToken(
+        String refreshToken
+    ) {
+        if (
+            refreshToken == null
+                || refreshToken.length()
+                != ENCODED_TOKEN_LENGTH
+                || !containsOnlyBase64UrlCharacters(
+                    refreshToken
+                )
+        ) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        byte[] decodedToken;
+
+        try {
+            decodedToken =
+                TOKEN_DECODER.decode(
+                    refreshToken
+                );
+        } catch (IllegalArgumentException ignored) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        if (
+            decodedToken.length
+                != TOKEN_LENGTH_BYTES
+        ) {
+            Arrays.fill(
+                decodedToken,
+                (byte) 0
+            );
+
+            throw new InvalidRefreshTokenException();
+        }
+
+        String canonicalValue =
+            TOKEN_ENCODER.encodeToString(
+                decodedToken
+            );
+
+        if (!canonicalValue.equals(refreshToken)) {
+            Arrays.fill(
+                decodedToken,
+                (byte) 0
+            );
+
+            throw new InvalidRefreshTokenException();
+        }
+
+        return decodedToken;
+    }
+
+    private static boolean
+    containsOnlyBase64UrlCharacters(
+        String value
+    ) {
+        for (
+            int index = 0;
+            index < value.length();
+            index++
+        ) {
+            char character =
+                value.charAt(index);
+
+            boolean supported =
+                character >= 'A'
+                    && character <= 'Z'
+                    || character >= 'a'
+                    && character <= 'z'
+                    || character >= '0'
+                    && character <= '9'
+                    || character == '-'
+                    || character == '_';
+
+            if (!supported) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static MessageDigest messageDigest() {
+        try {
+            return MessageDigest.getInstance(
+                SHA_256
+            );
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(
+                "SHA-256 message digest "
+                    + "is not available.",
+                exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/nursena/payflow/user/domain/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.user.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class InvalidRefreshTokenException
+    extends BusinessRuleException {
+
+    public InvalidRefreshTokenException() {
+        super(
+            "REFRESH_TOKEN_INVALID",
+            "Refresh token is invalid."
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/RefreshTokenCryptographyConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/RefreshTokenCryptographyConfigurationTest.java
@@ -1,0 +1,99 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class RefreshTokenCryptographyConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+        new ApplicationContextRunner()
+            .withUserConfiguration(
+                RefreshTokenCryptographyConfiguration
+                    .class
+            );
+
+    @Test
+    void shouldExposeBothRefreshTokenOutputPorts() {
+        contextRunner.run(context -> {
+            assertThat(context)
+                .hasSingleBean(
+                    RefreshTokenGenerationPort.class
+                );
+
+            assertThat(context)
+                .hasSingleBean(
+                    RefreshTokenDigestPort.class
+                );
+
+            assertThat(
+                context.getBean(
+                    RefreshTokenGenerationPort.class
+                )
+            )
+                .isInstanceOf(
+                    SecureRandomRefreshTokenGenerationAdapter
+                        .class
+                );
+
+            assertThat(
+                context.getBean(
+                    RefreshTokenDigestPort.class
+                )
+            )
+                .isInstanceOf(
+                    Sha256RefreshTokenDigestAdapter
+                        .class
+                );
+        });
+    }
+
+    @Test
+    void shouldGenerateAndDigestThroughConfiguredPorts() {
+        contextRunner.run(context -> {
+            RefreshTokenGenerationPort generationPort =
+                context.getBean(
+                    RefreshTokenGenerationPort.class
+                );
+
+            RefreshTokenDigestPort digestPort =
+                context.getBean(
+                    RefreshTokenDigestPort.class
+                );
+
+            GeneratedRefreshToken generated =
+                generationPort.generate();
+
+            RefreshTokenDigest digest =
+                digestPort.digest(
+                    generated.value()
+                );
+
+            assertThat(generated.value())
+                .matches(
+                    "[A-Za-z0-9_-]{43}"
+                );
+
+            assertThat(digest.value())
+                .hasSize(
+                    RefreshTokenDigest
+                        .SHA_256_LENGTH_BYTES
+                );
+
+            assertThat(generated.toString())
+                .doesNotContain(
+                    generated.value()
+                );
+
+            assertThat(digest.toString())
+                .isEqualTo(
+                    "RefreshTokenDigest[redacted]"
+                );
+        });
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/SecureRandomRefreshTokenGenerationAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/SecureRandomRefreshTokenGenerationAdapterTest.java
@@ -1,0 +1,156 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import org.junit.jupiter.api.Test;
+
+class SecureRandomRefreshTokenGenerationAdapterTest {
+
+    private static final String EXPECTED_TOKEN =
+        "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8";
+
+    @Test
+    void shouldGenerateExpectedCanonicalTokenFrom32Bytes() {
+        byte[] deterministicEntropy =
+            new byte[
+                SecureRandomRefreshTokenGenerationAdapter
+                    .ENTROPY_LENGTH_BYTES
+            ];
+
+        for (
+            int index = 0;
+            index < deterministicEntropy.length;
+            index++
+        ) {
+            deterministicEntropy[index] =
+                (byte) index;
+        }
+
+        SecureRandom secureRandom =
+            mock(SecureRandom.class);
+
+        doAnswer(invocation -> {
+            byte[] destination =
+                invocation.getArgument(0);
+
+            assertThat(destination)
+                .hasSize(
+                    SecureRandomRefreshTokenGenerationAdapter
+                        .ENTROPY_LENGTH_BYTES
+                );
+
+            System.arraycopy(
+                deterministicEntropy,
+                0,
+                destination,
+                0,
+                deterministicEntropy.length
+            );
+
+            return null;
+        })
+            .when(secureRandom)
+            .nextBytes(
+                any(byte[].class)
+            );
+
+        SecureRandomRefreshTokenGenerationAdapter
+            adapter =
+            new SecureRandomRefreshTokenGenerationAdapter(
+                secureRandom
+            );
+
+        GeneratedRefreshToken result =
+            adapter.generate();
+
+        assertThat(result.value())
+            .isEqualTo(EXPECTED_TOKEN);
+
+        assertThat(result.value())
+            .hasSize(
+                SecureRandomRefreshTokenGenerationAdapter
+                    .ENCODED_TOKEN_LENGTH
+            );
+
+        assertThat(
+            Base64.getUrlDecoder()
+                .decode(result.value())
+        )
+            .containsExactly(
+                deterministicEntropy
+            );
+
+        assertThat(result.toString())
+            .doesNotContain(
+                result.value()
+            );
+
+        verify(secureRandom)
+            .nextBytes(
+                any(byte[].class)
+            );
+    }
+
+    @Test
+    void shouldGenerateCanonicalBase64UrlTokens() {
+        SecureRandomRefreshTokenGenerationAdapter
+            adapter =
+            new SecureRandomRefreshTokenGenerationAdapter(
+                new SecureRandom()
+            );
+
+        for (
+            int attempt = 0;
+            attempt < 64;
+            attempt++
+        ) {
+            GeneratedRefreshToken generated =
+                adapter.generate();
+
+            assertThat(generated.value())
+                .hasSize(
+                    SecureRandomRefreshTokenGenerationAdapter
+                        .ENCODED_TOKEN_LENGTH
+                )
+                .matches(
+                    "[A-Za-z0-9_-]{43}"
+                )
+                .doesNotContain("=");
+
+            assertThat(
+                Base64.getUrlDecoder()
+                    .decode(
+                        generated.value()
+                    )
+            )
+                .hasSize(
+                    SecureRandomRefreshTokenGenerationAdapter
+                        .ENTROPY_LENGTH_BYTES
+                );
+        }
+    }
+
+    @Test
+    void shouldRequireSecureRandom() {
+        assertThatThrownBy(() ->
+            new SecureRandomRefreshTokenGenerationAdapter(
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "secureRandom must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/Sha256RefreshTokenDigestAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/Sha256RefreshTokenDigestAdapterTest.java
@@ -1,0 +1,138 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.HexFormat;
+import java.util.stream.Stream;
+
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class Sha256RefreshTokenDigestAdapterTest {
+
+    private static final String CANONICAL_TOKEN =
+        "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8";
+
+    private static final byte[] EXPECTED_DIGEST =
+        HexFormat.of().parseHex(
+            "630dcd2966c4336691125448bbb25b4f"
+                + "f412a49c732db2c8abc1b8581bd710dd"
+        );
+
+    private final Sha256RefreshTokenDigestAdapter
+        adapter =
+        new Sha256RefreshTokenDigestAdapter();
+
+    @Test
+    void shouldCalculateSha256OverDecodedTokenBytes() {
+        RefreshTokenDigest result =
+            adapter.digest(
+                CANONICAL_TOKEN
+            );
+
+        assertThat(result.value())
+            .containsExactly(
+                EXPECTED_DIGEST
+            );
+
+        assertThat(result.value())
+            .hasSize(
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            );
+
+        assertThat(result.toString())
+            .isEqualTo(
+                "RefreshTokenDigest[redacted]"
+            );
+    }
+
+    @Test
+    void shouldProduceDeterministicDigest() {
+        RefreshTokenDigest first =
+            adapter.digest(
+                CANONICAL_TOKEN
+            );
+
+        RefreshTokenDigest second =
+            adapter.digest(
+                CANONICAL_TOKEN
+            );
+
+        assertThat(first)
+            .isEqualTo(second);
+
+        assertThat(first.hashCode())
+            .isEqualTo(
+                second.hashCode()
+            );
+    }
+
+    @Test
+    void shouldRejectNullTokenWithoutExposingCredentialState() {
+        Throwable failure =
+            catchThrowable(() ->
+                adapter.digest(null)
+            );
+
+        assertThat(failure)
+            .isInstanceOf(
+                InvalidRefreshTokenException.class
+            )
+            .hasMessage(
+                "Refresh token is invalid."
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidTokens")
+    void shouldRejectMalformedOrNonCanonicalTokens(
+        String invalidToken
+    ) {
+        Throwable failure =
+            catchThrowable(() ->
+                adapter.digest(
+                    invalidToken
+                )
+            );
+
+        assertThat(failure)
+            .isInstanceOf(
+                InvalidRefreshTokenException.class
+            )
+            .hasMessage(
+                "Refresh token is invalid."
+            );
+
+        assertThat(failure.getCause())
+            .isNull();
+
+        if (!invalidToken.isBlank()) {
+            assertThat(failure.toString())
+                .doesNotContain(
+                    invalidToken
+                );
+        }
+    }
+
+    private static Stream<String> invalidTokens() {
+        return Stream.of(
+            "",
+            " ",
+            CANONICAL_TOKEN.substring(
+                0,
+                CANONICAL_TOKEN.length() - 1
+            ),
+            CANONICAL_TOKEN + "A",
+            CANONICAL_TOKEN.substring(0, 42) + "=",
+            CANONICAL_TOKEN.substring(0, 42) + "+",
+            CANONICAL_TOKEN.substring(0, 42) + "/",
+            " " + CANONICAL_TOKEN.substring(1),
+            CANONICAL_TOKEN.substring(0, 42) + "9"
+        );
+    }
+}


### PR DESCRIPTION
## Goal

Add the production cryptography adapters required for opaque PayFlow refresh tokens.

## Changes

- generate exactly 32 cryptographically secure random bytes
- encode tokens as canonical Base64 URL values without padding
- enforce the exact 43-character external token shape
- strictly decode and validate presented token values
- calculate SHA-256 over the decoded 32-byte credential
- clear temporary credential byte arrays after use
- expose focused generation and digest output-port beans
- return one stable generic invalid-token exception

## Security properties

- plaintext refresh tokens are not persisted or logged
- refresh-token digests are not logged or returned
- malformed token values are rejected without echoing their content
- no HTTP, database migration, duration configuration, OpenAPI or Postman changes

## Verification

- focused tests: 17 passed
- complete Maven clean verify: 706 tests passed
- Surefire reports: 150
- failures: 0
- errors: 0
- skipped: 0
- security audit: passed
- committed source encoding: UTF-8 without BOM, LF endings

## Tracking

Related to #82
