### PR TITLE
feat(auth): revoke refresh-token family on reuse

### DIFF
--- a/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsOutcome.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsOutcome.java
@@ -1,0 +1,28 @@
+package com.nursena.payflow.user.application.service;
+
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+
+sealed interface RotateRefreshCredentialsOutcome
+    permits RotateRefreshCredentialsOutcome.Succeeded,
+        RotateRefreshCredentialsOutcome.Rejected {
+
+    record Succeeded(
+        RotateRefreshCredentialsResult result
+    ) implements RotateRefreshCredentialsOutcome {
+
+        public Succeeded {
+            Objects.requireNonNull(
+                result,
+                "result must not be null"
+            );
+        }
+    }
+
+    enum Rejected
+        implements RotateRefreshCredentialsOutcome {
+
+        INSTANCE
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsService.java
@@ -1,31 +1,14 @@
 package com.nursena.payflow.user.application.service;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Objects;
-import java.util.UUID;
 
 import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsCommand;
 import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
 import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsUseCase;
-import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
-import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
-import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
 import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
-import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
 import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
-import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
-import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
-import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
-import com.nursena.payflow.user.domain.model.User;
-import com.nursena.payflow.user.domain.model.UserStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class RotateRefreshCredentialsService
@@ -34,38 +17,13 @@ public class RotateRefreshCredentialsService
     private final RefreshTokenDigestPort
         refreshTokenDigest;
 
-    private final RefreshTokenRecordRepositoryPort
-        recordRepository;
-
-    private final RefreshTokenFamilyRepositoryPort
-        familyRepository;
-
-    private final UserRepositoryPort userRepository;
-
-    private final RefreshTokenGenerationPort
-        refreshTokenGeneration;
-
-    private final AccessTokenGenerationPort
-        accessTokenGeneration;
-
-    private final RefreshSessionLifetimePolicy
-        lifetimePolicy;
-
-    private final Clock clock;
+    private final RotateRefreshCredentialsTransaction
+        rotationTransaction;
 
     public RotateRefreshCredentialsService(
         RefreshTokenDigestPort refreshTokenDigest,
-        RefreshTokenRecordRepositoryPort
-            recordRepository,
-        RefreshTokenFamilyRepositoryPort
-            familyRepository,
-        UserRepositoryPort userRepository,
-        RefreshTokenGenerationPort
-            refreshTokenGeneration,
-        AccessTokenGenerationPort
-            accessTokenGeneration,
-        RefreshSessionLifetimePolicy lifetimePolicy,
-        Clock clock
+        RotateRefreshCredentialsTransaction
+            rotationTransaction
     ) {
         this.refreshTokenDigest =
             Objects.requireNonNull(
@@ -73,56 +31,18 @@ public class RotateRefreshCredentialsService
                 "refreshTokenDigest must not be null"
             );
 
-        this.recordRepository =
+        this.rotationTransaction =
             Objects.requireNonNull(
-                recordRepository,
-                "recordRepository must not be null"
-            );
-
-        this.familyRepository =
-            Objects.requireNonNull(
-                familyRepository,
-                "familyRepository must not be null"
-            );
-
-        this.userRepository =
-            Objects.requireNonNull(
-                userRepository,
-                "userRepository must not be null"
-            );
-
-        this.refreshTokenGeneration =
-            Objects.requireNonNull(
-                refreshTokenGeneration,
-                "refreshTokenGeneration must not be null"
-            );
-
-        this.accessTokenGeneration =
-            Objects.requireNonNull(
-                accessTokenGeneration,
-                "accessTokenGeneration must not be null"
-            );
-
-        this.lifetimePolicy =
-            Objects.requireNonNull(
-                lifetimePolicy,
-                "lifetimePolicy must not be null"
-            );
-
-        this.clock =
-            Objects.requireNonNull(
-                clock,
-                "clock must not be null"
+                rotationTransaction,
+                "rotationTransaction must not be null"
             );
     }
 
     @Override
-    @Transactional
     public RotateRefreshCredentialsResult rotate(
         RotateRefreshCredentialsCommand command
     ) {
-        RotateRefreshCredentialsCommand
-            checkedCommand =
+        RotateRefreshCredentialsCommand checkedCommand =
             Objects.requireNonNull(
                 command,
                 "command must not be null"
@@ -133,107 +53,19 @@ public class RotateRefreshCredentialsService
                 checkedCommand.refreshToken()
             );
 
-        RefreshTokenRecord currentRecord =
-            recordRepository
-                .findByDigestForUpdate(
-                    currentDigest
-                )
-                .orElseThrow(
-                    InvalidRefreshTokenException::new
-                );
-
-        RefreshTokenFamily family =
-            familyRepository
-                .findByIdForUpdate(
-                    currentRecord.familyId()
-                )
-                .orElseThrow(
-                    InvalidRefreshTokenException::new
-                );
-
-        Instant rotatedAt =
-            clock.instant()
-                .truncatedTo(
-                    ChronoUnit.MICROS
-                );
+        RotateRefreshCredentialsOutcome outcome =
+            rotationTransaction.rotate(
+                currentDigest
+            );
 
         if (
-            !currentRecord.isActiveAt(
-                family,
-                rotatedAt
-            )
+            outcome instanceof
+                RotateRefreshCredentialsOutcome
+                    .Succeeded succeeded
         ) {
-            throw new InvalidRefreshTokenException();
+            return succeeded.result();
         }
 
-        User user =
-            userRepository
-                .findById(
-                    family.userId()
-                )
-                .filter(candidate ->
-                    candidate.status()
-                        == UserStatus.ACTIVE
-                )
-                .orElseThrow(
-                    InvalidRefreshTokenException::new
-                );
-
-        GeneratedRefreshToken generatedToken =
-            refreshTokenGeneration.generate();
-
-        RefreshTokenDigest successorDigest =
-            refreshTokenDigest.digest(
-                generatedToken.value()
-            );
-
-        RefreshTokenRecordId successorId =
-            RefreshTokenRecordId.of(
-                UUID.randomUUID()
-            );
-
-        Instant successorExpiresAt =
-            lifetimePolicy
-                .refreshTokenExpiresAt(
-                    rotatedAt,
-                    family.expiresAt()
-                );
-
-        RefreshTokenRecord successor =
-            RefreshTokenRecord.issue(
-                successorId,
-                family,
-                successorDigest,
-                rotatedAt,
-                successorExpiresAt
-            );
-
-        RefreshTokenRecord consumedCurrent =
-            currentRecord.consume(
-                successorId,
-                rotatedAt,
-                family
-            );
-
-        RefreshTokenRecord savedSuccessor =
-            recordRepository.save(
-                successor
-            );
-
-        recordRepository.save(
-            consumedCurrent
-        );
-
-        GeneratedAccessToken accessToken =
-            accessTokenGeneration.generate(
-                user
-            );
-
-        return new RotateRefreshCredentialsResult(
-            accessToken.value(),
-            accessToken.expiresAt(),
-            generatedToken.value(),
-            savedSuccessor.expiresAt()
-        );
+        throw new InvalidRefreshTokenException();
     }
 }

--- a/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsTransaction.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsTransaction.java
@@ -1,0 +1,275 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model.User;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+class RotateRefreshCredentialsTransaction {
+
+    private final RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    private final RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    private final UserRepositoryPort userRepository;
+
+    private final RefreshTokenGenerationPort
+        refreshTokenGeneration;
+
+    private final RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    private final AccessTokenGenerationPort
+        accessTokenGeneration;
+
+    private final RefreshSessionLifetimePolicy
+        lifetimePolicy;
+
+    private final Clock clock;
+
+    RotateRefreshCredentialsTransaction(
+        RefreshTokenRecordRepositoryPort
+            recordRepository,
+        RefreshTokenFamilyRepositoryPort
+            familyRepository,
+        UserRepositoryPort userRepository,
+        RefreshTokenGenerationPort
+            refreshTokenGeneration,
+        RefreshTokenDigestPort refreshTokenDigest,
+        AccessTokenGenerationPort
+            accessTokenGeneration,
+        RefreshSessionLifetimePolicy lifetimePolicy,
+        Clock clock
+    ) {
+        this.recordRepository =
+            Objects.requireNonNull(
+                recordRepository,
+                "recordRepository must not be null"
+            );
+
+        this.familyRepository =
+            Objects.requireNonNull(
+                familyRepository,
+                "familyRepository must not be null"
+            );
+
+        this.userRepository =
+            Objects.requireNonNull(
+                userRepository,
+                "userRepository must not be null"
+            );
+
+        this.refreshTokenGeneration =
+            Objects.requireNonNull(
+                refreshTokenGeneration,
+                "refreshTokenGeneration must not be null"
+            );
+
+        this.refreshTokenDigest =
+            Objects.requireNonNull(
+                refreshTokenDigest,
+                "refreshTokenDigest must not be null"
+            );
+
+        this.accessTokenGeneration =
+            Objects.requireNonNull(
+                accessTokenGeneration,
+                "accessTokenGeneration must not be null"
+            );
+
+        this.lifetimePolicy =
+            Objects.requireNonNull(
+                lifetimePolicy,
+                "lifetimePolicy must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+    }
+
+    @Transactional
+    public RotateRefreshCredentialsOutcome rotate(
+        RefreshTokenDigest currentDigest
+    ) {
+        RefreshTokenDigest checkedDigest =
+            Objects.requireNonNull(
+                currentDigest,
+                "currentDigest must not be null"
+            );
+
+        RefreshTokenRecord currentRecord =
+            recordRepository
+                .findByDigestForUpdate(
+                    checkedDigest
+                )
+                .orElse(null);
+
+        if (currentRecord == null) {
+            return rejected();
+        }
+
+        RefreshTokenFamily family =
+            familyRepository
+                .findByIdForUpdate(
+                    currentRecord.familyId()
+                )
+                .orElse(null);
+
+        if (family == null) {
+            return rejected();
+        }
+
+        Instant rotatedAt =
+            clock.instant()
+                .truncatedTo(
+                    ChronoUnit.MICROS
+                );
+
+        if (currentRecord.isConsumed()) {
+            revokeActiveFamilyForReuse(
+                family,
+                rotatedAt
+            );
+
+            return rejected();
+        }
+
+        if (
+            !currentRecord.isActiveAt(
+                family,
+                rotatedAt
+            )
+        ) {
+            return rejected();
+        }
+
+        User user =
+            userRepository
+                .findById(
+                    family.userId()
+                )
+                .filter(candidate ->
+                    candidate.status()
+                        == UserStatus.ACTIVE
+                )
+                .orElse(null);
+
+        if (user == null) {
+            return rejected();
+        }
+
+        GeneratedRefreshToken generatedToken =
+            refreshTokenGeneration.generate();
+
+        RefreshTokenDigest successorDigest =
+            refreshTokenDigest.digest(
+                generatedToken.value()
+            );
+
+        RefreshTokenRecordId successorId =
+            RefreshTokenRecordId.of(
+                UUID.randomUUID()
+            );
+
+        Instant successorExpiresAt =
+            lifetimePolicy
+                .refreshTokenExpiresAt(
+                    rotatedAt,
+                    family.expiresAt()
+                );
+
+        RefreshTokenRecord successor =
+            RefreshTokenRecord.issue(
+                successorId,
+                family,
+                successorDigest,
+                rotatedAt,
+                successorExpiresAt
+            );
+
+        RefreshTokenRecord consumedCurrent =
+            currentRecord.consume(
+                successorId,
+                rotatedAt,
+                family
+            );
+
+        RefreshTokenRecord savedSuccessor =
+            recordRepository.save(
+                successor
+            );
+
+        recordRepository.save(
+            consumedCurrent
+        );
+
+        GeneratedAccessToken accessToken =
+            accessTokenGeneration.generate(
+                user
+            );
+
+        RotateRefreshCredentialsResult result =
+            new RotateRefreshCredentialsResult(
+                accessToken.value(),
+                accessToken.expiresAt(),
+                generatedToken.value(),
+                savedSuccessor.expiresAt()
+            );
+
+        return new RotateRefreshCredentialsOutcome
+            .Succeeded(result);
+    }
+
+    private void revokeActiveFamilyForReuse(
+        RefreshTokenFamily family,
+        Instant detectedAt
+    ) {
+        if (!family.isActiveAt(detectedAt)) {
+            return;
+        }
+
+        RefreshTokenFamily revokedFamily =
+            family.revoke(
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED,
+                detectedAt
+            );
+
+        familyRepository.save(
+            revokedFamily
+        );
+    }
+
+    private static RotateRefreshCredentialsOutcome
+    rejected() {
+        return RotateRefreshCredentialsOutcome
+            .Rejected
+            .INSTANCE;
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsServiceTest.java
@@ -2,387 +2,68 @@ package com.nursena.payflow.user.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.lang.reflect.Method;
-import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsCommand;
 import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
-import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
-import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
-import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
 import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
-import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
-import com.nursena.payflow.user.domain.model.EmailAddress;
 import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
-import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
-import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
-import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
-import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
-import com.nursena.payflow.user.domain.model.User;
-import com.nursena.payflow.user.domain.model.UserRole;
-import com.nursena.payflow.user.domain.model.UserStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 class RotateRefreshCredentialsServiceTest {
 
-    private static final UUID USER_ID =
-        UUID.fromString(
-            "8805681d-d537-42f2-8906-5da1f0666ab7"
-        );
-
-    private static final RefreshTokenFamilyId
-        FAMILY_ID =
-        RefreshTokenFamilyId.of(
-            UUID.fromString(
-                "f89de08d-3035-407d-bbfd-e49eec447177"
-            )
-        );
-
-    private static final RefreshTokenRecordId
-        CURRENT_RECORD_ID =
-        RefreshTokenRecordId.of(
-            UUID.fromString(
-                "0d559bfd-05b6-43aa-8822-49b83eea3f1b"
-            )
-        );
-
-    private static final RefreshTokenRecordId
-        EXISTING_SUCCESSOR_ID =
-        RefreshTokenRecordId.of(
-            UUID.fromString(
-                "55667aa8-fd92-4ddb-836b-f83362e5932c"
-            )
-        );
-
-    private static final Instant NOW =
-        Instant.parse(
-            "2026-07-28T12:00:00Z"
-        );
-
-    private static final Instant FAMILY_CREATED_AT =
-        NOW.minus(
-            Duration.ofDays(1)
-        );
-
-    private static final Instant FAMILY_EXPIRES_AT =
-        NOW.plus(
-            Duration.ofDays(30)
-        );
-
-    private static final Instant CURRENT_ISSUED_AT =
-        NOW.minus(
-            Duration.ofHours(1)
-        );
-
-    private static final Instant CURRENT_EXPIRES_AT =
-        NOW.plus(
-            Duration.ofDays(6)
-        );
-
-    private static final Instant ACCESS_EXPIRES_AT =
-        NOW.plus(
-            Duration.ofMinutes(15)
-        );
-
-    private static final Instant SUCCESSOR_EXPIRES_AT =
-        NOW.plus(
-            Duration.ofDays(7)
-        );
-
     private static final String CURRENT_TOKEN =
         "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA";
-
-    private static final String SUCCESSOR_TOKEN =
-        "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8";
-
-    private static final String ACCESS_TOKEN =
-        "rotated.jwt.token";
 
     private static final RefreshTokenDigest
         CURRENT_DIGEST =
         digest((byte) 7);
 
-    private static final RefreshTokenDigest
-        SUCCESSOR_DIGEST =
-        digest((byte) 9);
+    private static final RotateRefreshCredentialsResult
+        SUCCESS_RESULT =
+        new RotateRefreshCredentialsResult(
+            "rotated.jwt.token",
+            Instant.parse(
+                "2026-07-28T12:15:00Z"
+            ),
+            "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8",
+            Instant.parse(
+                "2026-08-04T12:00:00Z"
+            )
+        );
 
     @Mock
     private RefreshTokenDigestPort
         refreshTokenDigest;
 
     @Mock
-    private RefreshTokenRecordRepositoryPort
-        recordRepository;
-
-    @Mock
-    private RefreshTokenFamilyRepositoryPort
-        familyRepository;
-
-    @Mock
-    private UserRepositoryPort userRepository;
-
-    @Mock
-    private RefreshTokenGenerationPort
-        refreshTokenGeneration;
-
-    @Mock
-    private AccessTokenGenerationPort
-        accessTokenGeneration;
-
-    private RefreshSessionLifetimePolicy
-        lifetimePolicy;
-
-    private Clock clock;
+    private RotateRefreshCredentialsTransaction
+        rotationTransaction;
 
     private RotateRefreshCredentialsService service;
 
     @BeforeEach
     void setUp() {
-        lifetimePolicy =
-            new RefreshSessionLifetimePolicy(
-                Duration.ofDays(7),
-                Duration.ofDays(30)
-            );
-
-        clock =
-            Clock.fixed(
-                NOW,
-                ZoneOffset.UTC
-            );
-
         service =
             new RotateRefreshCredentialsService(
                 refreshTokenDigest,
-                recordRepository,
-                familyRepository,
-                userRepository,
-                refreshTokenGeneration,
-                accessTokenGeneration,
-                lifetimePolicy,
-                clock
+                rotationTransaction
             );
     }
 
     @Test
-    void shouldRotateActiveRefreshCredentials() {
-        RefreshTokenFamily family =
-            activeFamily();
-
-        RefreshTokenRecord currentRecord =
-            activeRecord(family);
-
-        User user =
-            activeUser();
-
-        stubValidRotation(
-            family,
-            currentRecord,
-            user
-        );
-
-        when(recordRepository.save(
-            any(RefreshTokenRecord.class)
-        ))
-            .thenAnswer(
-                invocation ->
-                    invocation.getArgument(0)
-            );
-
-        when(accessTokenGeneration.generate(user))
-            .thenReturn(
-                new GeneratedAccessToken(
-                    ACCESS_TOKEN,
-                    ACCESS_EXPIRES_AT
-                )
-            );
-
-        RotateRefreshCredentialsResult result =
-            service.rotate(
-                command()
-            );
-
-        assertThat(result.accessToken())
-            .isEqualTo(
-                ACCESS_TOKEN
-            );
-
-        assertThat(result.expiresAt())
-            .isEqualTo(
-                ACCESS_EXPIRES_AT
-            );
-
-        assertThat(result.refreshToken())
-            .isEqualTo(
-                SUCCESSOR_TOKEN
-            );
-
-        assertThat(
-            result.refreshTokenExpiresAt()
-        )
-            .isEqualTo(
-                SUCCESSOR_EXPIRES_AT
-            );
-
-        ArgumentCaptor<RefreshTokenRecord>
-            recordCaptor =
-            ArgumentCaptor.forClass(
-                RefreshTokenRecord.class
-            );
-
-        verify(recordRepository, times(2))
-            .save(
-                recordCaptor.capture()
-            );
-
-        List<RefreshTokenRecord> savedRecords =
-            recordCaptor.getAllValues();
-
-        RefreshTokenRecord successor =
-            savedRecords.get(0);
-
-        RefreshTokenRecord consumedCurrent =
-            savedRecords.get(1);
-
-        assertThat(successor.id())
-            .isNotEqualTo(
-                CURRENT_RECORD_ID
-            );
-
-        assertThat(successor.familyId())
-            .isEqualTo(
-                FAMILY_ID
-            );
-
-        assertThat(successor.digest())
-            .isEqualTo(
-                SUCCESSOR_DIGEST
-            );
-
-        assertThat(successor.issuedAt())
-            .isEqualTo(
-                NOW
-            );
-
-        assertThat(successor.expiresAt())
-            .isEqualTo(
-                SUCCESSOR_EXPIRES_AT
-            );
-
-        assertThat(successor.isConsumed())
-            .isFalse();
-
-        assertThat(consumedCurrent.id())
-            .isEqualTo(
-                CURRENT_RECORD_ID
-            );
-
-        assertThat(consumedCurrent.consumedAt())
-            .isEqualTo(
-                NOW
-            );
-
-        assertThat(consumedCurrent.successorId())
-            .isEqualTo(
-                successor.id()
-            );
-
-        InOrder order =
-            inOrder(
-                refreshTokenDigest,
-                recordRepository,
-                familyRepository,
-                userRepository,
-                refreshTokenGeneration,
-                accessTokenGeneration
-            );
-
-        order.verify(refreshTokenDigest)
-            .digest(CURRENT_TOKEN);
-
-        order.verify(recordRepository)
-            .findByDigestForUpdate(
-                CURRENT_DIGEST
-            );
-
-        order.verify(familyRepository)
-            .findByIdForUpdate(
-                FAMILY_ID
-            );
-
-        order.verify(userRepository)
-            .findById(USER_ID);
-
-        order.verify(refreshTokenGeneration)
-            .generate();
-
-        order.verify(refreshTokenDigest)
-            .digest(SUCCESSOR_TOKEN);
-
-        order.verify(
-            recordRepository,
-            times(2)
-        )
-            .save(
-                any(RefreshTokenRecord.class)
-            );
-
-        order.verify(accessTokenGeneration)
-            .generate(user);
-    }
-
-    @Test
-    void shouldDeclareWriteTransaction()
-        throws NoSuchMethodException {
-
-        Method rotate =
-            RotateRefreshCredentialsService.class
-                .getDeclaredMethod(
-                    "rotate",
-                    RotateRefreshCredentialsCommand.class
-                );
-
-        Transactional transactional =
-            rotate.getAnnotation(
-                Transactional.class
-            );
-
-        assertThat(transactional)
-            .isNotNull();
-
-        assertThat(transactional.readOnly())
-            .isFalse();
-    }
-
-    @Test
-    void shouldRejectUnknownRefreshToken() {
+    void shouldReturnCommittedSuccessfulRotation() {
         when(refreshTokenDigest.digest(
             CURRENT_TOKEN
         ))
@@ -390,16 +71,55 @@ class RotateRefreshCredentialsServiceTest {
                 CURRENT_DIGEST
             );
 
-        when(recordRepository
-            .findByDigestForUpdate(
-                CURRENT_DIGEST
-            ))
+        when(rotationTransaction.rotate(
+            CURRENT_DIGEST
+        ))
             .thenReturn(
-                Optional.empty()
+                new RotateRefreshCredentialsOutcome
+                    .Succeeded(
+                        SUCCESS_RESULT
+                    )
+            );
+
+        RotateRefreshCredentialsResult result =
+            service.rotate(
+                command()
+            );
+
+        assertThat(result)
+            .isSameAs(
+                SUCCESS_RESULT
+            );
+
+        verify(refreshTokenDigest)
+            .digest(CURRENT_TOKEN);
+
+        verify(rotationTransaction)
+            .rotate(CURRENT_DIGEST);
+    }
+
+    @Test
+    void shouldRaisePublicFailureAfterRejectedTransaction() {
+        when(refreshTokenDigest.digest(
+            CURRENT_TOKEN
+        ))
+            .thenReturn(
+                CURRENT_DIGEST
+            );
+
+        when(rotationTransaction.rotate(
+            CURRENT_DIGEST
+        ))
+            .thenReturn(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
             );
 
         assertThatThrownBy(() ->
-            service.rotate(command())
+            service.rotate(
+                command()
+            )
         )
             .isInstanceOf(
                 InvalidRefreshTokenException.class
@@ -408,397 +128,58 @@ class RotateRefreshCredentialsServiceTest {
                 "Refresh token is invalid."
             );
 
-        verifyNoInteractions(
-            familyRepository,
-            userRepository,
-            refreshTokenGeneration,
-            accessTokenGeneration
-        );
-
-        verify(recordRepository, never())
-            .save(
-                any(RefreshTokenRecord.class)
-            );
+        verify(rotationTransaction)
+            .rotate(CURRENT_DIGEST);
     }
 
     @Test
-    void shouldRejectConsumedRefreshToken() {
-        RefreshTokenFamily family =
-            activeFamily();
+    void shouldRejectMalformedCredentialBeforeTransaction() {
+        InvalidRefreshTokenException failure =
+            new InvalidRefreshTokenException();
 
-        RefreshTokenRecord consumedRecord =
-            activeRecord(family)
-                .consume(
-                    EXISTING_SUCCESSOR_ID,
-                    NOW.minusSeconds(1),
-                    family
-                );
-
-        stubLockedSession(
-            family,
-            consumedRecord
-        );
-
-        assertThatThrownBy(() ->
-            service.rotate(command())
-        )
-            .isInstanceOf(
-                InvalidRefreshTokenException.class
-            );
-
-        verifyNoInteractions(
-            userRepository,
-            refreshTokenGeneration,
-            accessTokenGeneration
-        );
-
-        verify(recordRepository, never())
-            .save(
-                any(RefreshTokenRecord.class)
-            );
-    }
-
-    @Test
-    void shouldRejectExpiredRefreshToken() {
-        RefreshTokenFamily family =
-            activeFamily();
-
-        RefreshTokenRecord expiredRecord =
-            RefreshTokenRecord.issue(
-                CURRENT_RECORD_ID,
-                family,
-                CURRENT_DIGEST,
-                CURRENT_ISSUED_AT,
-                NOW
-            );
-
-        stubLockedSession(
-            family,
-            expiredRecord
-        );
-
-        assertThatThrownBy(() ->
-            service.rotate(command())
-        )
-            .isInstanceOf(
-                InvalidRefreshTokenException.class
-            );
-
-        verifyNoInteractions(
-            userRepository,
-            refreshTokenGeneration,
-            accessTokenGeneration
-        );
-    }
-
-    @Test
-    void shouldRejectUnavailableUser() {
-        RefreshTokenFamily family =
-            activeFamily();
-
-        RefreshTokenRecord currentRecord =
-            activeRecord(family);
-
-        stubLockedSession(
-            family,
-            currentRecord
-        );
-
-        when(userRepository.findById(USER_ID))
-            .thenReturn(
-                Optional.of(
-                    suspendedUser()
-                )
-            );
-
-        assertThatThrownBy(() ->
-            service.rotate(command())
-        )
-            .isInstanceOf(
-                InvalidRefreshTokenException.class
-            );
-
-        verifyNoInteractions(
-            refreshTokenGeneration,
-            accessTokenGeneration
-        );
-
-        verify(recordRepository, never())
-            .save(
-                any(RefreshTokenRecord.class)
-            );
-    }
-
-    @Test
-    void shouldStopWhenSuccessorPersistenceFails() {
-        RefreshTokenFamily family =
-            activeFamily();
-
-        RefreshTokenRecord currentRecord =
-            activeRecord(family);
-
-        User user =
-            activeUser();
-
-        stubValidRotation(
-            family,
-            currentRecord,
-            user
-        );
-
-        when(recordRepository.save(
-            any(RefreshTokenRecord.class)
-        ))
-            .thenThrow(
-                new IllegalStateException(
-                    "successor persistence failed"
-                )
-            );
-
-        assertThatThrownBy(() ->
-            service.rotate(command())
-        )
-            .isInstanceOf(
-                IllegalStateException.class
-            )
-            .hasMessage(
-                "successor persistence failed"
-            );
-
-        verify(recordRepository, times(1))
-            .save(
-                any(RefreshTokenRecord.class)
-            );
-
-        verifyNoInteractions(
-            accessTokenGeneration
-        );
-    }
-
-    @Test
-    void shouldStopWhenPredecessorPersistenceFails() {
-        RefreshTokenFamily family =
-            activeFamily();
-
-        RefreshTokenRecord currentRecord =
-            activeRecord(family);
-
-        User user =
-            activeUser();
-
-        stubValidRotation(
-            family,
-            currentRecord,
-            user
-        );
-
-        AtomicInteger saveAttempts =
-            new AtomicInteger();
-
-        when(recordRepository.save(
-            any(RefreshTokenRecord.class)
-        ))
-            .thenAnswer(invocation -> {
-                if (
-                    saveAttempts.getAndIncrement()
-                        == 0
-                ) {
-                    return invocation.getArgument(0);
-                }
-
-                throw new IllegalStateException(
-                    "predecessor persistence failed"
-                );
-            });
-
-        assertThatThrownBy(() ->
-            service.rotate(command())
-        )
-            .isInstanceOf(
-                IllegalStateException.class
-            )
-            .hasMessage(
-                "predecessor persistence failed"
-            );
-
-        verify(recordRepository, times(2))
-            .save(
-                any(RefreshTokenRecord.class)
-            );
-
-        verifyNoInteractions(
-            accessTokenGeneration
-        );
-    }
-
-    @Test
-    void shouldGenerateAccessTokenAfterBothRecordsPersist() {
-        RefreshTokenFamily family =
-            activeFamily();
-
-        RefreshTokenRecord currentRecord =
-            activeRecord(family);
-
-        User user =
-            activeUser();
-
-        stubValidRotation(
-            family,
-            currentRecord,
-            user
-        );
-
-        when(recordRepository.save(
-            any(RefreshTokenRecord.class)
-        ))
-            .thenAnswer(
-                invocation ->
-                    invocation.getArgument(0)
-            );
-
-        when(accessTokenGeneration.generate(user))
-            .thenThrow(
-                new IllegalStateException(
-                    "access-token generation failed"
-                )
-            );
-
-        assertThatThrownBy(() ->
-            service.rotate(command())
-        )
-            .isInstanceOf(
-                IllegalStateException.class
-            )
-            .hasMessage(
-                "access-token generation failed"
-            );
-
-        InOrder order =
-            inOrder(
-                recordRepository,
-                accessTokenGeneration
-            );
-
-        order.verify(
-            recordRepository,
-            times(2)
-        )
-            .save(
-                any(RefreshTokenRecord.class)
-            );
-
-        order.verify(accessTokenGeneration)
-            .generate(user);
-    }
-
-    private void stubValidRotation(
-        RefreshTokenFamily family,
-        RefreshTokenRecord currentRecord,
-        User user
-    ) {
-        stubLockedSession(
-            family,
-            currentRecord
-        );
-
-        when(userRepository.findById(USER_ID))
-            .thenReturn(
-                Optional.of(user)
-            );
-
-        when(refreshTokenGeneration.generate())
-            .thenReturn(
-                new GeneratedRefreshToken(
-                    SUCCESSOR_TOKEN
-                )
-            );
-
-        when(refreshTokenDigest.digest(
-            SUCCESSOR_TOKEN
-        ))
-            .thenReturn(
-                SUCCESSOR_DIGEST
-            );
-    }
-
-    private void stubLockedSession(
-        RefreshTokenFamily family,
-        RefreshTokenRecord currentRecord
-    ) {
         when(refreshTokenDigest.digest(
             CURRENT_TOKEN
         ))
-            .thenReturn(
-                CURRENT_DIGEST
+            .thenThrow(
+                failure
             );
 
-        when(recordRepository
-            .findByDigestForUpdate(
-                CURRENT_DIGEST
-            ))
-            .thenReturn(
-                Optional.of(currentRecord)
+        assertThatThrownBy(() ->
+            service.rotate(
+                command()
+            )
+        )
+            .isSameAs(
+                failure
             );
 
-        when(familyRepository
-            .findByIdForUpdate(
-                FAMILY_ID
-            ))
-            .thenReturn(
-                Optional.of(family)
+        verifyNoInteractions(
+            rotationTransaction
+        );
+    }
+
+    @Test
+    void shouldRequireCommand() {
+        assertThatThrownBy(() ->
+            service.rotate(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "command must not be null"
             );
+
+        verifyNoInteractions(
+            refreshTokenDigest,
+            rotationTransaction
+        );
     }
 
     private static RotateRefreshCredentialsCommand
     command() {
         return new RotateRefreshCredentialsCommand(
             CURRENT_TOKEN
-        );
-    }
-
-    private static RefreshTokenFamily
-    activeFamily() {
-        return RefreshTokenFamily.create(
-            FAMILY_ID,
-            USER_ID,
-            FAMILY_CREATED_AT,
-            FAMILY_EXPIRES_AT
-        );
-    }
-
-    private static RefreshTokenRecord activeRecord(
-        RefreshTokenFamily family
-    ) {
-        return RefreshTokenRecord.issue(
-            CURRENT_RECORD_ID,
-            family,
-            CURRENT_DIGEST,
-            CURRENT_ISSUED_AT,
-            CURRENT_EXPIRES_AT
-        );
-    }
-
-    private static User activeUser() {
-        return user(UserStatus.ACTIVE);
-    }
-
-    private static User suspendedUser() {
-        return user(UserStatus.SUSPENDED);
-    }
-
-    private static User user(
-        UserStatus status
-    ) {
-        return User.rehydrate(
-            USER_ID,
-            EmailAddress.of(
-                "nursena@example.com"
-            ),
-            "hashed-password",
-            UserRole.USER,
-            status,
-            FAMILY_CREATED_AT,
-            FAMILY_CREATED_AT
         );
     }
 

--- a/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsTransactionTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsTransactionTest.java
@@ -1,0 +1,936 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model.User;
+import com.nursena.payflow.user.domain.model.UserRole;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
+class RotateRefreshCredentialsTransactionTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final RefreshTokenFamilyId
+        FAMILY_ID =
+        RefreshTokenFamilyId.of(
+            UUID.fromString(
+                "f89de08d-3035-407d-bbfd-e49eec447177"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        CURRENT_RECORD_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "0d559bfd-05b6-43aa-8822-49b83eea3f1b"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        EXISTING_SUCCESSOR_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "55667aa8-fd92-4ddb-836b-f83362e5932c"
+            )
+        );
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-28T12:00:00Z"
+        );
+
+    private static final Instant FAMILY_CREATED_AT =
+        NOW.minus(
+            Duration.ofDays(1)
+        );
+
+    private static final Instant FAMILY_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(30)
+        );
+
+    private static final Instant CURRENT_ISSUED_AT =
+        NOW.minus(
+            Duration.ofHours(1)
+        );
+
+    private static final Instant CURRENT_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(6)
+        );
+
+    private static final Instant ACCESS_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofMinutes(15)
+        );
+
+    private static final Instant SUCCESSOR_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(7)
+        );
+
+    private static final String SUCCESSOR_TOKEN =
+        "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8";
+
+    private static final String ACCESS_TOKEN =
+        "rotated.jwt.token";
+
+    private static final RefreshTokenDigest
+        CURRENT_DIGEST =
+        digest((byte) 7);
+
+    private static final RefreshTokenDigest
+        SUCCESSOR_DIGEST =
+        digest((byte) 9);
+
+    @Mock
+    private RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    @Mock
+    private RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    @Mock
+    private UserRepositoryPort userRepository;
+
+    @Mock
+    private RefreshTokenGenerationPort
+        refreshTokenGeneration;
+
+    @Mock
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @Mock
+    private AccessTokenGenerationPort
+        accessTokenGeneration;
+
+    private RefreshSessionLifetimePolicy
+        lifetimePolicy;
+
+    private Clock clock;
+
+    private RotateRefreshCredentialsTransaction
+        transaction;
+
+    @BeforeEach
+    void setUp() {
+        lifetimePolicy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        clock =
+            Clock.fixed(
+                NOW,
+                ZoneOffset.UTC
+            );
+
+        transaction =
+            new RotateRefreshCredentialsTransaction(
+                recordRepository,
+                familyRepository,
+                userRepository,
+                refreshTokenGeneration,
+                refreshTokenDigest,
+                accessTokenGeneration,
+                lifetimePolicy,
+                clock
+            );
+    }
+
+    @Test
+    void shouldRotateActiveRefreshCredentials() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(accessTokenGeneration.generate(user))
+            .thenReturn(
+                new GeneratedAccessToken(
+                    ACCESS_TOKEN,
+                    ACCESS_EXPIRES_AT
+                )
+            );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isInstanceOf(
+                RotateRefreshCredentialsOutcome
+                    .Succeeded.class
+            );
+
+        RotateRefreshCredentialsResult result =
+            (
+                (RotateRefreshCredentialsOutcome
+                    .Succeeded) outcome
+            ).result();
+
+        assertThat(result.accessToken())
+            .isEqualTo(
+                ACCESS_TOKEN
+            );
+
+        assertThat(result.expiresAt())
+            .isEqualTo(
+                ACCESS_EXPIRES_AT
+            );
+
+        assertThat(result.refreshToken())
+            .isEqualTo(
+                SUCCESSOR_TOKEN
+            );
+
+        assertThat(
+            result.refreshTokenExpiresAt()
+        )
+            .isEqualTo(
+                SUCCESSOR_EXPIRES_AT
+            );
+
+        ArgumentCaptor<RefreshTokenRecord>
+            recordCaptor =
+            ArgumentCaptor.forClass(
+                RefreshTokenRecord.class
+            );
+
+        verify(recordRepository, times(2))
+            .save(
+                recordCaptor.capture()
+            );
+
+        List<RefreshTokenRecord> savedRecords =
+            recordCaptor.getAllValues();
+
+        RefreshTokenRecord successor =
+            savedRecords.get(0);
+
+        RefreshTokenRecord consumedCurrent =
+            savedRecords.get(1);
+
+        assertThat(successor.familyId())
+            .isEqualTo(
+                FAMILY_ID
+            );
+
+        assertThat(successor.digest())
+            .isEqualTo(
+                SUCCESSOR_DIGEST
+            );
+
+        assertThat(successor.issuedAt())
+            .isEqualTo(
+                NOW
+            );
+
+        assertThat(successor.expiresAt())
+            .isEqualTo(
+                SUCCESSOR_EXPIRES_AT
+            );
+
+        assertThat(successor.isConsumed())
+            .isFalse();
+
+        assertThat(consumedCurrent.id())
+            .isEqualTo(
+                CURRENT_RECORD_ID
+            );
+
+        assertThat(consumedCurrent.consumedAt())
+            .isEqualTo(
+                NOW
+            );
+
+        assertThat(consumedCurrent.successorId())
+            .isEqualTo(
+                successor.id()
+            );
+    }
+
+    @Test
+    void shouldDeclareWriteTransaction()
+        throws NoSuchMethodException {
+
+        Method rotate =
+            RotateRefreshCredentialsTransaction.class
+                .getDeclaredMethod(
+                    "rotate",
+                    RefreshTokenDigest.class
+                );
+
+        Transactional transactional =
+            rotate.getAnnotation(
+                Transactional.class
+            );
+
+        assertThat(transactional)
+            .isNotNull();
+
+        assertThat(transactional.readOnly())
+            .isFalse();
+    }
+
+    @Test
+    void shouldRejectUnknownRefreshToken() {
+        when(recordRepository
+            .findByDigestForUpdate(
+                CURRENT_DIGEST
+            ))
+            .thenReturn(
+                Optional.empty()
+            );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isSameAs(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
+            );
+
+        verifyNoInteractions(
+            familyRepository,
+            userRepository,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldRevokeActiveFamilyWhenConsumedTokenIsReused() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord consumedRecord =
+            consumedRecord(family);
+
+        stubLockedSession(
+            family,
+            consumedRecord
+        );
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isSameAs(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
+            );
+
+        ArgumentCaptor<RefreshTokenFamily>
+            familyCaptor =
+            ArgumentCaptor.forClass(
+                RefreshTokenFamily.class
+            );
+
+        verify(familyRepository)
+            .save(
+                familyCaptor.capture()
+            );
+
+        RefreshTokenFamily revoked =
+            familyCaptor.getValue();
+
+        assertThat(revoked.id())
+            .isEqualTo(
+                FAMILY_ID
+            );
+
+        assertThat(revoked.revokedAt())
+            .isEqualTo(
+                NOW
+            );
+
+        assertThat(revoked.revocationReason())
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED
+            );
+
+        assertThat(revoked.isActiveAt(NOW))
+            .isFalse();
+
+        verifyNoInteractions(
+            userRepository,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            accessTokenGeneration
+        );
+
+        verify(recordRepository, never())
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+    }
+
+    @Test
+    void shouldPreserveExistingFamilyRevocation() {
+        RefreshTokenFamily activeFamily =
+            activeFamily();
+
+        RefreshTokenRecord consumedRecord =
+            consumedRecord(activeFamily);
+
+        RefreshTokenFamily revokedFamily =
+            activeFamily.revoke(
+                RefreshTokenFamilyRevocationReason
+                    .ADMINISTRATIVE_REVOCATION,
+                NOW.minusSeconds(1)
+            );
+
+        stubLockedSession(
+            revokedFamily,
+            consumedRecord
+        );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isSameAs(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
+            );
+
+        verify(familyRepository, never())
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+
+        verifyNoInteractions(
+            userRepository,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldNotRevokeExpiredFamilyForConsumedToken() {
+        RefreshTokenFamily family =
+            RefreshTokenFamily.create(
+                FAMILY_ID,
+                USER_ID,
+                FAMILY_CREATED_AT,
+                NOW
+            );
+
+        RefreshTokenRecord consumedRecord =
+            RefreshTokenRecord.issue(
+                CURRENT_RECORD_ID,
+                family,
+                CURRENT_DIGEST,
+                CURRENT_ISSUED_AT,
+                NOW
+            )
+                .consume(
+                    EXISTING_SUCCESSOR_ID,
+                    NOW.minusSeconds(1),
+                    family
+                );
+
+        stubLockedSession(
+            family,
+            consumedRecord
+        );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isSameAs(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
+            );
+
+        verify(familyRepository, never())
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+
+        verifyNoInteractions(
+            userRepository,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldRejectExpiredUnconsumedTokenWithoutRevocation() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord expiredRecord =
+            RefreshTokenRecord.issue(
+                CURRENT_RECORD_ID,
+                family,
+                CURRENT_DIGEST,
+                CURRENT_ISSUED_AT,
+                NOW
+            );
+
+        stubLockedSession(
+            family,
+            expiredRecord
+        );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isSameAs(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
+            );
+
+        verify(familyRepository, never())
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+
+        verifyNoInteractions(
+            userRepository,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldRejectUnavailableUser() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        stubLockedSession(
+            family,
+            currentRecord
+        );
+
+        when(userRepository.findById(USER_ID))
+            .thenReturn(
+                Optional.of(
+                    suspendedUser()
+                )
+            );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isSameAs(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
+            );
+
+        verifyNoInteractions(
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            accessTokenGeneration
+        );
+
+        verify(recordRepository, never())
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+    }
+
+    @Test
+    void shouldStopWhenSuccessorPersistenceFails() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenThrow(
+                new IllegalStateException(
+                    "successor persistence failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            transaction.rotate(
+                CURRENT_DIGEST
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "successor persistence failed"
+            );
+
+        verify(recordRepository, times(1))
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        verifyNoInteractions(
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldStopWhenPredecessorPersistenceFails() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        AtomicInteger saveAttempts =
+            new AtomicInteger();
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(invocation -> {
+                if (
+                    saveAttempts.getAndIncrement()
+                        == 0
+                ) {
+                    return invocation.getArgument(0);
+                }
+
+                throw new IllegalStateException(
+                    "predecessor persistence failed"
+                );
+            });
+
+        assertThatThrownBy(() ->
+            transaction.rotate(
+                CURRENT_DIGEST
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "predecessor persistence failed"
+            );
+
+        verify(recordRepository, times(2))
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        verifyNoInteractions(
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldGenerateAccessTokenAfterBothRecordsPersist() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(accessTokenGeneration.generate(user))
+            .thenThrow(
+                new IllegalStateException(
+                    "access-token generation failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            transaction.rotate(
+                CURRENT_DIGEST
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "access-token generation failed"
+            );
+
+        InOrder order =
+            inOrder(
+                recordRepository,
+                accessTokenGeneration
+            );
+
+        order.verify(
+            recordRepository,
+            times(2)
+        )
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        order.verify(accessTokenGeneration)
+            .generate(user);
+    }
+
+    private void stubValidRotation(
+        RefreshTokenFamily family,
+        RefreshTokenRecord currentRecord,
+        User user
+    ) {
+        stubLockedSession(
+            family,
+            currentRecord
+        );
+
+        when(userRepository.findById(USER_ID))
+            .thenReturn(
+                Optional.of(user)
+            );
+
+        when(refreshTokenGeneration.generate())
+            .thenReturn(
+                new GeneratedRefreshToken(
+                    SUCCESSOR_TOKEN
+                )
+            );
+
+        when(refreshTokenDigest.digest(
+            SUCCESSOR_TOKEN
+        ))
+            .thenReturn(
+                SUCCESSOR_DIGEST
+            );
+    }
+
+    private void stubLockedSession(
+        RefreshTokenFamily family,
+        RefreshTokenRecord currentRecord
+    ) {
+        when(recordRepository
+            .findByDigestForUpdate(
+                CURRENT_DIGEST
+            ))
+            .thenReturn(
+                Optional.of(currentRecord)
+            );
+
+        when(familyRepository
+            .findByIdForUpdate(
+                FAMILY_ID
+            ))
+            .thenReturn(
+                Optional.of(family)
+            );
+    }
+
+    private static RefreshTokenFamily
+    activeFamily() {
+        return RefreshTokenFamily.create(
+            FAMILY_ID,
+            USER_ID,
+            FAMILY_CREATED_AT,
+            FAMILY_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenRecord activeRecord(
+        RefreshTokenFamily family
+    ) {
+        return RefreshTokenRecord.issue(
+            CURRENT_RECORD_ID,
+            family,
+            CURRENT_DIGEST,
+            CURRENT_ISSUED_AT,
+            CURRENT_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenRecord consumedRecord(
+        RefreshTokenFamily family
+    ) {
+        return activeRecord(family)
+            .consume(
+                EXISTING_SUCCESSOR_ID,
+                NOW.minusSeconds(1),
+                family
+            );
+    }
+
+    private static User activeUser() {
+        return user(UserStatus.ACTIVE);
+    }
+
+    private static User suspendedUser() {
+        return user(UserStatus.SUSPENDED);
+    }
+
+    private static User user(
+        UserStatus status
+    ) {
+        return User.rehydrate(
+            USER_ID,
+            EmailAddress.of(
+                "nursena@example.com"
+            ),
+            "hashed-password",
+            UserRole.USER,
+            status,
+            FAMILY_CREATED_AT,
+            FAMILY_CREATED_AT
+        );
+    }
+
+    private static RefreshTokenDigest digest(
+        byte fillValue
+    ) {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            bytes,
+            fillValue
+        );
+
+        return RefreshTokenDigest.of(
+            bytes
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsConcurrencyIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsConcurrencyIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
@@ -242,7 +243,7 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
                     Integer.class
                 );
 
-            Integer activeCount =
+            Integer unconsumedCount =
                 jdbcTemplate.queryForObject(
                     """
                     SELECT COUNT(*)
@@ -251,6 +252,11 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
                       AND successor_id IS NULL
                     """,
                     Integer.class
+                );
+
+            FamilyRevocation reuseRevocation =
+                findFamilyRevocation(
+                    initialRefreshToken
                 );
 
             byte[] successorDigest =
@@ -272,8 +278,14 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
             assertThat(consumedCount)
                 .isEqualTo(1);
 
-            assertThat(activeCount)
+            assertThat(unconsumedCount)
                 .isEqualTo(1);
+
+            assertThat(reuseRevocation.revokedAt())
+                .isNotNull();
+
+            assertThat(reuseRevocation.reason())
+                .isEqualTo("REUSE_DETECTED");
 
             assertThat(successorDigest)
                 .containsExactly(
@@ -289,6 +301,27 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
                 )
             )
                 .isFalse();
+
+            MvcResult successorResult =
+                performRefresh(
+                    successorToken
+                );
+
+            assertRefreshRejected(
+                successorResult
+            );
+
+            FamilyRevocation
+                afterSuccessorAttempt =
+                findFamilyRevocation(
+                    initialRefreshToken
+                );
+
+            assertThat(afterSuccessorAttempt)
+                .isEqualTo(reuseRevocation);
+
+            assertThat(countRecords())
+                .isEqualTo(2);
         } finally {
             recordRepository
                 .releaseFirstLookup();
@@ -314,6 +347,95 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
                 )
                 .isTrue();
         }
+    }
+
+    private void assertRefreshRejected(
+        MvcResult result
+    ) throws Exception {
+        assertThat(
+            result
+                .getResponse()
+                .getStatus()
+        )
+            .isEqualTo(401);
+
+        JsonNode response =
+            objectMapper.readTree(
+                result
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        assertThat(
+            response
+                .path("code")
+                .asText()
+        )
+            .isEqualTo(
+                "REFRESH_TOKEN_INVALID"
+            );
+
+        assertThat(
+            response
+                .path("message")
+                .asText()
+        )
+            .isEqualTo(
+                "Refresh token is invalid."
+            );
+
+        assertThat(response.has("accessToken"))
+            .isFalse();
+
+        assertThat(response.has("refreshToken"))
+            .isFalse();
+    }
+
+    private FamilyRevocation findFamilyRevocation(
+        String refreshToken
+    ) {
+        byte[] digest =
+            refreshTokenDigest
+                .digest(refreshToken)
+                .value();
+
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT family.revoked_at,
+                   family.revocation_reason
+            FROM refresh_token_families family
+            JOIN refresh_token_records record
+              ON record.family_id = family.id
+            WHERE record.token_digest = ?
+            """,
+            (resultSet, rowNumber) ->
+                new FamilyRevocation(
+                    resultSet
+                        .getTimestamp(
+                            "revoked_at"
+                        )
+                        .toInstant(),
+                    resultSet.getString(
+                        "revocation_reason"
+                    )
+                ),
+            digest
+        );
+    }
+
+    private int countRecords() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        return count == null
+            ? 0
+            : count;
     }
 
     private String issueInitialRefreshToken()
@@ -389,6 +511,12 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
                     )
             )
             .andReturn();
+    }
+
+    private record FamilyRevocation(
+        Instant revokedAt,
+        String reason
+    ) {
     }
 
     private record Credentials(

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsIntegrationTest.java
@@ -76,7 +76,7 @@ class RotateRefreshCredentialsIntegrationTest {
     }
 
     @Test
-    void shouldRotateAndPersistSingleSuccessor()
+    void shouldRotateOnceAndDurablyRevokeFamilyOnReuse()
         throws Exception {
 
         InitialCredential initial =
@@ -356,6 +356,47 @@ class RotateRefreshCredentialsIntegrationTest {
         assertThat(recordCount)
             .isEqualTo(2);
 
+        assertRefreshTokenRejected(
+            initial.refreshToken()
+        );
+
+        FamilyRevocation reuseRevocation =
+            findFamilyRevocation(
+                persisted.predecessorFamilyId()
+            );
+
+        assertThat(reuseRevocation.revokedAt())
+            .isNotNull()
+            .isAfterOrEqualTo(
+                persisted.predecessorConsumedAt()
+            );
+
+        assertThat(reuseRevocation.reason())
+            .isEqualTo("REUSE_DETECTED");
+
+        assertThat(countRecords())
+            .isEqualTo(2);
+
+        assertRefreshTokenRejected(
+            successorToken
+        );
+
+        FamilyRevocation afterSuccessorAttempt =
+            findFamilyRevocation(
+                persisted.predecessorFamilyId()
+            );
+
+        assertThat(afterSuccessorAttempt)
+            .isEqualTo(reuseRevocation);
+
+        assertThat(countRecords())
+            .isEqualTo(2);
+    }
+
+    private void assertRefreshTokenRejected(
+        String refreshToken
+    ) throws Exception {
+
         mockMvc.perform(
                 post("/api/v1/auth/refresh")
                     .contentType(
@@ -364,7 +405,7 @@ class RotateRefreshCredentialsIntegrationTest {
                     .content(
                         objectMapper.writeValueAsString(
                             new RefreshRequest(
-                                initial.refreshToken()
+                                refreshToken
                             )
                         )
                     )
@@ -385,7 +426,55 @@ class RotateRefreshCredentialsIntegrationTest {
                 ).value(
                     "Refresh token is invalid."
                 )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.accessToken"
+                ).doesNotExist()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.refreshToken"
+                ).doesNotExist()
             );
+    }
+
+    private FamilyRevocation findFamilyRevocation(
+        UUID familyId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT revoked_at, revocation_reason
+            FROM refresh_token_families
+            WHERE id = ?
+            """,
+            (resultSet, rowNumber) ->
+                new FamilyRevocation(
+                    nullableInstant(
+                        resultSet,
+                        "revoked_at"
+                    ),
+                    resultSet.getString(
+                        "revocation_reason"
+                    )
+                ),
+            familyId
+        );
+    }
+
+    private int countRecords() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        return count == null
+            ? 0
+            : count;
     }
 
     private InitialCredential issueInitialCredential(
@@ -540,6 +629,12 @@ class RotateRefreshCredentialsIntegrationTest {
     private record InitialCredential(
         String email,
         String refreshToken
+    ) {
+    }
+
+    private record FamilyRevocation(
+        Instant revokedAt,
+        String reason
     ) {
     }
 

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsRollbackIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsRollbackIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
@@ -17,8 +18,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
 import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
 import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
 import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
 import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
 import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
 import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
 import com.nursena.payflow.user.domain.model.User;
@@ -79,12 +84,17 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
         recordRepository;
 
     @Autowired
+    private FailureInjectingFamilyRepository
+        familyRepository;
+
+    @Autowired
     private FailureInjectingAccessTokenGeneration
         accessTokenGeneration;
 
     @BeforeEach
     void setUp() {
         recordRepository.reset();
+        familyRepository.reset();
         accessTokenGeneration.reset();
 
         jdbcTemplate.update(
@@ -192,6 +202,70 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
         assertInitialSessionUnchanged(
             refreshToken
         );
+    }
+
+    @Test
+    void shouldRollbackWhenReuseRevocationPersistenceFails()
+        throws Exception {
+
+        String initialRefreshToken =
+            issueInitialRefreshToken(
+                "reuse-revocation-failure"
+            );
+
+        org.springframework.test.web.servlet
+        .MvcResult firstRotation =
+            refresh(initialRefreshToken)
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode firstResponse =
+            objectMapper.readTree(
+                firstRotation
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        String successorToken =
+            firstResponse
+                .path("refreshToken")
+                .asText();
+
+        int accessGenerationCountBeforeReuse =
+            accessTokenGeneration
+                .generationCount();
+
+        familyRepository.failAfterNextSave(
+            "family revocation persistence failed"
+        );
+
+        assertThatThrownBy(() ->
+            refresh(initialRefreshToken)
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "family revocation persistence failed"
+            );
+
+        assertFamilyRevocationRolledBack(
+            initialRefreshToken
+        );
+
+        assertThat(
+            accessTokenGeneration
+                .generationCount()
+        )
+            .isEqualTo(
+                accessGenerationCountBeforeReuse
+            );
+
+        refresh(successorToken)
+            .andExpect(status().isOk());
     }
 
     private String issueInitialRefreshToken(
@@ -341,6 +415,93 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
             .isFalse();
     }
 
+    private void assertFamilyRevocationRolledBack(
+        String initialRefreshToken
+    ) {
+        byte[] digest =
+            refreshTokenDigest
+                .digest(initialRefreshToken)
+                .value();
+
+        FamilyState familyState =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT family.revoked_at,
+                       family.revocation_reason
+                FROM refresh_token_families family
+                JOIN refresh_token_records record
+                  ON record.family_id = family.id
+                WHERE record.token_digest = ?
+                """,
+                (resultSet, rowNumber) ->
+                    new FamilyState(
+                        resultSet
+                            .getTimestamp(
+                                "revoked_at"
+                            ),
+                        resultSet.getString(
+                            "revocation_reason"
+                        )
+                    ),
+                digest
+            );
+
+        Integer recordCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        Integer consumedCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                WHERE consumed_at IS NOT NULL
+                  AND successor_id IS NOT NULL
+                """,
+                Integer.class
+            );
+
+        Integer unconsumedCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                WHERE consumed_at IS NULL
+                  AND successor_id IS NULL
+                """,
+                Integer.class
+            );
+
+        assertThat(familyState)
+            .isNotNull();
+
+        assertThat(familyState.revokedAt())
+            .isNull();
+
+        assertThat(familyState.reason())
+            .isNull();
+
+        assertThat(recordCount)
+            .isEqualTo(2);
+
+        assertThat(consumedCount)
+            .isEqualTo(1);
+
+        assertThat(unconsumedCount)
+            .isEqualTo(1);
+    }
+
+    private record FamilyState(
+        java.sql.Timestamp revokedAt,
+        String reason
+    ) {
+    }
+
     private record Credentials(
         String email,
         String password
@@ -367,6 +528,20 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
             RefreshTokenRecordRepositoryPort delegate
         ) {
             return new FailureInjectingRecordRepository(
+                delegate
+            );
+        }
+
+        @Bean
+        @Primary
+        FailureInjectingFamilyRepository
+        failureInjectingRotationFamilyRepository(
+            @Qualifier(
+                "refreshTokenFamilyPersistenceAdapter"
+            )
+            RefreshTokenFamilyRepositoryPort delegate
+        ) {
+            return new FailureInjectingFamilyRepository(
                 delegate
             );
         }
@@ -460,6 +635,82 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
         }
     }
 
+    static final class FailureInjectingFamilyRepository
+        implements RefreshTokenFamilyRepositoryPort {
+
+        private final RefreshTokenFamilyRepositoryPort
+            delegate;
+
+        private final AtomicBoolean
+            failAfterNextSave =
+            new AtomicBoolean();
+
+        private volatile String failureMessage =
+            "";
+
+        FailureInjectingFamilyRepository(
+            RefreshTokenFamilyRepositoryPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void failAfterNextSave(
+            String message
+        ) {
+            failureMessage = message;
+            failAfterNextSave.set(true);
+        }
+
+        void reset() {
+            failAfterNextSave.set(false);
+            failureMessage = "";
+        }
+
+        @Override
+        public RefreshTokenFamily save(
+            RefreshTokenFamily family
+        ) {
+            RefreshTokenFamily saved =
+                delegate.save(family);
+
+            if (
+                failAfterNextSave.compareAndSet(
+                    true,
+                    false
+                )
+            ) {
+                throw new IllegalStateException(
+                    failureMessage
+                );
+            }
+
+            return saved;
+        }
+
+        @Override
+        public Optional<RefreshTokenFamily>
+        findByIdForUpdate(
+            RefreshTokenFamilyId familyId
+        ) {
+            return delegate.findByIdForUpdate(
+                familyId
+            );
+        }
+
+        @Override
+        public int revokeAllActiveByUserId(
+            UUID userId,
+            Instant revokedAt,
+            RefreshTokenFamilyRevocationReason reason
+        ) {
+            return delegate.revokeAllActiveByUserId(
+                userId,
+                revokedAt,
+                reason
+            );
+        }
+    }
+
     static final class FailureInjectingAccessTokenGeneration
         implements AccessTokenGenerationPort {
 
@@ -469,6 +720,10 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
         private final AtomicBoolean
             failNextGeneration =
             new AtomicBoolean();
+
+        private final AtomicInteger
+            generationCount =
+            new AtomicInteger();
 
         FailureInjectingAccessTokenGeneration(
             AccessTokenGenerationPort delegate
@@ -482,12 +737,19 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
 
         void reset() {
             failNextGeneration.set(false);
+            generationCount.set(0);
+        }
+
+        int generationCount() {
+            return generationCount.get();
         }
 
         @Override
         public GeneratedAccessToken generate(
             User user
         ) {
+            generationCount.incrementAndGet();
+
             if (
                 failNextGeneration.compareAndSet(
                     true,


### PR DESCRIPTION
## Summary

- separate the public refresh boundary from the transactional rotation worker
- detect reuse of a consumed refresh credential while its family is active
- durably revoke the complete refresh-token family with `REUSE_DETECTED`
- map the internal rejection to the existing generic `401 / REFRESH_TOKEN_INVALID` response only after transaction completion
- prevent access-token or successor generation after reuse classification
- preserve digest-only persistence and redacted credential representations

## Transaction and concurrency guarantees

- PostgreSQL pessimistic locks serialize competing requests for the same refresh-token record
- a delayed duplicate observes the consumed predecessor and revokes the family
- the successor returned by the first rotation is rejected after family revocation
- revocation persistence failure rolls back the complete revocation transaction
- concurrent duplicate requests do not create multiple successors

## Verification

- `./mvnw clean verify`
- 777 tests
- 0 failures
- 0 errors
- 0 skipped
- UTF-8 without BOM and LF line endings
- Git whitespace and high-confidence secret checks passed

Closes #88
