### PR TITLE
feat(auth): rotate refresh credentials

### DIFF
--- a/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
@@ -29,6 +29,46 @@ public final class OpenApiExamples {
         }
         """;
 
+    public static final String REFRESH_SUCCESS =
+        """
+        {
+          "accessToken": "eyJhbGciOiJSUzI1NiJ9...",
+          "tokenType": "Bearer",
+          "expiresAt": "2026-07-28T12:15:00Z",
+          "refreshToken": "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8",
+          "refreshTokenExpiresAt": "2026-08-04T12:00:00Z"
+        }
+        """;
+
+    public static final String REFRESH_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-28T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/auth/refresh",
+          "violations": [
+            {
+              "field": "refreshToken",
+              "message": "Refresh token is required."
+            }
+          ]
+        }
+        """;
+
+    public static final String INVALID_REFRESH_TOKEN =
+        """
+        {
+          "timestamp": "2026-07-28T12:00:00Z",
+          "status": 401,
+          "code": "REFRESH_TOKEN_INVALID",
+          "message": "Refresh token is invalid.",
+          "path": "/api/v1/auth/refresh",
+          "violations": []
+        }
+        """;
+
     public static final String REGISTER_VALIDATION_ERROR =
         """
         {

--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -27,7 +27,8 @@ public class SecurityConfiguration {
         "/swagger-ui.html",
         "/swagger-ui/**",
         "/api/v1/auth/register",
-        "/api/v1/auth/login"
+        "/api/v1/auth/login",
+        "/api/v1/auth/refresh"
     };
 
     @Bean

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsController.java
@@ -1,0 +1,132 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiExamples;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsCommand;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+    name = "Authentication",
+    description =
+        "Public user registration and authentication operations."
+)
+@RestController
+@RequestMapping("/api/v1/auth")
+public class RotateRefreshCredentialsController {
+
+    private static final String TOKEN_TYPE =
+        "Bearer";
+
+    private final RotateRefreshCredentialsUseCase
+        rotateRefreshCredentialsUseCase;
+
+    public RotateRefreshCredentialsController(
+        RotateRefreshCredentialsUseCase
+            rotateRefreshCredentialsUseCase
+    ) {
+        this.rotateRefreshCredentialsUseCase =
+            rotateRefreshCredentialsUseCase;
+    }
+
+    @Operation(
+        operationId = "rotateRefreshCredentials",
+        summary = "Rotate refresh credentials",
+        description =
+            "Consumes an active opaque refresh token "
+                + "and returns a new access and refresh "
+                + "credential pair."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description =
+                "Refresh credentials rotated successfully.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        RotateRefreshCredentialsResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples.REFRESH_SUCCESS
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .REFRESH_VALIDATION_ERROR
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "The refresh credential is invalid.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .INVALID_REFRESH_TOKEN
+                )
+            )
+        )
+    })
+    @PostMapping("/refresh")
+    public ResponseEntity<
+        RotateRefreshCredentialsResponse
+    > rotate(
+        @Valid @RequestBody
+        RotateRefreshCredentialsRequest request
+    ) {
+        RotateRefreshCredentialsCommand command =
+            new RotateRefreshCredentialsCommand(
+                request.refreshToken()
+            );
+
+        RotateRefreshCredentialsResult result =
+            rotateRefreshCredentialsUseCase.rotate(
+                command
+            );
+
+        RotateRefreshCredentialsResponse response =
+            new RotateRefreshCredentialsResponse(
+                result.accessToken(),
+                TOKEN_TYPE,
+                result.expiresAt(),
+                result.refreshToken(),
+                result.refreshTokenExpiresAt()
+            );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsRequest.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsRequest.java
@@ -1,0 +1,33 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(
+    name = "RotateRefreshCredentialsRequest",
+    description =
+        "Opaque refresh credential submitted for "
+            + "single-use rotation."
+)
+public record RotateRefreshCredentialsRequest(
+
+    @Schema(
+        description =
+            "Opaque refresh token returned by login "
+                + "or a previous refresh operation.",
+        example =
+            "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA",
+        format = "password",
+        accessMode = Schema.AccessMode.WRITE_ONLY
+    )
+    @NotBlank(
+        message = "Refresh token is required."
+    )
+    String refreshToken
+) {
+
+    @Override
+    public String toString() {
+        return "RotateRefreshCredentialsRequest[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsResponse.java
@@ -1,0 +1,98 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "RotateRefreshCredentialsResponse",
+    description =
+        "New access and refresh credentials returned "
+            + "after successful refresh-token rotation."
+)
+public record RotateRefreshCredentialsResponse(
+
+    @Schema(
+        description = "RSA-signed JWT access token.",
+        example = "eyJhbGciOiJSUzI1NiJ9..."
+    )
+    String accessToken,
+
+    @Schema(
+        description =
+            "Authentication scheme used with the access token.",
+        example = "Bearer"
+    )
+    String tokenType,
+
+    @Schema(
+        description = "Access-token expiration time.",
+        example = "2026-07-28T12:15:00Z",
+        format = "date-time"
+    )
+    Instant expiresAt,
+
+    @Schema(
+        description =
+            "New opaque refresh token replacing the "
+                + "presented refresh token.",
+        example =
+            "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8"
+    )
+    String refreshToken,
+
+    @Schema(
+        description = "New refresh-token expiration time.",
+        example = "2026-08-04T12:00:00Z",
+        format = "date-time"
+    )
+    Instant refreshTokenExpiresAt
+) {
+
+    public RotateRefreshCredentialsResponse {
+        Objects.requireNonNull(
+            accessToken,
+            "accessToken must not be null"
+        );
+        Objects.requireNonNull(
+            tokenType,
+            "tokenType must not be null"
+        );
+        Objects.requireNonNull(
+            expiresAt,
+            "expiresAt must not be null"
+        );
+        Objects.requireNonNull(
+            refreshToken,
+            "refreshToken must not be null"
+        );
+        Objects.requireNonNull(
+            refreshTokenExpiresAt,
+            "refreshTokenExpiresAt must not be null"
+        );
+
+        if (accessToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "accessToken must not be blank"
+            );
+        }
+
+        if (tokenType.isBlank()) {
+            throw new IllegalArgumentException(
+                "tokenType must not be blank"
+            );
+        }
+
+        if (refreshToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "refreshToken must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RotateRefreshCredentialsResponse[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/UserAuthenticationExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/UserAuthenticationExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.nursena.payflow.common.api.ApiError;
 import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
 import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.Ordered;
@@ -16,7 +17,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RestControllerAdvice(
-    assignableTypes = AuthenticateUserController.class
+    assignableTypes = {
+        AuthenticateUserController.class,
+        RotateRefreshCredentialsController.class
+    }
 )
 public class UserAuthenticationExceptionHandler {
 
@@ -40,6 +44,21 @@ public class UserAuthenticationExceptionHandler {
     ) {
         return buildResponse(
             HttpStatus.FORBIDDEN,
+            exception.getCode(),
+            exception.getMessage(),
+            request
+        );
+    }
+
+    @ExceptionHandler(
+        InvalidRefreshTokenException.class
+    )
+    ResponseEntity<ApiError> handleInvalidRefreshToken(
+        InvalidRefreshTokenException exception,
+        HttpServletRequest request
+    ) {
+        return buildResponse(
+            HttpStatus.UNAUTHORIZED,
             exception.getCode(),
             exception.getMessage(),
             request

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsCommand.java
@@ -1,0 +1,26 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.util.Objects;
+
+public record RotateRefreshCredentialsCommand(
+    String refreshToken
+) {
+
+    public RotateRefreshCredentialsCommand {
+        Objects.requireNonNull(
+            refreshToken,
+            "refreshToken must not be null"
+        );
+
+        if (refreshToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "refreshToken must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RotateRefreshCredentialsCommand[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsResult.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsResult.java
@@ -1,0 +1,48 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record RotateRefreshCredentialsResult(
+    String accessToken,
+    Instant expiresAt,
+    String refreshToken,
+    Instant refreshTokenExpiresAt
+) {
+
+    public RotateRefreshCredentialsResult {
+        Objects.requireNonNull(
+            accessToken,
+            "accessToken must not be null"
+        );
+        Objects.requireNonNull(
+            expiresAt,
+            "expiresAt must not be null"
+        );
+        Objects.requireNonNull(
+            refreshToken,
+            "refreshToken must not be null"
+        );
+        Objects.requireNonNull(
+            refreshTokenExpiresAt,
+            "refreshTokenExpiresAt must not be null"
+        );
+
+        if (accessToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "accessToken must not be blank"
+            );
+        }
+
+        if (refreshToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "refreshToken must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RotateRefreshCredentialsResult[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsUseCase.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsUseCase.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.user.application.port.in;
+
+public interface RotateRefreshCredentialsUseCase {
+
+    RotateRefreshCredentialsResult rotate(
+        RotateRefreshCredentialsCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsService.java
@@ -1,0 +1,239 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsCommand;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsUseCase;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model.User;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RotateRefreshCredentialsService
+    implements RotateRefreshCredentialsUseCase {
+
+    private final RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    private final RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    private final RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    private final UserRepositoryPort userRepository;
+
+    private final RefreshTokenGenerationPort
+        refreshTokenGeneration;
+
+    private final AccessTokenGenerationPort
+        accessTokenGeneration;
+
+    private final RefreshSessionLifetimePolicy
+        lifetimePolicy;
+
+    private final Clock clock;
+
+    public RotateRefreshCredentialsService(
+        RefreshTokenDigestPort refreshTokenDigest,
+        RefreshTokenRecordRepositoryPort
+            recordRepository,
+        RefreshTokenFamilyRepositoryPort
+            familyRepository,
+        UserRepositoryPort userRepository,
+        RefreshTokenGenerationPort
+            refreshTokenGeneration,
+        AccessTokenGenerationPort
+            accessTokenGeneration,
+        RefreshSessionLifetimePolicy lifetimePolicy,
+        Clock clock
+    ) {
+        this.refreshTokenDigest =
+            Objects.requireNonNull(
+                refreshTokenDigest,
+                "refreshTokenDigest must not be null"
+            );
+
+        this.recordRepository =
+            Objects.requireNonNull(
+                recordRepository,
+                "recordRepository must not be null"
+            );
+
+        this.familyRepository =
+            Objects.requireNonNull(
+                familyRepository,
+                "familyRepository must not be null"
+            );
+
+        this.userRepository =
+            Objects.requireNonNull(
+                userRepository,
+                "userRepository must not be null"
+            );
+
+        this.refreshTokenGeneration =
+            Objects.requireNonNull(
+                refreshTokenGeneration,
+                "refreshTokenGeneration must not be null"
+            );
+
+        this.accessTokenGeneration =
+            Objects.requireNonNull(
+                accessTokenGeneration,
+                "accessTokenGeneration must not be null"
+            );
+
+        this.lifetimePolicy =
+            Objects.requireNonNull(
+                lifetimePolicy,
+                "lifetimePolicy must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+    }
+
+    @Override
+    @Transactional
+    public RotateRefreshCredentialsResult rotate(
+        RotateRefreshCredentialsCommand command
+    ) {
+        RotateRefreshCredentialsCommand
+            checkedCommand =
+            Objects.requireNonNull(
+                command,
+                "command must not be null"
+            );
+
+        RefreshTokenDigest currentDigest =
+            refreshTokenDigest.digest(
+                checkedCommand.refreshToken()
+            );
+
+        RefreshTokenRecord currentRecord =
+            recordRepository
+                .findByDigestForUpdate(
+                    currentDigest
+                )
+                .orElseThrow(
+                    InvalidRefreshTokenException::new
+                );
+
+        RefreshTokenFamily family =
+            familyRepository
+                .findByIdForUpdate(
+                    currentRecord.familyId()
+                )
+                .orElseThrow(
+                    InvalidRefreshTokenException::new
+                );
+
+        Instant rotatedAt =
+            clock.instant()
+                .truncatedTo(
+                    ChronoUnit.MICROS
+                );
+
+        if (
+            !currentRecord.isActiveAt(
+                family,
+                rotatedAt
+            )
+        ) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        User user =
+            userRepository
+                .findById(
+                    family.userId()
+                )
+                .filter(candidate ->
+                    candidate.status()
+                        == UserStatus.ACTIVE
+                )
+                .orElseThrow(
+                    InvalidRefreshTokenException::new
+                );
+
+        GeneratedRefreshToken generatedToken =
+            refreshTokenGeneration.generate();
+
+        RefreshTokenDigest successorDigest =
+            refreshTokenDigest.digest(
+                generatedToken.value()
+            );
+
+        RefreshTokenRecordId successorId =
+            RefreshTokenRecordId.of(
+                UUID.randomUUID()
+            );
+
+        Instant successorExpiresAt =
+            lifetimePolicy
+                .refreshTokenExpiresAt(
+                    rotatedAt,
+                    family.expiresAt()
+                );
+
+        RefreshTokenRecord successor =
+            RefreshTokenRecord.issue(
+                successorId,
+                family,
+                successorDigest,
+                rotatedAt,
+                successorExpiresAt
+            );
+
+        RefreshTokenRecord consumedCurrent =
+            currentRecord.consume(
+                successorId,
+                rotatedAt,
+                family
+            );
+
+        RefreshTokenRecord savedSuccessor =
+            recordRepository.save(
+                successor
+            );
+
+        recordRepository.save(
+            consumedCurrent
+        );
+
+        GeneratedAccessToken accessToken =
+            accessTokenGeneration.generate(
+                user
+            );
+
+        return new RotateRefreshCredentialsResult(
+            accessToken.value(),
+            accessToken.expiresAt(),
+            generatedToken.value(),
+            savedSuccessor.expiresAt()
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -46,6 +46,9 @@ class OpenApiJsonContractIntegrationTest {
     private static final String LOGIN_PATH =
         "/api/v1/auth/login";
 
+    private static final String REFRESH_PATH =
+        "/api/v1/auth/refresh";
+
     private static final String USER_PROFILE_PATH =
         "/api/v1/users/me";
 
@@ -180,6 +183,7 @@ class OpenApiJsonContractIntegrationTest {
             SYSTEM_HEALTH_PATH,
             REGISTER_PATH,
             LOGIN_PATH,
+            REFRESH_PATH,
             USER_PROFILE_PATH,
             WALLETS_PATH,
             CURRENT_WALLET_PATH,
@@ -230,6 +234,29 @@ class OpenApiJsonContractIntegrationTest {
             "400",
             "401",
             "403"
+        );
+
+        JsonNode refresh =
+            operation(
+                REFRESH_PATH,
+                "post"
+            );
+
+        assertPublicOperation(refresh);
+
+        assertThat(
+            refresh
+                .path("operationId")
+                .asText()
+        ).isEqualTo(
+            "rotateRefreshCredentials"
+        );
+
+        assertResponseCodes(
+            refresh,
+            "200",
+            "400",
+            "401"
         );
     }
 
@@ -548,6 +575,159 @@ class OpenApiJsonContractIntegrationTest {
                 .asText()
         ).isEqualTo("string");
     }
+    @Test
+    void shouldExposeRefreshCredentialPairContract() {
+        JsonNode refresh =
+            operation(
+                REFRESH_PATH,
+                "post"
+            );
+
+        JsonNode requestSchema =
+            refresh
+                .path("requestBody")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .path("schema");
+
+        assertThat(
+            requestSchema
+                .path("$ref")
+                .asText()
+        ).isEqualTo(
+            "#/components/schemas/"
+                + "RotateRefreshCredentialsRequest"
+        );
+
+        JsonNode schemas =
+            openApi
+                .path("components")
+                .path("schemas");
+
+        JsonNode requestProperties =
+            schemas
+                .path(
+                    "RotateRefreshCredentialsRequest"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(requestProperties)
+        ).containsExactly(
+            "refreshToken"
+        );
+
+        assertThat(
+            requestProperties
+                .path("refreshToken")
+                .path("type")
+                .asText()
+        ).isEqualTo("string");
+
+        assertThat(
+            requestProperties
+                .path("refreshToken")
+                .path("writeOnly")
+                .asBoolean()
+        ).isTrue();
+
+        JsonNode successSchema =
+            refresh
+                .path("responses")
+                .path("200")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .path("schema");
+
+        assertThat(
+            successSchema
+                .path("$ref")
+                .asText()
+        ).isEqualTo(
+            "#/components/schemas/"
+                + "RotateRefreshCredentialsResponse"
+        );
+
+        JsonNode responseProperties =
+            schemas
+                .path(
+                    "RotateRefreshCredentialsResponse"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(responseProperties)
+        )
+            .containsExactlyInAnyOrder(
+                "accessToken",
+                "tokenType",
+                "expiresAt",
+                "refreshToken",
+                "refreshTokenExpiresAt"
+            )
+            .doesNotContain(
+                "tokenDigest",
+                "familyId",
+                "recordId",
+                "userId",
+                "revokedAt",
+                "consumedAt",
+                "successorId"
+            );
+
+        assertThat(
+            responseProperties
+                .path("expiresAt")
+                .path("format")
+                .asText()
+        ).isEqualTo("date-time");
+
+        assertThat(
+            responseProperties
+                .path(
+                    "refreshTokenExpiresAt"
+                )
+                .path("format")
+                .asText()
+        ).isEqualTo("date-time");
+
+        JsonNode unauthorizedContent =
+            refresh
+                .path("responses")
+                .path("401")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                );
+
+        assertThat(
+            unauthorizedContent.toString()
+        )
+            .contains(
+                "REFRESH_TOKEN_INVALID",
+                "Refresh token is invalid."
+            );
+
+        assertThat(
+            refresh
+                .path("responses")
+                .path("400")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .toString()
+        )
+            .contains(
+                "VALIDATION_FAILED",
+                "Refresh token is required."
+            );
+    }
+
     @Test
     void shouldExposeTransferContract() {
         JsonNode transfer =

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsControllerTest.java
@@ -1,0 +1,286 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsCommand;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsUseCase;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    RotateRefreshCredentialsController.class
+)
+@Import({
+    SecurityConfiguration.class,
+    UserAuthenticationExceptionHandler.class
+})
+class RotateRefreshCredentialsControllerTest {
+
+    private static final String CURRENT_TOKEN =
+        "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA";
+
+    private static final String SUCCESSOR_TOKEN =
+        "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8";
+
+    private static final Instant ACCESS_EXPIRES_AT =
+        Instant.parse(
+            "2026-07-28T12:15:00Z"
+        );
+
+    private static final Instant REFRESH_EXPIRES_AT =
+        Instant.parse(
+            "2026-08-04T12:00:00Z"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RotateRefreshCredentialsUseCase
+        rotateRefreshCredentialsUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldRotateCredentialsWithoutBearerAuthentication()
+        throws Exception {
+
+        when(rotateRefreshCredentialsUseCase.rotate(
+            any(RotateRefreshCredentialsCommand.class)
+        ))
+            .thenReturn(
+                new RotateRefreshCredentialsResult(
+                    "signed-access-token",
+                    ACCESS_EXPIRES_AT,
+                    SUCCESSOR_TOKEN,
+                    REFRESH_EXPIRES_AT
+                )
+            );
+
+        mockMvc.perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "refreshToken": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA"
+                        }
+                        """)
+            )
+            .andExpect(
+                status().isOk()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.accessToken"
+                ).value(
+                    "signed-access-token"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.tokenType"
+                ).value("Bearer")
+            )
+            .andExpect(
+                jsonPath(
+                    "$.expiresAt"
+                ).value(
+                    ACCESS_EXPIRES_AT.toString()
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.refreshToken"
+                ).value(
+                    SUCCESSOR_TOKEN
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.refreshTokenExpiresAt"
+                ).value(
+                    REFRESH_EXPIRES_AT.toString()
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.tokenDigest"
+                ).doesNotExist()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.familyId"
+                ).doesNotExist()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.recordId"
+                ).doesNotExist()
+            );
+
+        verify(rotateRefreshCredentialsUseCase)
+            .rotate(
+                argThat(command ->
+                    command.refreshToken()
+                        .equals(CURRENT_TOKEN)
+                )
+            );
+    }
+
+    @Test
+    void shouldRejectBlankRefreshToken()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "refreshToken": " "
+                        }
+                        """)
+            )
+            .andExpect(
+                status().isBadRequest()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "VALIDATION_FAILED"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.path"
+                ).value(
+                    "/api/v1/auth/refresh"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.violations[0].field"
+                ).value(
+                    "refreshToken"
+                )
+            );
+
+        verifyNoInteractions(
+            rotateRefreshCredentialsUseCase
+        );
+    }
+
+    @Test
+    void shouldReturnUnauthorizedForInvalidRefreshToken()
+        throws Exception {
+
+        when(rotateRefreshCredentialsUseCase.rotate(
+            any(RotateRefreshCredentialsCommand.class)
+        ))
+            .thenThrow(
+                new InvalidRefreshTokenException()
+            );
+
+        mockMvc.perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "refreshToken": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA"
+                        }
+                        """)
+            )
+            .andExpect(
+                status().isUnauthorized()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "REFRESH_TOKEN_INVALID"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.message"
+                ).value(
+                    "Refresh token is invalid."
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.path"
+                ).value(
+                    "/api/v1/auth/refresh"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.violations"
+                ).isEmpty()
+            );
+    }
+
+    @Test
+    void shouldRedactRefreshTokenFromRequestToString() {
+        RotateRefreshCredentialsRequest request =
+            new RotateRefreshCredentialsRequest(
+                "secret-refresh-token"
+            );
+
+        assertThat(request.toString())
+            .isEqualTo(
+                "RotateRefreshCredentialsRequest[redacted]"
+            )
+            .doesNotContain(
+                "secret-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRedactCredentialsFromResponseToString() {
+        RotateRefreshCredentialsResponse response =
+            new RotateRefreshCredentialsResponse(
+                "secret-access-token",
+                "Bearer",
+                ACCESS_EXPIRES_AT,
+                "secret-refresh-token",
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(response.toString())
+            .isEqualTo(
+                "RotateRefreshCredentialsResponse[redacted]"
+            )
+            .doesNotContain(
+                "secret-access-token",
+                "secret-refresh-token"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsCommandTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsCommandTest.java
@@ -1,0 +1,68 @@
+package com.nursena.payflow.user.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class RotateRefreshCredentialsCommandTest {
+
+    @Test
+    void shouldRetainRefreshToken() {
+        RotateRefreshCredentialsCommand command =
+            new RotateRefreshCredentialsCommand(
+                "opaque-refresh-token"
+            );
+
+        assertThat(command.refreshToken())
+            .isEqualTo(
+                "opaque-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRequireRefreshToken() {
+        assertThatThrownBy(() ->
+            new RotateRefreshCredentialsCommand(
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "refreshToken must not be null"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankRefreshToken() {
+        assertThatThrownBy(() ->
+            new RotateRefreshCredentialsCommand(
+                " "
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "refreshToken must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRedactRefreshTokenFromToString() {
+        RotateRefreshCredentialsCommand command =
+            new RotateRefreshCredentialsCommand(
+                "secret-refresh-token"
+            );
+
+        assertThat(command.toString())
+            .isEqualTo(
+                "RotateRefreshCredentialsCommand[redacted]"
+            )
+            .doesNotContain(
+                "secret-refresh-token"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsResultTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsResultTest.java
@@ -1,0 +1,143 @@
+package com.nursena.payflow.user.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class RotateRefreshCredentialsResultTest {
+
+    private static final Instant ACCESS_EXPIRES_AT =
+        Instant.parse(
+            "2026-07-28T12:15:00Z"
+        );
+
+    private static final Instant REFRESH_EXPIRES_AT =
+        Instant.parse(
+            "2026-08-04T12:00:00Z"
+        );
+
+    @Test
+    void shouldRetainCredentialPair() {
+        RotateRefreshCredentialsResult result =
+            new RotateRefreshCredentialsResult(
+                "signed-access-token",
+                ACCESS_EXPIRES_AT,
+                "opaque-refresh-token",
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(result.accessToken())
+            .isEqualTo(
+                "signed-access-token"
+            );
+
+        assertThat(result.expiresAt())
+            .isEqualTo(
+                ACCESS_EXPIRES_AT
+            );
+
+        assertThat(result.refreshToken())
+            .isEqualTo(
+                "opaque-refresh-token"
+            );
+
+        assertThat(
+            result.refreshTokenExpiresAt()
+        )
+            .isEqualTo(
+                REFRESH_EXPIRES_AT
+            );
+    }
+
+    @Test
+    void shouldRejectBlankAccessToken() {
+        assertThatThrownBy(() ->
+            new RotateRefreshCredentialsResult(
+                " ",
+                ACCESS_EXPIRES_AT,
+                "refresh-token",
+                REFRESH_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "accessToken must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankRefreshToken() {
+        assertThatThrownBy(() ->
+            new RotateRefreshCredentialsResult(
+                "access-token",
+                ACCESS_EXPIRES_AT,
+                " ",
+                REFRESH_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "refreshToken must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRequireCredentialExpirations() {
+        assertThatThrownBy(() ->
+            new RotateRefreshCredentialsResult(
+                "access-token",
+                null,
+                "refresh-token",
+                REFRESH_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "expiresAt must not be null"
+            );
+
+        assertThatThrownBy(() ->
+            new RotateRefreshCredentialsResult(
+                "access-token",
+                ACCESS_EXPIRES_AT,
+                "refresh-token",
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "refreshTokenExpiresAt must not be null"
+            );
+    }
+
+    @Test
+    void shouldRedactCredentialsFromToString() {
+        RotateRefreshCredentialsResult result =
+            new RotateRefreshCredentialsResult(
+                "secret-access-token",
+                ACCESS_EXPIRES_AT,
+                "secret-refresh-token",
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(result.toString())
+            .isEqualTo(
+                "RotateRefreshCredentialsResult[redacted]"
+            )
+            .doesNotContain(
+                "secret-access-token",
+                "secret-refresh-token"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsServiceTest.java
@@ -1,0 +1,823 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsCommand;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model.User;
+import com.nursena.payflow.user.domain.model.UserRole;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
+class RotateRefreshCredentialsServiceTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final RefreshTokenFamilyId
+        FAMILY_ID =
+        RefreshTokenFamilyId.of(
+            UUID.fromString(
+                "f89de08d-3035-407d-bbfd-e49eec447177"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        CURRENT_RECORD_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "0d559bfd-05b6-43aa-8822-49b83eea3f1b"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        EXISTING_SUCCESSOR_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "55667aa8-fd92-4ddb-836b-f83362e5932c"
+            )
+        );
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-28T12:00:00Z"
+        );
+
+    private static final Instant FAMILY_CREATED_AT =
+        NOW.minus(
+            Duration.ofDays(1)
+        );
+
+    private static final Instant FAMILY_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(30)
+        );
+
+    private static final Instant CURRENT_ISSUED_AT =
+        NOW.minus(
+            Duration.ofHours(1)
+        );
+
+    private static final Instant CURRENT_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(6)
+        );
+
+    private static final Instant ACCESS_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofMinutes(15)
+        );
+
+    private static final Instant SUCCESSOR_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(7)
+        );
+
+    private static final String CURRENT_TOKEN =
+        "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA";
+
+    private static final String SUCCESSOR_TOKEN =
+        "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8";
+
+    private static final String ACCESS_TOKEN =
+        "rotated.jwt.token";
+
+    private static final RefreshTokenDigest
+        CURRENT_DIGEST =
+        digest((byte) 7);
+
+    private static final RefreshTokenDigest
+        SUCCESSOR_DIGEST =
+        digest((byte) 9);
+
+    @Mock
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @Mock
+    private RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    @Mock
+    private RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    @Mock
+    private UserRepositoryPort userRepository;
+
+    @Mock
+    private RefreshTokenGenerationPort
+        refreshTokenGeneration;
+
+    @Mock
+    private AccessTokenGenerationPort
+        accessTokenGeneration;
+
+    private RefreshSessionLifetimePolicy
+        lifetimePolicy;
+
+    private Clock clock;
+
+    private RotateRefreshCredentialsService service;
+
+    @BeforeEach
+    void setUp() {
+        lifetimePolicy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        clock =
+            Clock.fixed(
+                NOW,
+                ZoneOffset.UTC
+            );
+
+        service =
+            new RotateRefreshCredentialsService(
+                refreshTokenDigest,
+                recordRepository,
+                familyRepository,
+                userRepository,
+                refreshTokenGeneration,
+                accessTokenGeneration,
+                lifetimePolicy,
+                clock
+            );
+    }
+
+    @Test
+    void shouldRotateActiveRefreshCredentials() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(accessTokenGeneration.generate(user))
+            .thenReturn(
+                new GeneratedAccessToken(
+                    ACCESS_TOKEN,
+                    ACCESS_EXPIRES_AT
+                )
+            );
+
+        RotateRefreshCredentialsResult result =
+            service.rotate(
+                command()
+            );
+
+        assertThat(result.accessToken())
+            .isEqualTo(
+                ACCESS_TOKEN
+            );
+
+        assertThat(result.expiresAt())
+            .isEqualTo(
+                ACCESS_EXPIRES_AT
+            );
+
+        assertThat(result.refreshToken())
+            .isEqualTo(
+                SUCCESSOR_TOKEN
+            );
+
+        assertThat(
+            result.refreshTokenExpiresAt()
+        )
+            .isEqualTo(
+                SUCCESSOR_EXPIRES_AT
+            );
+
+        ArgumentCaptor<RefreshTokenRecord>
+            recordCaptor =
+            ArgumentCaptor.forClass(
+                RefreshTokenRecord.class
+            );
+
+        verify(recordRepository, times(2))
+            .save(
+                recordCaptor.capture()
+            );
+
+        List<RefreshTokenRecord> savedRecords =
+            recordCaptor.getAllValues();
+
+        RefreshTokenRecord successor =
+            savedRecords.get(0);
+
+        RefreshTokenRecord consumedCurrent =
+            savedRecords.get(1);
+
+        assertThat(successor.id())
+            .isNotEqualTo(
+                CURRENT_RECORD_ID
+            );
+
+        assertThat(successor.familyId())
+            .isEqualTo(
+                FAMILY_ID
+            );
+
+        assertThat(successor.digest())
+            .isEqualTo(
+                SUCCESSOR_DIGEST
+            );
+
+        assertThat(successor.issuedAt())
+            .isEqualTo(
+                NOW
+            );
+
+        assertThat(successor.expiresAt())
+            .isEqualTo(
+                SUCCESSOR_EXPIRES_AT
+            );
+
+        assertThat(successor.isConsumed())
+            .isFalse();
+
+        assertThat(consumedCurrent.id())
+            .isEqualTo(
+                CURRENT_RECORD_ID
+            );
+
+        assertThat(consumedCurrent.consumedAt())
+            .isEqualTo(
+                NOW
+            );
+
+        assertThat(consumedCurrent.successorId())
+            .isEqualTo(
+                successor.id()
+            );
+
+        InOrder order =
+            inOrder(
+                refreshTokenDigest,
+                recordRepository,
+                familyRepository,
+                userRepository,
+                refreshTokenGeneration,
+                accessTokenGeneration
+            );
+
+        order.verify(refreshTokenDigest)
+            .digest(CURRENT_TOKEN);
+
+        order.verify(recordRepository)
+            .findByDigestForUpdate(
+                CURRENT_DIGEST
+            );
+
+        order.verify(familyRepository)
+            .findByIdForUpdate(
+                FAMILY_ID
+            );
+
+        order.verify(userRepository)
+            .findById(USER_ID);
+
+        order.verify(refreshTokenGeneration)
+            .generate();
+
+        order.verify(refreshTokenDigest)
+            .digest(SUCCESSOR_TOKEN);
+
+        order.verify(
+            recordRepository,
+            times(2)
+        )
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        order.verify(accessTokenGeneration)
+            .generate(user);
+    }
+
+    @Test
+    void shouldDeclareWriteTransaction()
+        throws NoSuchMethodException {
+
+        Method rotate =
+            RotateRefreshCredentialsService.class
+                .getDeclaredMethod(
+                    "rotate",
+                    RotateRefreshCredentialsCommand.class
+                );
+
+        Transactional transactional =
+            rotate.getAnnotation(
+                Transactional.class
+            );
+
+        assertThat(transactional)
+            .isNotNull();
+
+        assertThat(transactional.readOnly())
+            .isFalse();
+    }
+
+    @Test
+    void shouldRejectUnknownRefreshToken() {
+        when(refreshTokenDigest.digest(
+            CURRENT_TOKEN
+        ))
+            .thenReturn(
+                CURRENT_DIGEST
+            );
+
+        when(recordRepository
+            .findByDigestForUpdate(
+                CURRENT_DIGEST
+            ))
+            .thenReturn(
+                Optional.empty()
+            );
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                InvalidRefreshTokenException.class
+            )
+            .hasMessage(
+                "Refresh token is invalid."
+            );
+
+        verifyNoInteractions(
+            familyRepository,
+            userRepository,
+            refreshTokenGeneration,
+            accessTokenGeneration
+        );
+
+        verify(recordRepository, never())
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+    }
+
+    @Test
+    void shouldRejectConsumedRefreshToken() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord consumedRecord =
+            activeRecord(family)
+                .consume(
+                    EXISTING_SUCCESSOR_ID,
+                    NOW.minusSeconds(1),
+                    family
+                );
+
+        stubLockedSession(
+            family,
+            consumedRecord
+        );
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                InvalidRefreshTokenException.class
+            );
+
+        verifyNoInteractions(
+            userRepository,
+            refreshTokenGeneration,
+            accessTokenGeneration
+        );
+
+        verify(recordRepository, never())
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+    }
+
+    @Test
+    void shouldRejectExpiredRefreshToken() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord expiredRecord =
+            RefreshTokenRecord.issue(
+                CURRENT_RECORD_ID,
+                family,
+                CURRENT_DIGEST,
+                CURRENT_ISSUED_AT,
+                NOW
+            );
+
+        stubLockedSession(
+            family,
+            expiredRecord
+        );
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                InvalidRefreshTokenException.class
+            );
+
+        verifyNoInteractions(
+            userRepository,
+            refreshTokenGeneration,
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldRejectUnavailableUser() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        stubLockedSession(
+            family,
+            currentRecord
+        );
+
+        when(userRepository.findById(USER_ID))
+            .thenReturn(
+                Optional.of(
+                    suspendedUser()
+                )
+            );
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                InvalidRefreshTokenException.class
+            );
+
+        verifyNoInteractions(
+            refreshTokenGeneration,
+            accessTokenGeneration
+        );
+
+        verify(recordRepository, never())
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+    }
+
+    @Test
+    void shouldStopWhenSuccessorPersistenceFails() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenThrow(
+                new IllegalStateException(
+                    "successor persistence failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "successor persistence failed"
+            );
+
+        verify(recordRepository, times(1))
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        verifyNoInteractions(
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldStopWhenPredecessorPersistenceFails() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        AtomicInteger saveAttempts =
+            new AtomicInteger();
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(invocation -> {
+                if (
+                    saveAttempts.getAndIncrement()
+                        == 0
+                ) {
+                    return invocation.getArgument(0);
+                }
+
+                throw new IllegalStateException(
+                    "predecessor persistence failed"
+                );
+            });
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "predecessor persistence failed"
+            );
+
+        verify(recordRepository, times(2))
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        verifyNoInteractions(
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldGenerateAccessTokenAfterBothRecordsPersist() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(accessTokenGeneration.generate(user))
+            .thenThrow(
+                new IllegalStateException(
+                    "access-token generation failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "access-token generation failed"
+            );
+
+        InOrder order =
+            inOrder(
+                recordRepository,
+                accessTokenGeneration
+            );
+
+        order.verify(
+            recordRepository,
+            times(2)
+        )
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        order.verify(accessTokenGeneration)
+            .generate(user);
+    }
+
+    private void stubValidRotation(
+        RefreshTokenFamily family,
+        RefreshTokenRecord currentRecord,
+        User user
+    ) {
+        stubLockedSession(
+            family,
+            currentRecord
+        );
+
+        when(userRepository.findById(USER_ID))
+            .thenReturn(
+                Optional.of(user)
+            );
+
+        when(refreshTokenGeneration.generate())
+            .thenReturn(
+                new GeneratedRefreshToken(
+                    SUCCESSOR_TOKEN
+                )
+            );
+
+        when(refreshTokenDigest.digest(
+            SUCCESSOR_TOKEN
+        ))
+            .thenReturn(
+                SUCCESSOR_DIGEST
+            );
+    }
+
+    private void stubLockedSession(
+        RefreshTokenFamily family,
+        RefreshTokenRecord currentRecord
+    ) {
+        when(refreshTokenDigest.digest(
+            CURRENT_TOKEN
+        ))
+            .thenReturn(
+                CURRENT_DIGEST
+            );
+
+        when(recordRepository
+            .findByDigestForUpdate(
+                CURRENT_DIGEST
+            ))
+            .thenReturn(
+                Optional.of(currentRecord)
+            );
+
+        when(familyRepository
+            .findByIdForUpdate(
+                FAMILY_ID
+            ))
+            .thenReturn(
+                Optional.of(family)
+            );
+    }
+
+    private static RotateRefreshCredentialsCommand
+    command() {
+        return new RotateRefreshCredentialsCommand(
+            CURRENT_TOKEN
+        );
+    }
+
+    private static RefreshTokenFamily
+    activeFamily() {
+        return RefreshTokenFamily.create(
+            FAMILY_ID,
+            USER_ID,
+            FAMILY_CREATED_AT,
+            FAMILY_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenRecord activeRecord(
+        RefreshTokenFamily family
+    ) {
+        return RefreshTokenRecord.issue(
+            CURRENT_RECORD_ID,
+            family,
+            CURRENT_DIGEST,
+            CURRENT_ISSUED_AT,
+            CURRENT_EXPIRES_AT
+        );
+    }
+
+    private static User activeUser() {
+        return user(UserStatus.ACTIVE);
+    }
+
+    private static User suspendedUser() {
+        return user(UserStatus.SUSPENDED);
+    }
+
+    private static User user(
+        UserStatus status
+    ) {
+        return User.rehydrate(
+            USER_ID,
+            EmailAddress.of(
+                "nursena@example.com"
+            ),
+            "hashed-password",
+            UserRole.USER,
+            status,
+            FAMILY_CREATED_AT,
+            FAMILY_CREATED_AT
+        );
+    }
+
+    private static RefreshTokenDigest digest(
+        byte fillValue
+    ) {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            bytes,
+            fillValue
+        );
+
+        return RefreshTokenDigest.of(
+            bytes
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsConcurrencyIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsConcurrencyIntegrationTest.java
@@ -1,0 +1,577 @@
+package com.nursena.payflow.user.integration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+@Import(
+    RotateRefreshCredentialsConcurrencyIntegrationTest
+        .BlockingRepositoryConfiguration.class
+)
+class RotateRefreshCredentialsConcurrencyIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @Autowired
+    private BlockingRecordRepository
+        recordRepository;
+
+    @BeforeEach
+    void setUp() {
+        recordRepository.reset();
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldAllowOnlyOneConcurrentRotation()
+        throws Exception {
+
+        String initialRefreshToken =
+            issueInitialRefreshToken();
+
+        recordRepository.holdNextLookup();
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(2);
+
+        Future<MvcResult> firstFuture =
+            null;
+
+        Future<MvcResult> secondFuture =
+            null;
+
+        try {
+            firstFuture =
+                executor.submit(
+                    () ->
+                        performRefresh(
+                            initialRefreshToken
+                        )
+                );
+
+            assertThat(
+                recordRepository
+                    .awaitFirstLock()
+            )
+                .as(
+                    "first request should acquire the refresh-token row lock"
+                )
+                .isTrue();
+
+            secondFuture =
+                executor.submit(
+                    () ->
+                        performRefresh(
+                            initialRefreshToken
+                        )
+                );
+
+            assertThat(
+                recordRepository
+                    .awaitSecondLookup()
+            )
+                .as(
+                    "second request should reach the locked digest lookup"
+                )
+                .isTrue();
+
+            Thread.sleep(300);
+
+            assertThat(
+                secondFuture.isDone()
+            )
+                .as(
+                    "second request must remain blocked while the first transaction holds the row lock"
+                )
+                .isFalse();
+
+            recordRepository.releaseFirstLookup();
+
+            MvcResult firstResult =
+                firstFuture.get(
+                    15,
+                    SECONDS
+                );
+
+            MvcResult secondResult =
+                secondFuture.get(
+                    15,
+                    SECONDS
+                );
+
+            assertThat(
+                firstResult
+                    .getResponse()
+                    .getStatus()
+            )
+                .isEqualTo(200);
+
+            assertThat(
+                secondResult
+                    .getResponse()
+                    .getStatus()
+            )
+                .isEqualTo(401);
+
+            JsonNode successResponse =
+                objectMapper.readTree(
+                    firstResult
+                        .getResponse()
+                        .getContentAsByteArray()
+                );
+
+            JsonNode rejectedResponse =
+                objectMapper.readTree(
+                    secondResult
+                        .getResponse()
+                        .getContentAsByteArray()
+                );
+
+            assertThat(
+                rejectedResponse
+                    .path("code")
+                    .asText()
+            )
+                .isEqualTo(
+                    "REFRESH_TOKEN_INVALID"
+                );
+
+            String successorToken =
+                successResponse
+                    .path("refreshToken")
+                    .asText();
+
+            assertThat(successorToken)
+                .isNotBlank()
+                .isNotEqualTo(
+                    initialRefreshToken
+                );
+
+            Integer recordCount =
+                jdbcTemplate.queryForObject(
+                    """
+                    SELECT COUNT(*)
+                    FROM refresh_token_records
+                    """,
+                    Integer.class
+                );
+
+            Integer consumedCount =
+                jdbcTemplate.queryForObject(
+                    """
+                    SELECT COUNT(*)
+                    FROM refresh_token_records
+                    WHERE consumed_at IS NOT NULL
+                      AND successor_id IS NOT NULL
+                    """,
+                    Integer.class
+                );
+
+            Integer activeCount =
+                jdbcTemplate.queryForObject(
+                    """
+                    SELECT COUNT(*)
+                    FROM refresh_token_records
+                    WHERE consumed_at IS NULL
+                      AND successor_id IS NULL
+                    """,
+                    Integer.class
+                );
+
+            byte[] successorDigest =
+                jdbcTemplate.queryForObject(
+                    """
+                    SELECT token_digest
+                    FROM refresh_token_records
+                    WHERE token_digest = ?
+                    """,
+                    byte[].class,
+                    refreshTokenDigest
+                        .digest(successorToken)
+                        .value()
+                );
+
+            assertThat(recordCount)
+                .isEqualTo(2);
+
+            assertThat(consumedCount)
+                .isEqualTo(1);
+
+            assertThat(activeCount)
+                .isEqualTo(1);
+
+            assertThat(successorDigest)
+                .containsExactly(
+                    refreshTokenDigest
+                        .digest(successorToken)
+                        .value()
+                );
+
+            assertThat(
+                Arrays.equals(
+                    successorDigest,
+                    successorToken.getBytes(UTF_8)
+                )
+            )
+                .isFalse();
+        } finally {
+            recordRepository
+                .releaseFirstLookup();
+
+            if (firstFuture != null) {
+                firstFuture.cancel(true);
+            }
+
+            if (secondFuture != null) {
+                secondFuture.cancel(true);
+            }
+
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    SECONDS
+                )
+            )
+                .as(
+                    "concurrency executor should terminate cleanly"
+                )
+                .isTrue();
+        }
+    }
+
+    private String issueInitialRefreshToken()
+        throws Exception {
+
+        Credentials credentials =
+            new Credentials(
+                "rotation-concurrency-"
+                    + UUID.randomUUID()
+                    + "@example.com",
+                "StrongPassword123!"
+            );
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            credentials
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+
+        MvcResult loginResult =
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                credentials
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andReturn();
+
+        JsonNode response =
+            objectMapper.readTree(
+                loginResult
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        return response
+            .path("refreshToken")
+            .asText();
+    }
+
+    private MvcResult performRefresh(
+        String refreshToken
+    ) throws Exception {
+
+        return mockMvc.perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RefreshRequest(
+                                refreshToken
+                            )
+                        )
+                    )
+            )
+            .andReturn();
+    }
+
+    private record Credentials(
+        String email,
+        String password
+    ) {
+    }
+
+    private record RefreshRequest(
+        String refreshToken
+    ) {
+    }
+
+    @TestConfiguration(
+        proxyBeanMethods = false
+    )
+    static class BlockingRepositoryConfiguration {
+
+        @Bean
+        @Primary
+        BlockingRecordRepository
+        blockingRotationRecordRepository(
+            @Qualifier(
+                "refreshTokenRecordPersistenceAdapter"
+            )
+            RefreshTokenRecordRepositoryPort delegate
+        ) {
+            return new BlockingRecordRepository(
+                delegate
+            );
+        }
+    }
+
+    static final class BlockingRecordRepository
+        implements RefreshTokenRecordRepositoryPort {
+
+        private final RefreshTokenRecordRepositoryPort
+            delegate;
+
+        private final AtomicBoolean holdFirst =
+            new AtomicBoolean();
+
+        private final AtomicInteger lookupCount =
+            new AtomicInteger();
+
+        private volatile CountDownLatch
+            firstLockAcquired =
+            new CountDownLatch(0);
+
+        private volatile CountDownLatch
+            secondLookupStarted =
+            new CountDownLatch(0);
+
+        private volatile CountDownLatch
+            releaseFirst =
+            new CountDownLatch(0);
+
+        BlockingRecordRepository(
+            RefreshTokenRecordRepositoryPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void holdNextLookup() {
+            lookupCount.set(0);
+            holdFirst.set(true);
+
+            firstLockAcquired =
+                new CountDownLatch(1);
+
+            secondLookupStarted =
+                new CountDownLatch(1);
+
+            releaseFirst =
+                new CountDownLatch(1);
+        }
+
+        boolean awaitFirstLock()
+            throws InterruptedException {
+
+            return firstLockAcquired.await(
+                10,
+                SECONDS
+            );
+        }
+
+        boolean awaitSecondLookup()
+            throws InterruptedException {
+
+            return secondLookupStarted.await(
+                10,
+                SECONDS
+            );
+        }
+
+        void releaseFirstLookup() {
+            releaseFirst.countDown();
+        }
+
+        void reset() {
+            holdFirst.set(false);
+            lookupCount.set(0);
+            firstLockAcquired.countDown();
+            secondLookupStarted.countDown();
+            releaseFirst.countDown();
+        }
+
+        @Override
+        public RefreshTokenRecord save(
+            RefreshTokenRecord record
+        ) {
+            return delegate.save(record);
+        }
+
+        @Override
+        public Optional<RefreshTokenRecord>
+        findByDigestForUpdate(
+            RefreshTokenDigest digest
+        ) {
+            int invocation =
+                lookupCount.incrementAndGet();
+
+            if (invocation == 2) {
+                secondLookupStarted
+                    .countDown();
+            }
+
+            Optional<RefreshTokenRecord> result =
+                delegate
+                    .findByDigestForUpdate(
+                        digest
+                    );
+
+            if (
+                invocation == 1
+                    && holdFirst.compareAndSet(
+                        true,
+                        false
+                    )
+            ) {
+                firstLockAcquired
+                    .countDown();
+
+                awaitRelease();
+            }
+
+            return result;
+        }
+
+        @Override
+        public Optional<RefreshTokenRecord>
+        findById(
+            RefreshTokenRecordId recordId
+        ) {
+            return delegate.findById(
+                recordId
+            );
+        }
+
+        private void awaitRelease() {
+            try {
+                boolean released =
+                    releaseFirst.await(
+                        15,
+                        SECONDS
+                    );
+
+                if (!released) {
+                    throw new IllegalStateException(
+                        "first refresh-token lookup was not released"
+                    );
+                }
+            } catch (
+                InterruptedException exception
+            ) {
+                Thread.currentThread()
+                    .interrupt();
+
+                throw new IllegalStateException(
+                    "refresh-token lookup wait was interrupted",
+                    exception
+                );
+            }
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsIntegrationTest.java
@@ -1,0 +1,561 @@
+package com.nursena.payflow.user.integration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+class RotateRefreshCredentialsIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldRotateAndPersistSingleSuccessor()
+        throws Exception {
+
+        InitialCredential initial =
+            issueInitialCredential(
+                "rotation-success"
+            );
+
+        UUID predecessorId =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT record.id
+                FROM refresh_token_records record
+                JOIN refresh_token_families family
+                  ON family.id = record.family_id
+                JOIN users user_account
+                  ON user_account.id = family.user_id
+                WHERE user_account.email = ?
+                """,
+                UUID.class,
+                initial.email()
+            );
+
+        assertThat(predecessorId)
+            .isNotNull();
+
+        MvcResult rotationResult =
+            mockMvc.perform(
+                    post("/api/v1/auth/refresh")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                new RefreshRequest(
+                                    initial.refreshToken()
+                                )
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.accessToken"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.tokenType"
+                    ).value("Bearer")
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.expiresAt"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.refreshToken"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.refreshTokenExpiresAt"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.tokenDigest"
+                    ).doesNotExist()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.familyId"
+                    ).doesNotExist()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.recordId"
+                    ).doesNotExist()
+                )
+                .andReturn();
+
+        JsonNode response =
+            objectMapper.readTree(
+                rotationResult
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        String successorToken =
+            response
+                .path("refreshToken")
+                .asText();
+
+        Instant responseSuccessorExpiresAt =
+            Instant.parse(
+                response
+                    .path(
+                        "refreshTokenExpiresAt"
+                    )
+                    .asText()
+            );
+
+        assertThat(successorToken)
+            .hasSize(43)
+            .isNotEqualTo(
+                initial.refreshToken()
+            );
+
+        RotatedSession persisted =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT
+                    predecessor.id
+                        AS predecessor_id,
+                    predecessor.family_id
+                        AS predecessor_family_id,
+                    predecessor.token_digest
+                        AS predecessor_digest,
+                    predecessor.consumed_at
+                        AS predecessor_consumed_at,
+                    predecessor.successor_id
+                        AS predecessor_successor_id,
+                    successor.id
+                        AS successor_id,
+                    successor.family_id
+                        AS successor_family_id,
+                    successor.token_digest
+                        AS successor_digest,
+                    successor.issued_at
+                        AS successor_issued_at,
+                    successor.expires_at
+                        AS successor_expires_at,
+                    successor.consumed_at
+                        AS successor_consumed_at,
+                    successor.successor_id
+                        AS successor_successor_id
+                FROM refresh_token_records predecessor
+                JOIN refresh_token_records successor
+                  ON successor.id =
+                     predecessor.successor_id
+                 AND successor.family_id =
+                     predecessor.family_id
+                WHERE predecessor.id = ?
+                """,
+                RotateRefreshCredentialsIntegrationTest
+                    ::mapRotatedSession,
+                predecessorId
+            );
+
+        assertThat(persisted)
+            .isNotNull();
+
+        assertThat(
+            persisted.predecessorId()
+        )
+            .isEqualTo(
+                predecessorId
+            );
+
+        assertThat(
+            persisted.predecessorConsumedAt()
+        )
+            .isNotNull()
+            .isEqualTo(
+                persisted.successorIssuedAt()
+            );
+
+        assertThat(
+            persisted.predecessorSuccessorId()
+        )
+            .isEqualTo(
+                persisted.successorId()
+            );
+
+        assertThat(
+            persisted.predecessorFamilyId()
+        )
+            .isEqualTo(
+                persisted.successorFamilyId()
+            );
+
+        assertThat(
+            persisted.successorConsumedAt()
+        )
+            .isNull();
+
+        assertThat(
+            persisted.successorSuccessorId()
+        )
+            .isNull();
+
+        assertThat(
+            responseSuccessorExpiresAt
+        )
+            .isEqualTo(
+                persisted.successorExpiresAt()
+            );
+
+        assertThat(
+            Duration.between(
+                persisted.successorIssuedAt(),
+                persisted.successorExpiresAt()
+            )
+        )
+            .isEqualTo(
+                Duration.ofDays(7)
+            );
+
+        byte[] expectedPredecessorDigest =
+            refreshTokenDigest
+                .digest(
+                    initial.refreshToken()
+                )
+                .value();
+
+        byte[] expectedSuccessorDigest =
+            refreshTokenDigest
+                .digest(successorToken)
+                .value();
+
+        assertThat(
+            persisted.predecessorDigest()
+        )
+            .containsExactly(
+                expectedPredecessorDigest
+            );
+
+        assertThat(
+            persisted.successorDigest()
+        )
+            .containsExactly(
+                expectedSuccessorDigest
+            );
+
+        assertThat(
+            Arrays.equals(
+                persisted.predecessorDigest(),
+                initial
+                    .refreshToken()
+                    .getBytes(UTF_8)
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            Arrays.equals(
+                persisted.successorDigest(),
+                successorToken.getBytes(UTF_8)
+            )
+        )
+            .isFalse();
+
+        Integer familyCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                """,
+                Integer.class
+            );
+
+        Integer recordCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        assertThat(familyCount)
+            .isEqualTo(1);
+
+        assertThat(recordCount)
+            .isEqualTo(2);
+
+        mockMvc.perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RefreshRequest(
+                                initial.refreshToken()
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isUnauthorized()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "REFRESH_TOKEN_INVALID"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.message"
+                ).value(
+                    "Refresh token is invalid."
+                )
+            );
+    }
+
+    private InitialCredential issueInitialCredential(
+        String prefix
+    ) throws Exception {
+
+        String email =
+            prefix
+                + "-"
+                + UUID.randomUUID()
+                + "@example.com";
+
+        String password =
+            "StrongPassword123!";
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new Credentials(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+
+        MvcResult loginResult =
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                new Credentials(
+                                    email,
+                                    password
+                                )
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andReturn();
+
+        JsonNode loginResponse =
+            objectMapper.readTree(
+                loginResult
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        return new InitialCredential(
+            email,
+            loginResponse
+                .path("refreshToken")
+                .asText()
+        );
+    }
+
+    private static RotatedSession
+    mapRotatedSession(
+        ResultSet resultSet,
+        int rowNumber
+    ) throws SQLException {
+
+        return new RotatedSession(
+            resultSet.getObject(
+                "predecessor_id",
+                UUID.class
+            ),
+            resultSet.getObject(
+                "predecessor_family_id",
+                UUID.class
+            ),
+            resultSet.getBytes(
+                "predecessor_digest"
+            ),
+            resultSet
+                .getTimestamp(
+                    "predecessor_consumed_at"
+                )
+                .toInstant(),
+            resultSet.getObject(
+                "predecessor_successor_id",
+                UUID.class
+            ),
+            resultSet.getObject(
+                "successor_id",
+                UUID.class
+            ),
+            resultSet.getObject(
+                "successor_family_id",
+                UUID.class
+            ),
+            resultSet.getBytes(
+                "successor_digest"
+            ),
+            resultSet
+                .getTimestamp(
+                    "successor_issued_at"
+                )
+                .toInstant(),
+            resultSet
+                .getTimestamp(
+                    "successor_expires_at"
+                )
+                .toInstant(),
+            nullableInstant(
+                resultSet,
+                "successor_consumed_at"
+            ),
+            resultSet.getObject(
+                "successor_successor_id",
+                UUID.class
+            )
+        );
+    }
+
+    private static Instant nullableInstant(
+        ResultSet resultSet,
+        String column
+    ) throws SQLException {
+
+        java.sql.Timestamp timestamp =
+            resultSet.getTimestamp(column);
+
+        return timestamp == null
+            ? null
+            : timestamp.toInstant();
+    }
+
+    private record Credentials(
+        String email,
+        String password
+    ) {
+    }
+
+    private record RefreshRequest(
+        String refreshToken
+    ) {
+    }
+
+    private record InitialCredential(
+        String email,
+        String refreshToken
+    ) {
+    }
+
+    private record RotatedSession(
+        UUID predecessorId,
+        UUID predecessorFamilyId,
+        byte[] predecessorDigest,
+        Instant predecessorConsumedAt,
+        UUID predecessorSuccessorId,
+        UUID successorId,
+        UUID successorFamilyId,
+        byte[] successorDigest,
+        Instant successorIssuedAt,
+        Instant successorExpiresAt,
+        Instant successorConsumedAt,
+        UUID successorSuccessorId
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsRollbackIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsRollbackIntegrationTest.java
@@ -1,0 +1,505 @@
+package com.nursena.payflow.user.integration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+@Import(
+    RotateRefreshCredentialsRollbackIntegrationTest
+        .FailureInjectionConfiguration.class
+)
+class RotateRefreshCredentialsRollbackIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @Autowired
+    private FailureInjectingRecordRepository
+        recordRepository;
+
+    @Autowired
+    private FailureInjectingAccessTokenGeneration
+        accessTokenGeneration;
+
+    @BeforeEach
+    void setUp() {
+        recordRepository.reset();
+        accessTokenGeneration.reset();
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldRollbackWhenSuccessorPersistenceFails()
+        throws Exception {
+
+        String refreshToken =
+            issueInitialRefreshToken(
+                "successor-failure"
+            );
+
+        recordRepository.failOnSaveAttempt(
+            1,
+            "successor persistence failed"
+        );
+
+        assertThatThrownBy(() ->
+            refresh(refreshToken)
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "successor persistence failed"
+            );
+
+        assertInitialSessionUnchanged(
+            refreshToken
+        );
+    }
+
+    @Test
+    void shouldRollbackWhenPredecessorPersistenceFails()
+        throws Exception {
+
+        String refreshToken =
+            issueInitialRefreshToken(
+                "predecessor-failure"
+            );
+
+        recordRepository.failOnSaveAttempt(
+            2,
+            "predecessor persistence failed"
+        );
+
+        assertThatThrownBy(() ->
+            refresh(refreshToken)
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "predecessor persistence failed"
+            );
+
+        assertInitialSessionUnchanged(
+            refreshToken
+        );
+    }
+
+    @Test
+    void shouldRollbackWhenAccessTokenGenerationFails()
+        throws Exception {
+
+        String refreshToken =
+            issueInitialRefreshToken(
+                "access-failure"
+            );
+
+        accessTokenGeneration
+            .failNextGeneration();
+
+        assertThatThrownBy(() ->
+            refresh(refreshToken)
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "access-token generation failed"
+            );
+
+        assertInitialSessionUnchanged(
+            refreshToken
+        );
+    }
+
+    private String issueInitialRefreshToken(
+        String prefix
+    ) throws Exception {
+
+        Credentials credentials =
+            new Credentials(
+                prefix
+                    + "-"
+                    + UUID.randomUUID()
+                    + "@example.com",
+                "StrongPassword123!"
+            );
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            credentials
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+
+        org.springframework.test.web.servlet
+        .MvcResult loginResult =
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                credentials
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andReturn();
+
+        JsonNode response =
+            objectMapper.readTree(
+                loginResult
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        return response
+            .path("refreshToken")
+            .asText();
+    }
+
+    private org.springframework.test.web.servlet
+    .ResultActions refresh(
+        String refreshToken
+    ) throws Exception {
+
+        return mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    objectMapper.writeValueAsString(
+                        new RefreshRequest(
+                            refreshToken
+                        )
+                    )
+                )
+        );
+    }
+
+    private void assertInitialSessionUnchanged(
+        String refreshToken
+    ) {
+        byte[] digest =
+            refreshTokenDigest
+                .digest(refreshToken)
+                .value();
+
+        Integer familyCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                """,
+                Integer.class
+            );
+
+        Integer recordCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        Integer activeOriginalCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                WHERE token_digest = ?
+                  AND consumed_at IS NULL
+                  AND successor_id IS NULL
+                """,
+                Integer.class,
+                digest
+            );
+
+        byte[] persistedDigest =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT token_digest
+                FROM refresh_token_records
+                """,
+                byte[].class
+            );
+
+        assertThat(familyCount)
+            .isEqualTo(1);
+
+        assertThat(recordCount)
+            .isEqualTo(1);
+
+        assertThat(activeOriginalCount)
+            .isEqualTo(1);
+
+        assertThat(persistedDigest)
+            .containsExactly(digest);
+
+        assertThat(
+            Arrays.equals(
+                persistedDigest,
+                refreshToken.getBytes(UTF_8)
+            )
+        )
+            .isFalse();
+    }
+
+    private record Credentials(
+        String email,
+        String password
+    ) {
+    }
+
+    private record RefreshRequest(
+        String refreshToken
+    ) {
+    }
+
+    @TestConfiguration(
+        proxyBeanMethods = false
+    )
+    static class FailureInjectionConfiguration {
+
+        @Bean
+        @Primary
+        FailureInjectingRecordRepository
+        failureInjectingRotationRecordRepository(
+            @Qualifier(
+                "refreshTokenRecordPersistenceAdapter"
+            )
+            RefreshTokenRecordRepositoryPort delegate
+        ) {
+            return new FailureInjectingRecordRepository(
+                delegate
+            );
+        }
+
+        @Bean
+        @Primary
+        FailureInjectingAccessTokenGeneration
+        failureInjectingRotationAccessTokenGeneration(
+            @Qualifier(
+                "jwtAccessTokenGenerationAdapter"
+            )
+            AccessTokenGenerationPort delegate
+        ) {
+            return new FailureInjectingAccessTokenGeneration(
+                delegate
+            );
+        }
+    }
+
+    static final class FailureInjectingRecordRepository
+        implements RefreshTokenRecordRepositoryPort {
+
+        private final RefreshTokenRecordRepositoryPort
+            delegate;
+
+        private final AtomicInteger saveAttempts =
+            new AtomicInteger();
+
+        private volatile int failureAttempt =
+            -1;
+
+        private volatile String failureMessage =
+            "";
+
+        FailureInjectingRecordRepository(
+            RefreshTokenRecordRepositoryPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void failOnSaveAttempt(
+            int attempt,
+            String message
+        ) {
+            saveAttempts.set(0);
+            failureAttempt = attempt;
+            failureMessage = message;
+        }
+
+        void reset() {
+            saveAttempts.set(0);
+            failureAttempt = -1;
+            failureMessage = "";
+        }
+
+        @Override
+        public RefreshTokenRecord save(
+            RefreshTokenRecord record
+        ) {
+            int attempt =
+                saveAttempts.incrementAndGet();
+
+            if (attempt == failureAttempt) {
+                throw new IllegalStateException(
+                    failureMessage
+                );
+            }
+
+            return delegate.save(record);
+        }
+
+        @Override
+        public Optional<RefreshTokenRecord>
+        findByDigestForUpdate(
+            RefreshTokenDigest digest
+        ) {
+            return delegate
+                .findByDigestForUpdate(
+                    digest
+                );
+        }
+
+        @Override
+        public Optional<RefreshTokenRecord>
+        findById(
+            RefreshTokenRecordId recordId
+        ) {
+            return delegate.findById(
+                recordId
+            );
+        }
+    }
+
+    static final class FailureInjectingAccessTokenGeneration
+        implements AccessTokenGenerationPort {
+
+        private final AccessTokenGenerationPort
+            delegate;
+
+        private final AtomicBoolean
+            failNextGeneration =
+            new AtomicBoolean();
+
+        FailureInjectingAccessTokenGeneration(
+            AccessTokenGenerationPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void failNextGeneration() {
+            failNextGeneration.set(true);
+        }
+
+        void reset() {
+            failNextGeneration.set(false);
+        }
+
+        @Override
+        public GeneratedAccessToken generate(
+            User user
+        ) {
+            if (
+                failNextGeneration.compareAndSet(
+                    true,
+                    false
+                )
+            ) {
+                throw new IllegalStateException(
+                    "access-token generation failed"
+                );
+            }
+
+            return delegate.generate(user);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds transactional, single-use refresh-token rotation through `POST /api/v1/auth/refresh`.

The implementation:

- resolves opaque refresh credentials through SHA-256 digests
- acquires pessimistic write locks for the token record and family
- creates a successor in the same refresh-token family
- consumes and links the predecessor atomically
- caps successor expiration at the family expiration
- generates the access token after persistence operations
- returns generic public failures without exposing session state

## Architecture and security

- preserves the existing hexagonal application-port boundaries
- persists refresh-token digests only
- executes rotation within one transaction
- serializes competing rotations through PostgreSQL row locks
- uses the deferred same-family successor foreign key
- redacts credential-bearing DTO and application representations

## HTTP and OpenAPI contract

- public `POST /api/v1/auth/refresh`
- `200` returns a new access and refresh credential pair
- `400 / VALIDATION_FAILED` for request validation
- `401 / REFRESH_TOKEN_INVALID` for invalid credentials
- internal digest, family, record and revocation data remain private

## Verification

- Maven `clean verify`
- 770 tests
- 0 failures
- 0 errors
- 0 skipped
- PostgreSQL persistence coverage
- rollback coverage for all persistence and access-token failure points
- competing-request concurrency coverage
- OpenAPI JSON contract coverage

## Scope exclusions

Reuse detection, logout operations, session listing, Redis sessions and cookie transport remain outside this issue.

Implements #86
