### PR TITLE
feat(auth): issue refresh credentials on login

### DIFF
--- a/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
@@ -23,7 +23,9 @@ public final class OpenApiExamples {
         {
           "accessToken": "eyJhbGciOiJSUzI1NiJ9...",
           "tokenType": "Bearer",
-          "expiresAt": "2026-07-17T12:15:00Z"
+          "expiresAt": "2026-07-17T12:15:00Z",
+          "refreshToken": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA",
+          "refreshTokenExpiresAt": "2026-07-24T12:00:00Z"
         }
         """;
 

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserController.java
@@ -1,5 +1,9 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiExamples;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserUseCase;
@@ -16,37 +20,35 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-
-import com.nursena.payflow.common.api.ApiError;
-import com.nursena.payflow.configuration.OpenApiExamples;
 
 @Tag(
     name = "Authentication",
     description =
         "Public user registration and authentication operations."
 )
-
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthenticateUserController {
 
     private static final String TOKEN_TYPE = "Bearer";
 
-    private final AuthenticateUserUseCase authenticateUserUseCase;
+    private final AuthenticateUserUseCase
+        authenticateUserUseCase;
 
     public AuthenticateUserController(
         AuthenticateUserUseCase authenticateUserUseCase
     ) {
-        this.authenticateUserUseCase = authenticateUserUseCase;
+        this.authenticateUserUseCase =
+            authenticateUserUseCase;
     }
 
     @Operation(
         operationId = "authenticateUser",
         summary = "Authenticate a user",
         description =
-            "Validates user credentials and returns an "
-                + "RSA-signed JWT access token."
+            "Validates user credentials and returns "
+                + "an RSA-signed JWT access token and "
+                + "an opaque refresh token."
     )
     @ApiResponses({
         @ApiResponse(
@@ -110,10 +112,11 @@ public class AuthenticateUserController {
             )
         )
     })
-
     @PostMapping("/login")
-    public ResponseEntity<AuthenticateUserResponse> authenticate(
-        @Valid @RequestBody AuthenticateUserRequest request
+    public ResponseEntity<AuthenticateUserResponse>
+    authenticate(
+        @Valid @RequestBody
+        AuthenticateUserRequest request
     ) {
         AuthenticateUserCommand command =
             new AuthenticateUserCommand(
@@ -122,13 +125,17 @@ public class AuthenticateUserController {
             );
 
         AuthenticateUserResult result =
-            authenticateUserUseCase.authenticate(command);
+            authenticateUserUseCase.authenticate(
+                command
+            );
 
         AuthenticateUserResponse response =
             new AuthenticateUserResponse(
                 result.accessToken(),
                 TOKEN_TYPE,
-                result.expiresAt()
+                result.expiresAt(),
+                result.refreshToken(),
+                result.refreshTokenExpiresAt()
             );
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserResponse.java
@@ -1,13 +1,15 @@
 package com.nursena.payflow.user.adapter.in.web;
 
 import java.time.Instant;
+import java.util.Objects;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(
     name = "AuthenticateUserResponse",
     description =
-        "JWT access token returned after successful authentication."
+        "Access and refresh credentials returned after "
+            + "successful authentication."
 )
 public record AuthenticateUserResponse(
 
@@ -19,7 +21,7 @@ public record AuthenticateUserResponse(
 
     @Schema(
         description =
-            "Authentication scheme used with the token.",
+            "Authentication scheme used with the access token.",
         example = "Bearer"
     )
     String tokenType,
@@ -29,6 +31,67 @@ public record AuthenticateUserResponse(
         example = "2026-07-17T12:15:00Z",
         format = "date-time"
     )
-    Instant expiresAt
+    Instant expiresAt,
+
+    @Schema(
+        description =
+            "Opaque refresh token used to obtain new credentials.",
+        example =
+            "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA"
+    )
+    String refreshToken,
+
+    @Schema(
+        description = "Refresh-token expiration time.",
+        example = "2026-07-24T12:00:00Z",
+        format = "date-time"
+    )
+    Instant refreshTokenExpiresAt
 ) {
+
+    public AuthenticateUserResponse {
+        Objects.requireNonNull(
+            accessToken,
+            "accessToken must not be null"
+        );
+        Objects.requireNonNull(
+            tokenType,
+            "tokenType must not be null"
+        );
+        Objects.requireNonNull(
+            expiresAt,
+            "expiresAt must not be null"
+        );
+        Objects.requireNonNull(
+            refreshToken,
+            "refreshToken must not be null"
+        );
+        Objects.requireNonNull(
+            refreshTokenExpiresAt,
+            "refreshTokenExpiresAt must not be null"
+        );
+
+        if (accessToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "accessToken must not be blank"
+            );
+        }
+
+        if (tokenType.isBlank()) {
+            throw new IllegalArgumentException(
+                "tokenType must not be blank"
+            );
+        }
+
+        if (refreshToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "refreshToken must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AuthenticateUserResponse[redacted]";
+    }
 }

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/JwtConfiguration.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/JwtConfiguration.java
@@ -5,7 +5,6 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
-import java.time.Clock;
 import java.util.UUID;
 
 import com.nimbusds.jose.jwk.JWKSet;
@@ -30,10 +29,6 @@ class JwtConfiguration {
 
     private static final int RSA_KEY_SIZE = 2048;
 
-    @Bean
-    Clock jwtClock() {
-        return Clock.systemUTC();
-    }
 
     @Bean
     KeyPair jwtKeyPair() {

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionConfiguration.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionConfiguration.java
@@ -1,0 +1,24 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import com.nursena.payflow.user.application.service.RefreshSessionLifetimePolicy;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(
+    RefreshSessionProperties.class
+)
+class RefreshSessionConfiguration {
+
+    @Bean
+    RefreshSessionLifetimePolicy
+    refreshSessionLifetimePolicy(
+        RefreshSessionProperties properties
+    ) {
+        return new RefreshSessionLifetimePolicy(
+            properties.refreshTokenTtl(),
+            properties.familyTtl()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionProperties.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionProperties.java
@@ -1,0 +1,50 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(
+    prefix = "payflow.security.refresh-session"
+)
+public record RefreshSessionProperties(
+    Duration refreshTokenTtl,
+    Duration familyTtl
+) {
+
+    public RefreshSessionProperties {
+        Objects.requireNonNull(
+            refreshTokenTtl,
+            "refreshTokenTtl must not be null"
+        );
+        Objects.requireNonNull(
+            familyTtl,
+            "familyTtl must not be null"
+        );
+
+        requirePositive(
+            refreshTokenTtl,
+            "refreshTokenTtl"
+        );
+
+        requirePositive(
+            familyTtl,
+            "familyTtl"
+        );
+    }
+
+    private static void requirePositive(
+        Duration value,
+        String propertyName
+    ) {
+        if (
+            value.isZero()
+                || value.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                propertyName + " must be positive"
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/AuthenticateUserResult.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/AuthenticateUserResult.java
@@ -5,7 +5,9 @@ import java.util.Objects;
 
 public record AuthenticateUserResult(
     String accessToken,
-    Instant expiresAt
+    Instant expiresAt,
+    String refreshToken,
+    Instant refreshTokenExpiresAt
 ) {
 
     public AuthenticateUserResult {
@@ -17,11 +19,30 @@ public record AuthenticateUserResult(
             expiresAt,
             "expiresAt must not be null"
         );
+        Objects.requireNonNull(
+            refreshToken,
+            "refreshToken must not be null"
+        );
+        Objects.requireNonNull(
+            refreshTokenExpiresAt,
+            "refreshTokenExpiresAt must not be null"
+        );
 
         if (accessToken.isBlank()) {
             throw new IllegalArgumentException(
                 "accessToken must not be blank"
             );
         }
+
+        if (refreshToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "refreshToken must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AuthenticateUserResult[redacted]";
     }
 }

--- a/src/main/java/com/nursena/payflow/user/application/service/AuthenticateUserService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/AuthenticateUserService.java
@@ -1,53 +1,134 @@
 package com.nursena.payflow.user.application.service;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.UUID;
+
 import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserUseCase;
-import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
-import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
 import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
 import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
 import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
 import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
 import com.nursena.payflow.user.domain.model.User;
 import com.nursena.payflow.user.domain.model.UserStatus;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 public class AuthenticateUserService
     implements AuthenticateUserUseCase {
 
     private final UserRepositoryPort userRepository;
     private final PasswordVerificationPort passwordVerification;
+    private final RefreshTokenGenerationPort refreshTokenGeneration;
+    private final RefreshTokenDigestPort refreshTokenDigest;
+    private final RefreshTokenFamilyRepositoryPort familyRepository;
+    private final RefreshTokenRecordRepositoryPort recordRepository;
     private final AccessTokenGenerationPort accessTokenGeneration;
+    private final RefreshSessionLifetimePolicy lifetimePolicy;
+    private final Clock clock;
 
     public AuthenticateUserService(
         UserRepositoryPort userRepository,
         PasswordVerificationPort passwordVerification,
-        AccessTokenGenerationPort accessTokenGeneration
+        RefreshTokenGenerationPort refreshTokenGeneration,
+        RefreshTokenDigestPort refreshTokenDigest,
+        RefreshTokenFamilyRepositoryPort familyRepository,
+        RefreshTokenRecordRepositoryPort recordRepository,
+        AccessTokenGenerationPort accessTokenGeneration,
+        RefreshSessionLifetimePolicy lifetimePolicy,
+        Clock clock
     ) {
-        this.userRepository = userRepository;
-        this.passwordVerification = passwordVerification;
-        this.accessTokenGeneration = accessTokenGeneration;
+        this.userRepository =
+            Objects.requireNonNull(
+                userRepository,
+                "userRepository must not be null"
+            );
+
+        this.passwordVerification =
+            Objects.requireNonNull(
+                passwordVerification,
+                "passwordVerification must not be null"
+            );
+
+        this.refreshTokenGeneration =
+            Objects.requireNonNull(
+                refreshTokenGeneration,
+                "refreshTokenGeneration must not be null"
+            );
+
+        this.refreshTokenDigest =
+            Objects.requireNonNull(
+                refreshTokenDigest,
+                "refreshTokenDigest must not be null"
+            );
+
+        this.familyRepository =
+            Objects.requireNonNull(
+                familyRepository,
+                "familyRepository must not be null"
+            );
+
+        this.recordRepository =
+            Objects.requireNonNull(
+                recordRepository,
+                "recordRepository must not be null"
+            );
+
+        this.accessTokenGeneration =
+            Objects.requireNonNull(
+                accessTokenGeneration,
+                "accessTokenGeneration must not be null"
+            );
+
+        this.lifetimePolicy =
+            Objects.requireNonNull(
+                lifetimePolicy,
+                "lifetimePolicy must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public AuthenticateUserResult authenticate(
         AuthenticateUserCommand command
     ) {
-        EmailAddress email = EmailAddress.of(command.email());
+        EmailAddress email =
+            EmailAddress.of(command.email());
 
         User user = userRepository.findByEmail(email)
-            .orElseThrow(InvalidCredentialsException::new);
+            .orElseThrow(
+                InvalidCredentialsException::new
+            );
 
-        boolean passwordMatches = passwordVerification.matches(
-            command.rawPassword(),
-            user.passwordHash()
-        );
+        boolean passwordMatches =
+            passwordVerification.matches(
+                command.rawPassword(),
+                user.passwordHash()
+            );
 
         if (!passwordMatches) {
             throw new InvalidCredentialsException();
@@ -57,11 +138,72 @@ public class AuthenticateUserService
             throw new UserAccountUnavailableException();
         }
 
-        GeneratedAccessToken token = accessTokenGeneration.generate(user);
+        Instant issuedAt =
+            clock.instant()
+                .truncatedTo(
+                    ChronoUnit.MICROS
+                );
+
+        GeneratedRefreshToken generatedRefreshToken =
+            refreshTokenGeneration.generate();
+
+        RefreshTokenDigest digest =
+            refreshTokenDigest.digest(
+                generatedRefreshToken.value()
+            );
+
+        Instant familyExpiresAt =
+            lifetimePolicy.familyExpiresAt(
+                issuedAt
+            );
+
+        RefreshTokenFamily family =
+            RefreshTokenFamily.create(
+                RefreshTokenFamilyId.of(
+                    UUID.randomUUID()
+                ),
+                user.id(),
+                issuedAt,
+                familyExpiresAt
+            );
+
+        RefreshTokenFamily savedFamily =
+            familyRepository.save(
+                family
+            );
+
+        Instant refreshTokenExpiresAt =
+            lifetimePolicy.refreshTokenExpiresAt(
+                issuedAt,
+                savedFamily.expiresAt()
+            );
+
+        RefreshTokenRecord record =
+            RefreshTokenRecord.issue(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                ),
+                savedFamily,
+                digest,
+                issuedAt,
+                refreshTokenExpiresAt
+            );
+
+        RefreshTokenRecord savedRecord =
+            recordRepository.save(
+                record
+            );
+
+        GeneratedAccessToken accessToken =
+            accessTokenGeneration.generate(
+                user
+            );
 
         return new AuthenticateUserResult(
-            token.value(),
-            token.expiresAt()
+            accessToken.value(),
+            accessToken.expiresAt(),
+            generatedRefreshToken.value(),
+            savedRecord.expiresAt()
         );
     }
 }

--- a/src/main/java/com/nursena/payflow/user/application/service/RefreshSessionLifetimePolicy.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RefreshSessionLifetimePolicy.java
@@ -1,0 +1,102 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+public final class RefreshSessionLifetimePolicy {
+
+    private final Duration refreshTokenTtl;
+    private final Duration familyTtl;
+
+    public RefreshSessionLifetimePolicy(
+        Duration refreshTokenTtl,
+        Duration familyTtl
+    ) {
+        this.refreshTokenTtl =
+            requirePositive(
+                refreshTokenTtl,
+                "refreshTokenTtl"
+            );
+
+        this.familyTtl =
+            requirePositive(
+                familyTtl,
+                "familyTtl"
+            );
+    }
+
+    public Instant familyExpiresAt(
+        Instant issuedAt
+    ) {
+        Instant checkedIssuedAt =
+            Objects.requireNonNull(
+                issuedAt,
+                "issuedAt must not be null"
+            );
+
+        return checkedIssuedAt.plus(
+            familyTtl
+        );
+    }
+
+    public Instant refreshTokenExpiresAt(
+        Instant issuedAt,
+        Instant familyExpiresAt
+    ) {
+        Instant checkedIssuedAt =
+            Objects.requireNonNull(
+                issuedAt,
+                "issuedAt must not be null"
+            );
+
+        Instant checkedFamilyExpiresAt =
+            Objects.requireNonNull(
+                familyExpiresAt,
+                "familyExpiresAt must not be null"
+            );
+
+        if (
+            !checkedFamilyExpiresAt.isAfter(
+                checkedIssuedAt
+            )
+        ) {
+            throw new IllegalArgumentException(
+                "familyExpiresAt must be after issuedAt"
+            );
+        }
+
+        Instant requestedExpiresAt =
+            checkedIssuedAt.plus(
+                refreshTokenTtl
+            );
+
+        return requestedExpiresAt.isAfter(
+            checkedFamilyExpiresAt
+        )
+            ? checkedFamilyExpiresAt
+            : requestedExpiresAt;
+    }
+
+    private static Duration requirePositive(
+        Duration value,
+        String propertyName
+    ) {
+        Duration checkedValue =
+            Objects.requireNonNull(
+                value,
+                propertyName + " must not be null"
+            );
+
+        if (
+            checkedValue.isZero()
+                || checkedValue.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                propertyName + " must be positive"
+            );
+        }
+
+        return checkedValue;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,6 +73,9 @@ payflow:
     jwt:
       issuer: https://api.payflow.local
       access-token-ttl: 15m
+    refresh-session:
+      refresh-token-ttl: ${REFRESH_TOKEN_TTL:7d}
+      family-ttl: ${REFRESH_TOKEN_FAMILY_TTL:30d}
   outbox:
     kafka:
       send-timeout: ${OUTBOX_KAFKA_SEND_TIMEOUT:10s}

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -463,6 +463,92 @@ class OpenApiJsonContractIntegrationTest {
     }
 
     @Test
+    void shouldExposeLoginCredentialPairContract() {
+        JsonNode login =
+            operation(
+                LOGIN_PATH,
+                "post"
+            );
+
+        JsonNode successSchema =
+            login
+                .path("responses")
+                .path("200")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .path("schema");
+
+        assertThat(
+            successSchema
+                .path("$ref")
+                .asText()
+        ).isEqualTo(
+            "#/components/schemas/"
+                + "AuthenticateUserResponse"
+        );
+
+        JsonNode properties =
+            openApi
+                .path("components")
+                .path("schemas")
+                .path(
+                    "AuthenticateUserResponse"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(properties)
+        )
+            .containsExactlyInAnyOrder(
+                "accessToken",
+                "tokenType",
+                "expiresAt",
+                "refreshToken",
+                "refreshTokenExpiresAt"
+            )
+            .doesNotContain(
+                "tokenDigest",
+                "familyId",
+                "recordId",
+                "userId",
+                "revokedAt",
+                "consumedAt",
+                "successorId"
+            );
+
+        assertThat(
+            properties
+                .path("expiresAt")
+                .path("format")
+                .asText()
+        ).isEqualTo("date-time");
+
+        assertThat(
+            properties
+                .path(
+                    "refreshTokenExpiresAt"
+                )
+                .path("format")
+                .asText()
+        ).isEqualTo("date-time");
+
+        assertThat(
+            properties
+                .path("accessToken")
+                .path("type")
+                .asText()
+        ).isEqualTo("string");
+
+        assertThat(
+            properties
+                .path("refreshToken")
+                .path("type")
+                .asText()
+        ).isEqualTo("string");
+    }
+    @Test
     void shouldExposeTransferContract() {
         JsonNode transfer =
             operation(

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
@@ -21,9 +22,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
+
 @WebMvcTest(AuthenticateUserController.class)
 @Import({
     SecurityConfiguration.class,
@@ -31,74 +33,167 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 })
 class AuthenticateUserControllerTest {
 
-    private static final Instant EXPIRES_AT =
-        Instant.parse("2026-07-14T12:15:00Z");
+    private static final Instant ACCESS_EXPIRES_AT =
+        Instant.parse(
+            "2026-07-28T12:15:00Z"
+        );
+
+    private static final Instant REFRESH_EXPIRES_AT =
+        Instant.parse(
+            "2026-08-04T12:00:00Z"
+        );
 
     @Autowired
     private MockMvc mockMvc;
 
     @MockitoBean
-    private AuthenticateUserUseCase authenticateUserUseCase;
+    private AuthenticateUserUseCase
+        authenticateUserUseCase;
 
     @MockitoBean
     private JwtDecoder jwtDecoder;
 
     @Test
-    void shouldAuthenticateUser() throws Exception {
+    void shouldAuthenticateUserAndReturnCredentialPair()
+        throws Exception {
+
         when(authenticateUserUseCase.authenticate(
             any(AuthenticateUserCommand.class)
-        )).thenReturn(
-            new AuthenticateUserResult(
-                "signed-access-token",
-                EXPIRES_AT
-            )
-        );
+        ))
+            .thenReturn(
+                new AuthenticateUserResult(
+                    "signed-access-token",
+                    ACCESS_EXPIRES_AT,
+                    "opaque-refresh-token",
+                    REFRESH_EXPIRES_AT
+                )
+            );
 
         mockMvc.perform(
                 post("/api/v1/auth/login")
-                    .contentType(MediaType.APPLICATION_JSON)
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
                     .content("""
-                                        {
-                                          "email": "nursena@example.com",
-                                          "password": "StrongPassword123!"
-                                        }
-                                        """)
+                        {
+                          "email": "nursena@example.com",
+                          "password": "StrongPassword123!"
+                        }
+                        """)
             )
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.accessToken")
-                .value("signed-access-token"))
-            .andExpect(jsonPath("$.tokenType")
-                .value("Bearer"))
-            .andExpect(jsonPath("$.expiresAt")
-                .value(EXPIRES_AT.toString()));
+            .andExpect(
+                status().isOk()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.accessToken"
+                ).value(
+                    "signed-access-token"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.tokenType"
+                ).value("Bearer")
+            )
+            .andExpect(
+                jsonPath(
+                    "$.expiresAt"
+                ).value(
+                    ACCESS_EXPIRES_AT.toString()
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.refreshToken"
+                ).value(
+                    "opaque-refresh-token"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.refreshTokenExpiresAt"
+                ).value(
+                    REFRESH_EXPIRES_AT.toString()
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.tokenDigest"
+                ).doesNotExist()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.familyId"
+                ).doesNotExist()
+            );
 
