### PR TITLE
feat(auth): revoke current refresh-token session on logout

### DIFF
--- a/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
@@ -57,6 +57,23 @@ public final class OpenApiExamples {
         }
         """;
 
+    public static final String LOGOUT_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-29T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/auth/logout",
+          "violations": [
+            {
+              "field": "refreshToken",
+              "message": "Refresh token is required."
+            }
+          ]
+        }
+        """;
+
     public static final String INVALID_REFRESH_TOKEN =
         """
         {

--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -28,7 +28,8 @@ public class SecurityConfiguration {
         "/swagger-ui/**",
         "/api/v1/auth/register",
         "/api/v1/auth/login",
-        "/api/v1/auth/refresh"
+        "/api/v1/auth/refresh",
+        "/api/v1/auth/logout"
     };
 
     @Bean

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionController.java
@@ -1,0 +1,91 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiExamples;
+import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionCommand;
+import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+    name = "Authentication",
+    description =
+        "Public user registration and authentication operations."
+)
+@RestController
+@RequestMapping("/api/v1/auth")
+public class RevokeCurrentRefreshSessionController {
+
+    private final RevokeCurrentRefreshSessionUseCase
+        revokeCurrentRefreshSessionUseCase;
+
+    public RevokeCurrentRefreshSessionController(
+        RevokeCurrentRefreshSessionUseCase
+            revokeCurrentRefreshSessionUseCase
+    ) {
+        this.revokeCurrentRefreshSessionUseCase =
+            revokeCurrentRefreshSessionUseCase;
+    }
+
+    @Operation(
+        operationId = "revokeCurrentRefreshSession",
+        summary = "Log out the current refresh session",
+        description =
+            "Revokes the refresh-token family represented "
+                + "by the submitted opaque credential. "
+                + "The response does not reveal whether "
+                + "the credential exists or remains active."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description =
+                "The logout request was processed without "
+                    + "exposing refresh-token state."
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .LOGOUT_VALIDATION_ERROR
+                )
+            )
+        )
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+        @Valid @RequestBody
+        RevokeCurrentRefreshSessionRequest request
+    ) {
+        RevokeCurrentRefreshSessionCommand command =
+            new RevokeCurrentRefreshSessionCommand(
+                request.refreshToken()
+            );
+
+        revokeCurrentRefreshSessionUseCase.revoke(
+            command
+        );
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionRequest.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionRequest.java
@@ -1,0 +1,33 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(
+    name = "RevokeCurrentRefreshSessionRequest",
+    description =
+        "Opaque refresh credential submitted to end "
+            + "the represented refresh-token session."
+)
+public record RevokeCurrentRefreshSessionRequest(
+
+    @Schema(
+        description =
+            "Opaque refresh token returned by login "
+                + "or a previous refresh operation.",
+        example =
+            "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA",
+        format = "password",
+        accessMode = Schema.AccessMode.WRITE_ONLY
+    )
+    @NotBlank(
+        message = "Refresh token is required."
+    )
+    String refreshToken
+) {
+
+    @Override
+    public String toString() {
+        return "RevokeCurrentRefreshSessionRequest[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RevokeCurrentRefreshSessionCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RevokeCurrentRefreshSessionCommand.java
@@ -1,0 +1,26 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.util.Objects;
+
+public record RevokeCurrentRefreshSessionCommand(
+    String refreshToken
+) {
+
+    public RevokeCurrentRefreshSessionCommand {
+        Objects.requireNonNull(
+            refreshToken,
+            "refreshToken must not be null"
+        );
+
+        if (refreshToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "refreshToken must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RevokeCurrentRefreshSessionCommand[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RevokeCurrentRefreshSessionUseCase.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RevokeCurrentRefreshSessionUseCase.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.user.application.port.in;
+
+public interface RevokeCurrentRefreshSessionUseCase {
+
+    void revoke(
+        RevokeCurrentRefreshSessionCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionService.java
@@ -1,0 +1,68 @@
+package com.nursena.payflow.user.application.service;
+
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionCommand;
+import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionUseCase;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RevokeCurrentRefreshSessionService
+    implements RevokeCurrentRefreshSessionUseCase {
+
+    private final RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    private final RevokeCurrentRefreshSessionTransaction
+        revocationTransaction;
+
+    public RevokeCurrentRefreshSessionService(
+        RefreshTokenDigestPort refreshTokenDigest,
+        RevokeCurrentRefreshSessionTransaction
+            revocationTransaction
+    ) {
+        this.refreshTokenDigest =
+            Objects.requireNonNull(
+                refreshTokenDigest,
+                "refreshTokenDigest must not be null"
+            );
+
+        this.revocationTransaction =
+            Objects.requireNonNull(
+                revocationTransaction,
+                "revocationTransaction must not be null"
+            );
+    }
+
+    @Override
+    public void revoke(
+        RevokeCurrentRefreshSessionCommand command
+    ) {
+        RevokeCurrentRefreshSessionCommand
+            checkedCommand =
+            Objects.requireNonNull(
+                command,
+                "command must not be null"
+            );
+
+        RefreshTokenDigest digest;
+
+        try {
+            digest =
+                refreshTokenDigest.digest(
+                    checkedCommand.refreshToken()
+                );
+        } catch (
+            InvalidRefreshTokenException ignored
+        ) {
+            return;
+        }
+
+        revocationTransaction.revoke(
+            digest
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionTransaction.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionTransaction.java
@@ -1,0 +1,107 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+class RevokeCurrentRefreshSessionTransaction {
+
+    private final RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    private final RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    private final Clock clock;
+
+    RevokeCurrentRefreshSessionTransaction(
+        RefreshTokenRecordRepositoryPort
+            recordRepository,
+        RefreshTokenFamilyRepositoryPort
+            familyRepository,
+        Clock clock
+    ) {
+        this.recordRepository =
+            Objects.requireNonNull(
+                recordRepository,
+                "recordRepository must not be null"
+            );
+
+        this.familyRepository =
+            Objects.requireNonNull(
+                familyRepository,
+                "familyRepository must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+    }
+
+    @Transactional
+    public void revoke(
+        RefreshTokenDigest digest
+    ) {
+        RefreshTokenDigest checkedDigest =
+            Objects.requireNonNull(
+                digest,
+                "digest must not be null"
+            );
+
+        RefreshTokenRecord record =
+            recordRepository
+                .findByDigestForUpdate(
+                    checkedDigest
+                )
+                .orElse(null);
+
+        if (record == null) {
+            return;
+        }
+
+        RefreshTokenFamily family =
+            familyRepository
+                .findByIdForUpdate(
+                    record.familyId()
+                )
+                .orElse(null);
+
+        if (family == null) {
+            return;
+        }
+
+        Instant revokedAt =
+            clock.instant()
+                .truncatedTo(
+                    ChronoUnit.MICROS
+                );
+
+        if (!family.isActiveAt(revokedAt)) {
+            return;
+        }
+
+        RefreshTokenFamily revokedFamily =
+            family.revoke(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT,
+                revokedAt
+            );
+
+        familyRepository.save(
+            revokedFamily
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/SecurityConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/SecurityConfigurationTest.java
@@ -4,6 +4,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request
     .MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request
+    .MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result
     .MockMvcResultMatchers.status;
 
@@ -49,6 +51,16 @@ class SecurityConfigurationTest {
     private JwtDecoder jwtDecoder;
     @MockitoBean
     private SecurityProbeController.ProbeService probeService;
+    @Test
+    void shouldPermitAnonymousCurrentSessionLogout()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/logout")
+            )
+            .andExpect(status().isNotFound());
+    }
+
     @Test
     void shouldPermitAnonymousRequestToPrometheusEndpoint()
         throws Exception {

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -49,6 +49,9 @@ class OpenApiJsonContractIntegrationTest {
     private static final String REFRESH_PATH =
         "/api/v1/auth/refresh";
 
+    private static final String LOGOUT_PATH =
+        "/api/v1/auth/logout";
+
     private static final String USER_PROFILE_PATH =
         "/api/v1/users/me";
 
@@ -184,6 +187,7 @@ class OpenApiJsonContractIntegrationTest {
             REGISTER_PATH,
             LOGIN_PATH,
             REFRESH_PATH,
+            LOGOUT_PATH,
             USER_PROFILE_PATH,
             WALLETS_PATH,
             CURRENT_WALLET_PATH,
@@ -257,6 +261,28 @@ class OpenApiJsonContractIntegrationTest {
             "200",
             "400",
             "401"
+        );
+
+        JsonNode logout =
+            operation(
+                LOGOUT_PATH,
+                "post"
+            );
+
+        assertPublicOperation(logout);
+
+        assertThat(
+            logout
+                .path("operationId")
+                .asText()
+        ).isEqualTo(
+            "revokeCurrentRefreshSession"
+        );
+
+        assertResponseCodes(
+            logout,
+            "204",
+            "400"
         );
     }
 
@@ -725,6 +751,89 @@ class OpenApiJsonContractIntegrationTest {
             .contains(
                 "VALIDATION_FAILED",
                 "Refresh token is required."
+            );
+    }
+
+    @Test
+    void shouldExposeCurrentSessionLogoutContract() {
+        JsonNode logout =
+            operation(
+                LOGOUT_PATH,
+                "post"
+            );
+
+        JsonNode requestSchema =
+            logout
+                .path("requestBody")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .path("schema");
+
+        assertThat(
+            requestSchema
+                .path("$ref")
+                .asText()
+        ).isEqualTo(
+            "#/components/schemas/"
+                + "RevokeCurrentRefreshSessionRequest"
+        );
+
+        JsonNode requestProperties =
+            openApi
+                .path("components")
+                .path("schemas")
+                .path(
+                    "RevokeCurrentRefreshSessionRequest"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(requestProperties)
+        ).containsExactly(
+            "refreshToken"
+        );
+
+        assertThat(
+            requestProperties
+                .path("refreshToken")
+                .path("type")
+                .asText()
+        ).isEqualTo("string");
+
+        assertThat(
+            requestProperties
+                .path("refreshToken")
+                .path("writeOnly")
+                .asBoolean()
+        ).isTrue();
+
+        JsonNode responses =
+            logout.path("responses");
+
+        assertThat(responses.has("401"))
+            .isFalse();
+
+        assertThat(
+            responses
+                .path("204")
+                .has("content")
+        ).isFalse();
+
+        assertThat(
+            responses
+                .path("400")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .toString()
+        )
+            .contains(
+                "VALIDATION_FAILED",
+                "Refresh token is required.",
+                "/api/v1/auth/logout"
             );
     }
 

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionControllerTest.java
@@ -1,0 +1,164 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionUseCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    RevokeCurrentRefreshSessionController.class
+)
+@Import(SecurityConfiguration.class)
+class RevokeCurrentRefreshSessionControllerTest {
+
+    private static final String CURRENT_TOKEN =
+        "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RevokeCurrentRefreshSessionUseCase
+        revokeCurrentRefreshSessionUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldLogoutWithoutBearerAuthentication()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/logout")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "refreshToken": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA"
+                        }
+                        """)
+            )
+            .andExpect(
+                status().isNoContent()
+            )
+            .andExpect(
+                content().string("")
+            );
+
+        verify(revokeCurrentRefreshSessionUseCase)
+            .revoke(
+                argThat(command ->
+                    command.refreshToken()
+                        .equals(CURRENT_TOKEN)
+                )
+            );
+    }
+
+    @Test
+    void shouldReturnNoContentForMalformedCredential()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/logout")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "refreshToken": "not-canonical"
+                        }
+                        """)
+            )
+            .andExpect(
+                status().isNoContent()
+            )
+            .andExpect(
+                content().string("")
+            );
+
+        verify(revokeCurrentRefreshSessionUseCase)
+            .revoke(
+                argThat(command ->
+                    command.refreshToken()
+                        .equals("not-canonical")
+                )
+            );
+    }
+
+    @Test
+    void shouldRejectBlankRefreshToken()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/logout")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "refreshToken": " "
+                        }
+                        """)
+            )
+            .andExpect(
+                status().isBadRequest()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "VALIDATION_FAILED"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.path"
+                ).value(
+                    "/api/v1/auth/logout"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.violations[0].field"
+                ).value(
+                    "refreshToken"
+                )
+            );
+
+        verifyNoInteractions(
+            revokeCurrentRefreshSessionUseCase
+        );
+    }
+
+    @Test
+    void shouldRedactRefreshTokenFromRequestToString() {
+        RevokeCurrentRefreshSessionRequest request =
+            new RevokeCurrentRefreshSessionRequest(
+                "secret-refresh-token"
+            );
+
+        assertThat(request.toString())
+            .isEqualTo(
+                "RevokeCurrentRefreshSessionRequest[redacted]"
+            )
+            .doesNotContain(
+                "secret-refresh-token"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/port/in/RevokeCurrentRefreshSessionCommandTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/in/RevokeCurrentRefreshSessionCommandTest.java
@@ -1,0 +1,68 @@
+package com.nursena.payflow.user.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class RevokeCurrentRefreshSessionCommandTest {
+
+    @Test
+    void shouldRetainRefreshToken() {
+        RevokeCurrentRefreshSessionCommand command =
+            new RevokeCurrentRefreshSessionCommand(
+                "opaque-refresh-token"
+            );
+
+        assertThat(command.refreshToken())
+            .isEqualTo(
+                "opaque-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRequireRefreshToken() {
+        assertThatThrownBy(() ->
+            new RevokeCurrentRefreshSessionCommand(
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "refreshToken must not be null"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankRefreshToken() {
+        assertThatThrownBy(() ->
+            new RevokeCurrentRefreshSessionCommand(
+                " "
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "refreshToken must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRedactRefreshTokenFromToString() {
+        RevokeCurrentRefreshSessionCommand command =
+            new RevokeCurrentRefreshSessionCommand(
+                "secret-refresh-token"
+            );
+
+        assertThat(command.toString())
+            .isEqualTo(
+                "RevokeCurrentRefreshSessionCommand[redacted]"
+            )
+            .doesNotContain(
+                "secret-refresh-token"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionServiceTest.java
@@ -1,0 +1,174 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionCommand;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RevokeCurrentRefreshSessionServiceTest {
+
+    private static final String REFRESH_TOKEN =
+        "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA";
+
+    private static final RefreshTokenDigest DIGEST =
+        digest((byte) 7);
+
+    @Mock
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @Mock
+    private RevokeCurrentRefreshSessionTransaction
+        revocationTransaction;
+
+    private RevokeCurrentRefreshSessionService
+        service;
+
+    @BeforeEach
+    void setUp() {
+        service =
+            new RevokeCurrentRefreshSessionService(
+                refreshTokenDigest,
+                revocationTransaction
+            );
+    }
+
+    @Test
+    void shouldRevokeCurrentRefreshSession() {
+        when(refreshTokenDigest.digest(
+            REFRESH_TOKEN
+        ))
+            .thenReturn(
+                DIGEST
+            );
+
+        service.revoke(
+            command()
+        );
+
+        verify(refreshTokenDigest)
+            .digest(
+                REFRESH_TOKEN
+            );
+
+        verify(revocationTransaction)
+            .revoke(
+                DIGEST
+            );
+    }
+
+    @Test
+    void shouldCompleteWhenRefreshTokenIsMalformed() {
+        when(refreshTokenDigest.digest(
+            REFRESH_TOKEN
+        ))
+            .thenThrow(
+                new InvalidRefreshTokenException()
+            );
+
+        service.revoke(
+            command()
+        );
+
+        verify(refreshTokenDigest)
+            .digest(
+                REFRESH_TOKEN
+            );
+
+        verifyNoInteractions(
+            revocationTransaction
+        );
+    }
+
+    @Test
+    void shouldPropagateRevocationInfrastructureFailure() {
+        when(refreshTokenDigest.digest(
+            REFRESH_TOKEN
+        ))
+            .thenReturn(
+                DIGEST
+            );
+
+        doThrow(
+            new IllegalStateException(
+                "revocation persistence failed"
+            )
+        )
+            .when(revocationTransaction)
+            .revoke(
+                DIGEST
+            );
+
+        assertThatThrownBy(() ->
+            service.revoke(
+                command()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "revocation persistence failed"
+            );
+    }
+
+    @Test
+    void shouldRequireCommand() {
+        assertThatThrownBy(() ->
+            service.revoke(
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "command must not be null"
+            );
+
+        verifyNoInteractions(
+            refreshTokenDigest,
+            revocationTransaction
+        );
+    }
+
+    private static RevokeCurrentRefreshSessionCommand
+    command() {
+        return new RevokeCurrentRefreshSessionCommand(
+            REFRESH_TOKEN
+        );
+    }
+
+    private static RefreshTokenDigest digest(
+        byte fillValue
+    ) {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            bytes,
+            fillValue
+        );
+
+        return RefreshTokenDigest.of(
+            bytes
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionTransactionTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionTransactionTest.java
@@ -1,0 +1,563 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
+class RevokeCurrentRefreshSessionTransactionTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final RefreshTokenFamilyId
+        FAMILY_ID =
+        RefreshTokenFamilyId.of(
+            UUID.fromString(
+                "f89de08d-3035-407d-bbfd-e49eec447177"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        RECORD_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "0d559bfd-05b6-43aa-8822-49b83eea3f1b"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        SUCCESSOR_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "55667aa8-fd92-4ddb-836b-f83362e5932c"
+            )
+        );
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-29T12:00:00Z"
+        );
+
+    private static final Instant FAMILY_CREATED_AT =
+        NOW.minus(
+            Duration.ofDays(1)
+        );
+
+    private static final Instant FAMILY_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(30)
+        );
+
+    private static final Instant RECORD_ISSUED_AT =
+        NOW.minus(
+            Duration.ofHours(2)
+        );
+
+    private static final Instant RECORD_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(6)
+        );
+
+    private static final RefreshTokenDigest DIGEST =
+        digest((byte) 7);
+
+    @Mock
+    private RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    @Mock
+    private RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    private RevokeCurrentRefreshSessionTransaction
+        transaction;
+
+    @BeforeEach
+    void setUp() {
+        transaction =
+            new RevokeCurrentRefreshSessionTransaction(
+                recordRepository,
+                familyRepository,
+                Clock.fixed(
+                    NOW,
+                    ZoneOffset.UTC
+                )
+            );
+    }
+
+    @Test
+    void shouldRevokeActiveFamily() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord record =
+            activeRecord(family);
+
+        stubLockedSession(
+            family,
+            record
+        );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        ArgumentCaptor<RefreshTokenFamily>
+            familyCaptor =
+            ArgumentCaptor.forClass(
+                RefreshTokenFamily.class
+            );
+
+        InOrder order =
+            inOrder(
+                recordRepository,
+                familyRepository
+            );
+
+        order.verify(recordRepository)
+            .findByDigestForUpdate(
+                DIGEST
+            );
+
+        order.verify(familyRepository)
+            .findByIdForUpdate(
+                FAMILY_ID
+            );
+
+        order.verify(familyRepository)
+            .save(
+                familyCaptor.capture()
+            );
+
+        RefreshTokenFamily savedFamily =
+            familyCaptor.getValue();
+
+        assertThat(savedFamily.id())
+            .isEqualTo(
+                FAMILY_ID
+            );
+
+        assertThat(savedFamily.revokedAt())
+            .isEqualTo(
+                NOW
+            );
+
+        assertThat(savedFamily.revocationReason())
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT
+            );
+    }
+
+    @Test
+    void shouldDeclareWriteTransaction()
+        throws NoSuchMethodException {
+
+        Method method =
+            RevokeCurrentRefreshSessionTransaction
+                .class
+                .getDeclaredMethod(
+                    "revoke",
+                    RefreshTokenDigest.class
+                );
+
+        assertThat(
+            method.getAnnotation(
+                Transactional.class
+            )
+        ).isNotNull();
+    }
+
+    @Test
+    void shouldCompleteForUnknownRefreshToken() {
+        when(recordRepository
+            .findByDigestForUpdate(
+                DIGEST
+            ))
+            .thenReturn(
+                Optional.empty()
+            );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        verifyNoInteractions(
+            familyRepository
+        );
+    }
+
+    @Test
+    void shouldCompleteWhenFamilyIsMissing() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord record =
+            activeRecord(family);
+
+        when(recordRepository
+            .findByDigestForUpdate(
+                DIGEST
+            ))
+            .thenReturn(
+                Optional.of(record)
+            );
+
+        when(familyRepository
+            .findByIdForUpdate(
+                FAMILY_ID
+            ))
+            .thenReturn(
+                Optional.empty()
+            );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        verify(familyRepository, never())
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+    }
+
+    @Test
+    void shouldRevokeActiveFamilyForConsumedRecord() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord record =
+            consumedRecord(family);
+
+        stubLockedSession(
+            family,
+            record
+        );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        verify(familyRepository)
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+    }
+
+    @Test
+    void shouldRevokeActiveFamilyForExpiredRecord() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord record =
+            expiredRecord(family);
+
+        stubLockedSession(
+            family,
+            record
+        );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        verify(familyRepository)
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+    }
+
+    @Test
+    void shouldPreserveExistingFamilyRevocation() {
+        RefreshTokenFamily family =
+            revokedFamily();
+
+        RefreshTokenRecord record =
+            rehydratedRecord(family);
+
+        stubLockedSession(
+            family,
+            record
+        );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        verify(familyRepository, never())
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+
+        assertThat(family.revocationReason())
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED
+            );
+    }
+
+    @Test
+    void shouldNotRevokeExpiredFamily() {
+        RefreshTokenFamily family =
+            expiredFamily();
+
+        RefreshTokenRecord record =
+            activeAtIssueTimeRecord(family);
+
+        stubLockedSession(
+            family,
+            record
+        );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        verify(familyRepository, never())
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+    }
+
+    @Test
+    void shouldPropagateFamilyPersistenceFailure() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord record =
+            activeRecord(family);
+
+        stubLockedSession(
+            family,
+            record
+        );
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenThrow(
+                new IllegalStateException(
+                    "family persistence failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            transaction.revoke(
+                DIGEST
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "family persistence failed"
+            );
+    }
+
+    @Test
+    void shouldRequireDigest() {
+        assertThatThrownBy(() ->
+            transaction.revoke(
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "digest must not be null"
+            );
+
+        verifyNoInteractions(
+            recordRepository,
+            familyRepository
+        );
+    }
+
+    private void stubLockedSession(
+        RefreshTokenFamily family,
+        RefreshTokenRecord record
+    ) {
+        when(recordRepository
+            .findByDigestForUpdate(
+                DIGEST
+            ))
+            .thenReturn(
+                Optional.of(record)
+            );
+
+        when(familyRepository
+            .findByIdForUpdate(
+                FAMILY_ID
+            ))
+            .thenReturn(
+                Optional.of(family)
+            );
+    }
+
+    private static RefreshTokenFamily
+    activeFamily() {
+        return RefreshTokenFamily.create(
+            FAMILY_ID,
+            USER_ID,
+            FAMILY_CREATED_AT,
+            FAMILY_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenFamily
+    revokedFamily() {
+        return RefreshTokenFamily.rehydrate(
+            FAMILY_ID,
+            USER_ID,
+            FAMILY_CREATED_AT,
+            FAMILY_EXPIRES_AT,
+            NOW.minus(
+                Duration.ofMinutes(5)
+            ),
+            RefreshTokenFamilyRevocationReason
+                .REUSE_DETECTED
+        );
+    }
+
+    private static RefreshTokenFamily
+    expiredFamily() {
+        return RefreshTokenFamily.create(
+            FAMILY_ID,
+            USER_ID,
+            FAMILY_CREATED_AT,
+            NOW.minus(
+                Duration.ofMinutes(1)
+            )
+        );
+    }
+
+    private static RefreshTokenRecord activeRecord(
+        RefreshTokenFamily family
+    ) {
+        return RefreshTokenRecord.issue(
+            RECORD_ID,
+            family,
+            DIGEST,
+            RECORD_ISSUED_AT,
+            RECORD_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenRecord consumedRecord(
+        RefreshTokenFamily family
+    ) {
+        return activeRecord(family)
+            .consume(
+                SUCCESSOR_ID,
+                NOW.minus(
+                    Duration.ofMinutes(1)
+                ),
+                family
+            );
+    }
+
+    private static RefreshTokenRecord expiredRecord(
+        RefreshTokenFamily family
+    ) {
+        return RefreshTokenRecord.issue(
+            RECORD_ID,
+            family,
+            DIGEST,
+            RECORD_ISSUED_AT,
+            NOW.minus(
+                Duration.ofMinutes(1)
+            )
+        );
+    }
+
+    private static RefreshTokenRecord rehydratedRecord(
+        RefreshTokenFamily family
+    ) {
+        return RefreshTokenRecord.rehydrate(
+            RECORD_ID,
+            FAMILY_ID,
+            DIGEST,
+            RECORD_ISSUED_AT,
+            RECORD_EXPIRES_AT,
+            null,
+            null,
+            family
+        );
+    }
+
+    private static RefreshTokenRecord
+    activeAtIssueTimeRecord(
+        RefreshTokenFamily family
+    ) {
+        Instant issuedAt =
+            family.expiresAt()
+                .minus(
+                    Duration.ofHours(1)
+                );
+
+        return RefreshTokenRecord.issue(
+            RECORD_ID,
+            family,
+            DIGEST,
+            issuedAt,
+            family.expiresAt()
+                .minus(
+                    Duration.ofMinutes(1)
+                )
+        );
+    }
+
+    private static RefreshTokenDigest digest(
+        byte fillValue
+    ) {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            bytes,
+            fillValue
+        );
+
+        return RefreshTokenDigest.of(
+            bytes
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RevokeCurrentRefreshSessionIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RevokeCurrentRefreshSessionIntegrationTest.java
@@ -1,0 +1,519 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+class RevokeCurrentRefreshSessionIntegrationTest {
+
+    private static final String UNKNOWN_CANONICAL_TOKEN =
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldDurablyRevokeActiveCurrentSession()
+        throws Exception {
+
+        InitialCredential initial =
+            issueInitialCredential(
+                "logout-active"
+            );
+
+        UUID familyId =
+            findFamilyId(initial.email());
+
+        assertLogoutNoContent(
+            initial.refreshToken()
+        );
+
+        FamilyRevocation revocation =
+            findFamilyRevocation(familyId);
+
+        assertThat(revocation.revokedAt())
+            .isNotNull();
+
+        assertThat(revocation.reason())
+            .isEqualTo(
+                "CURRENT_SESSION_LOGOUT"
+            );
+
+        assertThat(countFamilies())
+            .isEqualTo(1);
+
+        assertThat(countRecords())
+            .isEqualTo(1);
+
+        assertRefreshTokenRejected(
+            initial.refreshToken()
+        );
+
+        assertThat(
+            findFamilyRevocation(familyId)
+        ).isEqualTo(revocation);
+
+        assertThat(countRecords())
+            .isEqualTo(1);
+    }
+
+    @Test
+    void shouldRevokeFamilyThroughConsumedPredecessor()
+        throws Exception {
+
+        InitialCredential initial =
+            issueInitialCredential(
+                "logout-consumed"
+            );
+
+        UUID familyId =
+            findFamilyId(initial.email());
+
+        String successorToken =
+            rotate(initial.refreshToken());
+
+        assertThat(countRecords())
+            .isEqualTo(2);
+
+        assertLogoutNoContent(
+            initial.refreshToken()
+        );
+
+        FamilyRevocation revocation =
+            findFamilyRevocation(familyId);
+
+        assertThat(revocation.revokedAt())
+            .isNotNull();
+
+        assertThat(revocation.reason())
+            .isEqualTo(
+                "CURRENT_SESSION_LOGOUT"
+            );
+
+        assertRefreshTokenRejected(
+            initial.refreshToken()
+        );
+
+        assertRefreshTokenRejected(
+            successorToken
+        );
+
+        assertThat(
+            findFamilyRevocation(familyId)
+        ).isEqualTo(revocation);
+
+        assertThat(countRecords())
+            .isEqualTo(2);
+    }
+
+    @Test
+    void shouldHideMalformedAndUnknownCredentialState()
+        throws Exception {
+
+        assertLogoutNoContent(
+            "not-canonical"
+        );
+
+        assertLogoutNoContent(
+            UNKNOWN_CANONICAL_TOKEN
+        );
+
+        assertThat(countFamilies())
+            .isZero();
+
+        assertThat(countRecords())
+            .isZero();
+    }
+
+    @Test
+    void shouldPreserveExistingReuseRevocationReason()
+        throws Exception {
+
+        InitialCredential initial =
+            issueInitialCredential(
+                "logout-reuse"
+            );
+
+        UUID familyId =
+            findFamilyId(initial.email());
+
+        String successorToken =
+            rotate(initial.refreshToken());
+
+        assertRefreshTokenRejected(
+            initial.refreshToken()
+        );
+
+        FamilyRevocation reuseRevocation =
+            findFamilyRevocation(familyId);
+
+        assertThat(reuseRevocation.revokedAt())
+            .isNotNull();
+
+        assertThat(reuseRevocation.reason())
+            .isEqualTo("REUSE_DETECTED");
+
+        assertLogoutNoContent(
+            successorToken
+        );
+
+        assertLogoutNoContent(
+            successorToken
+        );
+
+        assertThat(
+            findFamilyRevocation(familyId)
+        ).isEqualTo(reuseRevocation);
+
+        assertThat(countRecords())
+            .isEqualTo(2);
+    }
+
+    private void assertLogoutNoContent(
+        String refreshToken
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/logout")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RefreshRequest(
+                                refreshToken
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isNoContent()
+            )
+            .andExpect(
+                content().string("")
+            );
+    }
+
+    private String rotate(
+        String refreshToken
+    ) throws Exception {
+
+        MvcResult result =
+            mockMvc.perform(
+                    post("/api/v1/auth/refresh")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                new RefreshRequest(
+                                    refreshToken
+                                )
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.refreshToken"
+                    ).isNotEmpty()
+                )
+                .andReturn();
+
+        JsonNode response =
+            objectMapper.readTree(
+                result
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        String successorToken =
+            response
+                .path("refreshToken")
+                .asText();
+
+        assertThat(successorToken)
+            .hasSize(43)
+            .isNotEqualTo(refreshToken);
+
+        return successorToken;
+    }
+
+    private void assertRefreshTokenRejected(
+        String refreshToken
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RefreshRequest(
+                                refreshToken
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isUnauthorized()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "REFRESH_TOKEN_INVALID"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.message"
+                ).value(
+                    "Refresh token is invalid."
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.accessToken"
+                ).doesNotExist()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.refreshToken"
+                ).doesNotExist()
+            );
+    }
+
+    private InitialCredential issueInitialCredential(
+        String prefix
+    ) throws Exception {
+
+        String email =
+            prefix
+                + "-"
+                + UUID.randomUUID()
+                + "@example.com";
+
+        String password =
+            "StrongPassword123!";
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new Credentials(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+
+        MvcResult loginResult =
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                new Credentials(
+                                    email,
+                                    password
+                                )
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andReturn();
+
+        JsonNode loginResponse =
+            objectMapper.readTree(
+                loginResult
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        return new InitialCredential(
+            email,
+            loginResponse
+                .path("refreshToken")
+                .asText()
+        );
+    }
+
+    private UUID findFamilyId(
+        String email
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT family.id
+            FROM refresh_token_families family
+            JOIN users user_account
+              ON user_account.id = family.user_id
+            WHERE user_account.email = ?
+            """,
+            UUID.class,
+            email
+        );
+    }
+
+    private FamilyRevocation findFamilyRevocation(
+        UUID familyId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT revoked_at, revocation_reason
+            FROM refresh_token_families
+            WHERE id = ?
+            """,
+            RevokeCurrentRefreshSessionIntegrationTest
+                ::mapFamilyRevocation,
+            familyId
+        );
+    }
+
+    private int countFamilies() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                """,
+                Integer.class
+            );
+
+        return count == null
+            ? 0
+            : count;
+    }
+
+    private int countRecords() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        return count == null
+            ? 0
+            : count;
+    }
+
+    private static FamilyRevocation
+    mapFamilyRevocation(
+        ResultSet resultSet,
+        int rowNumber
+    ) throws SQLException {
+
+        java.sql.Timestamp revokedAt =
+            resultSet.getTimestamp(
+                "revoked_at"
+            );
+
+        return new FamilyRevocation(
+            revokedAt == null
+                ? null
+                : revokedAt.toInstant(),
+            resultSet.getString(
+                "revocation_reason"
+            )
+        );
+    }
+
+    private record Credentials(
+        String email,
+        String password
+    ) {
+    }
+
+    private record RefreshRequest(
+        String refreshToken
+    ) {
+    }
+
+    private record InitialCredential(
+        String email,
+        String refreshToken
+    ) {
+    }
+
+    private record FamilyRevocation(
+        Instant revokedAt,
+        String reason
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsConcurrencyIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsConcurrencyIntegrationTest.java
@@ -349,6 +349,324 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
         }
     }
 
+    @Test
+    void shouldRejectRotationWhenLogoutHoldsTokenLockFirst()
+        throws Exception {
+
+        String initialRefreshToken =
+            issueInitialRefreshToken();
+
+        recordRepository.holdNextLookup();
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(2);
+
+        Future<MvcResult> logoutFuture =
+            null;
+
+        Future<MvcResult> refreshFuture =
+            null;
+
+        try {
+            logoutFuture =
+                executor.submit(
+                    () ->
+                        performLogout(
+                            initialRefreshToken
+                        )
+                );
+
+            assertThat(
+                recordRepository
+                    .awaitFirstLock()
+            )
+                .as(
+                    "logout should acquire the refresh-token row lock first"
+                )
+                .isTrue();
+
+            refreshFuture =
+                executor.submit(
+                    () ->
+                        performRefresh(
+                            initialRefreshToken
+                        )
+                );
+
+            assertThat(
+                recordRepository
+                    .awaitSecondLookup()
+            )
+                .as(
+                    "rotation should reach the locked digest lookup"
+                )
+                .isTrue();
+
+            Thread.sleep(300);
+
+            assertThat(refreshFuture.isDone())
+                .as(
+                    "rotation must remain blocked while logout holds the row lock"
+                )
+                .isFalse();
+
+            recordRepository.releaseFirstLookup();
+
+            MvcResult logoutResult =
+                logoutFuture.get(
+                    15,
+                    SECONDS
+                );
+
+            MvcResult refreshResult =
+                refreshFuture.get(
+                    15,
+                    SECONDS
+                );
+
+            assertLogoutCompleted(
+                logoutResult
+            );
+
+            assertRefreshRejected(
+                refreshResult
+            );
+
+            FamilyRevocation logoutRevocation =
+                findFamilyRevocation(
+                    initialRefreshToken
+                );
+
+            assertThat(logoutRevocation.revokedAt())
+                .isNotNull();
+
+            assertThat(logoutRevocation.reason())
+                .isEqualTo(
+                    "CURRENT_SESSION_LOGOUT"
+                );
+
+            assertThat(countRecords())
+                .isEqualTo(1);
+
+            assertRefreshRejected(
+                performRefresh(
+                    initialRefreshToken
+                )
+            );
+
+            assertThat(
+                findFamilyRevocation(
+                    initialRefreshToken
+                )
+            ).isEqualTo(logoutRevocation);
+
+            assertThat(countRecords())
+                .isEqualTo(1);
+        } finally {
+            recordRepository
+                .releaseFirstLookup();
+
+            if (logoutFuture != null) {
+                logoutFuture.cancel(true);
+            }
+
+            if (refreshFuture != null) {
+                refreshFuture.cancel(true);
+            }
+
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    SECONDS
+                )
+            )
+                .as(
+                    "logout-first concurrency executor should terminate cleanly"
+                )
+                .isTrue();
+        }
+    }
+
+    @Test
+    void shouldRevokeReturnedSuccessorWhenRotationHoldsTokenLockFirst()
+        throws Exception {
+
+        String initialRefreshToken =
+            issueInitialRefreshToken();
+
+        recordRepository.holdNextLookup();
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(2);
+
+        Future<MvcResult> refreshFuture =
+            null;
+
+        Future<MvcResult> logoutFuture =
+            null;
+
+        try {
+            refreshFuture =
+                executor.submit(
+                    () ->
+                        performRefresh(
+                            initialRefreshToken
+                        )
+                );
+
+            assertThat(
+                recordRepository
+                    .awaitFirstLock()
+            )
+                .as(
+                    "rotation should acquire the refresh-token row lock first"
+                )
+                .isTrue();
+
+            logoutFuture =
+                executor.submit(
+                    () ->
+                        performLogout(
+                            initialRefreshToken
+                        )
+                );
+
+            assertThat(
+                recordRepository
+                    .awaitSecondLookup()
+            )
+                .as(
+                    "logout should reach the locked digest lookup"
+                )
+                .isTrue();
+
+            Thread.sleep(300);
+
+            assertThat(logoutFuture.isDone())
+                .as(
+                    "logout must remain blocked while rotation holds the row lock"
+                )
+                .isFalse();
+
+            recordRepository.releaseFirstLookup();
+
+            MvcResult refreshResult =
+                refreshFuture.get(
+                    15,
+                    SECONDS
+                );
+
+            MvcResult logoutResult =
+                logoutFuture.get(
+                    15,
+                    SECONDS
+                );
+
+            assertThat(
+                refreshResult
+                    .getResponse()
+                    .getStatus()
+            )
+                .isEqualTo(200);
+
+            assertLogoutCompleted(
+                logoutResult
+            );
+
+            JsonNode refreshResponse =
+                objectMapper.readTree(
+                    refreshResult
+                        .getResponse()
+                        .getContentAsByteArray()
+                );
+
+            String successorToken =
+                refreshResponse
+                    .path("refreshToken")
+                    .asText();
+
+            assertThat(successorToken)
+                .isNotBlank()
+                .isNotEqualTo(
+                    initialRefreshToken
+                );
+
+            FamilyRevocation logoutRevocation =
+                findFamilyRevocation(
+                    initialRefreshToken
+                );
+
+            assertThat(logoutRevocation.revokedAt())
+                .isNotNull();
+
+            assertThat(logoutRevocation.reason())
+                .isEqualTo(
+                    "CURRENT_SESSION_LOGOUT"
+                );
+
+            assertThat(countRecords())
+                .isEqualTo(2);
+
+            assertRefreshRejected(
+                performRefresh(
+                    successorToken
+                )
+            );
+
+            assertThat(
+                findFamilyRevocation(
+                    initialRefreshToken
+                )
+            ).isEqualTo(logoutRevocation);
+
+            assertThat(countRecords())
+                .isEqualTo(2);
+        } finally {
+            recordRepository
+                .releaseFirstLookup();
+
+            if (refreshFuture != null) {
+                refreshFuture.cancel(true);
+            }
+
+            if (logoutFuture != null) {
+                logoutFuture.cancel(true);
+            }
+
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    SECONDS
+                )
+            )
+                .as(
+                    "rotation-first concurrency executor should terminate cleanly"
+                )
+                .isTrue();
+        }
+    }
+
+    private void assertLogoutCompleted(
+        MvcResult result
+    ) {
+        assertThat(
+            result
+                .getResponse()
+                .getStatus()
+        )
+            .isEqualTo(204);
+
+        assertThat(
+            result
+                .getResponse()
+                .getContentAsByteArray()
+        ).isEmpty();
+    }
+
     private void assertRefreshRejected(
         MvcResult result
     ) throws Exception {
@@ -499,6 +817,26 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
 
         return mockMvc.perform(
                 post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RefreshRequest(
+                                refreshToken
+                            )
+                        )
+                    )
+            )
+            .andReturn();
+    }
+
+    private MvcResult performLogout(
+        String refreshToken
+    ) throws Exception {
+
+        return mockMvc.perform(
+                post("/api/v1/auth/logout")
                     .contentType(
                         MediaType.APPLICATION_JSON
                     )

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsRollbackIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsRollbackIntegrationTest.java
@@ -205,6 +205,56 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
     }
 
     @Test
+    void shouldRollbackWhenCurrentSessionLogoutRevocationPersistenceFails()
+        throws Exception {
+
+        String refreshToken =
+            issueInitialRefreshToken(
+                "logout-revocation-failure"
+            );
+
+        int accessGenerationCountBeforeLogout =
+            accessTokenGeneration
+                .generationCount();
+
+        familyRepository.failAfterNextSave(
+            "current-session logout revocation persistence failed"
+        );
+
+        assertThatThrownBy(() ->
+            logout(refreshToken)
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "current-session logout revocation persistence failed"
+            );
+
+        assertInitialSessionUnchanged(
+            refreshToken
+        );
+
+        assertFamilyRemainsActive(
+            refreshToken
+        );
+
+        assertThat(
+            accessTokenGeneration
+                .generationCount()
+        )
+            .isEqualTo(
+                accessGenerationCountBeforeLogout
+            );
+
+        refresh(refreshToken)
+            .andExpect(status().isOk());
+    }
+
+    @Test
     void shouldRollbackWhenReuseRevocationPersistenceFails()
         throws Exception {
 
@@ -344,6 +394,66 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
                     )
                 )
         );
+    }
+
+    private org.springframework.test.web.servlet
+    .ResultActions logout(
+        String refreshToken
+    ) throws Exception {
+
+        return mockMvc.perform(
+            post("/api/v1/auth/logout")
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    objectMapper.writeValueAsString(
+                        new RefreshRequest(
+                            refreshToken
+                        )
+                    )
+                )
+        );
+    }
+
+    private void assertFamilyRemainsActive(
+        String refreshToken
+    ) {
+        byte[] digest =
+            refreshTokenDigest
+                .digest(refreshToken)
+                .value();
+
+        FamilyState familyState =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT family.revoked_at,
+                       family.revocation_reason
+                FROM refresh_token_families family
+                JOIN refresh_token_records record
+                  ON record.family_id = family.id
+                WHERE record.token_digest = ?
+                """,
+                (resultSet, rowNumber) ->
+                    new FamilyState(
+                        resultSet.getTimestamp(
+                            "revoked_at"
+                        ),
+                        resultSet.getString(
+                            "revocation_reason"
+                        )
+                    ),
+                digest
+            );
+
+        assertThat(familyState)
+            .isNotNull();
+
+        assertThat(familyState.revokedAt())
+            .isNull();
+
+        assertThat(familyState.reason())
+            .isNull();
     }
 
     private void assertInitialSessionUnchanged(


### PR DESCRIPTION
## Summary

- add public `POST /api/v1/auth/logout`
- accept an opaque refresh token through a redacted write-only request DTO
- return `204 No Content` without revealing token or family state
- lock the refresh-token record and family before applying current-session revocation
- durably revoke an active family with `CURRENT_SESSION_LOGOUT`
- allow consumed or expired historical records to identify and revoke a still-active family
- preserve an earlier family revocation reason
- generate no access token or successor refresh credential during logout

## Transaction and concurrency guarantees

- family persistence is flushed inside the logout transaction
- persistence failure rolls back the complete revocation
- logout and refresh rotation serialize through PostgreSQL pessimistic row locks
- logout-first rejects the competing rotation without creating a successor
- rotation-first may return one successor, then delayed logout revokes the family
- the returned successor is rejected after logout
- no additional successor records are created

## API and security contract

- anonymous access is permitted so an expired access token cannot block logout
- missing or blank credentials use the standard validation-error response
- malformed, unknown, consumed, expired, and already-revoked credentials share the same public `204` outcome
- OpenAPI marks the refresh token as write-only and documents no authentication requirement

## Verification

- `./mvnw clean verify`
- 808 tests
- 0 failures
- 0 errors
- 0 skipped
- UTF-8 without BOM and LF line endings
- Git whitespace and high-confidence secret checks passed

Closes #90