-        verify(authenticateUserUseCase).authenticate(
-            argThat(command ->
-                command.email()
-                    .equals("nursena@example.com")
-                    && command.rawPassword()
-                    .equals("StrongPassword123!")
-            )
-        );
+        verify(authenticateUserUseCase)
+            .authenticate(
+                argThat(command ->
+                    command.email().equals(
+                        "nursena@example.com"
+                    )
+                        && command.rawPassword()
+                            .equals(
+                                "StrongPassword123!"
+                            )
+                )
+            );
     }
 
     @Test
-    void shouldRejectInvalidEmail() throws Exception {
+    void shouldRedactCredentialValuesFromResponseToString() {
+        AuthenticateUserResponse response =
+            new AuthenticateUserResponse(
+                "secret-access-token",
+                "Bearer",
+                ACCESS_EXPIRES_AT,
+                "secret-refresh-token",
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(response.toString())
+            .isEqualTo(
+                "AuthenticateUserResponse[redacted]"
+            )
+            .doesNotContain(
+                "secret-access-token",
+                "secret-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRejectInvalidEmail()
+        throws Exception {
+
         mockMvc.perform(
                 post("/api/v1/auth/login")
-                    .contentType(MediaType.APPLICATION_JSON)
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
                     .content("""
-                                        {
-                                          "email": "not-an-email",
-                                          "password": "StrongPassword123!"
-                                        }
-                                        """)
+                        {
+                          "email": "not-an-email",
+                          "password": "StrongPassword123!"
+                        }
+                        """)
             )
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.code")
-                .value("VALIDATION_FAILED"))
-            .andExpect(jsonPath("$.violations[0].field")
-                .value("email"));
+            .andExpect(
+                status().isBadRequest()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "VALIDATION_FAILED"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.violations[0].field"
+                ).value("email")
+            );
     }
 
     @Test
@@ -107,25 +202,47 @@ class AuthenticateUserControllerTest {
 
         when(authenticateUserUseCase.authenticate(
             any(AuthenticateUserCommand.class)
-        )).thenThrow(new InvalidCredentialsException());
+        ))
+            .thenThrow(
+                new InvalidCredentialsException()
+            );
 
         mockMvc.perform(
                 post("/api/v1/auth/login")
-                    .contentType(MediaType.APPLICATION_JSON)
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
                     .content("""
-                                        {
-                                          "email": "nursena@example.com",
-                                          "password": "WrongPassword123!"
-                                        }
-                                        """)
+                        {
+                          "email": "nursena@example.com",
+                          "password": "WrongPassword123!"
+                        }
+                        """)
             )
-            .andExpect(status().isUnauthorized())
-            .andExpect(jsonPath("$.code")
-                .value("INVALID_CREDENTIALS"))
-            .andExpect(jsonPath("$.message")
-                .value("Email or password is incorrect."))
-            .andExpect(jsonPath("$.path")
-                .value("/api/v1/auth/login"));
+            .andExpect(
+                status().isUnauthorized()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "INVALID_CREDENTIALS"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.message"
+                ).value(
+                    "Email or password is incorrect."
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.path"
+                ).value(
+                    "/api/v1/auth/login"
+                )
+            );
     }
 
     @Test
@@ -134,26 +251,46 @@ class AuthenticateUserControllerTest {
 
         when(authenticateUserUseCase.authenticate(
             any(AuthenticateUserCommand.class)
-        )).thenThrow(new UserAccountUnavailableException());
+        ))
+            .thenThrow(
+                new UserAccountUnavailableException()
+            );
 
         mockMvc.perform(
                 post("/api/v1/auth/login")
-                    .contentType(MediaType.APPLICATION_JSON)
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
                     .content("""
-                                        {
-                                          "email": "nursena@example.com",
-                                          "password": "StrongPassword123!"
-                                        }
-                                        """)
+                        {
+                          "email": "nursena@example.com",
+                          "password": "StrongPassword123!"
+                        }
+                        """)
             )
-            .andExpect(status().isForbidden())
-            .andExpect(jsonPath("$.code")
-                .value("USER_ACCOUNT_UNAVAILABLE"))
-            .andExpect(jsonPath("$.message")
-                .value(
+            .andExpect(
+                status().isForbidden()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "USER_ACCOUNT_UNAVAILABLE"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.message"
+                ).value(
                     "User account is not available for authentication."
-                ))
-            .andExpect(jsonPath("$.path")
-                .value("/api/v1/auth/login"));
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.path"
+                ).value(
+                    "/api/v1/auth/login"
+                )
+            );
     }
 }

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/JwtConfigurationClockTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/JwtConfigurationClockTest.java
@@ -1,0 +1,59 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+import com.nursena.payflow.configuration.TimeConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class JwtConfigurationClockTest {
+
+    private final ApplicationContextRunner contextRunner =
+        new ApplicationContextRunner()
+            .withUserConfiguration(
+                TimeConfiguration.class,
+                JwtConfiguration.class
+            )
+            .withPropertyValues(
+                "payflow.security.jwt."
+                    + "issuer=https://api.payflow.local",
+                "payflow.security.jwt."
+                    + "access-token-ttl=15m"
+            );
+
+    @Test
+    void shouldUseSingleSharedUtcClock() {
+        contextRunner.run(context -> {
+            assertThat(context)
+                .hasNotFailed();
+
+            Map<String, Clock> clocks =
+                context.getBeansOfType(
+                    Clock.class
+                );
+
+            assertThat(clocks)
+                .containsOnlyKeys("clock");
+
+            assertThat(
+                context.containsBean(
+                    "jwtClock"
+                )
+            )
+                .isFalse();
+
+            assertThat(
+                context.getBean(
+                    Clock.class
+                ).getZone()
+            )
+                .isEqualTo(
+                    ZoneOffset.UTC
+                );
+        });
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionConfigurationTest.java
@@ -1,0 +1,99 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import com.nursena.payflow.user.application.service.RefreshSessionLifetimePolicy;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class RefreshSessionConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+        new ApplicationContextRunner()
+            .withUserConfiguration(
+                RefreshSessionConfiguration.class
+            );
+
+    @Test
+    void shouldBindDurationsAndExposeLifetimePolicy() {
+        contextRunner
+            .withPropertyValues(
+                "payflow.security.refresh-session."
+                    + "refresh-token-ttl=7d",
+                "payflow.security.refresh-session."
+                    + "family-ttl=30d"
+            )
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed();
+
+                assertThat(context)
+                    .hasSingleBean(
+                        RefreshSessionProperties.class
+                    );
+
+                assertThat(context)
+                    .hasSingleBean(
+                        RefreshSessionLifetimePolicy.class
+                    );
+
+                RefreshSessionProperties properties =
+                    context.getBean(
+                        RefreshSessionProperties.class
+                    );
+
+                assertThat(
+                    properties.refreshTokenTtl()
+                )
+                    .isEqualTo(
+                        Duration.ofDays(7)
+                    );
+
+                assertThat(
+                    properties.familyTtl()
+                )
+                    .isEqualTo(
+                        Duration.ofDays(30)
+                    );
+
+                RefreshSessionLifetimePolicy policy =
+                    context.getBean(
+                        RefreshSessionLifetimePolicy.class
+                    );
+
+                Instant issuedAt =
+                    Instant.parse(
+                        "2026-07-28T12:00:00Z"
+                    );
+
+                assertThat(
+                    policy.familyExpiresAt(
+                        issuedAt
+                    )
+                )
+                    .isEqualTo(
+                        issuedAt.plus(
+                            Duration.ofDays(30)
+                        )
+                    );
+            });
+    }
+
+    @Test
+    void shouldRejectNonPositiveConfiguration() {
+        contextRunner
+            .withPropertyValues(
+                "payflow.security.refresh-session."
+                    + "refresh-token-ttl=-1s",
+                "payflow.security.refresh-session."
+                    + "family-ttl=30d"
+            )
+            .run(context ->
+                assertThat(context)
+                    .hasFailed()
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionPropertiesTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionPropertiesTest.java
@@ -1,0 +1,113 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RefreshSessionPropertiesTest {
+
+    @Test
+    void shouldRetainValidDurations() {
+        Duration refreshTokenTtl =
+            Duration.ofDays(7);
+
+        Duration familyTtl =
+            Duration.ofDays(30);
+
+        RefreshSessionProperties properties =
+            new RefreshSessionProperties(
+                refreshTokenTtl,
+                familyTtl
+            );
+
+        assertThat(properties.refreshTokenTtl())
+            .isEqualTo(refreshTokenTtl);
+
+        assertThat(properties.familyTtl())
+            .isEqualTo(familyTtl);
+    }
+
+    @Test
+    void shouldRequireRefreshTokenTtl() {
+        assertThatThrownBy(() ->
+            new RefreshSessionProperties(
+                null,
+                Duration.ofDays(30)
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "refreshTokenTtl must not be null"
+            );
+    }
+
+    @Test
+    void shouldRequireFamilyTtl() {
+        assertThatThrownBy(() ->
+            new RefreshSessionProperties(
+                Duration.ofDays(7),
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "familyTtl must not be null"
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonPositiveDurations")
+    void shouldRejectNonPositiveRefreshTokenTtl(
+        Duration invalidDuration
+    ) {
+        assertThatThrownBy(() ->
+            new RefreshSessionProperties(
+                invalidDuration,
+                Duration.ofDays(30)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "refreshTokenTtl must be positive"
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonPositiveDurations")
+    void shouldRejectNonPositiveFamilyTtl(
+        Duration invalidDuration
+    ) {
+        assertThatThrownBy(() ->
+            new RefreshSessionProperties(
+                Duration.ofDays(7),
+                invalidDuration
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "familyTtl must be positive"
+            );
+    }
+
+    private static Stream<Duration>
+    nonPositiveDurations() {
+        return Stream.of(
+            Duration.ZERO,
+            Duration.ofSeconds(-1)
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/port/in/AuthenticateUserResultTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/in/AuthenticateUserResultTest.java
@@ -1,0 +1,146 @@
+package com.nursena.payflow.user.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class AuthenticateUserResultTest {
+
+    private static final Instant ACCESS_EXPIRES_AT =
+        Instant.parse(
+            "2026-07-28T12:15:00Z"
+        );
+
+    private static final Instant REFRESH_EXPIRES_AT =
+        Instant.parse(
+            "2026-08-04T12:00:00Z"
+        );
+
+    @Test
+    void shouldRetainCredentialPair() {
+        AuthenticateUserResult result =
+            new AuthenticateUserResult(
+                "signed-access-token",
+                ACCESS_EXPIRES_AT,
+                "opaque-refresh-token",
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(result.accessToken())
+            .isEqualTo(
+                "signed-access-token"
+            );
+
+        assertThat(result.expiresAt())
+            .isEqualTo(
+                ACCESS_EXPIRES_AT
+            );
+
+        assertThat(result.refreshToken())
+            .isEqualTo(
+                "opaque-refresh-token"
+            );
+
+        assertThat(
+            result.refreshTokenExpiresAt()
+        )
+            .isEqualTo(
+                REFRESH_EXPIRES_AT
+            );
+    }
+
+    @Test
+    void shouldRedactCredentialValuesFromToString() {
+        AuthenticateUserResult result =
+            new AuthenticateUserResult(
+                "secret-access-token",
+                ACCESS_EXPIRES_AT,
+                "secret-refresh-token",
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(result.toString())
+            .isEqualTo(
+                "AuthenticateUserResult[redacted]"
+            )
+            .doesNotContain(
+                "secret-access-token",
+                "secret-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankAccessToken() {
+        assertThatThrownBy(() ->
+            new AuthenticateUserResult(
+                " ",
+                ACCESS_EXPIRES_AT,
+                "refresh-token",
+                REFRESH_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "accessToken must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankRefreshToken() {
+        assertThatThrownBy(() ->
+            new AuthenticateUserResult(
+                "access-token",
+                ACCESS_EXPIRES_AT,
+                " ",
+                REFRESH_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "refreshToken must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRequireAccessExpiration() {
+        assertThatThrownBy(() ->
+            new AuthenticateUserResult(
+                "access-token",
+                null,
+                "refresh-token",
+                REFRESH_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "expiresAt must not be null"
+            );
+    }
+
+    @Test
+    void shouldRequireRefreshExpiration() {
+        assertThatThrownBy(() ->
+            new AuthenticateUserResult(
+                "access-token",
+                ACCESS_EXPIRES_AT,
+                "refresh-token",
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "refreshTokenExpiresAt must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/AuthenticateUserServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/AuthenticateUserServiceTest.java
@@ -2,32 +2,50 @@ package com.nursena.payflow.user.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 
 import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
-import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
-import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
 import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
 import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
 import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
 import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
 import com.nursena.payflow.user.domain.model.User;
 import com.nursena.payflow.user.domain.model.UserRole;
 import com.nursena.payflow.user.domain.model.UserStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 class AuthenticateUserServiceTest {
@@ -38,19 +56,36 @@ class AuthenticateUserServiceTest {
         );
 
     private static final Instant NOW =
-        Instant.parse("2026-07-12T12:00:00Z");
+        Instant.parse(
+            "2026-07-28T12:00:00Z"
+        );
 
-    private static final Instant EXPIRES_AT =
-        Instant.parse("2026-07-12T12:15:00Z");
+    private static final Instant ACCESS_EXPIRES_AT =
+        Instant.parse(
+            "2026-07-28T12:15:00Z"
+        );
+
+    private static final Instant FAMILY_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(30)
+        );
+
+    private static final Instant REFRESH_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(7)
+        );
 
     private static final String RAW_PASSWORD =
         "StrongPassword123!";
 
     private static final String PASSWORD_HASH =
-        "$2a$12$hashed-password";
+        "hashed-password";
 
     private static final String ACCESS_TOKEN =
         "generated.jwt.token";
+
+    private static final String REFRESH_TOKEN =
+        "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA";
 
     @Mock
     private UserRepositoryPort userRepository;
@@ -59,37 +94,111 @@ class AuthenticateUserServiceTest {
     private PasswordVerificationPort passwordVerification;
 
     @Mock
+    private RefreshTokenGenerationPort refreshTokenGeneration;
+
+    @Mock
+    private RefreshTokenDigestPort refreshTokenDigest;
+
+    @Mock
+    private RefreshTokenFamilyRepositoryPort familyRepository;
+
+    @Mock
+    private RefreshTokenRecordRepositoryPort recordRepository;
+
+    @Mock
     private AccessTokenGenerationPort accessTokenGeneration;
 
+    private RefreshSessionLifetimePolicy lifetimePolicy;
+    private Clock clock;
     private AuthenticateUserService authenticateUserService;
 
     @BeforeEach
     void setUp() {
-        authenticateUserService = new AuthenticateUserService(
-            userRepository,
-            passwordVerification,
-            accessTokenGeneration
-        );
+        lifetimePolicy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        clock =
+            Clock.fixed(
+                NOW,
+                ZoneOffset.UTC
+            );
+
+        authenticateUserService =
+            new AuthenticateUserService(
+                userRepository,
+                passwordVerification,
+                refreshTokenGeneration,
+                refreshTokenDigest,
+                familyRepository,
+                recordRepository,
+                accessTokenGeneration,
+                lifetimePolicy,
+                clock
+            );
     }
 
     @Test
-    void shouldAuthenticateActiveUser() {
+    void shouldAuthenticateAndIssueInitialRefreshSession() {
         EmailAddress email =
-            EmailAddress.of("nursena@example.com");
+            EmailAddress.of(
+                "nursena@example.com"
+            );
 
-        User user = activeUser(email);
+        User user =
+            activeUser(email);
+
+        RefreshTokenDigest digest =
+            digest();
 
         when(userRepository.findByEmail(email))
-            .thenReturn(Optional.of(user));
+            .thenReturn(
+                Optional.of(user)
+            );
+
         when(passwordVerification.matches(
             RAW_PASSWORD,
             PASSWORD_HASH
-        )).thenReturn(true);
+        ))
+            .thenReturn(true);
+
+        when(refreshTokenGeneration.generate())
+            .thenReturn(
+                new GeneratedRefreshToken(
+                    REFRESH_TOKEN
+                )
+            );
+
+        when(refreshTokenDigest.digest(
+            REFRESH_TOKEN
+        ))
+            .thenReturn(digest);
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
         when(accessTokenGeneration.generate(user))
-            .thenReturn(new GeneratedAccessToken(
-                ACCESS_TOKEN,
-                EXPIRES_AT
-            ));
+            .thenReturn(
+                new GeneratedAccessToken(
+                    ACCESS_TOKEN,
+                    ACCESS_EXPIRES_AT
+                )
+            );
 
         AuthenticateUserResult result =
             authenticateUserService.authenticate(
@@ -101,24 +210,171 @@ class AuthenticateUserServiceTest {
 
         assertThat(result.accessToken())
             .isEqualTo(ACCESS_TOKEN);
-        assertThat(result.expiresAt())
-            .isEqualTo(EXPIRES_AT);
 
-        verify(userRepository).findByEmail(email);
-        verify(passwordVerification).matches(
-            RAW_PASSWORD,
-            PASSWORD_HASH
-        );
-        verify(accessTokenGeneration).generate(user);
+        assertThat(result.expiresAt())
+            .isEqualTo(
+                ACCESS_EXPIRES_AT
+            );
+
+        assertThat(result.refreshToken())
+            .isEqualTo(
+                REFRESH_TOKEN
+            );
+
+        assertThat(
+            result.refreshTokenExpiresAt()
+        )
+            .isEqualTo(
+                REFRESH_EXPIRES_AT
+            );
+
+        ArgumentCaptor<RefreshTokenFamily>
+            familyCaptor =
+            ArgumentCaptor.forClass(
+                RefreshTokenFamily.class
+            );
+
+        ArgumentCaptor<RefreshTokenRecord>
+            recordCaptor =
+            ArgumentCaptor.forClass(
+                RefreshTokenRecord.class
+            );
+
+        InOrder issuanceOrder =
+            inOrder(
+                refreshTokenGeneration,
+                refreshTokenDigest,
+                familyRepository,
+                recordRepository,
+                accessTokenGeneration
+            );
+
+        issuanceOrder
+            .verify(refreshTokenGeneration)
+            .generate();
+
+        issuanceOrder
+            .verify(refreshTokenDigest)
+            .digest(REFRESH_TOKEN);
+
+        issuanceOrder
+            .verify(familyRepository)
+            .save(
+                familyCaptor.capture()
+            );
+
+        issuanceOrder
+            .verify(recordRepository)
+            .save(
+                recordCaptor.capture()
+            );
+
+        issuanceOrder
+            .verify(accessTokenGeneration)
+            .generate(user);
+
+        RefreshTokenFamily savedFamily =
+            familyCaptor.getValue();
+
+        RefreshTokenRecord savedRecord =
+            recordCaptor.getValue();
+
+        assertThat(savedFamily.id())
+            .isNotNull();
+
+        assertThat(savedFamily.userId())
+            .isEqualTo(USER_ID);
+
+        assertThat(savedFamily.createdAt())
+            .isEqualTo(NOW);
+
+        assertThat(savedFamily.expiresAt())
+            .isEqualTo(
+                FAMILY_EXPIRES_AT
+            );
+
+        assertThat(savedFamily.isRevoked())
+            .isFalse();
+
+        assertThat(savedRecord.id())
+            .isNotNull();
+
+        assertThat(savedRecord.familyId())
+            .isEqualTo(
+                savedFamily.id()
+            );
+
+        assertThat(savedRecord.digest())
+            .isEqualTo(digest);
+
+        assertThat(savedRecord.issuedAt())
+            .isEqualTo(NOW);
+
+        assertThat(savedRecord.expiresAt())
+            .isEqualTo(
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(
+            savedRecord.isActiveAt(
+                savedFamily,
+                NOW
+            )
+        )
+            .isTrue();
+
+        verify(userRepository)
+            .findByEmail(email);
+
+        verify(passwordVerification)
+            .matches(
+                RAW_PASSWORD,
+                PASSWORD_HASH
+            );
     }
 
     @Test
-    void shouldRejectUnknownEmail() {
+    void shouldDeclareWriteTransactionOnAuthentication()
+        throws NoSuchMethodException {
+
+        Method authenticate =
+            AuthenticateUserService.class
+                .getDeclaredMethod(
+                    "authenticate",
+                    AuthenticateUserCommand.class
+                );
+
+        Transactional transactional =
+            authenticate.getAnnotation(
+                Transactional.class
+            );
+
+        assertThat(transactional)
+            .isNotNull();
+
+        assertThat(transactional.readOnly())
+            .isFalse();
+
+        assertThat(
+            AuthenticateUserService.class
+                .getAnnotation(
+                    Transactional.class
+                )
+        )
+            .isNull();
+    }
+
+    @Test
+    void shouldRejectUnknownEmailWithoutIssuingCredentials() {
         EmailAddress email =
-            EmailAddress.of("unknown@example.com");
+            EmailAddress.of(
+                "unknown@example.com"
+            );
 
         when(userRepository.findByEmail(email))
-            .thenReturn(Optional.empty());
+            .thenReturn(
+                Optional.empty()
+            );
 
         assertThatThrownBy(() ->
             authenticateUserService.authenticate(
@@ -126,30 +382,48 @@ class AuthenticateUserServiceTest {
                     "unknown@example.com",
                     RAW_PASSWORD
                 )
-            ))
-            .isInstanceOf(InvalidCredentialsException.class)
-            .hasMessage("Email or password is incorrect.");
+            )
+        )
+            .isInstanceOf(
+                InvalidCredentialsException.class
+            )
+            .hasMessage(
+                "Email or password is incorrect."
+            );
 
-        verify(userRepository).findByEmail(email);
+        verify(userRepository)
+            .findByEmail(email);
+
         verifyNoInteractions(
             passwordVerification,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            familyRepository,
+            recordRepository,
             accessTokenGeneration
         );
     }
 
     @Test
-    void shouldRejectIncorrectPassword() {
+    void shouldRejectIncorrectPasswordWithoutIssuingCredentials() {
         EmailAddress email =
-            EmailAddress.of("nursena@example.com");
+            EmailAddress.of(
+                "nursena@example.com"
+            );
 
-        User user = activeUser(email);
+        User user =
+            activeUser(email);
 
         when(userRepository.findByEmail(email))
-            .thenReturn(Optional.of(user));
+            .thenReturn(
+                Optional.of(user)
+            );
+
         when(passwordVerification.matches(
             "IncorrectPassword123!",
             PASSWORD_HASH
-        )).thenReturn(false);
+        ))
+            .thenReturn(false);
 
         assertThatThrownBy(() ->
             authenticateUserService.authenticate(
@@ -157,26 +431,41 @@ class AuthenticateUserServiceTest {
                     "nursena@example.com",
                     "IncorrectPassword123!"
                 )
-            ))
-            .isInstanceOf(InvalidCredentialsException.class)
-            .hasMessage("Email or password is incorrect.");
+            )
+        )
+            .isInstanceOf(
+                InvalidCredentialsException.class
+            );
 
-        verify(accessTokenGeneration, never()).generate(user);
+        verifyNoInteractions(
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            familyRepository,
+            recordRepository,
+            accessTokenGeneration
+        );
     }
 
     @Test
-    void shouldRejectUnavailableUserAccount() {
+    void shouldRejectUnavailableAccountWithoutIssuingCredentials() {
         EmailAddress email =
-            EmailAddress.of("nursena@example.com");
+            EmailAddress.of(
+                "nursena@example.com"
+            );
 
-        User user = unavailableUser(email);
+        User user =
+            unavailableUser(email);
 
         when(userRepository.findByEmail(email))
-            .thenReturn(Optional.of(user));
+            .thenReturn(
+                Optional.of(user)
+            );
+
         when(passwordVerification.matches(
             RAW_PASSWORD,
             PASSWORD_HASH
-        )).thenReturn(true);
+        ))
+            .thenReturn(true);
 
         assertThatThrownBy(() ->
             authenticateUserService.authenticate(
@@ -184,18 +473,233 @@ class AuthenticateUserServiceTest {
                     "nursena@example.com",
                     RAW_PASSWORD
                 )
-            ))
+            )
+        )
             .isInstanceOf(
                 UserAccountUnavailableException.class
-            )
-            .hasMessage(
-                "User account is not available for authentication."
             );
 
-        verify(accessTokenGeneration, never()).generate(user);
+        verifyNoInteractions(
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            familyRepository,
+            recordRepository,
+            accessTokenGeneration
+        );
     }
 
-    private static User activeUser(EmailAddress email) {
+    @Test
+    void shouldStopWhenFamilyPersistenceFails() {
+        User user =
+            activeUser(
+                EmailAddress.of(
+                    "nursena@example.com"
+                )
+            );
+
+        stubValidAuthentication(user);
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenThrow(
+                new IllegalStateException(
+                    "family persistence failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            authenticateUserService.authenticate(
+                command()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "family persistence failed"
+            );
+
+        verify(recordRepository, never())
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        verifyNoInteractions(
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldStopWhenRecordPersistenceFails() {
+        User user =
+            activeUser(
+                EmailAddress.of(
+                    "nursena@example.com"
+                )
+            );
+
+        stubValidAuthentication(user);
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenThrow(
+                new IllegalStateException(
+                    "record persistence failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            authenticateUserService.authenticate(
+                command()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "record persistence failed"
+            );
+
+        verifyNoInteractions(
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldGenerateAccessTokenAfterSessionPersistence() {
+        User user =
+            activeUser(
+                EmailAddress.of(
+                    "nursena@example.com"
+                )
+            );
+
+        stubValidAuthentication(user);
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(accessTokenGeneration.generate(user))
+            .thenThrow(
+                new IllegalStateException(
+                    "access token generation failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            authenticateUserService.authenticate(
+                command()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "access token generation failed"
+            );
+
+        InOrder order =
+            inOrder(
+                familyRepository,
+                recordRepository,
+                accessTokenGeneration
+            );
+
+        order.verify(familyRepository)
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+
+        order.verify(recordRepository)
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        order.verify(accessTokenGeneration)
+            .generate(user);
+    }
+
+    private void stubValidAuthentication(
+        User user
+    ) {
+        when(userRepository.findByEmail(
+            user.email()
+        ))
+            .thenReturn(
+                Optional.of(user)
+            );
+
+        when(passwordVerification.matches(
+            RAW_PASSWORD,
+            PASSWORD_HASH
+        ))
+            .thenReturn(true);
+
+        when(refreshTokenGeneration.generate())
+            .thenReturn(
+                new GeneratedRefreshToken(
+                    REFRESH_TOKEN
+                )
+            );
+
+        when(refreshTokenDigest.digest(
+            REFRESH_TOKEN
+        ))
+            .thenReturn(
+                digest()
+            );
+    }
+
+    private static AuthenticateUserCommand command() {
+        return new AuthenticateUserCommand(
+            "nursena@example.com",
+            RAW_PASSWORD
+        );
+    }
+
+    private static RefreshTokenDigest digest() {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            bytes,
+            (byte) 7
+        );
+
+        return RefreshTokenDigest.of(
+            bytes
+        );
+    }
+
+    private static User activeUser(
+        EmailAddress email
+    ) {
         return User.rehydrate(
             USER_ID,
             email,
@@ -207,7 +711,9 @@ class AuthenticateUserServiceTest {
         );
     }
 
-    private static User unavailableUser(EmailAddress email) {
+    private static User unavailableUser(
+        EmailAddress email
+    ) {
         return User.rehydrate(
             USER_ID,
             email,

--- a/src/test/java/com/nursena/payflow/user/application/service/RefreshSessionLifetimePolicyTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RefreshSessionLifetimePolicyTest.java
@@ -1,0 +1,188 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RefreshSessionLifetimePolicyTest {
+
+    private static final Instant ISSUED_AT =
+        Instant.parse(
+            "2026-07-28T12:00:00Z"
+        );
+
+    @Test
+    void shouldCalculateAbsoluteFamilyExpiration() {
+        RefreshSessionLifetimePolicy policy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        assertThat(
+            policy.familyExpiresAt(
+                ISSUED_AT
+            )
+        )
+            .isEqualTo(
+                ISSUED_AT.plus(
+                    Duration.ofDays(30)
+                )
+            );
+    }
+
+    @Test
+    void shouldCalculateRefreshTokenExpiration() {
+        RefreshSessionLifetimePolicy policy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        Instant familyExpiresAt =
+            ISSUED_AT.plus(
+                Duration.ofDays(30)
+            );
+
+        assertThat(
+            policy.refreshTokenExpiresAt(
+                ISSUED_AT,
+                familyExpiresAt
+            )
+        )
+            .isEqualTo(
+                ISSUED_AT.plus(
+                    Duration.ofDays(7)
+                )
+            );
+    }
+
+    @Test
+    void shouldCapRefreshTokenAtFamilyExpiration() {
+        RefreshSessionLifetimePolicy policy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(60),
+                Duration.ofDays(30)
+            );
+
+        Instant familyExpiresAt =
+            ISSUED_AT.plus(
+                Duration.ofDays(30)
+            );
+
+        assertThat(
+            policy.refreshTokenExpiresAt(
+                ISSUED_AT,
+                familyExpiresAt
+            )
+        )
+            .isEqualTo(
+                familyExpiresAt
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidFamilyExpirations")
+    void shouldRequireFamilyExpirationAfterIssuance(
+        Instant invalidFamilyExpiresAt
+    ) {
+        RefreshSessionLifetimePolicy policy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        assertThatThrownBy(() ->
+            policy.refreshTokenExpiresAt(
+                ISSUED_AT,
+                invalidFamilyExpiresAt
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "familyExpiresAt must be after issuedAt"
+            );
+    }
+
+    @Test
+    void shouldRequireIssuanceTime() {
+        RefreshSessionLifetimePolicy policy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        assertThatThrownBy(() ->
+            policy.familyExpiresAt(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "issuedAt must not be null"
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonPositiveDurations")
+    void shouldRejectNonPositiveRefreshTokenTtl(
+        Duration invalidDuration
+    ) {
+        assertThatThrownBy(() ->
+            new RefreshSessionLifetimePolicy(
+                invalidDuration,
+                Duration.ofDays(30)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "refreshTokenTtl must be positive"
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonPositiveDurations")
+    void shouldRejectNonPositiveFamilyTtl(
+        Duration invalidDuration
+    ) {
+        assertThatThrownBy(() ->
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                invalidDuration
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "familyTtl must be positive"
+            );
+    }
+
+    private static Stream<Instant>
+    invalidFamilyExpirations() {
+        return Stream.of(
+            ISSUED_AT,
+            ISSUED_AT.minusSeconds(1)
+        );
+    }
+
+    private static Stream<Duration>
+    nonPositiveDurations() {
+        return Stream.of(
+            Duration.ZERO,
+            Duration.ofSeconds(-1)
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/AuthenticateUserIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/AuthenticateUserIntegrationTest.java
@@ -1,0 +1,425 @@
+package com.nursena.payflow.user.integration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+class AuthenticateUserIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldIssueAndPersistInitialRefreshSession()
+        throws Exception {
+
+        String email =
+            "login-success-"
+                + UUID.randomUUID()
+                + "@example.com";
+
+        String password =
+            "StrongPassword123!";
+
+        registerUser(
+            email,
+            password
+        );
+
+        MvcResult loginResult =
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                new LoginRequest(
+                                    email,
+                                    password
+                                )
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.accessToken"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.tokenType"
+                    ).value("Bearer")
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.expiresAt"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.refreshToken"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.refreshTokenExpiresAt"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.tokenDigest"
+                    ).doesNotExist()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.familyId"
+                    ).doesNotExist()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.recordId"
+                    ).doesNotExist()
+                )
+                .andReturn();
+
+        JsonNode response =
+            objectMapper.readTree(
+                loginResult
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        String refreshToken =
+            response
+                .path("refreshToken")
+                .asText();
+
+        Instant responseRefreshExpiresAt =
+            Instant.parse(
+                response
+                    .path(
+                        "refreshTokenExpiresAt"
+                    )
+                    .asText()
+            );
+
+        assertThat(refreshToken)
+            .hasSize(43);
+
+        UUID userId =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT id
+                FROM users
+                WHERE email = ?
+                """,
+                UUID.class,
+                email
+            );
+
+        assertThat(userId)
+            .isNotNull();
+
+        Integer familyCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                WHERE user_id = ?
+                """,
+                Integer.class,
+                userId
+            );
+
+        Integer recordCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records record
+                JOIN refresh_token_families family
+                  ON family.id = record.family_id
+                WHERE family.user_id = ?
+                """,
+                Integer.class,
+                userId
+            );
+
+        assertThat(familyCount)
+            .isEqualTo(1);
+
+        assertThat(recordCount)
+            .isEqualTo(1);
+
+        PersistedSession persisted =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT
+                    family.created_at
+                        AS family_created_at,
+                    family.expires_at
+                        AS family_expires_at,
+                    family.revoked_at
+                        AS family_revoked_at,
+                    record.token_digest,
+                    record.issued_at
+                        AS record_issued_at,
+                    record.expires_at
+                        AS record_expires_at,
+                    record.consumed_at,
+                    record.successor_id
+                FROM refresh_token_families family
+                JOIN refresh_token_records record
+                  ON record.family_id = family.id
+                WHERE family.user_id = ?
+                """,
+                AuthenticateUserIntegrationTest
+                    ::mapPersistedSession,
+                userId
+            );
+
+        assertThat(persisted)
+            .isNotNull();
+
+        assertThat(
+            persisted.familyCreatedAt()
+        )
+            .isEqualTo(
+                persisted.recordIssuedAt()
+            );
+
+        assertThat(
+            Duration.between(
+                persisted.familyCreatedAt(),
+                persisted.familyExpiresAt()
+            )
+        )
+            .isEqualTo(
+                Duration.ofDays(30)
+            );
+
+        assertThat(
+            Duration.between(
+                persisted.recordIssuedAt(),
+                persisted.recordExpiresAt()
+            )
+        )
+            .isEqualTo(
+                Duration.ofDays(7)
+            );
+
+        assertThat(
+            responseRefreshExpiresAt
+        )
+            .isEqualTo(
+                persisted.recordExpiresAt()
+            );
+
+        assertThat(
+            persisted.tokenDigest()
+        )
+            .containsExactly(
+                refreshTokenDigest
+                    .digest(refreshToken)
+                    .value()
+            );
+
+        assertThat(
+            Arrays.equals(
+                persisted.tokenDigest(),
+                refreshToken.getBytes(UTF_8)
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            persisted.familyRevokedAt()
+        )
+            .isNull();
+
+        assertThat(
+            persisted.consumedAt()
+        )
+            .isNull();
+
+        assertThat(
+            persisted.successorId()
+        )
+            .isNull();
+    }
+
+    private void registerUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RegistrationRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+    }
+
+    private static PersistedSession
+    mapPersistedSession(
+        ResultSet resultSet,
+        int rowNumber
+    ) throws SQLException {
+
+        return new PersistedSession(
+            resultSet
+                .getTimestamp(
+                    "family_created_at"
+                )
+                .toInstant(),
+            resultSet
+                .getTimestamp(
+                    "family_expires_at"
+                )
+                .toInstant(),
+            nullableInstant(
+                resultSet,
+                "family_revoked_at"
+            ),
+            resultSet.getBytes(
+                "token_digest"
+            ),
+            resultSet
+                .getTimestamp(
+                    "record_issued_at"
+                )
+                .toInstant(),
+            resultSet
+                .getTimestamp(
+                    "record_expires_at"
+                )
+                .toInstant(),
+            nullableInstant(
+                resultSet,
+                "consumed_at"
+            ),
+            resultSet.getObject(
+                "successor_id",
+                UUID.class
+            )
+        );
+    }
+
+    private static Instant nullableInstant(
+        ResultSet resultSet,
+        String column
+    ) throws SQLException {
+
+        java.sql.Timestamp timestamp =
+            resultSet.getTimestamp(column);
+
+        return timestamp == null
+            ? null
+            : timestamp.toInstant();
+    }
+
+    private record RegistrationRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record LoginRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record PersistedSession(
+        Instant familyCreatedAt,
+        Instant familyExpiresAt,
+        Instant familyRevokedAt,
+        byte[] tokenDigest,
+        Instant recordIssuedAt,
+        Instant recordExpiresAt,
+        Instant consumedAt,
+        UUID successorId
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/AuthenticateUserRollbackIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/AuthenticateUserRollbackIntegrationTest.java
@@ -1,0 +1,375 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+@Import(
+    AuthenticateUserRollbackIntegrationTest
+        .FailureInjectionConfiguration.class
+)
+class AuthenticateUserRollbackIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private FailureInjectingRecordRepository
+        recordRepository;
+
+    @Autowired
+    private FailureInjectingAccessTokenGeneration
+        accessTokenGeneration;
+
+    @BeforeEach
+    void setUp() {
+        recordRepository.reset();
+        accessTokenGeneration.reset();
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldRollbackFamilyWhenInitialRecordPersistenceFails()
+        throws Exception {
+
+        Credentials credentials =
+            registerUniqueUser(
+                "record-failure"
+            );
+
+        recordRepository.failNextSave();
+
+        assertThatThrownBy(() ->
+            authenticate(
+                credentials
+            )
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "initial refresh-token record persistence failed"
+            );
+
+        assertRefreshSessionTablesAreEmpty();
+    }
+
+    @Test
+    void shouldRollbackFamilyAndRecordWhenAccessTokenGenerationFails()
+        throws Exception {
+
+        Credentials credentials =
+            registerUniqueUser(
+                "access-failure"
+            );
+
+        accessTokenGeneration
+            .failNextGeneration();
+
+        assertThatThrownBy(() ->
+            authenticate(
+                credentials
+            )
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "access-token generation failed"
+            );
+
+        assertRefreshSessionTablesAreEmpty();
+    }
+
+    private Credentials registerUniqueUser(
+        String prefix
+    ) throws Exception {
+
+        Credentials credentials =
+            new Credentials(
+                prefix
+                    + "-"
+                    + UUID.randomUUID()
+                    + "@example.com",
+                "StrongPassword123!"
+            );
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            credentials
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+
+        return credentials;
+    }
+
+    private org.springframework.test.web.servlet
+    .ResultActions authenticate(
+        Credentials credentials
+    ) throws Exception {
+
+        return mockMvc.perform(
+            post("/api/v1/auth/login")
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    objectMapper.writeValueAsString(
+                        credentials
+                    )
+                )
+        );
+    }
+
+    private void assertRefreshSessionTablesAreEmpty() {
+        Integer familyCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                """,
+                Integer.class
+            );
+
+        Integer recordCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        assertThat(familyCount)
+            .isZero();
+
+        assertThat(recordCount)
+            .isZero();
+    }
+
+    private record Credentials(
+        String email,
+        String password
+    ) {
+    }
+
+    @TestConfiguration(
+        proxyBeanMethods = false
+    )
+    static class FailureInjectionConfiguration {
+
+        @Bean
+        @Primary
+        FailureInjectingRecordRepository
+        failureInjectingRecordRepository(
+            @Qualifier(
+                "refreshTokenRecordPersistenceAdapter"
+            )
+            RefreshTokenRecordRepositoryPort delegate
+        ) {
+            return new FailureInjectingRecordRepository(
+                delegate
+            );
+        }
+
+        @Bean
+        @Primary
+        FailureInjectingAccessTokenGeneration
+        failureInjectingAccessTokenGeneration(
+            @Qualifier(
+                "jwtAccessTokenGenerationAdapter"
+            )
+            AccessTokenGenerationPort delegate
+        ) {
+            return new FailureInjectingAccessTokenGeneration(
+                delegate
+            );
+        }
+    }
+
+    static final class FailureInjectingRecordRepository
+        implements RefreshTokenRecordRepositoryPort {
+
+        private final RefreshTokenRecordRepositoryPort
+            delegate;
+
+        private final AtomicBoolean failNextSave =
+            new AtomicBoolean();
+
+        FailureInjectingRecordRepository(
+            RefreshTokenRecordRepositoryPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void failNextSave() {
+            failNextSave.set(true);
+        }
+
+        void reset() {
+            failNextSave.set(false);
+        }
+
+        @Override
+        public RefreshTokenRecord save(
+            RefreshTokenRecord record
+        ) {
+            if (
+                failNextSave.compareAndSet(
+                    true,
+                    false
+                )
+            ) {
+                throw new IllegalStateException(
+                    "initial refresh-token "
+                        + "record persistence failed"
+                );
+            }
+
+            return delegate.save(record);
+        }
+
+        @Override
+        public Optional<RefreshTokenRecord>
+        findByDigestForUpdate(
+            RefreshTokenDigest digest
+        ) {
+            return delegate
+                .findByDigestForUpdate(
+                    digest
+                );
+        }
+
+        @Override
+        public Optional<RefreshTokenRecord>
+        findById(
+            RefreshTokenRecordId recordId
+        ) {
+            return delegate.findById(
+                recordId
+            );
+        }
+    }
+
+    static final class FailureInjectingAccessTokenGeneration
+        implements AccessTokenGenerationPort {
+
+        private final AccessTokenGenerationPort
+            delegate;
+
+        private final AtomicBoolean
+            failNextGeneration =
+            new AtomicBoolean();
+
+        FailureInjectingAccessTokenGeneration(
+            AccessTokenGenerationPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void failNextGeneration() {
+            failNextGeneration.set(true);
+        }
+
+        void reset() {
+            failNextGeneration.set(false);
+        }
+
+        @Override
+        public GeneratedAccessToken generate(
+            User user
+        ) {
+            if (
+                failNextGeneration.compareAndSet(
+                    true,
+                    false
+                )
+            ) {
+                throw new IllegalStateException(
+                    "access-token generation failed"
+                );
+            }
+
+            return delegate.generate(user);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a refresh-session lifetime policy with configurable token and family TTLs
- use one shared UTC Clock for access-token and refresh-session issuance
- persist an initial refresh-token family and record during successful login
- return access and refresh credentials without exposing internal session fields
- redact credential values from result and HTTP response string representations
- document the credential-pair response in the OpenAPI contract

## Transaction safety

- reject invalid credentials before creating refresh-session state
- roll back the family when initial-record persistence fails
- roll back both family and record when access-token generation fails
- persist only the SHA-256 refresh-token digest

## Verification

- `.\mvnw.cmd clean verify`
- 741 tests
- 0 failures
- 0 errors
- 0 skipped
- staged-patch secret scan passed

Closes #84
