### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+<!-- payflow-release-v0.8.0 -->
+# Changelog
+
+All notable PayFlow changes are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.8.0] - 2026-07-29
+
+### Added
+
+- Durable opaque refresh-token sessions backed by PostgreSQL.
+- SHA-256 digest-only refresh credential persistence and secure token generation.
+- Refresh credentials issued during successful login.
+- Single-use refresh-token rotation with access and refresh credential renewal.
+- Refresh-token family revocation when consumed-token reuse is detected.
+- Public `POST /api/v1/auth/logout` for current-session family revocation.
+- OpenAPI contracts and security configuration for refresh and logout operations.
+- PostgreSQL integration coverage for persistence, locking, rollback, and concurrency.
+
+### Security
+
+- Raw refresh credentials and stored digests remain redacted from public representations.
+- Refresh rotation serializes on pessimistic record and family locks.
+- Reuse detection invalidates every credential in the affected family.
+- Logout returns a state-independent `204 No Content` response for validly shaped credentials.
+- Logout-versus-rotation races preserve one-successor and first-revocation-reason guarantees.
+- Persistence failures roll back session mutations instead of returning false success.
+
+### Database
+
+- Added `V14__create_refresh_token_sessions.sql` for refresh-token families and records.
+
+### Completed milestone work
+
+- [#80](https://github.com/nursena-pc/payflow/issues/80) chore: start v0.8.0 development
+- [#82](https://github.com/nursena-pc/payflow/issues/82) feat(auth): add secure refresh-token cryptography adapters
+- [#84](https://github.com/nursena-pc/payflow/issues/84) feat(auth): issue refresh credentials on login
+- [#86](https://github.com/nursena-pc/payflow/issues/86) feat(auth): rotate refresh credentials
+- [#88](https://github.com/nursena-pc/payflow/issues/88) feat(auth): revoke refresh-token family on reuse
+- [#90](https://github.com/nursena-pc/payflow/issues/90) feat(auth): revoke current refresh-token session on logout
+
+[0.8.0]: https://github.com/nursena-pc/payflow/compare/v0.7.0...v0.8.0

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.8.0</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0-SNAPSHOT</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 

--- a/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
@@ -29,6 +29,46 @@ public final class OpenApiExamples {
         }
         """;
 
+    public static final String REFRESH_SUCCESS =
+        """
+        {
+          "accessToken": "eyJhbGciOiJSUzI1NiJ9...",
+          "tokenType": "Bearer",
+          "expiresAt": "2026-07-28T12:15:00Z",
+          "refreshToken": "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8",
+          "refreshTokenExpiresAt": "2026-08-04T12:00:00Z"
+        }
+        """;
+
+    public static final String REFRESH_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-28T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/auth/refresh",
+          "violations": [
+            {
+              "field": "refreshToken",
+              "message": "Refresh token is required."
+            }
+          ]
+        }
+        """;
+
+    public static final String INVALID_REFRESH_TOKEN =
+        """
+        {
+          "timestamp": "2026-07-28T12:00:00Z",
+          "status": 401,
+          "code": "REFRESH_TOKEN_INVALID",
+          "message": "Refresh token is invalid.",
+          "path": "/api/v1/auth/refresh",
+          "violations": []
+        }
+        """;
+
     public static final String REGISTER_VALIDATION_ERROR =
         """
         {

--- a/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
@@ -23,7 +23,9 @@ public final class OpenApiExamples {
         {
           "accessToken": "eyJhbGciOiJSUzI1NiJ9...",
           "tokenType": "Bearer",
-          "expiresAt": "2026-07-17T12:15:00Z"
+          "expiresAt": "2026-07-17T12:15:00Z",
+          "refreshToken": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA",
+          "refreshTokenExpiresAt": "2026-07-24T12:00:00Z"
         }
         """;
 

--- a/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
@@ -57,6 +57,23 @@ public final class OpenApiExamples {
         }
         """;
 
+    public static final String LOGOUT_VALIDATION_ERROR =
+        """
+        {
+          "timestamp": "2026-07-29T12:00:00Z",
+          "status": 400,
+          "code": "VALIDATION_FAILED",
+          "message": "Request validation failed.",
+          "path": "/api/v1/auth/logout",
+          "violations": [
+            {
+              "field": "refreshToken",
+              "message": "Refresh token is required."
+            }
+          ]
+        }
+        """;
+
     public static final String INVALID_REFRESH_TOKEN =
         """
         {

--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -28,7 +28,8 @@ public class SecurityConfiguration {
         "/swagger-ui/**",
         "/api/v1/auth/register",
         "/api/v1/auth/login",
-        "/api/v1/auth/refresh"
+        "/api/v1/auth/refresh",
+        "/api/v1/auth/logout"
     };
 
     @Bean

--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -27,7 +27,8 @@ public class SecurityConfiguration {
         "/swagger-ui.html",
         "/swagger-ui/**",
         "/api/v1/auth/register",
-        "/api/v1/auth/login"
+        "/api/v1/auth/login",
+        "/api/v1/auth/refresh"
     };
 
     @Bean

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserController.java
@@ -1,5 +1,9 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiExamples;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserUseCase;
@@ -16,37 +20,35 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-
-import com.nursena.payflow.common.api.ApiError;
-import com.nursena.payflow.configuration.OpenApiExamples;
 
 @Tag(
     name = "Authentication",
     description =
         "Public user registration and authentication operations."
 )
-
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthenticateUserController {
 
     private static final String TOKEN_TYPE = "Bearer";
 
-    private final AuthenticateUserUseCase authenticateUserUseCase;
+    private final AuthenticateUserUseCase
+        authenticateUserUseCase;
 
     public AuthenticateUserController(
         AuthenticateUserUseCase authenticateUserUseCase
     ) {
-        this.authenticateUserUseCase = authenticateUserUseCase;
+        this.authenticateUserUseCase =
+            authenticateUserUseCase;
     }
 
     @Operation(
         operationId = "authenticateUser",
         summary = "Authenticate a user",
         description =
-            "Validates user credentials and returns an "
-                + "RSA-signed JWT access token."
+            "Validates user credentials and returns "
+                + "an RSA-signed JWT access token and "
+                + "an opaque refresh token."
     )
     @ApiResponses({
         @ApiResponse(
@@ -110,10 +112,11 @@ public class AuthenticateUserController {
             )
         )
     })
-
     @PostMapping("/login")
-    public ResponseEntity<AuthenticateUserResponse> authenticate(
-        @Valid @RequestBody AuthenticateUserRequest request
+    public ResponseEntity<AuthenticateUserResponse>
+    authenticate(
+        @Valid @RequestBody
+        AuthenticateUserRequest request
     ) {
         AuthenticateUserCommand command =
             new AuthenticateUserCommand(
@@ -122,13 +125,17 @@ public class AuthenticateUserController {
             );
 
         AuthenticateUserResult result =
-            authenticateUserUseCase.authenticate(command);
+            authenticateUserUseCase.authenticate(
+                command
+            );
 
         AuthenticateUserResponse response =
             new AuthenticateUserResponse(
                 result.accessToken(),
                 TOKEN_TYPE,
-                result.expiresAt()
+                result.expiresAt(),
+                result.refreshToken(),
+                result.refreshTokenExpiresAt()
             );
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserResponse.java
@@ -1,13 +1,15 @@
 package com.nursena.payflow.user.adapter.in.web;
 
 import java.time.Instant;
+import java.util.Objects;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(
     name = "AuthenticateUserResponse",
     description =
-        "JWT access token returned after successful authentication."
+        "Access and refresh credentials returned after "
+            + "successful authentication."
 )
 public record AuthenticateUserResponse(
 
@@ -19,7 +21,7 @@ public record AuthenticateUserResponse(
 
     @Schema(
         description =
-            "Authentication scheme used with the token.",
+            "Authentication scheme used with the access token.",
         example = "Bearer"
     )
     String tokenType,
@@ -29,6 +31,67 @@ public record AuthenticateUserResponse(
         example = "2026-07-17T12:15:00Z",
         format = "date-time"
     )
-    Instant expiresAt
+    Instant expiresAt,
+
+    @Schema(
+        description =
+            "Opaque refresh token used to obtain new credentials.",
+        example =
+            "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA"
+    )
+    String refreshToken,
+
+    @Schema(
+        description = "Refresh-token expiration time.",
+        example = "2026-07-24T12:00:00Z",
+        format = "date-time"
+    )
+    Instant refreshTokenExpiresAt
 ) {
+
+    public AuthenticateUserResponse {
+        Objects.requireNonNull(
+            accessToken,
+            "accessToken must not be null"
+        );
+        Objects.requireNonNull(
+            tokenType,
+            "tokenType must not be null"
+        );
+        Objects.requireNonNull(
+            expiresAt,
+            "expiresAt must not be null"
+        );
+        Objects.requireNonNull(
+            refreshToken,
+            "refreshToken must not be null"
+        );
+        Objects.requireNonNull(
+            refreshTokenExpiresAt,
+            "refreshTokenExpiresAt must not be null"
+        );
+
+        if (accessToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "accessToken must not be blank"
+            );
+        }
+
+        if (tokenType.isBlank()) {
+            throw new IllegalArgumentException(
+                "tokenType must not be blank"
+            );
+        }
+
+        if (refreshToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "refreshToken must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AuthenticateUserResponse[redacted]";
+    }
 }

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionController.java
@@ -1,0 +1,91 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiExamples;
+import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionCommand;
+import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+    name = "Authentication",
+    description =
+        "Public user registration and authentication operations."
+)
+@RestController
+@RequestMapping("/api/v1/auth")
+public class RevokeCurrentRefreshSessionController {
+
+    private final RevokeCurrentRefreshSessionUseCase
+        revokeCurrentRefreshSessionUseCase;
+
+    public RevokeCurrentRefreshSessionController(
+        RevokeCurrentRefreshSessionUseCase
+            revokeCurrentRefreshSessionUseCase
+    ) {
+        this.revokeCurrentRefreshSessionUseCase =
+            revokeCurrentRefreshSessionUseCase;
+    }
+
+    @Operation(
+        operationId = "revokeCurrentRefreshSession",
+        summary = "Log out the current refresh session",
+        description =
+            "Revokes the refresh-token family represented "
+                + "by the submitted opaque credential. "
+                + "The response does not reveal whether "
+                + "the credential exists or remains active."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description =
+                "The logout request was processed without "
+                    + "exposing refresh-token state."
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .LOGOUT_VALIDATION_ERROR
+                )
+            )
+        )
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+        @Valid @RequestBody
+        RevokeCurrentRefreshSessionRequest request
+    ) {
+        RevokeCurrentRefreshSessionCommand command =
+            new RevokeCurrentRefreshSessionCommand(
+                request.refreshToken()
+            );
+
+        revokeCurrentRefreshSessionUseCase.revoke(
+            command
+        );
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionRequest.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionRequest.java
@@ -1,0 +1,33 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(
+    name = "RevokeCurrentRefreshSessionRequest",
+    description =
+        "Opaque refresh credential submitted to end "
+            + "the represented refresh-token session."
+)
+public record RevokeCurrentRefreshSessionRequest(
+
+    @Schema(
+        description =
+            "Opaque refresh token returned by login "
+                + "or a previous refresh operation.",
+        example =
+            "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA",
+        format = "password",
+        accessMode = Schema.AccessMode.WRITE_ONLY
+    )
+    @NotBlank(
+        message = "Refresh token is required."
+    )
+    String refreshToken
+) {
+
+    @Override
+    public String toString() {
+        return "RevokeCurrentRefreshSessionRequest[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsController.java
@@ -1,0 +1,132 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.configuration.OpenApiExamples;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsCommand;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+    name = "Authentication",
+    description =
+        "Public user registration and authentication operations."
+)
+@RestController
+@RequestMapping("/api/v1/auth")
+public class RotateRefreshCredentialsController {
+
+    private static final String TOKEN_TYPE =
+        "Bearer";
+
+    private final RotateRefreshCredentialsUseCase
+        rotateRefreshCredentialsUseCase;
+
+    public RotateRefreshCredentialsController(
+        RotateRefreshCredentialsUseCase
+            rotateRefreshCredentialsUseCase
+    ) {
+        this.rotateRefreshCredentialsUseCase =
+            rotateRefreshCredentialsUseCase;
+    }
+
+    @Operation(
+        operationId = "rotateRefreshCredentials",
+        summary = "Rotate refresh credentials",
+        description =
+            "Consumes an active opaque refresh token "
+                + "and returns a new access and refresh "
+                + "credential pair."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description =
+                "Refresh credentials rotated successfully.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation =
+                        RotateRefreshCredentialsResponse.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples.REFRESH_SUCCESS
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Request validation failed.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .REFRESH_VALIDATION_ERROR
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "The refresh credential is invalid.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .INVALID_REFRESH_TOKEN
+                )
+            )
+        )
+    })
+    @PostMapping("/refresh")
+    public ResponseEntity<
+        RotateRefreshCredentialsResponse
+    > rotate(
+        @Valid @RequestBody
+        RotateRefreshCredentialsRequest request
+    ) {
+        RotateRefreshCredentialsCommand command =
+            new RotateRefreshCredentialsCommand(
+                request.refreshToken()
+            );
+
+        RotateRefreshCredentialsResult result =
+            rotateRefreshCredentialsUseCase.rotate(
+                command
+            );
+
+        RotateRefreshCredentialsResponse response =
+            new RotateRefreshCredentialsResponse(
+                result.accessToken(),
+                TOKEN_TYPE,
+                result.expiresAt(),
+                result.refreshToken(),
+                result.refreshTokenExpiresAt()
+            );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsRequest.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsRequest.java
@@ -1,0 +1,33 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(
+    name = "RotateRefreshCredentialsRequest",
+    description =
+        "Opaque refresh credential submitted for "
+            + "single-use rotation."
+)
+public record RotateRefreshCredentialsRequest(
+
+    @Schema(
+        description =
+            "Opaque refresh token returned by login "
+                + "or a previous refresh operation.",
+        example =
+            "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA",
+        format = "password",
+        accessMode = Schema.AccessMode.WRITE_ONLY
+    )
+    @NotBlank(
+        message = "Refresh token is required."
+    )
+    String refreshToken
+) {
+
+    @Override
+    public String toString() {
+        return "RotateRefreshCredentialsRequest[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsResponse.java
@@ -1,0 +1,98 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "RotateRefreshCredentialsResponse",
+    description =
+        "New access and refresh credentials returned "
+            + "after successful refresh-token rotation."
+)
+public record RotateRefreshCredentialsResponse(
+
+    @Schema(
+        description = "RSA-signed JWT access token.",
+        example = "eyJhbGciOiJSUzI1NiJ9..."
+    )
+    String accessToken,
+
+    @Schema(
+        description =
+            "Authentication scheme used with the access token.",
+        example = "Bearer"
+    )
+    String tokenType,
+
+    @Schema(
+        description = "Access-token expiration time.",
+        example = "2026-07-28T12:15:00Z",
+        format = "date-time"
+    )
+    Instant expiresAt,
+
+    @Schema(
+        description =
+            "New opaque refresh token replacing the "
+                + "presented refresh token.",
+        example =
+            "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8"
+    )
+    String refreshToken,
+
+    @Schema(
+        description = "New refresh-token expiration time.",
+        example = "2026-08-04T12:00:00Z",
+        format = "date-time"
+    )
+    Instant refreshTokenExpiresAt
+) {
+
+    public RotateRefreshCredentialsResponse {
+        Objects.requireNonNull(
+            accessToken,
+            "accessToken must not be null"
+        );
+        Objects.requireNonNull(
+            tokenType,
+            "tokenType must not be null"
+        );
+        Objects.requireNonNull(
+            expiresAt,
+            "expiresAt must not be null"
+        );
+        Objects.requireNonNull(
+            refreshToken,
+            "refreshToken must not be null"
+        );
+        Objects.requireNonNull(
+            refreshTokenExpiresAt,
+            "refreshTokenExpiresAt must not be null"
+        );
+
+        if (accessToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "accessToken must not be blank"
+            );
+        }
+
+        if (tokenType.isBlank()) {
+            throw new IllegalArgumentException(
+                "tokenType must not be blank"
+            );
+        }
+
+        if (refreshToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "refreshToken must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RotateRefreshCredentialsResponse[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/UserAuthenticationExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/UserAuthenticationExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.nursena.payflow.common.api.ApiError;
 import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
 import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.Ordered;
@@ -16,7 +17,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RestControllerAdvice(
-    assignableTypes = AuthenticateUserController.class
+    assignableTypes = {
+        AuthenticateUserController.class,
+        RotateRefreshCredentialsController.class
+    }
 )
 public class UserAuthenticationExceptionHandler {
 
@@ -40,6 +44,21 @@ public class UserAuthenticationExceptionHandler {
     ) {
         return buildResponse(
             HttpStatus.FORBIDDEN,
+            exception.getCode(),
+            exception.getMessage(),
+            request
+        );
+    }
+
+    @ExceptionHandler(
+        InvalidRefreshTokenException.class
+    )
+    ResponseEntity<ApiError> handleInvalidRefreshToken(
+        InvalidRefreshTokenException exception,
+        HttpServletRequest request
+    ) {
+        return buildResponse(
+            HttpStatus.UNAUTHORIZED,
             exception.getCode(),
             exception.getMessage(),
             request

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/JwtConfiguration.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/JwtConfiguration.java
@@ -5,7 +5,6 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
-import java.time.Clock;
 import java.util.UUID;
 
 import com.nimbusds.jose.jwk.JWKSet;
@@ -30,10 +29,6 @@ class JwtConfiguration {
 
     private static final int RSA_KEY_SIZE = 2048;
 
-    @Bean
-    Clock jwtClock() {
-        return Clock.systemUTC();
-    }
 
     @Bean
     KeyPair jwtKeyPair() {

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionConfiguration.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionConfiguration.java
@@ -1,0 +1,24 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import com.nursena.payflow.user.application.service.RefreshSessionLifetimePolicy;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(
+    RefreshSessionProperties.class
+)
+class RefreshSessionConfiguration {
+
+    @Bean
+    RefreshSessionLifetimePolicy
+    refreshSessionLifetimePolicy(
+        RefreshSessionProperties properties
+    ) {
+        return new RefreshSessionLifetimePolicy(
+            properties.refreshTokenTtl(),
+            properties.familyTtl()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionProperties.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionProperties.java
@@ -1,0 +1,50 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(
+    prefix = "payflow.security.refresh-session"
+)
+public record RefreshSessionProperties(
+    Duration refreshTokenTtl,
+    Duration familyTtl
+) {
+
+    public RefreshSessionProperties {
+        Objects.requireNonNull(
+            refreshTokenTtl,
+            "refreshTokenTtl must not be null"
+        );
+        Objects.requireNonNull(
+            familyTtl,
+            "familyTtl must not be null"
+        );
+
+        requirePositive(
+            refreshTokenTtl,
+            "refreshTokenTtl"
+        );
+
+        requirePositive(
+            familyTtl,
+            "familyTtl"
+        );
+    }
+
+    private static void requirePositive(
+        Duration value,
+        String propertyName
+    ) {
+        if (
+            value.isZero()
+                || value.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                propertyName + " must be positive"
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/RefreshTokenCryptographyConfiguration.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/RefreshTokenCryptographyConfiguration.java
@@ -1,0 +1,28 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import java.security.SecureRandom;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+class RefreshTokenCryptographyConfiguration {
+
+    @Bean
+    RefreshTokenGenerationPort
+    refreshTokenGenerationPort() {
+        return new
+            SecureRandomRefreshTokenGenerationAdapter(
+            new SecureRandom()
+        );
+    }
+
+    @Bean
+    RefreshTokenDigestPort
+    refreshTokenDigestPort() {
+        return new
+            Sha256RefreshTokenDigestAdapter();
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/SecureRandomRefreshTokenGenerationAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/SecureRandomRefreshTokenGenerationAdapter.java
@@ -1,0 +1,66 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+
+final class SecureRandomRefreshTokenGenerationAdapter
+    implements RefreshTokenGenerationPort {
+
+    static final int ENTROPY_LENGTH_BYTES = 32;
+    static final int ENCODED_TOKEN_LENGTH = 43;
+
+    private static final Base64.Encoder TOKEN_ENCODER =
+        Base64.getUrlEncoder()
+            .withoutPadding();
+
+    private final SecureRandom secureRandom;
+
+    SecureRandomRefreshTokenGenerationAdapter(
+        SecureRandom secureRandom
+    ) {
+        this.secureRandom =
+            Objects.requireNonNull(
+                secureRandom,
+                "secureRandom must not be null"
+            );
+    }
+
+    @Override
+    public GeneratedRefreshToken generate() {
+        byte[] randomBytes =
+            new byte[ENTROPY_LENGTH_BYTES];
+
+        try {
+            secureRandom.nextBytes(randomBytes);
+
+            String encodedToken =
+                TOKEN_ENCODER.encodeToString(
+                    randomBytes
+                );
+
+            if (
+                encodedToken.length()
+                    != ENCODED_TOKEN_LENGTH
+            ) {
+                throw new IllegalStateException(
+                    "Generated refresh token has "
+                        + "an unexpected encoded length."
+                );
+            }
+
+            return new GeneratedRefreshToken(
+                encodedToken
+            );
+        } finally {
+            Arrays.fill(
+                randomBytes,
+                (byte) 0
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/Sha256RefreshTokenDigestAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/Sha256RefreshTokenDigestAdapter.java
@@ -1,0 +1,151 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+
+final class Sha256RefreshTokenDigestAdapter
+    implements RefreshTokenDigestPort {
+
+    static final int TOKEN_LENGTH_BYTES = 32;
+    static final int ENCODED_TOKEN_LENGTH = 43;
+
+    private static final String SHA_256 =
+        "SHA-256";
+
+    private static final Base64.Decoder TOKEN_DECODER =
+        Base64.getUrlDecoder();
+
+    private static final Base64.Encoder TOKEN_ENCODER =
+        Base64.getUrlEncoder()
+            .withoutPadding();
+
+    @Override
+    public RefreshTokenDigest digest(
+        String refreshToken
+    ) {
+        byte[] decodedToken =
+            decodeCanonicalToken(
+                refreshToken
+            );
+
+        try {
+            byte[] digestBytes =
+                messageDigest().digest(
+                    decodedToken
+                );
+
+            return RefreshTokenDigest.of(
+                digestBytes
+            );
+        } finally {
+            Arrays.fill(
+                decodedToken,
+                (byte) 0
+            );
+        }
+    }
+
+    private static byte[] decodeCanonicalToken(
+        String refreshToken
+    ) {
+        if (
+            refreshToken == null
+                || refreshToken.length()
+                != ENCODED_TOKEN_LENGTH
+                || !containsOnlyBase64UrlCharacters(
+                    refreshToken
+                )
+        ) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        byte[] decodedToken;
+
+        try {
+            decodedToken =
+                TOKEN_DECODER.decode(
+                    refreshToken
+                );
+        } catch (IllegalArgumentException ignored) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        if (
+            decodedToken.length
+                != TOKEN_LENGTH_BYTES
+        ) {
+            Arrays.fill(
+                decodedToken,
+                (byte) 0
+            );
+
+            throw new InvalidRefreshTokenException();
+        }
+
+        String canonicalValue =
+            TOKEN_ENCODER.encodeToString(
+                decodedToken
+            );
+
+        if (!canonicalValue.equals(refreshToken)) {
+            Arrays.fill(
+                decodedToken,
+                (byte) 0
+            );
+
+            throw new InvalidRefreshTokenException();
+        }
+
+        return decodedToken;
+    }
+
+    private static boolean
+    containsOnlyBase64UrlCharacters(
+        String value
+    ) {
+        for (
+            int index = 0;
+            index < value.length();
+            index++
+        ) {
+            char character =
+                value.charAt(index);
+
+            boolean supported =
+                character >= 'A'
+                    && character <= 'Z'
+                    || character >= 'a'
+                    && character <= 'z'
+                    || character >= '0'
+                    && character <= '9'
+                    || character == '-'
+                    || character == '_';
+
+            if (!supported) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static MessageDigest messageDigest() {
+        try {
+            return MessageDigest.getInstance(
+                SHA_256
+            );
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(
+                "SHA-256 message digest "
+                    + "is not available.",
+                exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/AuthenticateUserResult.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/AuthenticateUserResult.java
@@ -5,7 +5,9 @@ import java.util.Objects;
 
 public record AuthenticateUserResult(
     String accessToken,
-    Instant expiresAt
+    Instant expiresAt,
+    String refreshToken,
+    Instant refreshTokenExpiresAt
 ) {
 
     public AuthenticateUserResult {
@@ -17,11 +19,30 @@ public record AuthenticateUserResult(
             expiresAt,
             "expiresAt must not be null"
         );
+        Objects.requireNonNull(
+            refreshToken,
+            "refreshToken must not be null"
+        );
+        Objects.requireNonNull(
+            refreshTokenExpiresAt,
+            "refreshTokenExpiresAt must not be null"
+        );
 
         if (accessToken.isBlank()) {
             throw new IllegalArgumentException(
                 "accessToken must not be blank"
             );
         }
+
+        if (refreshToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "refreshToken must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AuthenticateUserResult[redacted]";
     }
 }

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RevokeCurrentRefreshSessionCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RevokeCurrentRefreshSessionCommand.java
@@ -1,0 +1,26 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.util.Objects;
+
+public record RevokeCurrentRefreshSessionCommand(
+    String refreshToken
+) {
+
+    public RevokeCurrentRefreshSessionCommand {
+        Objects.requireNonNull(
+            refreshToken,
+            "refreshToken must not be null"
+        );
+
+        if (refreshToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "refreshToken must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RevokeCurrentRefreshSessionCommand[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RevokeCurrentRefreshSessionUseCase.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RevokeCurrentRefreshSessionUseCase.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.user.application.port.in;
+
+public interface RevokeCurrentRefreshSessionUseCase {
+
+    void revoke(
+        RevokeCurrentRefreshSessionCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsCommand.java
@@ -1,0 +1,26 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.util.Objects;
+
+public record RotateRefreshCredentialsCommand(
+    String refreshToken
+) {
+
+    public RotateRefreshCredentialsCommand {
+        Objects.requireNonNull(
+            refreshToken,
+            "refreshToken must not be null"
+        );
+
+        if (refreshToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "refreshToken must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RotateRefreshCredentialsCommand[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsResult.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsResult.java
@@ -1,0 +1,48 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record RotateRefreshCredentialsResult(
+    String accessToken,
+    Instant expiresAt,
+    String refreshToken,
+    Instant refreshTokenExpiresAt
+) {
+
+    public RotateRefreshCredentialsResult {
+        Objects.requireNonNull(
+            accessToken,
+            "accessToken must not be null"
+        );
+        Objects.requireNonNull(
+            expiresAt,
+            "expiresAt must not be null"
+        );
+        Objects.requireNonNull(
+            refreshToken,
+            "refreshToken must not be null"
+        );
+        Objects.requireNonNull(
+            refreshTokenExpiresAt,
+            "refreshTokenExpiresAt must not be null"
+        );
+
+        if (accessToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "accessToken must not be blank"
+            );
+        }
+
+        if (refreshToken.isBlank()) {
+            throw new IllegalArgumentException(
+                "refreshToken must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RotateRefreshCredentialsResult[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsUseCase.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsUseCase.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.user.application.port.in;
+
+public interface RotateRefreshCredentialsUseCase {
+
+    RotateRefreshCredentialsResult rotate(
+        RotateRefreshCredentialsCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/AuthenticateUserService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/AuthenticateUserService.java
@@ -1,53 +1,134 @@
 package com.nursena.payflow.user.application.service;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.UUID;
+
 import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserUseCase;
-import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
-import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
 import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
 import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
 import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
 import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
 import com.nursena.payflow.user.domain.model.User;
 import com.nursena.payflow.user.domain.model.UserStatus;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 public class AuthenticateUserService
     implements AuthenticateUserUseCase {
 
     private final UserRepositoryPort userRepository;
     private final PasswordVerificationPort passwordVerification;
+    private final RefreshTokenGenerationPort refreshTokenGeneration;
+    private final RefreshTokenDigestPort refreshTokenDigest;
+    private final RefreshTokenFamilyRepositoryPort familyRepository;
+    private final RefreshTokenRecordRepositoryPort recordRepository;
     private final AccessTokenGenerationPort accessTokenGeneration;
+    private final RefreshSessionLifetimePolicy lifetimePolicy;
+    private final Clock clock;
 
     public AuthenticateUserService(
         UserRepositoryPort userRepository,
         PasswordVerificationPort passwordVerification,
-        AccessTokenGenerationPort accessTokenGeneration
+        RefreshTokenGenerationPort refreshTokenGeneration,
+        RefreshTokenDigestPort refreshTokenDigest,
+        RefreshTokenFamilyRepositoryPort familyRepository,
+        RefreshTokenRecordRepositoryPort recordRepository,
+        AccessTokenGenerationPort accessTokenGeneration,
+        RefreshSessionLifetimePolicy lifetimePolicy,
+        Clock clock
     ) {
-        this.userRepository = userRepository;
-        this.passwordVerification = passwordVerification;
-        this.accessTokenGeneration = accessTokenGeneration;
+        this.userRepository =
+            Objects.requireNonNull(
+                userRepository,
+                "userRepository must not be null"
+            );
+
+        this.passwordVerification =
+            Objects.requireNonNull(
+                passwordVerification,
+                "passwordVerification must not be null"
+            );
+
+        this.refreshTokenGeneration =
+            Objects.requireNonNull(
+                refreshTokenGeneration,
+                "refreshTokenGeneration must not be null"
+            );
+
+        this.refreshTokenDigest =
+            Objects.requireNonNull(
+                refreshTokenDigest,
+                "refreshTokenDigest must not be null"
+            );
+
+        this.familyRepository =
+            Objects.requireNonNull(
+                familyRepository,
+                "familyRepository must not be null"
+            );
+
+        this.recordRepository =
+            Objects.requireNonNull(
+                recordRepository,
+                "recordRepository must not be null"
+            );
+
+        this.accessTokenGeneration =
+            Objects.requireNonNull(
+                accessTokenGeneration,
+                "accessTokenGeneration must not be null"
+            );
+
+        this.lifetimePolicy =
+            Objects.requireNonNull(
+                lifetimePolicy,
+                "lifetimePolicy must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public AuthenticateUserResult authenticate(
         AuthenticateUserCommand command
     ) {
-        EmailAddress email = EmailAddress.of(command.email());
+        EmailAddress email =
+            EmailAddress.of(command.email());
 
         User user = userRepository.findByEmail(email)
-            .orElseThrow(InvalidCredentialsException::new);
+            .orElseThrow(
+                InvalidCredentialsException::new
+            );
 
-        boolean passwordMatches = passwordVerification.matches(
-            command.rawPassword(),
-            user.passwordHash()
-        );
+        boolean passwordMatches =
+            passwordVerification.matches(
+                command.rawPassword(),
+                user.passwordHash()
+            );
 
         if (!passwordMatches) {
             throw new InvalidCredentialsException();
@@ -57,11 +138,72 @@ public class AuthenticateUserService
             throw new UserAccountUnavailableException();
         }
 
-        GeneratedAccessToken token = accessTokenGeneration.generate(user);
+        Instant issuedAt =
+            clock.instant()
+                .truncatedTo(
+                    ChronoUnit.MICROS
+                );
+
+        GeneratedRefreshToken generatedRefreshToken =
+            refreshTokenGeneration.generate();
+
+        RefreshTokenDigest digest =
+            refreshTokenDigest.digest(
+                generatedRefreshToken.value()
+            );
+
+        Instant familyExpiresAt =
+            lifetimePolicy.familyExpiresAt(
+                issuedAt
+            );
+
+        RefreshTokenFamily family =
+            RefreshTokenFamily.create(
+                RefreshTokenFamilyId.of(
+                    UUID.randomUUID()
+                ),
+                user.id(),
+                issuedAt,
+                familyExpiresAt
+            );
+
+        RefreshTokenFamily savedFamily =
+            familyRepository.save(
+                family
+            );
+
+        Instant refreshTokenExpiresAt =
+            lifetimePolicy.refreshTokenExpiresAt(
+                issuedAt,
+                savedFamily.expiresAt()
+            );
+
+        RefreshTokenRecord record =
+            RefreshTokenRecord.issue(
+                RefreshTokenRecordId.of(
+                    UUID.randomUUID()
+                ),
+                savedFamily,
+                digest,
+                issuedAt,
+                refreshTokenExpiresAt
+            );
+
+        RefreshTokenRecord savedRecord =
+            recordRepository.save(
+                record
+            );
+
+        GeneratedAccessToken accessToken =
+            accessTokenGeneration.generate(
+                user
+            );
 
         return new AuthenticateUserResult(
-            token.value(),
-            token.expiresAt()
+            accessToken.value(),
+            accessToken.expiresAt(),
+            generatedRefreshToken.value(),
+            savedRecord.expiresAt()
         );
     }
 }

--- a/src/main/java/com/nursena/payflow/user/application/service/RefreshSessionLifetimePolicy.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RefreshSessionLifetimePolicy.java
@@ -1,0 +1,102 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+public final class RefreshSessionLifetimePolicy {
+
+    private final Duration refreshTokenTtl;
+    private final Duration familyTtl;
+
+    public RefreshSessionLifetimePolicy(
+        Duration refreshTokenTtl,
+        Duration familyTtl
+    ) {
+        this.refreshTokenTtl =
+            requirePositive(
+                refreshTokenTtl,
+                "refreshTokenTtl"
+            );
+
+        this.familyTtl =
+            requirePositive(
+                familyTtl,
+                "familyTtl"
+            );
+    }
+
+    public Instant familyExpiresAt(
+        Instant issuedAt
+    ) {
+        Instant checkedIssuedAt =
+            Objects.requireNonNull(
+                issuedAt,
+                "issuedAt must not be null"
+            );
+
+        return checkedIssuedAt.plus(
+            familyTtl
+        );
+    }
+
+    public Instant refreshTokenExpiresAt(
+        Instant issuedAt,
+        Instant familyExpiresAt
+    ) {
+        Instant checkedIssuedAt =
+            Objects.requireNonNull(
+                issuedAt,
+                "issuedAt must not be null"
+            );
+
+        Instant checkedFamilyExpiresAt =
+            Objects.requireNonNull(
+                familyExpiresAt,
+                "familyExpiresAt must not be null"
+            );
+
+        if (
+            !checkedFamilyExpiresAt.isAfter(
+                checkedIssuedAt
+            )
+        ) {
+            throw new IllegalArgumentException(
+                "familyExpiresAt must be after issuedAt"
+            );
+        }
+
+        Instant requestedExpiresAt =
+            checkedIssuedAt.plus(
+                refreshTokenTtl
+            );
+
+        return requestedExpiresAt.isAfter(
+            checkedFamilyExpiresAt
+        )
+            ? checkedFamilyExpiresAt
+            : requestedExpiresAt;
+    }
+
+    private static Duration requirePositive(
+        Duration value,
+        String propertyName
+    ) {
+        Duration checkedValue =
+            Objects.requireNonNull(
+                value,
+                propertyName + " must not be null"
+            );
+
+        if (
+            checkedValue.isZero()
+                || checkedValue.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                propertyName + " must be positive"
+            );
+        }
+
+        return checkedValue;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionService.java
@@ -1,0 +1,68 @@
+package com.nursena.payflow.user.application.service;
+
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionCommand;
+import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionUseCase;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RevokeCurrentRefreshSessionService
+    implements RevokeCurrentRefreshSessionUseCase {
+
+    private final RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    private final RevokeCurrentRefreshSessionTransaction
+        revocationTransaction;
+
+    public RevokeCurrentRefreshSessionService(
+        RefreshTokenDigestPort refreshTokenDigest,
+        RevokeCurrentRefreshSessionTransaction
+            revocationTransaction
+    ) {
+        this.refreshTokenDigest =
+            Objects.requireNonNull(
+                refreshTokenDigest,
+                "refreshTokenDigest must not be null"
+            );
+
+        this.revocationTransaction =
+            Objects.requireNonNull(
+                revocationTransaction,
+                "revocationTransaction must not be null"
+            );
+    }
+
+    @Override
+    public void revoke(
+        RevokeCurrentRefreshSessionCommand command
+    ) {
+        RevokeCurrentRefreshSessionCommand
+            checkedCommand =
+            Objects.requireNonNull(
+                command,
+                "command must not be null"
+            );
+
+        RefreshTokenDigest digest;
+
+        try {
+            digest =
+                refreshTokenDigest.digest(
+                    checkedCommand.refreshToken()
+                );
+        } catch (
+            InvalidRefreshTokenException ignored
+        ) {
+            return;
+        }
+
+        revocationTransaction.revoke(
+            digest
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionTransaction.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionTransaction.java
@@ -1,0 +1,107 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+class RevokeCurrentRefreshSessionTransaction {
+
+    private final RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    private final RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    private final Clock clock;
+
+    RevokeCurrentRefreshSessionTransaction(
+        RefreshTokenRecordRepositoryPort
+            recordRepository,
+        RefreshTokenFamilyRepositoryPort
+            familyRepository,
+        Clock clock
+    ) {
+        this.recordRepository =
+            Objects.requireNonNull(
+                recordRepository,
+                "recordRepository must not be null"
+            );
+
+        this.familyRepository =
+            Objects.requireNonNull(
+                familyRepository,
+                "familyRepository must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+    }
+
+    @Transactional
+    public void revoke(
+        RefreshTokenDigest digest
+    ) {
+        RefreshTokenDigest checkedDigest =
+            Objects.requireNonNull(
+                digest,
+                "digest must not be null"
+            );
+
+        RefreshTokenRecord record =
+            recordRepository
+                .findByDigestForUpdate(
+                    checkedDigest
+                )
+                .orElse(null);
+
+        if (record == null) {
+            return;
+        }
+
+        RefreshTokenFamily family =
+            familyRepository
+                .findByIdForUpdate(
+                    record.familyId()
+                )
+                .orElse(null);
+
+        if (family == null) {
+            return;
+        }
+
+        Instant revokedAt =
+            clock.instant()
+                .truncatedTo(
+                    ChronoUnit.MICROS
+                );
+
+        if (!family.isActiveAt(revokedAt)) {
+            return;
+        }
+
+        RefreshTokenFamily revokedFamily =
+            family.revoke(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT,
+                revokedAt
+            );
+
+        familyRepository.save(
+            revokedFamily
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsOutcome.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsOutcome.java
@@ -1,0 +1,28 @@
+package com.nursena.payflow.user.application.service;
+
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+
+sealed interface RotateRefreshCredentialsOutcome
+    permits RotateRefreshCredentialsOutcome.Succeeded,
+        RotateRefreshCredentialsOutcome.Rejected {
+
+    record Succeeded(
+        RotateRefreshCredentialsResult result
+    ) implements RotateRefreshCredentialsOutcome {
+
+        public Succeeded {
+            Objects.requireNonNull(
+                result,
+                "result must not be null"
+            );
+        }
+    }
+
+    enum Rejected
+        implements RotateRefreshCredentialsOutcome {
+
+        INSTANCE
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsService.java
@@ -1,31 +1,14 @@
 package com.nursena.payflow.user.application.service;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Objects;
-import java.util.UUID;
 
 import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsCommand;
 import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
 import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsUseCase;
-import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
-import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
-import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
 import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
-import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
 import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
-import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
-import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
-import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
-import com.nursena.payflow.user.domain.model.User;
-import com.nursena.payflow.user.domain.model.UserStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class RotateRefreshCredentialsService
@@ -34,38 +17,13 @@ public class RotateRefreshCredentialsService
     private final RefreshTokenDigestPort
         refreshTokenDigest;
 
-    private final RefreshTokenRecordRepositoryPort
-        recordRepository;
-
-    private final RefreshTokenFamilyRepositoryPort
-        familyRepository;
-
-    private final UserRepositoryPort userRepository;
-
-    private final RefreshTokenGenerationPort
-        refreshTokenGeneration;
-
-    private final AccessTokenGenerationPort
-        accessTokenGeneration;
-
-    private final RefreshSessionLifetimePolicy
-        lifetimePolicy;
-
-    private final Clock clock;
+    private final RotateRefreshCredentialsTransaction
+        rotationTransaction;
 
     public RotateRefreshCredentialsService(
         RefreshTokenDigestPort refreshTokenDigest,
-        RefreshTokenRecordRepositoryPort
-            recordRepository,
-        RefreshTokenFamilyRepositoryPort
-            familyRepository,
-        UserRepositoryPort userRepository,
-        RefreshTokenGenerationPort
-            refreshTokenGeneration,
-        AccessTokenGenerationPort
-            accessTokenGeneration,
-        RefreshSessionLifetimePolicy lifetimePolicy,
-        Clock clock
+        RotateRefreshCredentialsTransaction
+            rotationTransaction
     ) {
         this.refreshTokenDigest =
             Objects.requireNonNull(
@@ -73,56 +31,18 @@ public class RotateRefreshCredentialsService
                 "refreshTokenDigest must not be null"
             );
 
-        this.recordRepository =
+        this.rotationTransaction =
             Objects.requireNonNull(
-                recordRepository,
-                "recordRepository must not be null"
-            );
-
-        this.familyRepository =
-            Objects.requireNonNull(
-                familyRepository,
-                "familyRepository must not be null"
-            );
-
-        this.userRepository =
-            Objects.requireNonNull(
-                userRepository,
-                "userRepository must not be null"
-            );
-
-        this.refreshTokenGeneration =
-            Objects.requireNonNull(
-                refreshTokenGeneration,
-                "refreshTokenGeneration must not be null"
-            );
-
-        this.accessTokenGeneration =
-            Objects.requireNonNull(
-                accessTokenGeneration,
-                "accessTokenGeneration must not be null"
-            );
-
-        this.lifetimePolicy =
-            Objects.requireNonNull(
-                lifetimePolicy,
-                "lifetimePolicy must not be null"
-            );
-
-        this.clock =
-            Objects.requireNonNull(
-                clock,
-                "clock must not be null"
+                rotationTransaction,
+                "rotationTransaction must not be null"
             );
     }
 
     @Override
-    @Transactional
     public RotateRefreshCredentialsResult rotate(
         RotateRefreshCredentialsCommand command
     ) {
-        RotateRefreshCredentialsCommand
-            checkedCommand =
+        RotateRefreshCredentialsCommand checkedCommand =
             Objects.requireNonNull(
                 command,
                 "command must not be null"
@@ -133,107 +53,19 @@ public class RotateRefreshCredentialsService
                 checkedCommand.refreshToken()
             );
 
-        RefreshTokenRecord currentRecord =
-            recordRepository
-                .findByDigestForUpdate(
-                    currentDigest
-                )
-                .orElseThrow(
-                    InvalidRefreshTokenException::new
-                );
-
-        RefreshTokenFamily family =
-            familyRepository
-                .findByIdForUpdate(
-                    currentRecord.familyId()
-                )
-                .orElseThrow(
-                    InvalidRefreshTokenException::new
-                );
-
-        Instant rotatedAt =
-            clock.instant()
-                .truncatedTo(
-                    ChronoUnit.MICROS
-                );
+        RotateRefreshCredentialsOutcome outcome =
+            rotationTransaction.rotate(
+                currentDigest
+            );
 
         if (
-            !currentRecord.isActiveAt(
-                family,
-                rotatedAt
-            )
+            outcome instanceof
+                RotateRefreshCredentialsOutcome
+                    .Succeeded succeeded
         ) {
-            throw new InvalidRefreshTokenException();
+            return succeeded.result();
         }
 
-        User user =
-            userRepository
-                .findById(
-                    family.userId()
-                )
-                .filter(candidate ->
-                    candidate.status()
-                        == UserStatus.ACTIVE
-                )
-                .orElseThrow(
-                    InvalidRefreshTokenException::new
-                );
-
-        GeneratedRefreshToken generatedToken =
-            refreshTokenGeneration.generate();
-
-        RefreshTokenDigest successorDigest =
-            refreshTokenDigest.digest(
-                generatedToken.value()
-            );
-
-        RefreshTokenRecordId successorId =
-            RefreshTokenRecordId.of(
-                UUID.randomUUID()
-            );
-
-        Instant successorExpiresAt =
-            lifetimePolicy
-                .refreshTokenExpiresAt(
-                    rotatedAt,
-                    family.expiresAt()
-                );
-
-        RefreshTokenRecord successor =
-            RefreshTokenRecord.issue(
-                successorId,
-                family,
-                successorDigest,
-                rotatedAt,
-                successorExpiresAt
-            );
-
-        RefreshTokenRecord consumedCurrent =
-            currentRecord.consume(
-                successorId,
-                rotatedAt,
-                family
-            );
-
-        RefreshTokenRecord savedSuccessor =
-            recordRepository.save(
-                successor
-            );
-
-        recordRepository.save(
-            consumedCurrent
-        );
-
-        GeneratedAccessToken accessToken =
-            accessTokenGeneration.generate(
-                user
-            );
-
-        return new RotateRefreshCredentialsResult(
-            accessToken.value(),
-            accessToken.expiresAt(),
-            generatedToken.value(),
-            savedSuccessor.expiresAt()
-        );
+        throw new InvalidRefreshTokenException();
     }
 }

--- a/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsService.java
@@ -1,0 +1,239 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsCommand;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsUseCase;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model.User;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RotateRefreshCredentialsService
+    implements RotateRefreshCredentialsUseCase {
+
+    private final RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    private final RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    private final RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    private final UserRepositoryPort userRepository;
+
+    private final RefreshTokenGenerationPort
+        refreshTokenGeneration;
+
+    private final AccessTokenGenerationPort
+        accessTokenGeneration;
+
+    private final RefreshSessionLifetimePolicy
+        lifetimePolicy;
+
+    private final Clock clock;
+
+    public RotateRefreshCredentialsService(
+        RefreshTokenDigestPort refreshTokenDigest,
+        RefreshTokenRecordRepositoryPort
+            recordRepository,
+        RefreshTokenFamilyRepositoryPort
+            familyRepository,
+        UserRepositoryPort userRepository,
+        RefreshTokenGenerationPort
+            refreshTokenGeneration,
+        AccessTokenGenerationPort
+            accessTokenGeneration,
+        RefreshSessionLifetimePolicy lifetimePolicy,
+        Clock clock
+    ) {
+        this.refreshTokenDigest =
+            Objects.requireNonNull(
+                refreshTokenDigest,
+                "refreshTokenDigest must not be null"
+            );
+
+        this.recordRepository =
+            Objects.requireNonNull(
+                recordRepository,
+                "recordRepository must not be null"
+            );
+
+        this.familyRepository =
+            Objects.requireNonNull(
+                familyRepository,
+                "familyRepository must not be null"
+            );
+
+        this.userRepository =
+            Objects.requireNonNull(
+                userRepository,
+                "userRepository must not be null"
+            );
+
+        this.refreshTokenGeneration =
+            Objects.requireNonNull(
+                refreshTokenGeneration,
+                "refreshTokenGeneration must not be null"
+            );
+
+        this.accessTokenGeneration =
+            Objects.requireNonNull(
+                accessTokenGeneration,
+                "accessTokenGeneration must not be null"
+            );
+
+        this.lifetimePolicy =
+            Objects.requireNonNull(
+                lifetimePolicy,
+                "lifetimePolicy must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+    }
+
+    @Override
+    @Transactional
+    public RotateRefreshCredentialsResult rotate(
+        RotateRefreshCredentialsCommand command
+    ) {
+        RotateRefreshCredentialsCommand
+            checkedCommand =
+            Objects.requireNonNull(
+                command,
+                "command must not be null"
+            );
+
+        RefreshTokenDigest currentDigest =
+            refreshTokenDigest.digest(
+                checkedCommand.refreshToken()
+            );
+
+        RefreshTokenRecord currentRecord =
+            recordRepository
+                .findByDigestForUpdate(
+                    currentDigest
+                )
+                .orElseThrow(
+                    InvalidRefreshTokenException::new
+                );
+
+        RefreshTokenFamily family =
+            familyRepository
+                .findByIdForUpdate(
+                    currentRecord.familyId()
+                )
+                .orElseThrow(
+                    InvalidRefreshTokenException::new
+                );
+
+        Instant rotatedAt =
+            clock.instant()
+                .truncatedTo(
+                    ChronoUnit.MICROS
+                );
+
+        if (
+            !currentRecord.isActiveAt(
+                family,
+                rotatedAt
+            )
+        ) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        User user =
+            userRepository
+                .findById(
+                    family.userId()
+                )
+                .filter(candidate ->
+                    candidate.status()
+                        == UserStatus.ACTIVE
+                )
+                .orElseThrow(
+                    InvalidRefreshTokenException::new
+                );
+
+        GeneratedRefreshToken generatedToken =
+            refreshTokenGeneration.generate();
+
+        RefreshTokenDigest successorDigest =
+            refreshTokenDigest.digest(
+                generatedToken.value()
+            );
+
+        RefreshTokenRecordId successorId =
+            RefreshTokenRecordId.of(
+                UUID.randomUUID()
+            );
+
+        Instant successorExpiresAt =
+            lifetimePolicy
+                .refreshTokenExpiresAt(
+                    rotatedAt,
+                    family.expiresAt()
+                );
+
+        RefreshTokenRecord successor =
+            RefreshTokenRecord.issue(
+                successorId,
+                family,
+                successorDigest,
+                rotatedAt,
+                successorExpiresAt
+            );
+
+        RefreshTokenRecord consumedCurrent =
+            currentRecord.consume(
+                successorId,
+                rotatedAt,
+                family
+            );
+
+        RefreshTokenRecord savedSuccessor =
+            recordRepository.save(
+                successor
+            );
+
+        recordRepository.save(
+            consumedCurrent
+        );
+
+        GeneratedAccessToken accessToken =
+            accessTokenGeneration.generate(
+                user
+            );
+
+        return new RotateRefreshCredentialsResult(
+            accessToken.value(),
+            accessToken.expiresAt(),
+            generatedToken.value(),
+            savedSuccessor.expiresAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsTransaction.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsTransaction.java
@@ -1,0 +1,275 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model.User;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+class RotateRefreshCredentialsTransaction {
+
+    private final RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    private final RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    private final UserRepositoryPort userRepository;
+
+    private final RefreshTokenGenerationPort
+        refreshTokenGeneration;
+
+    private final RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    private final AccessTokenGenerationPort
+        accessTokenGeneration;
+
+    private final RefreshSessionLifetimePolicy
+        lifetimePolicy;
+
+    private final Clock clock;
+
+    RotateRefreshCredentialsTransaction(
+        RefreshTokenRecordRepositoryPort
+            recordRepository,
+        RefreshTokenFamilyRepositoryPort
+            familyRepository,
+        UserRepositoryPort userRepository,
+        RefreshTokenGenerationPort
+            refreshTokenGeneration,
+        RefreshTokenDigestPort refreshTokenDigest,
+        AccessTokenGenerationPort
+            accessTokenGeneration,
+        RefreshSessionLifetimePolicy lifetimePolicy,
+        Clock clock
+    ) {
+        this.recordRepository =
+            Objects.requireNonNull(
+                recordRepository,
+                "recordRepository must not be null"
+            );
+
+        this.familyRepository =
+            Objects.requireNonNull(
+                familyRepository,
+                "familyRepository must not be null"
+            );
+
+        this.userRepository =
+            Objects.requireNonNull(
+                userRepository,
+                "userRepository must not be null"
+            );
+
+        this.refreshTokenGeneration =
+            Objects.requireNonNull(
+                refreshTokenGeneration,
+                "refreshTokenGeneration must not be null"
+            );
+
+        this.refreshTokenDigest =
+            Objects.requireNonNull(
+                refreshTokenDigest,
+                "refreshTokenDigest must not be null"
+            );
+
+        this.accessTokenGeneration =
+            Objects.requireNonNull(
+                accessTokenGeneration,
+                "accessTokenGeneration must not be null"
+            );
+
+        this.lifetimePolicy =
+            Objects.requireNonNull(
+                lifetimePolicy,
+                "lifetimePolicy must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+    }
+
+    @Transactional
+    public RotateRefreshCredentialsOutcome rotate(
+        RefreshTokenDigest currentDigest
+    ) {
+        RefreshTokenDigest checkedDigest =
+            Objects.requireNonNull(
+                currentDigest,
+                "currentDigest must not be null"
+            );
+
+        RefreshTokenRecord currentRecord =
+            recordRepository
+                .findByDigestForUpdate(
+                    checkedDigest
+                )
+                .orElse(null);
+
+        if (currentRecord == null) {
+            return rejected();
+        }
+
+        RefreshTokenFamily family =
+            familyRepository
+                .findByIdForUpdate(
+                    currentRecord.familyId()
+                )
+                .orElse(null);
+
+        if (family == null) {
+            return rejected();
+        }
+
+        Instant rotatedAt =
+            clock.instant()
+                .truncatedTo(
+                    ChronoUnit.MICROS
+                );
+
+        if (currentRecord.isConsumed()) {
+            revokeActiveFamilyForReuse(
+                family,
+                rotatedAt
+            );
+
+            return rejected();
+        }
+
+        if (
+            !currentRecord.isActiveAt(
+                family,
+                rotatedAt
+            )
+        ) {
+            return rejected();
+        }
+
+        User user =
+            userRepository
+                .findById(
+                    family.userId()
+                )
+                .filter(candidate ->
+                    candidate.status()
+                        == UserStatus.ACTIVE
+                )
+                .orElse(null);
+
+        if (user == null) {
+            return rejected();
+        }
+
+        GeneratedRefreshToken generatedToken =
+            refreshTokenGeneration.generate();
+
+        RefreshTokenDigest successorDigest =
+            refreshTokenDigest.digest(
+                generatedToken.value()
+            );
+
+        RefreshTokenRecordId successorId =
+            RefreshTokenRecordId.of(
+                UUID.randomUUID()
+            );
+
+        Instant successorExpiresAt =
+            lifetimePolicy
+                .refreshTokenExpiresAt(
+                    rotatedAt,
+                    family.expiresAt()
+                );
+
+        RefreshTokenRecord successor =
+            RefreshTokenRecord.issue(
+                successorId,
+                family,
+                successorDigest,
+                rotatedAt,
+                successorExpiresAt
+            );
+
+        RefreshTokenRecord consumedCurrent =
+            currentRecord.consume(
+                successorId,
+                rotatedAt,
+                family
+            );
+
+        RefreshTokenRecord savedSuccessor =
+            recordRepository.save(
+                successor
+            );
+
+        recordRepository.save(
+            consumedCurrent
+        );
+
+        GeneratedAccessToken accessToken =
+            accessTokenGeneration.generate(
+                user
+            );
+
+        RotateRefreshCredentialsResult result =
+            new RotateRefreshCredentialsResult(
+                accessToken.value(),
+                accessToken.expiresAt(),
+                generatedToken.value(),
+                savedSuccessor.expiresAt()
+            );
+
+        return new RotateRefreshCredentialsOutcome
+            .Succeeded(result);
+    }
+
+    private void revokeActiveFamilyForReuse(
+        RefreshTokenFamily family,
+        Instant detectedAt
+    ) {
+        if (!family.isActiveAt(detectedAt)) {
+            return;
+        }
+
+        RefreshTokenFamily revokedFamily =
+            family.revoke(
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED,
+                detectedAt
+            );
+
+        familyRepository.save(
+            revokedFamily
+        );
+    }
+
+    private static RotateRefreshCredentialsOutcome
+    rejected() {
+        return RotateRefreshCredentialsOutcome
+            .Rejected
+            .INSTANCE;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/nursena/payflow/user/domain/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.user.domain.exception;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+
+public final class InvalidRefreshTokenException
+    extends BusinessRuleException {
+
+    public InvalidRefreshTokenException() {
+        super(
+            "REFRESH_TOKEN_INVALID",
+            "Refresh token is invalid."
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,6 +73,9 @@ payflow:
     jwt:
       issuer: https://api.payflow.local
       access-token-ttl: 15m
+    refresh-session:
+      refresh-token-ttl: ${REFRESH_TOKEN_TTL:7d}
+      family-ttl: ${REFRESH_TOKEN_FAMILY_TTL:30d}
   outbox:
     kafka:
       send-timeout: ${OUTBOX_KAFKA_SEND_TIMEOUT:10s}

--- a/src/test/java/com/nursena/payflow/configuration/SecurityConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/SecurityConfigurationTest.java
@@ -4,6 +4,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request
     .MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request
+    .MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result
     .MockMvcResultMatchers.status;
 
@@ -49,6 +51,16 @@ class SecurityConfigurationTest {
     private JwtDecoder jwtDecoder;
     @MockitoBean
     private SecurityProbeController.ProbeService probeService;
+    @Test
+    void shouldPermitAnonymousCurrentSessionLogout()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/logout")
+            )
+            .andExpect(status().isNotFound());
+    }
+
     @Test
     void shouldPermitAnonymousRequestToPrometheusEndpoint()
         throws Exception {

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -49,6 +49,9 @@ class OpenApiJsonContractIntegrationTest {
     private static final String REFRESH_PATH =
         "/api/v1/auth/refresh";
 
+    private static final String LOGOUT_PATH =
+        "/api/v1/auth/logout";
+
     private static final String USER_PROFILE_PATH =
         "/api/v1/users/me";
 
@@ -184,6 +187,7 @@ class OpenApiJsonContractIntegrationTest {
             REGISTER_PATH,
             LOGIN_PATH,
             REFRESH_PATH,
+            LOGOUT_PATH,
             USER_PROFILE_PATH,
             WALLETS_PATH,
             CURRENT_WALLET_PATH,
@@ -257,6 +261,28 @@ class OpenApiJsonContractIntegrationTest {
             "200",
             "400",
             "401"
+        );
+
+        JsonNode logout =
+            operation(
+                LOGOUT_PATH,
+                "post"
+            );
+
+        assertPublicOperation(logout);
+
+        assertThat(
+            logout
+                .path("operationId")
+                .asText()
+        ).isEqualTo(
+            "revokeCurrentRefreshSession"
+        );
+
+        assertResponseCodes(
+            logout,
+            "204",
+            "400"
         );
     }
 
@@ -725,6 +751,89 @@ class OpenApiJsonContractIntegrationTest {
             .contains(
                 "VALIDATION_FAILED",
                 "Refresh token is required."
+            );
+    }
+
+    @Test
+    void shouldExposeCurrentSessionLogoutContract() {
+        JsonNode logout =
+            operation(
+                LOGOUT_PATH,
+                "post"
+            );
+
+        JsonNode requestSchema =
+            logout
+                .path("requestBody")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .path("schema");
+
+        assertThat(
+            requestSchema
+                .path("$ref")
+                .asText()
+        ).isEqualTo(
+            "#/components/schemas/"
+                + "RevokeCurrentRefreshSessionRequest"
+        );
+
+        JsonNode requestProperties =
+            openApi
+                .path("components")
+                .path("schemas")
+                .path(
+                    "RevokeCurrentRefreshSessionRequest"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(requestProperties)
+        ).containsExactly(
+            "refreshToken"
+        );
+
+        assertThat(
+            requestProperties
+                .path("refreshToken")
+                .path("type")
+                .asText()
+        ).isEqualTo("string");
+
+        assertThat(
+            requestProperties
+                .path("refreshToken")
+                .path("writeOnly")
+                .asBoolean()
+        ).isTrue();
+
+        JsonNode responses =
+            logout.path("responses");
+
+        assertThat(responses.has("401"))
+            .isFalse();
+
+        assertThat(
+            responses
+                .path("204")
+                .has("content")
+        ).isFalse();
+
+        assertThat(
+            responses
+                .path("400")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .toString()
+        )
+            .contains(
+                "VALIDATION_FAILED",
+                "Refresh token is required.",
+                "/api/v1/auth/logout"
             );
     }
 

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -46,6 +46,9 @@ class OpenApiJsonContractIntegrationTest {
     private static final String LOGIN_PATH =
         "/api/v1/auth/login";
 
+    private static final String REFRESH_PATH =
+        "/api/v1/auth/refresh";
+
     private static final String USER_PROFILE_PATH =
         "/api/v1/users/me";
 
@@ -180,6 +183,7 @@ class OpenApiJsonContractIntegrationTest {
             SYSTEM_HEALTH_PATH,
             REGISTER_PATH,
             LOGIN_PATH,
+            REFRESH_PATH,
             USER_PROFILE_PATH,
             WALLETS_PATH,
             CURRENT_WALLET_PATH,
@@ -230,6 +234,29 @@ class OpenApiJsonContractIntegrationTest {
             "400",
             "401",
             "403"
+        );
+
+        JsonNode refresh =
+            operation(
+                REFRESH_PATH,
+                "post"
+            );
+
+        assertPublicOperation(refresh);
+
+        assertThat(
+            refresh
+                .path("operationId")
+                .asText()
+        ).isEqualTo(
+            "rotateRefreshCredentials"
+        );
+
+        assertResponseCodes(
+            refresh,
+            "200",
+            "400",
+            "401"
         );
     }
 
@@ -548,6 +575,159 @@ class OpenApiJsonContractIntegrationTest {
                 .asText()
         ).isEqualTo("string");
     }
+    @Test
+    void shouldExposeRefreshCredentialPairContract() {
+        JsonNode refresh =
+            operation(
+                REFRESH_PATH,
+                "post"
+            );
+
+        JsonNode requestSchema =
+            refresh
+                .path("requestBody")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .path("schema");
+
+        assertThat(
+            requestSchema
+                .path("$ref")
+                .asText()
+        ).isEqualTo(
+            "#/components/schemas/"
+                + "RotateRefreshCredentialsRequest"
+        );
+
+        JsonNode schemas =
+            openApi
+                .path("components")
+                .path("schemas");
+
+        JsonNode requestProperties =
+            schemas
+                .path(
+                    "RotateRefreshCredentialsRequest"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(requestProperties)
+        ).containsExactly(
+            "refreshToken"
+        );
+
+        assertThat(
+            requestProperties
+                .path("refreshToken")
+                .path("type")
+                .asText()
+        ).isEqualTo("string");
+
+        assertThat(
+            requestProperties
+                .path("refreshToken")
+                .path("writeOnly")
+                .asBoolean()
+        ).isTrue();
+
+        JsonNode successSchema =
+            refresh
+                .path("responses")
+                .path("200")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .path("schema");
+
+        assertThat(
+            successSchema
+                .path("$ref")
+                .asText()
+        ).isEqualTo(
+            "#/components/schemas/"
+                + "RotateRefreshCredentialsResponse"
+        );
+
+        JsonNode responseProperties =
+            schemas
+                .path(
+                    "RotateRefreshCredentialsResponse"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(responseProperties)
+        )
+            .containsExactlyInAnyOrder(
+                "accessToken",
+                "tokenType",
+                "expiresAt",
+                "refreshToken",
+                "refreshTokenExpiresAt"
+            )
+            .doesNotContain(
+                "tokenDigest",
+                "familyId",
+                "recordId",
+                "userId",
+                "revokedAt",
+                "consumedAt",
+                "successorId"
+            );
+
+        assertThat(
+            responseProperties
+                .path("expiresAt")
+                .path("format")
+                .asText()
+        ).isEqualTo("date-time");
+
+        assertThat(
+            responseProperties
+                .path(
+                    "refreshTokenExpiresAt"
+                )
+                .path("format")
+                .asText()
+        ).isEqualTo("date-time");
+
+        JsonNode unauthorizedContent =
+            refresh
+                .path("responses")
+                .path("401")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                );
+
+        assertThat(
+            unauthorizedContent.toString()
+        )
+            .contains(
+                "REFRESH_TOKEN_INVALID",
+                "Refresh token is invalid."
+            );
+
+        assertThat(
+            refresh
+                .path("responses")
+                .path("400")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .toString()
+        )
+            .contains(
+                "VALIDATION_FAILED",
+                "Refresh token is required."
+            );
+    }
+
     @Test
     void shouldExposeTransferContract() {
         JsonNode transfer =

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -463,6 +463,92 @@ class OpenApiJsonContractIntegrationTest {
     }
 
     @Test
+    void shouldExposeLoginCredentialPairContract() {
+        JsonNode login =
+            operation(
+                LOGIN_PATH,
+                "post"
+            );
+
+        JsonNode successSchema =
+            login
+                .path("responses")
+                .path("200")
+                .path("content")
+                .path(
+                    MediaType.APPLICATION_JSON_VALUE
+                )
+                .path("schema");
+
+        assertThat(
+            successSchema
+                .path("$ref")
+                .asText()
+        ).isEqualTo(
+            "#/components/schemas/"
+                + "AuthenticateUserResponse"
+        );
+
+        JsonNode properties =
+            openApi
+                .path("components")
+                .path("schemas")
+                .path(
+                    "AuthenticateUserResponse"
+                )
+                .path("properties");
+
+        assertThat(
+            fieldNames(properties)
+        )
+            .containsExactlyInAnyOrder(
+                "accessToken",
+                "tokenType",
+                "expiresAt",
+                "refreshToken",
+                "refreshTokenExpiresAt"
+            )
+            .doesNotContain(
+                "tokenDigest",
+                "familyId",
+                "recordId",
+                "userId",
+                "revokedAt",
+                "consumedAt",
+                "successorId"
+            );
+
+        assertThat(
+            properties
+                .path("expiresAt")
+                .path("format")
+                .asText()
+        ).isEqualTo("date-time");
+
+        assertThat(
+            properties
+                .path(
+                    "refreshTokenExpiresAt"
+                )
+                .path("format")
+                .asText()
+        ).isEqualTo("date-time");
+
+        assertThat(
+            properties
+                .path("accessToken")
+                .path("type")
+                .asText()
+        ).isEqualTo("string");
+
+        assertThat(
+            properties
+                .path("refreshToken")
+                .path("type")
+                .asText()
+        ).isEqualTo("string");
+    }
+    @Test
     void shouldExposeTransferContract() {
         JsonNode transfer =
             operation(

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
@@ -21,9 +22,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
+
 @WebMvcTest(AuthenticateUserController.class)
 @Import({
     SecurityConfiguration.class,
@@ -31,74 +33,167 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 })
 class AuthenticateUserControllerTest {
 
-    private static final Instant EXPIRES_AT =
-        Instant.parse("2026-07-14T12:15:00Z");
+    private static final Instant ACCESS_EXPIRES_AT =
+        Instant.parse(
+            "2026-07-28T12:15:00Z"
+        );
+
+    private static final Instant REFRESH_EXPIRES_AT =
+        Instant.parse(
+            "2026-08-04T12:00:00Z"
+        );
 
     @Autowired
     private MockMvc mockMvc;
 
     @MockitoBean
-    private AuthenticateUserUseCase authenticateUserUseCase;
+    private AuthenticateUserUseCase
+        authenticateUserUseCase;
 
     @MockitoBean
     private JwtDecoder jwtDecoder;
 
     @Test
-    void shouldAuthenticateUser() throws Exception {
+    void shouldAuthenticateUserAndReturnCredentialPair()
+        throws Exception {
+
         when(authenticateUserUseCase.authenticate(
             any(AuthenticateUserCommand.class)
-        )).thenReturn(
-            new AuthenticateUserResult(
-                "signed-access-token",
-                EXPIRES_AT
-            )
-        );
+        ))
+            .thenReturn(
+                new AuthenticateUserResult(
+                    "signed-access-token",
+                    ACCESS_EXPIRES_AT,
+                    "opaque-refresh-token",
+                    REFRESH_EXPIRES_AT
+                )
+            );
 
         mockMvc.perform(
                 post("/api/v1/auth/login")
-                    .contentType(MediaType.APPLICATION_JSON)
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
                     .content("""
-                                        {
-                                          "email": "nursena@example.com",
-                                          "password": "StrongPassword123!"
-                                        }
-                                        """)
+                        {
+                          "email": "nursena@example.com",
+                          "password": "StrongPassword123!"
+                        }
+                        """)
             )
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.accessToken")
-                .value("signed-access-token"))
-            .andExpect(jsonPath("$.tokenType")
-                .value("Bearer"))
-            .andExpect(jsonPath("$.expiresAt")
-                .value(EXPIRES_AT.toString()));
+            .andExpect(
+                status().isOk()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.accessToken"
+                ).value(
+                    "signed-access-token"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.tokenType"
+                ).value("Bearer")
+            )
+            .andExpect(
+                jsonPath(
+                    "$.expiresAt"
+                ).value(
+                    ACCESS_EXPIRES_AT.toString()
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.refreshToken"
+                ).value(
+                    "opaque-refresh-token"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.refreshTokenExpiresAt"
+                ).value(
+                    REFRESH_EXPIRES_AT.toString()
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.tokenDigest"
+                ).doesNotExist()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.familyId"
+                ).doesNotExist()
+            );
 
-        verify(authenticateUserUseCase).authenticate(
-            argThat(command ->
-                command.email()
-                    .equals("nursena@example.com")
-                    && command.rawPassword()
-                    .equals("StrongPassword123!")
-            )
-        );
+        verify(authenticateUserUseCase)
+            .authenticate(
+                argThat(command ->
+                    command.email().equals(
+                        "nursena@example.com"
+                    )
+                        && command.rawPassword()
+                            .equals(
+                                "StrongPassword123!"
+                            )
+                )
+            );
     }
 
     @Test
-    void shouldRejectInvalidEmail() throws Exception {
+    void shouldRedactCredentialValuesFromResponseToString() {
+        AuthenticateUserResponse response =
+            new AuthenticateUserResponse(
+                "secret-access-token",
+                "Bearer",
+                ACCESS_EXPIRES_AT,
+                "secret-refresh-token",
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(response.toString())
+            .isEqualTo(
+                "AuthenticateUserResponse[redacted]"
+            )
+            .doesNotContain(
+                "secret-access-token",
+                "secret-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRejectInvalidEmail()
+        throws Exception {
+
         mockMvc.perform(
                 post("/api/v1/auth/login")
-                    .contentType(MediaType.APPLICATION_JSON)
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
                     .content("""
-                                        {
-                                          "email": "not-an-email",
-                                          "password": "StrongPassword123!"
-                                        }
-                                        """)
+                        {
+                          "email": "not-an-email",
+                          "password": "StrongPassword123!"
+                        }
+                        """)
             )
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.code")
-                .value("VALIDATION_FAILED"))
-            .andExpect(jsonPath("$.violations[0].field")
-                .value("email"));
+            .andExpect(
+                status().isBadRequest()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "VALIDATION_FAILED"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.violations[0].field"
+                ).value("email")
+            );
     }
 
     @Test
@@ -107,25 +202,47 @@ class AuthenticateUserControllerTest {
 
         when(authenticateUserUseCase.authenticate(
             any(AuthenticateUserCommand.class)
-        )).thenThrow(new InvalidCredentialsException());
+        ))
+            .thenThrow(
+                new InvalidCredentialsException()
+            );
 
         mockMvc.perform(
                 post("/api/v1/auth/login")
-                    .contentType(MediaType.APPLICATION_JSON)
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
                     .content("""
-                                        {
-                                          "email": "nursena@example.com",
-                                          "password": "WrongPassword123!"
-                                        }
-                                        """)
+                        {
+                          "email": "nursena@example.com",
+                          "password": "WrongPassword123!"
+                        }
+                        """)
             )
-            .andExpect(status().isUnauthorized())
-            .andExpect(jsonPath("$.code")
-                .value("INVALID_CREDENTIALS"))
-            .andExpect(jsonPath("$.message")
-                .value("Email or password is incorrect."))
-            .andExpect(jsonPath("$.path")
-                .value("/api/v1/auth/login"));
+            .andExpect(
+                status().isUnauthorized()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "INVALID_CREDENTIALS"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.message"
+                ).value(
+                    "Email or password is incorrect."
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.path"
+                ).value(
+                    "/api/v1/auth/login"
+                )
+            );
     }
 
     @Test
@@ -134,26 +251,46 @@ class AuthenticateUserControllerTest {
 
         when(authenticateUserUseCase.authenticate(
             any(AuthenticateUserCommand.class)
-        )).thenThrow(new UserAccountUnavailableException());
+        ))
+            .thenThrow(
+                new UserAccountUnavailableException()
+            );
 
         mockMvc.perform(
                 post("/api/v1/auth/login")
-                    .contentType(MediaType.APPLICATION_JSON)
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
                     .content("""
-                                        {
-                                          "email": "nursena@example.com",
-                                          "password": "StrongPassword123!"
-                                        }
-                                        """)
+                        {
+                          "email": "nursena@example.com",
+                          "password": "StrongPassword123!"
+                        }
+                        """)
             )
-            .andExpect(status().isForbidden())
-            .andExpect(jsonPath("$.code")
-                .value("USER_ACCOUNT_UNAVAILABLE"))
-            .andExpect(jsonPath("$.message")
-                .value(
+            .andExpect(
+                status().isForbidden()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "USER_ACCOUNT_UNAVAILABLE"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.message"
+                ).value(
                     "User account is not available for authentication."
-                ))
-            .andExpect(jsonPath("$.path")
-                .value("/api/v1/auth/login"));
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.path"
+                ).value(
+                    "/api/v1/auth/login"
+                )
+            );
     }
 }

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionControllerTest.java
@@ -1,0 +1,164 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionUseCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    RevokeCurrentRefreshSessionController.class
+)
+@Import(SecurityConfiguration.class)
+class RevokeCurrentRefreshSessionControllerTest {
+
+    private static final String CURRENT_TOKEN =
+        "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RevokeCurrentRefreshSessionUseCase
+        revokeCurrentRefreshSessionUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldLogoutWithoutBearerAuthentication()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/logout")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "refreshToken": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA"
+                        }
+                        """)
+            )
+            .andExpect(
+                status().isNoContent()
+            )
+            .andExpect(
+                content().string("")
+            );
+
+        verify(revokeCurrentRefreshSessionUseCase)
+            .revoke(
+                argThat(command ->
+                    command.refreshToken()
+                        .equals(CURRENT_TOKEN)
+                )
+            );
+    }
+
+    @Test
+    void shouldReturnNoContentForMalformedCredential()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/logout")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "refreshToken": "not-canonical"
+                        }
+                        """)
+            )
+            .andExpect(
+                status().isNoContent()
+            )
+            .andExpect(
+                content().string("")
+            );
+
+        verify(revokeCurrentRefreshSessionUseCase)
+            .revoke(
+                argThat(command ->
+                    command.refreshToken()
+                        .equals("not-canonical")
+                )
+            );
+    }
+
+    @Test
+    void shouldRejectBlankRefreshToken()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/logout")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "refreshToken": " "
+                        }
+                        """)
+            )
+            .andExpect(
+                status().isBadRequest()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "VALIDATION_FAILED"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.path"
+                ).value(
+                    "/api/v1/auth/logout"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.violations[0].field"
+                ).value(
+                    "refreshToken"
+                )
+            );
+
+        verifyNoInteractions(
+            revokeCurrentRefreshSessionUseCase
+        );
+    }
+
+    @Test
+    void shouldRedactRefreshTokenFromRequestToString() {
+        RevokeCurrentRefreshSessionRequest request =
+            new RevokeCurrentRefreshSessionRequest(
+                "secret-refresh-token"
+            );
+
+        assertThat(request.toString())
+            .isEqualTo(
+                "RevokeCurrentRefreshSessionRequest[redacted]"
+            )
+            .doesNotContain(
+                "secret-refresh-token"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsControllerTest.java
@@ -1,0 +1,286 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsCommand;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsUseCase;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    RotateRefreshCredentialsController.class
+)
+@Import({
+    SecurityConfiguration.class,
+    UserAuthenticationExceptionHandler.class
+})
+class RotateRefreshCredentialsControllerTest {
+
+    private static final String CURRENT_TOKEN =
+        "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA";
+
+    private static final String SUCCESSOR_TOKEN =
+        "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8";
+
+    private static final Instant ACCESS_EXPIRES_AT =
+        Instant.parse(
+            "2026-07-28T12:15:00Z"
+        );
+
+    private static final Instant REFRESH_EXPIRES_AT =
+        Instant.parse(
+            "2026-08-04T12:00:00Z"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RotateRefreshCredentialsUseCase
+        rotateRefreshCredentialsUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldRotateCredentialsWithoutBearerAuthentication()
+        throws Exception {
+
+        when(rotateRefreshCredentialsUseCase.rotate(
+            any(RotateRefreshCredentialsCommand.class)
+        ))
+            .thenReturn(
+                new RotateRefreshCredentialsResult(
+                    "signed-access-token",
+                    ACCESS_EXPIRES_AT,
+                    SUCCESSOR_TOKEN,
+                    REFRESH_EXPIRES_AT
+                )
+            );
+
+        mockMvc.perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "refreshToken": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA"
+                        }
+                        """)
+            )
+            .andExpect(
+                status().isOk()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.accessToken"
+                ).value(
+                    "signed-access-token"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.tokenType"
+                ).value("Bearer")
+            )
+            .andExpect(
+                jsonPath(
+                    "$.expiresAt"
+                ).value(
+                    ACCESS_EXPIRES_AT.toString()
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.refreshToken"
+                ).value(
+                    SUCCESSOR_TOKEN
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.refreshTokenExpiresAt"
+                ).value(
+                    REFRESH_EXPIRES_AT.toString()
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.tokenDigest"
+                ).doesNotExist()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.familyId"
+                ).doesNotExist()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.recordId"
+                ).doesNotExist()
+            );
+
+        verify(rotateRefreshCredentialsUseCase)
+            .rotate(
+                argThat(command ->
+                    command.refreshToken()
+                        .equals(CURRENT_TOKEN)
+                )
+            );
+    }
+
+    @Test
+    void shouldRejectBlankRefreshToken()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "refreshToken": " "
+                        }
+                        """)
+            )
+            .andExpect(
+                status().isBadRequest()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "VALIDATION_FAILED"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.path"
+                ).value(
+                    "/api/v1/auth/refresh"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.violations[0].field"
+                ).value(
+                    "refreshToken"
+                )
+            );
+
+        verifyNoInteractions(
+            rotateRefreshCredentialsUseCase
+        );
+    }
+
+    @Test
+    void shouldReturnUnauthorizedForInvalidRefreshToken()
+        throws Exception {
+
+        when(rotateRefreshCredentialsUseCase.rotate(
+            any(RotateRefreshCredentialsCommand.class)
+        ))
+            .thenThrow(
+                new InvalidRefreshTokenException()
+            );
+
+        mockMvc.perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content("""
+                        {
+                          "refreshToken": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA"
+                        }
+                        """)
+            )
+            .andExpect(
+                status().isUnauthorized()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "REFRESH_TOKEN_INVALID"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.message"
+                ).value(
+                    "Refresh token is invalid."
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.path"
+                ).value(
+                    "/api/v1/auth/refresh"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.violations"
+                ).isEmpty()
+            );
+    }
+
+    @Test
+    void shouldRedactRefreshTokenFromRequestToString() {
+        RotateRefreshCredentialsRequest request =
+            new RotateRefreshCredentialsRequest(
+                "secret-refresh-token"
+            );
+
+        assertThat(request.toString())
+            .isEqualTo(
+                "RotateRefreshCredentialsRequest[redacted]"
+            )
+            .doesNotContain(
+                "secret-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRedactCredentialsFromResponseToString() {
+        RotateRefreshCredentialsResponse response =
+            new RotateRefreshCredentialsResponse(
+                "secret-access-token",
+                "Bearer",
+                ACCESS_EXPIRES_AT,
+                "secret-refresh-token",
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(response.toString())
+            .isEqualTo(
+                "RotateRefreshCredentialsResponse[redacted]"
+            )
+            .doesNotContain(
+                "secret-access-token",
+                "secret-refresh-token"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/JwtConfigurationClockTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/JwtConfigurationClockTest.java
@@ -1,0 +1,59 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+import com.nursena.payflow.configuration.TimeConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class JwtConfigurationClockTest {
+
+    private final ApplicationContextRunner contextRunner =
+        new ApplicationContextRunner()
+            .withUserConfiguration(
+                TimeConfiguration.class,
+                JwtConfiguration.class
+            )
+            .withPropertyValues(
+                "payflow.security.jwt."
+                    + "issuer=https://api.payflow.local",
+                "payflow.security.jwt."
+                    + "access-token-ttl=15m"
+            );
+
+    @Test
+    void shouldUseSingleSharedUtcClock() {
+        contextRunner.run(context -> {
+            assertThat(context)
+                .hasNotFailed();
+
+            Map<String, Clock> clocks =
+                context.getBeansOfType(
+                    Clock.class
+                );
+
+            assertThat(clocks)
+                .containsOnlyKeys("clock");
+
+            assertThat(
+                context.containsBean(
+                    "jwtClock"
+                )
+            )
+                .isFalse();
+
+            assertThat(
+                context.getBean(
+                    Clock.class
+                ).getZone()
+            )
+                .isEqualTo(
+                    ZoneOffset.UTC
+                );
+        });
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionConfigurationTest.java
@@ -1,0 +1,99 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import com.nursena.payflow.user.application.service.RefreshSessionLifetimePolicy;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class RefreshSessionConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+        new ApplicationContextRunner()
+            .withUserConfiguration(
+                RefreshSessionConfiguration.class
+            );
+
+    @Test
+    void shouldBindDurationsAndExposeLifetimePolicy() {
+        contextRunner
+            .withPropertyValues(
+                "payflow.security.refresh-session."
+                    + "refresh-token-ttl=7d",
+                "payflow.security.refresh-session."
+                    + "family-ttl=30d"
+            )
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed();
+
+                assertThat(context)
+                    .hasSingleBean(
+                        RefreshSessionProperties.class
+                    );
+
+                assertThat(context)
+                    .hasSingleBean(
+                        RefreshSessionLifetimePolicy.class
+                    );
+
+                RefreshSessionProperties properties =
+                    context.getBean(
+                        RefreshSessionProperties.class
+                    );
+
+                assertThat(
+                    properties.refreshTokenTtl()
+                )
+                    .isEqualTo(
+                        Duration.ofDays(7)
+                    );
+
+                assertThat(
+                    properties.familyTtl()
+                )
+                    .isEqualTo(
+                        Duration.ofDays(30)
+                    );
+
+                RefreshSessionLifetimePolicy policy =
+                    context.getBean(
+                        RefreshSessionLifetimePolicy.class
+                    );
+
+                Instant issuedAt =
+                    Instant.parse(
+                        "2026-07-28T12:00:00Z"
+                    );
+
+                assertThat(
+                    policy.familyExpiresAt(
+                        issuedAt
+                    )
+                )
+                    .isEqualTo(
+                        issuedAt.plus(
+                            Duration.ofDays(30)
+                        )
+                    );
+            });
+    }
+
+    @Test
+    void shouldRejectNonPositiveConfiguration() {
+        contextRunner
+            .withPropertyValues(
+                "payflow.security.refresh-session."
+                    + "refresh-token-ttl=-1s",
+                "payflow.security.refresh-session."
+                    + "family-ttl=30d"
+            )
+            .run(context ->
+                assertThat(context)
+                    .hasFailed()
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionPropertiesTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/RefreshSessionPropertiesTest.java
@@ -1,0 +1,113 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RefreshSessionPropertiesTest {
+
+    @Test
+    void shouldRetainValidDurations() {
+        Duration refreshTokenTtl =
+            Duration.ofDays(7);
+
+        Duration familyTtl =
+            Duration.ofDays(30);
+
+        RefreshSessionProperties properties =
+            new RefreshSessionProperties(
+                refreshTokenTtl,
+                familyTtl
+            );
+
+        assertThat(properties.refreshTokenTtl())
+            .isEqualTo(refreshTokenTtl);
+
+        assertThat(properties.familyTtl())
+            .isEqualTo(familyTtl);
+    }
+
+    @Test
+    void shouldRequireRefreshTokenTtl() {
+        assertThatThrownBy(() ->
+            new RefreshSessionProperties(
+                null,
+                Duration.ofDays(30)
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "refreshTokenTtl must not be null"
+            );
+    }
+
+    @Test
+    void shouldRequireFamilyTtl() {
+        assertThatThrownBy(() ->
+            new RefreshSessionProperties(
+                Duration.ofDays(7),
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "familyTtl must not be null"
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonPositiveDurations")
+    void shouldRejectNonPositiveRefreshTokenTtl(
+        Duration invalidDuration
+    ) {
+        assertThatThrownBy(() ->
+            new RefreshSessionProperties(
+                invalidDuration,
+                Duration.ofDays(30)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "refreshTokenTtl must be positive"
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonPositiveDurations")
+    void shouldRejectNonPositiveFamilyTtl(
+        Duration invalidDuration
+    ) {
+        assertThatThrownBy(() ->
+            new RefreshSessionProperties(
+                Duration.ofDays(7),
+                invalidDuration
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "familyTtl must be positive"
+            );
+    }
+
+    private static Stream<Duration>
+    nonPositiveDurations() {
+        return Stream.of(
+            Duration.ZERO,
+            Duration.ofSeconds(-1)
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/RefreshTokenCryptographyConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/RefreshTokenCryptographyConfigurationTest.java
@@ -1,0 +1,99 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class RefreshTokenCryptographyConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+        new ApplicationContextRunner()
+            .withUserConfiguration(
+                RefreshTokenCryptographyConfiguration
+                    .class
+            );
+
+    @Test
+    void shouldExposeBothRefreshTokenOutputPorts() {
+        contextRunner.run(context -> {
+            assertThat(context)
+                .hasSingleBean(
+                    RefreshTokenGenerationPort.class
+                );
+
+            assertThat(context)
+                .hasSingleBean(
+                    RefreshTokenDigestPort.class
+                );
+
+            assertThat(
+                context.getBean(
+                    RefreshTokenGenerationPort.class
+                )
+            )
+                .isInstanceOf(
+                    SecureRandomRefreshTokenGenerationAdapter
+                        .class
+                );
+
+            assertThat(
+                context.getBean(
+                    RefreshTokenDigestPort.class
+                )
+            )
+                .isInstanceOf(
+                    Sha256RefreshTokenDigestAdapter
+                        .class
+                );
+        });
+    }
+
+    @Test
+    void shouldGenerateAndDigestThroughConfiguredPorts() {
+        contextRunner.run(context -> {
+            RefreshTokenGenerationPort generationPort =
+                context.getBean(
+                    RefreshTokenGenerationPort.class
+                );
+
+            RefreshTokenDigestPort digestPort =
+                context.getBean(
+                    RefreshTokenDigestPort.class
+                );
+
+            GeneratedRefreshToken generated =
+                generationPort.generate();
+
+            RefreshTokenDigest digest =
+                digestPort.digest(
+                    generated.value()
+                );
+
+            assertThat(generated.value())
+                .matches(
+                    "[A-Za-z0-9_-]{43}"
+                );
+
+            assertThat(digest.value())
+                .hasSize(
+                    RefreshTokenDigest
+                        .SHA_256_LENGTH_BYTES
+                );
+
+            assertThat(generated.toString())
+                .doesNotContain(
+                    generated.value()
+                );
+
+            assertThat(digest.toString())
+                .isEqualTo(
+                    "RefreshTokenDigest[redacted]"
+                );
+        });
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/SecureRandomRefreshTokenGenerationAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/SecureRandomRefreshTokenGenerationAdapterTest.java
@@ -1,0 +1,156 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import org.junit.jupiter.api.Test;
+
+class SecureRandomRefreshTokenGenerationAdapterTest {
+
+    private static final String EXPECTED_TOKEN =
+        "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8";
+
+    @Test
+    void shouldGenerateExpectedCanonicalTokenFrom32Bytes() {
+        byte[] deterministicEntropy =
+            new byte[
+                SecureRandomRefreshTokenGenerationAdapter
+                    .ENTROPY_LENGTH_BYTES
+            ];
+
+        for (
+            int index = 0;
+            index < deterministicEntropy.length;
+            index++
+        ) {
+            deterministicEntropy[index] =
+                (byte) index;
+        }
+
+        SecureRandom secureRandom =
+            mock(SecureRandom.class);
+
+        doAnswer(invocation -> {
+            byte[] destination =
+                invocation.getArgument(0);
+
+            assertThat(destination)
+                .hasSize(
+                    SecureRandomRefreshTokenGenerationAdapter
+                        .ENTROPY_LENGTH_BYTES
+                );
+
+            System.arraycopy(
+                deterministicEntropy,
+                0,
+                destination,
+                0,
+                deterministicEntropy.length
+            );
+
+            return null;
+        })
+            .when(secureRandom)
+            .nextBytes(
+                any(byte[].class)
+            );
+
+        SecureRandomRefreshTokenGenerationAdapter
+            adapter =
+            new SecureRandomRefreshTokenGenerationAdapter(
+                secureRandom
+            );
+
+        GeneratedRefreshToken result =
+            adapter.generate();
+
+        assertThat(result.value())
+            .isEqualTo(EXPECTED_TOKEN);
+
+        assertThat(result.value())
+            .hasSize(
+                SecureRandomRefreshTokenGenerationAdapter
+                    .ENCODED_TOKEN_LENGTH
+            );
+
+        assertThat(
+            Base64.getUrlDecoder()
+                .decode(result.value())
+        )
+            .containsExactly(
+                deterministicEntropy
+            );
+
+        assertThat(result.toString())
+            .doesNotContain(
+                result.value()
+            );
+
+        verify(secureRandom)
+            .nextBytes(
+                any(byte[].class)
+            );
+    }
+
+    @Test
+    void shouldGenerateCanonicalBase64UrlTokens() {
+        SecureRandomRefreshTokenGenerationAdapter
+            adapter =
+            new SecureRandomRefreshTokenGenerationAdapter(
+                new SecureRandom()
+            );
+
+        for (
+            int attempt = 0;
+            attempt < 64;
+            attempt++
+        ) {
+            GeneratedRefreshToken generated =
+                adapter.generate();
+
+            assertThat(generated.value())
+                .hasSize(
+                    SecureRandomRefreshTokenGenerationAdapter
+                        .ENCODED_TOKEN_LENGTH
+                )
+                .matches(
+                    "[A-Za-z0-9_-]{43}"
+                )
+                .doesNotContain("=");
+
+            assertThat(
+                Base64.getUrlDecoder()
+                    .decode(
+                        generated.value()
+                    )
+            )
+                .hasSize(
+                    SecureRandomRefreshTokenGenerationAdapter
+                        .ENTROPY_LENGTH_BYTES
+                );
+        }
+    }
+
+    @Test
+    void shouldRequireSecureRandom() {
+        assertThatThrownBy(() ->
+            new SecureRandomRefreshTokenGenerationAdapter(
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "secureRandom must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/Sha256RefreshTokenDigestAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/Sha256RefreshTokenDigestAdapterTest.java
@@ -1,0 +1,138 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.HexFormat;
+import java.util.stream.Stream;
+
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class Sha256RefreshTokenDigestAdapterTest {
+
+    private static final String CANONICAL_TOKEN =
+        "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8";
+
+    private static final byte[] EXPECTED_DIGEST =
+        HexFormat.of().parseHex(
+            "630dcd2966c4336691125448bbb25b4f"
+                + "f412a49c732db2c8abc1b8581bd710dd"
+        );
+
+    private final Sha256RefreshTokenDigestAdapter
+        adapter =
+        new Sha256RefreshTokenDigestAdapter();
+
+    @Test
+    void shouldCalculateSha256OverDecodedTokenBytes() {
+        RefreshTokenDigest result =
+            adapter.digest(
+                CANONICAL_TOKEN
+            );
+
+        assertThat(result.value())
+            .containsExactly(
+                EXPECTED_DIGEST
+            );
+
+        assertThat(result.value())
+            .hasSize(
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            );
+
+        assertThat(result.toString())
+            .isEqualTo(
+                "RefreshTokenDigest[redacted]"
+            );
+    }
+
+    @Test
+    void shouldProduceDeterministicDigest() {
+        RefreshTokenDigest first =
+            adapter.digest(
+                CANONICAL_TOKEN
+            );
+
+        RefreshTokenDigest second =
+            adapter.digest(
+                CANONICAL_TOKEN
+            );
+
+        assertThat(first)
+            .isEqualTo(second);
+
+        assertThat(first.hashCode())
+            .isEqualTo(
+                second.hashCode()
+            );
+    }
+
+    @Test
+    void shouldRejectNullTokenWithoutExposingCredentialState() {
+        Throwable failure =
+            catchThrowable(() ->
+                adapter.digest(null)
+            );
+
+        assertThat(failure)
+            .isInstanceOf(
+                InvalidRefreshTokenException.class
+            )
+            .hasMessage(
+                "Refresh token is invalid."
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidTokens")
+    void shouldRejectMalformedOrNonCanonicalTokens(
+        String invalidToken
+    ) {
+        Throwable failure =
+            catchThrowable(() ->
+                adapter.digest(
+                    invalidToken
+                )
+            );
+
+        assertThat(failure)
+            .isInstanceOf(
+                InvalidRefreshTokenException.class
+            )
+            .hasMessage(
+                "Refresh token is invalid."
+            );
+
+        assertThat(failure.getCause())
+            .isNull();
+
+        if (!invalidToken.isBlank()) {
+            assertThat(failure.toString())
+                .doesNotContain(
+                    invalidToken
+                );
+        }
+    }
+
+    private static Stream<String> invalidTokens() {
+        return Stream.of(
+            "",
+            " ",
+            CANONICAL_TOKEN.substring(
+                0,
+                CANONICAL_TOKEN.length() - 1
+            ),
+            CANONICAL_TOKEN + "A",
+            CANONICAL_TOKEN.substring(0, 42) + "=",
+            CANONICAL_TOKEN.substring(0, 42) + "+",
+            CANONICAL_TOKEN.substring(0, 42) + "/",
+            " " + CANONICAL_TOKEN.substring(1),
+            CANONICAL_TOKEN.substring(0, 42) + "9"
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/port/in/AuthenticateUserResultTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/in/AuthenticateUserResultTest.java
@@ -1,0 +1,146 @@
+package com.nursena.payflow.user.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class AuthenticateUserResultTest {
+
+    private static final Instant ACCESS_EXPIRES_AT =
+        Instant.parse(
+            "2026-07-28T12:15:00Z"
+        );
+
+    private static final Instant REFRESH_EXPIRES_AT =
+        Instant.parse(
+            "2026-08-04T12:00:00Z"
+        );
+
+    @Test
+    void shouldRetainCredentialPair() {
+        AuthenticateUserResult result =
+            new AuthenticateUserResult(
+                "signed-access-token",
+                ACCESS_EXPIRES_AT,
+                "opaque-refresh-token",
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(result.accessToken())
+            .isEqualTo(
+                "signed-access-token"
+            );
+
+        assertThat(result.expiresAt())
+            .isEqualTo(
+                ACCESS_EXPIRES_AT
+            );
+
+        assertThat(result.refreshToken())
+            .isEqualTo(
+                "opaque-refresh-token"
+            );
+
+        assertThat(
+            result.refreshTokenExpiresAt()
+        )
+            .isEqualTo(
+                REFRESH_EXPIRES_AT
+            );
+    }
+
+    @Test
+    void shouldRedactCredentialValuesFromToString() {
+        AuthenticateUserResult result =
+            new AuthenticateUserResult(
+                "secret-access-token",
+                ACCESS_EXPIRES_AT,
+                "secret-refresh-token",
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(result.toString())
+            .isEqualTo(
+                "AuthenticateUserResult[redacted]"
+            )
+            .doesNotContain(
+                "secret-access-token",
+                "secret-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankAccessToken() {
+        assertThatThrownBy(() ->
+            new AuthenticateUserResult(
+                " ",
+                ACCESS_EXPIRES_AT,
+                "refresh-token",
+                REFRESH_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "accessToken must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankRefreshToken() {
+        assertThatThrownBy(() ->
+            new AuthenticateUserResult(
+                "access-token",
+                ACCESS_EXPIRES_AT,
+                " ",
+                REFRESH_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "refreshToken must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRequireAccessExpiration() {
+        assertThatThrownBy(() ->
+            new AuthenticateUserResult(
+                "access-token",
+                null,
+                "refresh-token",
+                REFRESH_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "expiresAt must not be null"
+            );
+    }
+
+    @Test
+    void shouldRequireRefreshExpiration() {
+        assertThatThrownBy(() ->
+            new AuthenticateUserResult(
+                "access-token",
+                ACCESS_EXPIRES_AT,
+                "refresh-token",
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "refreshTokenExpiresAt must not be null"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/port/in/RevokeCurrentRefreshSessionCommandTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/in/RevokeCurrentRefreshSessionCommandTest.java
@@ -1,0 +1,68 @@
+package com.nursena.payflow.user.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class RevokeCurrentRefreshSessionCommandTest {
+
+    @Test
+    void shouldRetainRefreshToken() {
+        RevokeCurrentRefreshSessionCommand command =
+            new RevokeCurrentRefreshSessionCommand(
+                "opaque-refresh-token"
+            );
+
+        assertThat(command.refreshToken())
+            .isEqualTo(
+                "opaque-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRequireRefreshToken() {
+        assertThatThrownBy(() ->
+            new RevokeCurrentRefreshSessionCommand(
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "refreshToken must not be null"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankRefreshToken() {
+        assertThatThrownBy(() ->
+            new RevokeCurrentRefreshSessionCommand(
+                " "
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "refreshToken must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRedactRefreshTokenFromToString() {
+        RevokeCurrentRefreshSessionCommand command =
+            new RevokeCurrentRefreshSessionCommand(
+                "secret-refresh-token"
+            );
+
+        assertThat(command.toString())
+            .isEqualTo(
+                "RevokeCurrentRefreshSessionCommand[redacted]"
+            )
+            .doesNotContain(
+                "secret-refresh-token"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsCommandTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsCommandTest.java
@@ -1,0 +1,68 @@
+package com.nursena.payflow.user.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class RotateRefreshCredentialsCommandTest {
+
+    @Test
+    void shouldRetainRefreshToken() {
+        RotateRefreshCredentialsCommand command =
+            new RotateRefreshCredentialsCommand(
+                "opaque-refresh-token"
+            );
+
+        assertThat(command.refreshToken())
+            .isEqualTo(
+                "opaque-refresh-token"
+            );
+    }
+
+    @Test
+    void shouldRequireRefreshToken() {
+        assertThatThrownBy(() ->
+            new RotateRefreshCredentialsCommand(
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "refreshToken must not be null"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankRefreshToken() {
+        assertThatThrownBy(() ->
+            new RotateRefreshCredentialsCommand(
+                " "
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "refreshToken must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRedactRefreshTokenFromToString() {
+        RotateRefreshCredentialsCommand command =
+            new RotateRefreshCredentialsCommand(
+                "secret-refresh-token"
+            );
+
+        assertThat(command.toString())
+            .isEqualTo(
+                "RotateRefreshCredentialsCommand[redacted]"
+            )
+            .doesNotContain(
+                "secret-refresh-token"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsResultTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/in/RotateRefreshCredentialsResultTest.java
@@ -1,0 +1,143 @@
+package com.nursena.payflow.user.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class RotateRefreshCredentialsResultTest {
+
+    private static final Instant ACCESS_EXPIRES_AT =
+        Instant.parse(
+            "2026-07-28T12:15:00Z"
+        );
+
+    private static final Instant REFRESH_EXPIRES_AT =
+        Instant.parse(
+            "2026-08-04T12:00:00Z"
+        );
+
+    @Test
+    void shouldRetainCredentialPair() {
+        RotateRefreshCredentialsResult result =
+            new RotateRefreshCredentialsResult(
+                "signed-access-token",
+                ACCESS_EXPIRES_AT,
+                "opaque-refresh-token",
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(result.accessToken())
+            .isEqualTo(
+                "signed-access-token"
+            );
+
+        assertThat(result.expiresAt())
+            .isEqualTo(
+                ACCESS_EXPIRES_AT
+            );
+
+        assertThat(result.refreshToken())
+            .isEqualTo(
+                "opaque-refresh-token"
+            );
+
+        assertThat(
+            result.refreshTokenExpiresAt()
+        )
+            .isEqualTo(
+                REFRESH_EXPIRES_AT
+            );
+    }
+
+    @Test
+    void shouldRejectBlankAccessToken() {
+        assertThatThrownBy(() ->
+            new RotateRefreshCredentialsResult(
+                " ",
+                ACCESS_EXPIRES_AT,
+                "refresh-token",
+                REFRESH_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "accessToken must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankRefreshToken() {
+        assertThatThrownBy(() ->
+            new RotateRefreshCredentialsResult(
+                "access-token",
+                ACCESS_EXPIRES_AT,
+                " ",
+                REFRESH_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "refreshToken must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRequireCredentialExpirations() {
+        assertThatThrownBy(() ->
+            new RotateRefreshCredentialsResult(
+                "access-token",
+                null,
+                "refresh-token",
+                REFRESH_EXPIRES_AT
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "expiresAt must not be null"
+            );
+
+        assertThatThrownBy(() ->
+            new RotateRefreshCredentialsResult(
+                "access-token",
+                ACCESS_EXPIRES_AT,
+                "refresh-token",
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "refreshTokenExpiresAt must not be null"
+            );
+    }
+
+    @Test
+    void shouldRedactCredentialsFromToString() {
+        RotateRefreshCredentialsResult result =
+            new RotateRefreshCredentialsResult(
+                "secret-access-token",
+                ACCESS_EXPIRES_AT,
+                "secret-refresh-token",
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(result.toString())
+            .isEqualTo(
+                "RotateRefreshCredentialsResult[redacted]"
+            )
+            .doesNotContain(
+                "secret-access-token",
+                "secret-refresh-token"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/AuthenticateUserServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/AuthenticateUserServiceTest.java
@@ -2,32 +2,50 @@ package com.nursena.payflow.user.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 
 import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
-import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
-import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
 import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
 import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
 import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
 import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
 import com.nursena.payflow.user.domain.model.User;
 import com.nursena.payflow.user.domain.model.UserRole;
 import com.nursena.payflow.user.domain.model.UserStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 class AuthenticateUserServiceTest {
@@ -38,19 +56,36 @@ class AuthenticateUserServiceTest {
         );
 
     private static final Instant NOW =
-        Instant.parse("2026-07-12T12:00:00Z");
+        Instant.parse(
+            "2026-07-28T12:00:00Z"
+        );
 
-    private static final Instant EXPIRES_AT =
-        Instant.parse("2026-07-12T12:15:00Z");
+    private static final Instant ACCESS_EXPIRES_AT =
+        Instant.parse(
+            "2026-07-28T12:15:00Z"
+        );
+
+    private static final Instant FAMILY_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(30)
+        );
+
+    private static final Instant REFRESH_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(7)
+        );
 
     private static final String RAW_PASSWORD =
         "StrongPassword123!";
 
     private static final String PASSWORD_HASH =
-        "$2a$12$hashed-password";
+        "hashed-password";
 
     private static final String ACCESS_TOKEN =
         "generated.jwt.token";
+
+    private static final String REFRESH_TOKEN =
+        "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA";
 
     @Mock
     private UserRepositoryPort userRepository;
@@ -59,37 +94,111 @@ class AuthenticateUserServiceTest {
     private PasswordVerificationPort passwordVerification;
 
     @Mock
+    private RefreshTokenGenerationPort refreshTokenGeneration;
+
+    @Mock
+    private RefreshTokenDigestPort refreshTokenDigest;
+
+    @Mock
+    private RefreshTokenFamilyRepositoryPort familyRepository;
+
+    @Mock
+    private RefreshTokenRecordRepositoryPort recordRepository;
+
+    @Mock
     private AccessTokenGenerationPort accessTokenGeneration;
 
+    private RefreshSessionLifetimePolicy lifetimePolicy;
+    private Clock clock;
     private AuthenticateUserService authenticateUserService;
 
     @BeforeEach
     void setUp() {
-        authenticateUserService = new AuthenticateUserService(
-            userRepository,
-            passwordVerification,
-            accessTokenGeneration
-        );
+        lifetimePolicy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        clock =
+            Clock.fixed(
+                NOW,
+                ZoneOffset.UTC
+            );
+
+        authenticateUserService =
+            new AuthenticateUserService(
+                userRepository,
+                passwordVerification,
+                refreshTokenGeneration,
+                refreshTokenDigest,
+                familyRepository,
+                recordRepository,
+                accessTokenGeneration,
+                lifetimePolicy,
+                clock
+            );
     }
 
     @Test
-    void shouldAuthenticateActiveUser() {
+    void shouldAuthenticateAndIssueInitialRefreshSession() {
         EmailAddress email =
-            EmailAddress.of("nursena@example.com");
+            EmailAddress.of(
+                "nursena@example.com"
+            );
 
-        User user = activeUser(email);
+        User user =
+            activeUser(email);
+
+        RefreshTokenDigest digest =
+            digest();
 
         when(userRepository.findByEmail(email))
-            .thenReturn(Optional.of(user));
+            .thenReturn(
+                Optional.of(user)
+            );
+
         when(passwordVerification.matches(
             RAW_PASSWORD,
             PASSWORD_HASH
-        )).thenReturn(true);
+        ))
+            .thenReturn(true);
+
+        when(refreshTokenGeneration.generate())
+            .thenReturn(
+                new GeneratedRefreshToken(
+                    REFRESH_TOKEN
+                )
+            );
+
+        when(refreshTokenDigest.digest(
+            REFRESH_TOKEN
+        ))
+            .thenReturn(digest);
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
         when(accessTokenGeneration.generate(user))
-            .thenReturn(new GeneratedAccessToken(
-                ACCESS_TOKEN,
-                EXPIRES_AT
-            ));
+            .thenReturn(
+                new GeneratedAccessToken(
+                    ACCESS_TOKEN,
+                    ACCESS_EXPIRES_AT
+                )
+            );
 
         AuthenticateUserResult result =
             authenticateUserService.authenticate(
@@ -101,24 +210,171 @@ class AuthenticateUserServiceTest {
 
         assertThat(result.accessToken())
             .isEqualTo(ACCESS_TOKEN);
-        assertThat(result.expiresAt())
-            .isEqualTo(EXPIRES_AT);
 
-        verify(userRepository).findByEmail(email);
-        verify(passwordVerification).matches(
-            RAW_PASSWORD,
-            PASSWORD_HASH
-        );
-        verify(accessTokenGeneration).generate(user);
+        assertThat(result.expiresAt())
+            .isEqualTo(
+                ACCESS_EXPIRES_AT
+            );
+
+        assertThat(result.refreshToken())
+            .isEqualTo(
+                REFRESH_TOKEN
+            );
+
+        assertThat(
+            result.refreshTokenExpiresAt()
+        )
+            .isEqualTo(
+                REFRESH_EXPIRES_AT
+            );
+
+        ArgumentCaptor<RefreshTokenFamily>
+            familyCaptor =
+            ArgumentCaptor.forClass(
+                RefreshTokenFamily.class
+            );
+
+        ArgumentCaptor<RefreshTokenRecord>
+            recordCaptor =
+            ArgumentCaptor.forClass(
+                RefreshTokenRecord.class
+            );
+
+        InOrder issuanceOrder =
+            inOrder(
+                refreshTokenGeneration,
+                refreshTokenDigest,
+                familyRepository,
+                recordRepository,
+                accessTokenGeneration
+            );
+
+        issuanceOrder
+            .verify(refreshTokenGeneration)
+            .generate();
+
+        issuanceOrder
+            .verify(refreshTokenDigest)
+            .digest(REFRESH_TOKEN);
+
+        issuanceOrder
+            .verify(familyRepository)
+            .save(
+                familyCaptor.capture()
+            );
+
+        issuanceOrder
+            .verify(recordRepository)
+            .save(
+                recordCaptor.capture()
+            );
+
+        issuanceOrder
+            .verify(accessTokenGeneration)
+            .generate(user);
+
+        RefreshTokenFamily savedFamily =
+            familyCaptor.getValue();
+
+        RefreshTokenRecord savedRecord =
+            recordCaptor.getValue();
+
+        assertThat(savedFamily.id())
+            .isNotNull();
+
+        assertThat(savedFamily.userId())
+            .isEqualTo(USER_ID);
+
+        assertThat(savedFamily.createdAt())
+            .isEqualTo(NOW);
+
+        assertThat(savedFamily.expiresAt())
+            .isEqualTo(
+                FAMILY_EXPIRES_AT
+            );
+
+        assertThat(savedFamily.isRevoked())
+            .isFalse();
+
+        assertThat(savedRecord.id())
+            .isNotNull();
+
+        assertThat(savedRecord.familyId())
+            .isEqualTo(
+                savedFamily.id()
+            );
+
+        assertThat(savedRecord.digest())
+            .isEqualTo(digest);
+
+        assertThat(savedRecord.issuedAt())
+            .isEqualTo(NOW);
+
+        assertThat(savedRecord.expiresAt())
+            .isEqualTo(
+                REFRESH_EXPIRES_AT
+            );
+
+        assertThat(
+            savedRecord.isActiveAt(
+                savedFamily,
+                NOW
+            )
+        )
+            .isTrue();
+
+        verify(userRepository)
+            .findByEmail(email);
+
+        verify(passwordVerification)
+            .matches(
+                RAW_PASSWORD,
+                PASSWORD_HASH
+            );
     }
 
     @Test
-    void shouldRejectUnknownEmail() {
+    void shouldDeclareWriteTransactionOnAuthentication()
+        throws NoSuchMethodException {
+
+        Method authenticate =
+            AuthenticateUserService.class
+                .getDeclaredMethod(
+                    "authenticate",
+                    AuthenticateUserCommand.class
+                );
+
+        Transactional transactional =
+            authenticate.getAnnotation(
+                Transactional.class
+            );
+
+        assertThat(transactional)
+            .isNotNull();
+
+        assertThat(transactional.readOnly())
+            .isFalse();
+
+        assertThat(
+            AuthenticateUserService.class
+                .getAnnotation(
+                    Transactional.class
+                )
+        )
+            .isNull();
+    }
+
+    @Test
+    void shouldRejectUnknownEmailWithoutIssuingCredentials() {
         EmailAddress email =
-            EmailAddress.of("unknown@example.com");
+            EmailAddress.of(
+                "unknown@example.com"
+            );
 
         when(userRepository.findByEmail(email))
-            .thenReturn(Optional.empty());
+            .thenReturn(
+                Optional.empty()
+            );
 
         assertThatThrownBy(() ->
             authenticateUserService.authenticate(
@@ -126,30 +382,48 @@ class AuthenticateUserServiceTest {
                     "unknown@example.com",
                     RAW_PASSWORD
                 )
-            ))
-            .isInstanceOf(InvalidCredentialsException.class)
-            .hasMessage("Email or password is incorrect.");
+            )
+        )
+            .isInstanceOf(
+                InvalidCredentialsException.class
+            )
+            .hasMessage(
+                "Email or password is incorrect."
+            );
 
-        verify(userRepository).findByEmail(email);
+        verify(userRepository)
+            .findByEmail(email);
+
         verifyNoInteractions(
             passwordVerification,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            familyRepository,
+            recordRepository,
             accessTokenGeneration
         );
     }
 
     @Test
-    void shouldRejectIncorrectPassword() {
+    void shouldRejectIncorrectPasswordWithoutIssuingCredentials() {
         EmailAddress email =
-            EmailAddress.of("nursena@example.com");
+            EmailAddress.of(
+                "nursena@example.com"
+            );
 
-        User user = activeUser(email);
+        User user =
+            activeUser(email);
 
         when(userRepository.findByEmail(email))
-            .thenReturn(Optional.of(user));
+            .thenReturn(
+                Optional.of(user)
+            );
+
         when(passwordVerification.matches(
             "IncorrectPassword123!",
             PASSWORD_HASH
-        )).thenReturn(false);
+        ))
+            .thenReturn(false);
 
         assertThatThrownBy(() ->
             authenticateUserService.authenticate(
@@ -157,26 +431,41 @@ class AuthenticateUserServiceTest {
                     "nursena@example.com",
                     "IncorrectPassword123!"
                 )
-            ))
-            .isInstanceOf(InvalidCredentialsException.class)
-            .hasMessage("Email or password is incorrect.");
+            )
+        )
+            .isInstanceOf(
+                InvalidCredentialsException.class
+            );
 
-        verify(accessTokenGeneration, never()).generate(user);
+        verifyNoInteractions(
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            familyRepository,
+            recordRepository,
+            accessTokenGeneration
+        );
     }
 
     @Test
-    void shouldRejectUnavailableUserAccount() {
+    void shouldRejectUnavailableAccountWithoutIssuingCredentials() {
         EmailAddress email =
-            EmailAddress.of("nursena@example.com");
+            EmailAddress.of(
+                "nursena@example.com"
+            );
 
-        User user = unavailableUser(email);
+        User user =
+            unavailableUser(email);
 
         when(userRepository.findByEmail(email))
-            .thenReturn(Optional.of(user));
+            .thenReturn(
+                Optional.of(user)
+            );
+
         when(passwordVerification.matches(
             RAW_PASSWORD,
             PASSWORD_HASH
-        )).thenReturn(true);
+        ))
+            .thenReturn(true);
 
         assertThatThrownBy(() ->
             authenticateUserService.authenticate(
@@ -184,18 +473,233 @@ class AuthenticateUserServiceTest {
                     "nursena@example.com",
                     RAW_PASSWORD
                 )
-            ))
+            )
+        )
             .isInstanceOf(
                 UserAccountUnavailableException.class
-            )
-            .hasMessage(
-                "User account is not available for authentication."
             );
 
-        verify(accessTokenGeneration, never()).generate(user);
+        verifyNoInteractions(
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            familyRepository,
+            recordRepository,
+            accessTokenGeneration
+        );
     }
 
-    private static User activeUser(EmailAddress email) {
+    @Test
+    void shouldStopWhenFamilyPersistenceFails() {
+        User user =
+            activeUser(
+                EmailAddress.of(
+                    "nursena@example.com"
+                )
+            );
+
+        stubValidAuthentication(user);
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenThrow(
+                new IllegalStateException(
+                    "family persistence failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            authenticateUserService.authenticate(
+                command()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "family persistence failed"
+            );
+
+        verify(recordRepository, never())
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        verifyNoInteractions(
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldStopWhenRecordPersistenceFails() {
+        User user =
+            activeUser(
+                EmailAddress.of(
+                    "nursena@example.com"
+                )
+            );
+
+        stubValidAuthentication(user);
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenThrow(
+                new IllegalStateException(
+                    "record persistence failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            authenticateUserService.authenticate(
+                command()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "record persistence failed"
+            );
+
+        verifyNoInteractions(
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldGenerateAccessTokenAfterSessionPersistence() {
+        User user =
+            activeUser(
+                EmailAddress.of(
+                    "nursena@example.com"
+                )
+            );
+
+        stubValidAuthentication(user);
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(accessTokenGeneration.generate(user))
+            .thenThrow(
+                new IllegalStateException(
+                    "access token generation failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            authenticateUserService.authenticate(
+                command()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "access token generation failed"
+            );
+
+        InOrder order =
+            inOrder(
+                familyRepository,
+                recordRepository,
+                accessTokenGeneration
+            );
+
+        order.verify(familyRepository)
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+
+        order.verify(recordRepository)
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        order.verify(accessTokenGeneration)
+            .generate(user);
+    }
+
+    private void stubValidAuthentication(
+        User user
+    ) {
+        when(userRepository.findByEmail(
+            user.email()
+        ))
+            .thenReturn(
+                Optional.of(user)
+            );
+
+        when(passwordVerification.matches(
+            RAW_PASSWORD,
+            PASSWORD_HASH
+        ))
+            .thenReturn(true);
+
+        when(refreshTokenGeneration.generate())
+            .thenReturn(
+                new GeneratedRefreshToken(
+                    REFRESH_TOKEN
+                )
+            );
+
+        when(refreshTokenDigest.digest(
+            REFRESH_TOKEN
+        ))
+            .thenReturn(
+                digest()
+            );
+    }
+
+    private static AuthenticateUserCommand command() {
+        return new AuthenticateUserCommand(
+            "nursena@example.com",
+            RAW_PASSWORD
+        );
+    }
+
+    private static RefreshTokenDigest digest() {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            bytes,
+            (byte) 7
+        );
+
+        return RefreshTokenDigest.of(
+            bytes
+        );
+    }
+
+    private static User activeUser(
+        EmailAddress email
+    ) {
         return User.rehydrate(
             USER_ID,
             email,
@@ -207,7 +711,9 @@ class AuthenticateUserServiceTest {
         );
     }
 
-    private static User unavailableUser(EmailAddress email) {
+    private static User unavailableUser(
+        EmailAddress email
+    ) {
         return User.rehydrate(
             USER_ID,
             email,

--- a/src/test/java/com/nursena/payflow/user/application/service/RefreshSessionLifetimePolicyTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RefreshSessionLifetimePolicyTest.java
@@ -1,0 +1,188 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RefreshSessionLifetimePolicyTest {
+
+    private static final Instant ISSUED_AT =
+        Instant.parse(
+            "2026-07-28T12:00:00Z"
+        );
+
+    @Test
+    void shouldCalculateAbsoluteFamilyExpiration() {
+        RefreshSessionLifetimePolicy policy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        assertThat(
+            policy.familyExpiresAt(
+                ISSUED_AT
+            )
+        )
+            .isEqualTo(
+                ISSUED_AT.plus(
+                    Duration.ofDays(30)
+                )
+            );
+    }
+
+    @Test
+    void shouldCalculateRefreshTokenExpiration() {
+        RefreshSessionLifetimePolicy policy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        Instant familyExpiresAt =
+            ISSUED_AT.plus(
+                Duration.ofDays(30)
+            );
+
+        assertThat(
+            policy.refreshTokenExpiresAt(
+                ISSUED_AT,
+                familyExpiresAt
+            )
+        )
+            .isEqualTo(
+                ISSUED_AT.plus(
+                    Duration.ofDays(7)
+                )
+            );
+    }
+
+    @Test
+    void shouldCapRefreshTokenAtFamilyExpiration() {
+        RefreshSessionLifetimePolicy policy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(60),
+                Duration.ofDays(30)
+            );
+
+        Instant familyExpiresAt =
+            ISSUED_AT.plus(
+                Duration.ofDays(30)
+            );
+
+        assertThat(
+            policy.refreshTokenExpiresAt(
+                ISSUED_AT,
+                familyExpiresAt
+            )
+        )
+            .isEqualTo(
+                familyExpiresAt
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidFamilyExpirations")
+    void shouldRequireFamilyExpirationAfterIssuance(
+        Instant invalidFamilyExpiresAt
+    ) {
+        RefreshSessionLifetimePolicy policy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        assertThatThrownBy(() ->
+            policy.refreshTokenExpiresAt(
+                ISSUED_AT,
+                invalidFamilyExpiresAt
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "familyExpiresAt must be after issuedAt"
+            );
+    }
+
+    @Test
+    void shouldRequireIssuanceTime() {
+        RefreshSessionLifetimePolicy policy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        assertThatThrownBy(() ->
+            policy.familyExpiresAt(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "issuedAt must not be null"
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonPositiveDurations")
+    void shouldRejectNonPositiveRefreshTokenTtl(
+        Duration invalidDuration
+    ) {
+        assertThatThrownBy(() ->
+            new RefreshSessionLifetimePolicy(
+                invalidDuration,
+                Duration.ofDays(30)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "refreshTokenTtl must be positive"
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonPositiveDurations")
+    void shouldRejectNonPositiveFamilyTtl(
+        Duration invalidDuration
+    ) {
+        assertThatThrownBy(() ->
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                invalidDuration
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "familyTtl must be positive"
+            );
+    }
+
+    private static Stream<Instant>
+    invalidFamilyExpirations() {
+        return Stream.of(
+            ISSUED_AT,
+            ISSUED_AT.minusSeconds(1)
+        );
+    }
+
+    private static Stream<Duration>
+    nonPositiveDurations() {
+        return Stream.of(
+            Duration.ZERO,
+            Duration.ofSeconds(-1)
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionServiceTest.java
@@ -1,0 +1,174 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionCommand;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RevokeCurrentRefreshSessionServiceTest {
+
+    private static final String REFRESH_TOKEN =
+        "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA";
+
+    private static final RefreshTokenDigest DIGEST =
+        digest((byte) 7);
+
+    @Mock
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @Mock
+    private RevokeCurrentRefreshSessionTransaction
+        revocationTransaction;
+
+    private RevokeCurrentRefreshSessionService
+        service;
+
+    @BeforeEach
+    void setUp() {
+        service =
+            new RevokeCurrentRefreshSessionService(
+                refreshTokenDigest,
+                revocationTransaction
+            );
+    }
+
+    @Test
+    void shouldRevokeCurrentRefreshSession() {
+        when(refreshTokenDigest.digest(
+            REFRESH_TOKEN
+        ))
+            .thenReturn(
+                DIGEST
+            );
+
+        service.revoke(
+            command()
+        );
+
+        verify(refreshTokenDigest)
+            .digest(
+                REFRESH_TOKEN
+            );
+
+        verify(revocationTransaction)
+            .revoke(
+                DIGEST
+            );
+    }
+
+    @Test
+    void shouldCompleteWhenRefreshTokenIsMalformed() {
+        when(refreshTokenDigest.digest(
+            REFRESH_TOKEN
+        ))
+            .thenThrow(
+                new InvalidRefreshTokenException()
+            );
+
+        service.revoke(
+            command()
+        );
+
+        verify(refreshTokenDigest)
+            .digest(
+                REFRESH_TOKEN
+            );
+
+        verifyNoInteractions(
+            revocationTransaction
+        );
+    }
+
+    @Test
+    void shouldPropagateRevocationInfrastructureFailure() {
+        when(refreshTokenDigest.digest(
+            REFRESH_TOKEN
+        ))
+            .thenReturn(
+                DIGEST
+            );
+
+        doThrow(
+            new IllegalStateException(
+                "revocation persistence failed"
+            )
+        )
+            .when(revocationTransaction)
+            .revoke(
+                DIGEST
+            );
+
+        assertThatThrownBy(() ->
+            service.revoke(
+                command()
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "revocation persistence failed"
+            );
+    }
+
+    @Test
+    void shouldRequireCommand() {
+        assertThatThrownBy(() ->
+            service.revoke(
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "command must not be null"
+            );
+
+        verifyNoInteractions(
+            refreshTokenDigest,
+            revocationTransaction
+        );
+    }
+
+    private static RevokeCurrentRefreshSessionCommand
+    command() {
+        return new RevokeCurrentRefreshSessionCommand(
+            REFRESH_TOKEN
+        );
+    }
+
+    private static RefreshTokenDigest digest(
+        byte fillValue
+    ) {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            bytes,
+            fillValue
+        );
+
+        return RefreshTokenDigest.of(
+            bytes
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionTransactionTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RevokeCurrentRefreshSessionTransactionTest.java
@@ -1,0 +1,563 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
+class RevokeCurrentRefreshSessionTransactionTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final RefreshTokenFamilyId
+        FAMILY_ID =
+        RefreshTokenFamilyId.of(
+            UUID.fromString(
+                "f89de08d-3035-407d-bbfd-e49eec447177"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        RECORD_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "0d559bfd-05b6-43aa-8822-49b83eea3f1b"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        SUCCESSOR_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "55667aa8-fd92-4ddb-836b-f83362e5932c"
+            )
+        );
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-29T12:00:00Z"
+        );
+
+    private static final Instant FAMILY_CREATED_AT =
+        NOW.minus(
+            Duration.ofDays(1)
+        );
+
+    private static final Instant FAMILY_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(30)
+        );
+
+    private static final Instant RECORD_ISSUED_AT =
+        NOW.minus(
+            Duration.ofHours(2)
+        );
+
+    private static final Instant RECORD_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(6)
+        );
+
+    private static final RefreshTokenDigest DIGEST =
+        digest((byte) 7);
+
+    @Mock
+    private RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    @Mock
+    private RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    private RevokeCurrentRefreshSessionTransaction
+        transaction;
+
+    @BeforeEach
+    void setUp() {
+        transaction =
+            new RevokeCurrentRefreshSessionTransaction(
+                recordRepository,
+                familyRepository,
+                Clock.fixed(
+                    NOW,
+                    ZoneOffset.UTC
+                )
+            );
+    }
+
+    @Test
+    void shouldRevokeActiveFamily() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord record =
+            activeRecord(family);
+
+        stubLockedSession(
+            family,
+            record
+        );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        ArgumentCaptor<RefreshTokenFamily>
+            familyCaptor =
+            ArgumentCaptor.forClass(
+                RefreshTokenFamily.class
+            );
+
+        InOrder order =
+            inOrder(
+                recordRepository,
+                familyRepository
+            );
+
+        order.verify(recordRepository)
+            .findByDigestForUpdate(
+                DIGEST
+            );
+
+        order.verify(familyRepository)
+            .findByIdForUpdate(
+                FAMILY_ID
+            );
+
+        order.verify(familyRepository)
+            .save(
+                familyCaptor.capture()
+            );
+
+        RefreshTokenFamily savedFamily =
+            familyCaptor.getValue();
+
+        assertThat(savedFamily.id())
+            .isEqualTo(
+                FAMILY_ID
+            );
+
+        assertThat(savedFamily.revokedAt())
+            .isEqualTo(
+                NOW
+            );
+
+        assertThat(savedFamily.revocationReason())
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .CURRENT_SESSION_LOGOUT
+            );
+    }
+
+    @Test
+    void shouldDeclareWriteTransaction()
+        throws NoSuchMethodException {
+
+        Method method =
+            RevokeCurrentRefreshSessionTransaction
+                .class
+                .getDeclaredMethod(
+                    "revoke",
+                    RefreshTokenDigest.class
+                );
+
+        assertThat(
+            method.getAnnotation(
+                Transactional.class
+            )
+        ).isNotNull();
+    }
+
+    @Test
+    void shouldCompleteForUnknownRefreshToken() {
+        when(recordRepository
+            .findByDigestForUpdate(
+                DIGEST
+            ))
+            .thenReturn(
+                Optional.empty()
+            );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        verifyNoInteractions(
+            familyRepository
+        );
+    }
+
+    @Test
+    void shouldCompleteWhenFamilyIsMissing() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord record =
+            activeRecord(family);
+
+        when(recordRepository
+            .findByDigestForUpdate(
+                DIGEST
+            ))
+            .thenReturn(
+                Optional.of(record)
+            );
+
+        when(familyRepository
+            .findByIdForUpdate(
+                FAMILY_ID
+            ))
+            .thenReturn(
+                Optional.empty()
+            );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        verify(familyRepository, never())
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+    }
+
+    @Test
+    void shouldRevokeActiveFamilyForConsumedRecord() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord record =
+            consumedRecord(family);
+
+        stubLockedSession(
+            family,
+            record
+        );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        verify(familyRepository)
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+    }
+
+    @Test
+    void shouldRevokeActiveFamilyForExpiredRecord() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord record =
+            expiredRecord(family);
+
+        stubLockedSession(
+            family,
+            record
+        );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        verify(familyRepository)
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+    }
+
+    @Test
+    void shouldPreserveExistingFamilyRevocation() {
+        RefreshTokenFamily family =
+            revokedFamily();
+
+        RefreshTokenRecord record =
+            rehydratedRecord(family);
+
+        stubLockedSession(
+            family,
+            record
+        );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        verify(familyRepository, never())
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+
+        assertThat(family.revocationReason())
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED
+            );
+    }
+
+    @Test
+    void shouldNotRevokeExpiredFamily() {
+        RefreshTokenFamily family =
+            expiredFamily();
+
+        RefreshTokenRecord record =
+            activeAtIssueTimeRecord(family);
+
+        stubLockedSession(
+            family,
+            record
+        );
+
+        transaction.revoke(
+            DIGEST
+        );
+
+        verify(familyRepository, never())
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+    }
+
+    @Test
+    void shouldPropagateFamilyPersistenceFailure() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord record =
+            activeRecord(family);
+
+        stubLockedSession(
+            family,
+            record
+        );
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenThrow(
+                new IllegalStateException(
+                    "family persistence failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            transaction.revoke(
+                DIGEST
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "family persistence failed"
+            );
+    }
+
+    @Test
+    void shouldRequireDigest() {
+        assertThatThrownBy(() ->
+            transaction.revoke(
+                null
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "digest must not be null"
+            );
+
+        verifyNoInteractions(
+            recordRepository,
+            familyRepository
+        );
+    }
+
+    private void stubLockedSession(
+        RefreshTokenFamily family,
+        RefreshTokenRecord record
+    ) {
+        when(recordRepository
+            .findByDigestForUpdate(
+                DIGEST
+            ))
+            .thenReturn(
+                Optional.of(record)
+            );
+
+        when(familyRepository
+            .findByIdForUpdate(
+                FAMILY_ID
+            ))
+            .thenReturn(
+                Optional.of(family)
+            );
+    }
+
+    private static RefreshTokenFamily
+    activeFamily() {
+        return RefreshTokenFamily.create(
+            FAMILY_ID,
+            USER_ID,
+            FAMILY_CREATED_AT,
+            FAMILY_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenFamily
+    revokedFamily() {
+        return RefreshTokenFamily.rehydrate(
+            FAMILY_ID,
+            USER_ID,
+            FAMILY_CREATED_AT,
+            FAMILY_EXPIRES_AT,
+            NOW.minus(
+                Duration.ofMinutes(5)
+            ),
+            RefreshTokenFamilyRevocationReason
+                .REUSE_DETECTED
+        );
+    }
+
+    private static RefreshTokenFamily
+    expiredFamily() {
+        return RefreshTokenFamily.create(
+            FAMILY_ID,
+            USER_ID,
+            FAMILY_CREATED_AT,
+            NOW.minus(
+                Duration.ofMinutes(1)
+            )
+        );
+    }
+
+    private static RefreshTokenRecord activeRecord(
+        RefreshTokenFamily family
+    ) {
+        return RefreshTokenRecord.issue(
+            RECORD_ID,
+            family,
+            DIGEST,
+            RECORD_ISSUED_AT,
+            RECORD_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenRecord consumedRecord(
+        RefreshTokenFamily family
+    ) {
+        return activeRecord(family)
+            .consume(
+                SUCCESSOR_ID,
+                NOW.minus(
+                    Duration.ofMinutes(1)
+                ),
+                family
+            );
+    }
+
+    private static RefreshTokenRecord expiredRecord(
+        RefreshTokenFamily family
+    ) {
+        return RefreshTokenRecord.issue(
+            RECORD_ID,
+            family,
+            DIGEST,
+            RECORD_ISSUED_AT,
+            NOW.minus(
+                Duration.ofMinutes(1)
+            )
+        );
+    }
+
+    private static RefreshTokenRecord rehydratedRecord(
+        RefreshTokenFamily family
+    ) {
+        return RefreshTokenRecord.rehydrate(
+            RECORD_ID,
+            FAMILY_ID,
+            DIGEST,
+            RECORD_ISSUED_AT,
+            RECORD_EXPIRES_AT,
+            null,
+            null,
+            family
+        );
+    }
+
+    private static RefreshTokenRecord
+    activeAtIssueTimeRecord(
+        RefreshTokenFamily family
+    ) {
+        Instant issuedAt =
+            family.expiresAt()
+                .minus(
+                    Duration.ofHours(1)
+                );
+
+        return RefreshTokenRecord.issue(
+            RECORD_ID,
+            family,
+            DIGEST,
+            issuedAt,
+            family.expiresAt()
+                .minus(
+                    Duration.ofMinutes(1)
+                )
+        );
+    }
+
+    private static RefreshTokenDigest digest(
+        byte fillValue
+    ) {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            bytes,
+            fillValue
+        );
+
+        return RefreshTokenDigest.of(
+            bytes
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsServiceTest.java
@@ -1,0 +1,823 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsCommand;
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model.User;
+import com.nursena.payflow.user.domain.model.UserRole;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
+class RotateRefreshCredentialsServiceTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final RefreshTokenFamilyId
+        FAMILY_ID =
+        RefreshTokenFamilyId.of(
+            UUID.fromString(
+                "f89de08d-3035-407d-bbfd-e49eec447177"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        CURRENT_RECORD_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "0d559bfd-05b6-43aa-8822-49b83eea3f1b"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        EXISTING_SUCCESSOR_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "55667aa8-fd92-4ddb-836b-f83362e5932c"
+            )
+        );
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-28T12:00:00Z"
+        );
+
+    private static final Instant FAMILY_CREATED_AT =
+        NOW.minus(
+            Duration.ofDays(1)
+        );
+
+    private static final Instant FAMILY_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(30)
+        );
+
+    private static final Instant CURRENT_ISSUED_AT =
+        NOW.minus(
+            Duration.ofHours(1)
+        );
+
+    private static final Instant CURRENT_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(6)
+        );
+
+    private static final Instant ACCESS_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofMinutes(15)
+        );
+
+    private static final Instant SUCCESSOR_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(7)
+        );
+
+    private static final String CURRENT_TOKEN =
+        "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA";
+
+    private static final String SUCCESSOR_TOKEN =
+        "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8";
+
+    private static final String ACCESS_TOKEN =
+        "rotated.jwt.token";
+
+    private static final RefreshTokenDigest
+        CURRENT_DIGEST =
+        digest((byte) 7);
+
+    private static final RefreshTokenDigest
+        SUCCESSOR_DIGEST =
+        digest((byte) 9);
+
+    @Mock
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @Mock
+    private RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    @Mock
+    private RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    @Mock
+    private UserRepositoryPort userRepository;
+
+    @Mock
+    private RefreshTokenGenerationPort
+        refreshTokenGeneration;
+
+    @Mock
+    private AccessTokenGenerationPort
+        accessTokenGeneration;
+
+    private RefreshSessionLifetimePolicy
+        lifetimePolicy;
+
+    private Clock clock;
+
+    private RotateRefreshCredentialsService service;
+
+    @BeforeEach
+    void setUp() {
+        lifetimePolicy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        clock =
+            Clock.fixed(
+                NOW,
+                ZoneOffset.UTC
+            );
+
+        service =
+            new RotateRefreshCredentialsService(
+                refreshTokenDigest,
+                recordRepository,
+                familyRepository,
+                userRepository,
+                refreshTokenGeneration,
+                accessTokenGeneration,
+                lifetimePolicy,
+                clock
+            );
+    }
+
+    @Test
+    void shouldRotateActiveRefreshCredentials() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(accessTokenGeneration.generate(user))
+            .thenReturn(
+                new GeneratedAccessToken(
+                    ACCESS_TOKEN,
+                    ACCESS_EXPIRES_AT
+                )
+            );
+
+        RotateRefreshCredentialsResult result =
+            service.rotate(
+                command()
+            );
+
+        assertThat(result.accessToken())
+            .isEqualTo(
+                ACCESS_TOKEN
+            );
+
+        assertThat(result.expiresAt())
+            .isEqualTo(
+                ACCESS_EXPIRES_AT
+            );
+
+        assertThat(result.refreshToken())
+            .isEqualTo(
+                SUCCESSOR_TOKEN
+            );
+
+        assertThat(
+            result.refreshTokenExpiresAt()
+        )
+            .isEqualTo(
+                SUCCESSOR_EXPIRES_AT
+            );
+
+        ArgumentCaptor<RefreshTokenRecord>
+            recordCaptor =
+            ArgumentCaptor.forClass(
+                RefreshTokenRecord.class
+            );
+
+        verify(recordRepository, times(2))
+            .save(
+                recordCaptor.capture()
+            );
+
+        List<RefreshTokenRecord> savedRecords =
+            recordCaptor.getAllValues();
+
+        RefreshTokenRecord successor =
+            savedRecords.get(0);
+
+        RefreshTokenRecord consumedCurrent =
+            savedRecords.get(1);
+
+        assertThat(successor.id())
+            .isNotEqualTo(
+                CURRENT_RECORD_ID
+            );
+
+        assertThat(successor.familyId())
+            .isEqualTo(
+                FAMILY_ID
+            );
+
+        assertThat(successor.digest())
+            .isEqualTo(
+                SUCCESSOR_DIGEST
+            );
+
+        assertThat(successor.issuedAt())
+            .isEqualTo(
+                NOW
+            );
+
+        assertThat(successor.expiresAt())
+            .isEqualTo(
+                SUCCESSOR_EXPIRES_AT
+            );
+
+        assertThat(successor.isConsumed())
+            .isFalse();
+
+        assertThat(consumedCurrent.id())
+            .isEqualTo(
+                CURRENT_RECORD_ID
+            );
+
+        assertThat(consumedCurrent.consumedAt())
+            .isEqualTo(
+                NOW
+            );
+
+        assertThat(consumedCurrent.successorId())
+            .isEqualTo(
+                successor.id()
+            );
+
+        InOrder order =
+            inOrder(
+                refreshTokenDigest,
+                recordRepository,
+                familyRepository,
+                userRepository,
+                refreshTokenGeneration,
+                accessTokenGeneration
+            );
+
+        order.verify(refreshTokenDigest)
+            .digest(CURRENT_TOKEN);
+
+        order.verify(recordRepository)
+            .findByDigestForUpdate(
+                CURRENT_DIGEST
+            );
+
+        order.verify(familyRepository)
+            .findByIdForUpdate(
+                FAMILY_ID
+            );
+
+        order.verify(userRepository)
+            .findById(USER_ID);
+
+        order.verify(refreshTokenGeneration)
+            .generate();
+
+        order.verify(refreshTokenDigest)
+            .digest(SUCCESSOR_TOKEN);
+
+        order.verify(
+            recordRepository,
+            times(2)
+        )
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        order.verify(accessTokenGeneration)
+            .generate(user);
+    }
+
+    @Test
+    void shouldDeclareWriteTransaction()
+        throws NoSuchMethodException {
+
+        Method rotate =
+            RotateRefreshCredentialsService.class
+                .getDeclaredMethod(
+                    "rotate",
+                    RotateRefreshCredentialsCommand.class
+                );
+
+        Transactional transactional =
+            rotate.getAnnotation(
+                Transactional.class
+            );
+
+        assertThat(transactional)
+            .isNotNull();
+
+        assertThat(transactional.readOnly())
+            .isFalse();
+    }
+
+    @Test
+    void shouldRejectUnknownRefreshToken() {
+        when(refreshTokenDigest.digest(
+            CURRENT_TOKEN
+        ))
+            .thenReturn(
+                CURRENT_DIGEST
+            );
+
+        when(recordRepository
+            .findByDigestForUpdate(
+                CURRENT_DIGEST
+            ))
+            .thenReturn(
+                Optional.empty()
+            );
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                InvalidRefreshTokenException.class
+            )
+            .hasMessage(
+                "Refresh token is invalid."
+            );
+
+        verifyNoInteractions(
+            familyRepository,
+            userRepository,
+            refreshTokenGeneration,
+            accessTokenGeneration
+        );
+
+        verify(recordRepository, never())
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+    }
+
+    @Test
+    void shouldRejectConsumedRefreshToken() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord consumedRecord =
+            activeRecord(family)
+                .consume(
+                    EXISTING_SUCCESSOR_ID,
+                    NOW.minusSeconds(1),
+                    family
+                );
+
+        stubLockedSession(
+            family,
+            consumedRecord
+        );
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                InvalidRefreshTokenException.class
+            );
+
+        verifyNoInteractions(
+            userRepository,
+            refreshTokenGeneration,
+            accessTokenGeneration
+        );
+
+        verify(recordRepository, never())
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+    }
+
+    @Test
+    void shouldRejectExpiredRefreshToken() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord expiredRecord =
+            RefreshTokenRecord.issue(
+                CURRENT_RECORD_ID,
+                family,
+                CURRENT_DIGEST,
+                CURRENT_ISSUED_AT,
+                NOW
+            );
+
+        stubLockedSession(
+            family,
+            expiredRecord
+        );
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                InvalidRefreshTokenException.class
+            );
+
+        verifyNoInteractions(
+            userRepository,
+            refreshTokenGeneration,
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldRejectUnavailableUser() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        stubLockedSession(
+            family,
+            currentRecord
+        );
+
+        when(userRepository.findById(USER_ID))
+            .thenReturn(
+                Optional.of(
+                    suspendedUser()
+                )
+            );
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                InvalidRefreshTokenException.class
+            );
+
+        verifyNoInteractions(
+            refreshTokenGeneration,
+            accessTokenGeneration
+        );
+
+        verify(recordRepository, never())
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+    }
+
+    @Test
+    void shouldStopWhenSuccessorPersistenceFails() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenThrow(
+                new IllegalStateException(
+                    "successor persistence failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "successor persistence failed"
+            );
+
+        verify(recordRepository, times(1))
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        verifyNoInteractions(
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldStopWhenPredecessorPersistenceFails() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        AtomicInteger saveAttempts =
+            new AtomicInteger();
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(invocation -> {
+                if (
+                    saveAttempts.getAndIncrement()
+                        == 0
+                ) {
+                    return invocation.getArgument(0);
+                }
+
+                throw new IllegalStateException(
+                    "predecessor persistence failed"
+                );
+            });
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "predecessor persistence failed"
+            );
+
+        verify(recordRepository, times(2))
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        verifyNoInteractions(
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldGenerateAccessTokenAfterBothRecordsPersist() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(accessTokenGeneration.generate(user))
+            .thenThrow(
+                new IllegalStateException(
+                    "access-token generation failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            service.rotate(command())
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "access-token generation failed"
+            );
+
+        InOrder order =
+            inOrder(
+                recordRepository,
+                accessTokenGeneration
+            );
+
+        order.verify(
+            recordRepository,
+            times(2)
+        )
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        order.verify(accessTokenGeneration)
+            .generate(user);
+    }
+
+    private void stubValidRotation(
+        RefreshTokenFamily family,
+        RefreshTokenRecord currentRecord,
+        User user
+    ) {
+        stubLockedSession(
+            family,
+            currentRecord
+        );
+
+        when(userRepository.findById(USER_ID))
+            .thenReturn(
+                Optional.of(user)
+            );
+
+        when(refreshTokenGeneration.generate())
+            .thenReturn(
+                new GeneratedRefreshToken(
+                    SUCCESSOR_TOKEN
+                )
+            );
+
+        when(refreshTokenDigest.digest(
+            SUCCESSOR_TOKEN
+        ))
+            .thenReturn(
+                SUCCESSOR_DIGEST
+            );
+    }
+
+    private void stubLockedSession(
+        RefreshTokenFamily family,
+        RefreshTokenRecord currentRecord
+    ) {
+        when(refreshTokenDigest.digest(
+            CURRENT_TOKEN
+        ))
+            .thenReturn(
+                CURRENT_DIGEST
+            );
+
+        when(recordRepository
+            .findByDigestForUpdate(
+                CURRENT_DIGEST
+            ))
+            .thenReturn(
+                Optional.of(currentRecord)
+            );
+
+        when(familyRepository
+            .findByIdForUpdate(
+                FAMILY_ID
+            ))
+            .thenReturn(
+                Optional.of(family)
+            );
+    }
+
+    private static RotateRefreshCredentialsCommand
+    command() {
+        return new RotateRefreshCredentialsCommand(
+            CURRENT_TOKEN
+        );
+    }
+
+    private static RefreshTokenFamily
+    activeFamily() {
+        return RefreshTokenFamily.create(
+            FAMILY_ID,
+            USER_ID,
+            FAMILY_CREATED_AT,
+            FAMILY_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenRecord activeRecord(
+        RefreshTokenFamily family
+    ) {
+        return RefreshTokenRecord.issue(
+            CURRENT_RECORD_ID,
+            family,
+            CURRENT_DIGEST,
+            CURRENT_ISSUED_AT,
+            CURRENT_EXPIRES_AT
+        );
+    }
+
+    private static User activeUser() {
+        return user(UserStatus.ACTIVE);
+    }
+
+    private static User suspendedUser() {
+        return user(UserStatus.SUSPENDED);
+    }
+
+    private static User user(
+        UserStatus status
+    ) {
+        return User.rehydrate(
+            USER_ID,
+            EmailAddress.of(
+                "nursena@example.com"
+            ),
+            "hashed-password",
+            UserRole.USER,
+            status,
+            FAMILY_CREATED_AT,
+            FAMILY_CREATED_AT
+        );
+    }
+
+    private static RefreshTokenDigest digest(
+        byte fillValue
+    ) {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            bytes,
+            fillValue
+        );
+
+        return RefreshTokenDigest.of(
+            bytes
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsServiceTest.java
@@ -2,387 +2,68 @@ package com.nursena.payflow.user.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.lang.reflect.Method;
-import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsCommand;
 import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
-import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
-import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
-import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
 import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
-import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
-import com.nursena.payflow.user.domain.model.EmailAddress;
 import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
-import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
-import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
-import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
-import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
-import com.nursena.payflow.user.domain.model.User;
-import com.nursena.payflow.user.domain.model.UserRole;
-import com.nursena.payflow.user.domain.model.UserStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 class RotateRefreshCredentialsServiceTest {
 
-    private static final UUID USER_ID =
-        UUID.fromString(
-            "8805681d-d537-42f2-8906-5da1f0666ab7"
-        );
-
-    private static final RefreshTokenFamilyId
-        FAMILY_ID =
-        RefreshTokenFamilyId.of(
-            UUID.fromString(
-                "f89de08d-3035-407d-bbfd-e49eec447177"
-            )
-        );
-
-    private static final RefreshTokenRecordId
-        CURRENT_RECORD_ID =
-        RefreshTokenRecordId.of(
-            UUID.fromString(
-                "0d559bfd-05b6-43aa-8822-49b83eea3f1b"
-            )
-        );
-
-    private static final RefreshTokenRecordId
-        EXISTING_SUCCESSOR_ID =
-        RefreshTokenRecordId.of(
-            UUID.fromString(
-                "55667aa8-fd92-4ddb-836b-f83362e5932c"
-            )
-        );
-
-    private static final Instant NOW =
-        Instant.parse(
-            "2026-07-28T12:00:00Z"
-        );
-
-    private static final Instant FAMILY_CREATED_AT =
-        NOW.minus(
-            Duration.ofDays(1)
-        );
-
-    private static final Instant FAMILY_EXPIRES_AT =
-        NOW.plus(
-            Duration.ofDays(30)
-        );
-
-    private static final Instant CURRENT_ISSUED_AT =
-        NOW.minus(
-            Duration.ofHours(1)
-        );
-
-    private static final Instant CURRENT_EXPIRES_AT =
-        NOW.plus(
-            Duration.ofDays(6)
-        );
-
-    private static final Instant ACCESS_EXPIRES_AT =
-        NOW.plus(
-            Duration.ofMinutes(15)
-        );
-
-    private static final Instant SUCCESSOR_EXPIRES_AT =
-        NOW.plus(
-            Duration.ofDays(7)
-        );
-
     private static final String CURRENT_TOKEN =
         "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA";
-
-    private static final String SUCCESSOR_TOKEN =
-        "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8";
-
-    private static final String ACCESS_TOKEN =
-        "rotated.jwt.token";
 
     private static final RefreshTokenDigest
         CURRENT_DIGEST =
         digest((byte) 7);
 
-    private static final RefreshTokenDigest
-        SUCCESSOR_DIGEST =
-        digest((byte) 9);
+    private static final RotateRefreshCredentialsResult
+        SUCCESS_RESULT =
+        new RotateRefreshCredentialsResult(
+            "rotated.jwt.token",
+            Instant.parse(
+                "2026-07-28T12:15:00Z"
+            ),
+            "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8",
+            Instant.parse(
+                "2026-08-04T12:00:00Z"
+            )
+        );
 
     @Mock
     private RefreshTokenDigestPort
         refreshTokenDigest;
 
     @Mock
-    private RefreshTokenRecordRepositoryPort
-        recordRepository;
-
-    @Mock
-    private RefreshTokenFamilyRepositoryPort
-        familyRepository;
-
-    @Mock
-    private UserRepositoryPort userRepository;
-
-    @Mock
-    private RefreshTokenGenerationPort
-        refreshTokenGeneration;
-
-    @Mock
-    private AccessTokenGenerationPort
-        accessTokenGeneration;
-
-    private RefreshSessionLifetimePolicy
-        lifetimePolicy;
-
-    private Clock clock;
+    private RotateRefreshCredentialsTransaction
+        rotationTransaction;
 
     private RotateRefreshCredentialsService service;
 
     @BeforeEach
     void setUp() {
-        lifetimePolicy =
-            new RefreshSessionLifetimePolicy(
-                Duration.ofDays(7),
-                Duration.ofDays(30)
-            );
-
-        clock =
-            Clock.fixed(
-                NOW,
-                ZoneOffset.UTC
-            );
-
         service =
             new RotateRefreshCredentialsService(
                 refreshTokenDigest,
-                recordRepository,
-                familyRepository,
-                userRepository,
-                refreshTokenGeneration,
-                accessTokenGeneration,
-                lifetimePolicy,
-                clock
+                rotationTransaction
             );
     }
 
     @Test
-    void shouldRotateActiveRefreshCredentials() {
-        RefreshTokenFamily family =
-            activeFamily();
-
-        RefreshTokenRecord currentRecord =
-            activeRecord(family);
-
-        User user =
-            activeUser();
-
-        stubValidRotation(
-            family,
-            currentRecord,
-            user
-        );
-
-        when(recordRepository.save(
-            any(RefreshTokenRecord.class)
-        ))
-            .thenAnswer(
-                invocation ->
-                    invocation.getArgument(0)
-            );
-
-        when(accessTokenGeneration.generate(user))
-            .thenReturn(
-                new GeneratedAccessToken(
-                    ACCESS_TOKEN,
-                    ACCESS_EXPIRES_AT
-                )
-            );
-
-        RotateRefreshCredentialsResult result =
-            service.rotate(
-                command()
-            );
-
-        assertThat(result.accessToken())
-            .isEqualTo(
-                ACCESS_TOKEN
-            );
-
-        assertThat(result.expiresAt())
-            .isEqualTo(
-                ACCESS_EXPIRES_AT
-            );
-
-        assertThat(result.refreshToken())
-            .isEqualTo(
-                SUCCESSOR_TOKEN
-            );
-
-        assertThat(
-            result.refreshTokenExpiresAt()
-        )
-            .isEqualTo(
-                SUCCESSOR_EXPIRES_AT
-            );
-
-        ArgumentCaptor<RefreshTokenRecord>
-            recordCaptor =
-            ArgumentCaptor.forClass(
-                RefreshTokenRecord.class
-            );
-
-        verify(recordRepository, times(2))
-            .save(
-                recordCaptor.capture()
-            );
-
-        List<RefreshTokenRecord> savedRecords =
-            recordCaptor.getAllValues();
-
-        RefreshTokenRecord successor =
-            savedRecords.get(0);
-
-        RefreshTokenRecord consumedCurrent =
-            savedRecords.get(1);
-
-        assertThat(successor.id())
-            .isNotEqualTo(
-                CURRENT_RECORD_ID
-            );
-
-        assertThat(successor.familyId())
-            .isEqualTo(
-                FAMILY_ID
-            );
-
-        assertThat(successor.digest())
-            .isEqualTo(
-                SUCCESSOR_DIGEST
-            );
-
-        assertThat(successor.issuedAt())
-            .isEqualTo(
-                NOW
-            );
-
-        assertThat(successor.expiresAt())
-            .isEqualTo(
-                SUCCESSOR_EXPIRES_AT
-            );
-
-        assertThat(successor.isConsumed())
-            .isFalse();
-
-        assertThat(consumedCurrent.id())
-            .isEqualTo(
-                CURRENT_RECORD_ID
-            );
-
-        assertThat(consumedCurrent.consumedAt())
-            .isEqualTo(
-                NOW
-            );
-
-        assertThat(consumedCurrent.successorId())
-            .isEqualTo(
-                successor.id()
-            );
-
-        InOrder order =
-            inOrder(
-                refreshTokenDigest,
-                recordRepository,
-                familyRepository,
-                userRepository,
-                refreshTokenGeneration,
-                accessTokenGeneration
-            );
-
-        order.verify(refreshTokenDigest)
-            .digest(CURRENT_TOKEN);
-
-        order.verify(recordRepository)
-            .findByDigestForUpdate(
-                CURRENT_DIGEST
-            );
-
-        order.verify(familyRepository)
-            .findByIdForUpdate(
-                FAMILY_ID
-            );
-
-        order.verify(userRepository)
-            .findById(USER_ID);
-
-        order.verify(refreshTokenGeneration)
-            .generate();
-
-        order.verify(refreshTokenDigest)
-            .digest(SUCCESSOR_TOKEN);
-
-        order.verify(
-            recordRepository,
-            times(2)
-        )
-            .save(
-                any(RefreshTokenRecord.class)
-            );
-
-        order.verify(accessTokenGeneration)
-            .generate(user);
-    }
-
-    @Test
-    void shouldDeclareWriteTransaction()
-        throws NoSuchMethodException {
-
-        Method rotate =
-            RotateRefreshCredentialsService.class
-                .getDeclaredMethod(
-                    "rotate",
-                    RotateRefreshCredentialsCommand.class
-                );
-
-        Transactional transactional =
-            rotate.getAnnotation(
-                Transactional.class
-            );
-
-        assertThat(transactional)
-            .isNotNull();
-
-        assertThat(transactional.readOnly())
-            .isFalse();
-    }
-
-    @Test
-    void shouldRejectUnknownRefreshToken() {
+    void shouldReturnCommittedSuccessfulRotation() {
         when(refreshTokenDigest.digest(
             CURRENT_TOKEN
         ))
@@ -390,16 +71,55 @@ class RotateRefreshCredentialsServiceTest {
                 CURRENT_DIGEST
             );
 
-        when(recordRepository
-            .findByDigestForUpdate(
-                CURRENT_DIGEST
-            ))
+        when(rotationTransaction.rotate(
+            CURRENT_DIGEST
+        ))
             .thenReturn(
-                Optional.empty()
+                new RotateRefreshCredentialsOutcome
+                    .Succeeded(
+                        SUCCESS_RESULT
+                    )
+            );
+
+        RotateRefreshCredentialsResult result =
+            service.rotate(
+                command()
+            );
+
+        assertThat(result)
+            .isSameAs(
+                SUCCESS_RESULT
+            );
+
+        verify(refreshTokenDigest)
+            .digest(CURRENT_TOKEN);
+
+        verify(rotationTransaction)
+            .rotate(CURRENT_DIGEST);
+    }
+
+    @Test
+    void shouldRaisePublicFailureAfterRejectedTransaction() {
+        when(refreshTokenDigest.digest(
+            CURRENT_TOKEN
+        ))
+            .thenReturn(
+                CURRENT_DIGEST
+            );
+
+        when(rotationTransaction.rotate(
+            CURRENT_DIGEST
+        ))
+            .thenReturn(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
             );
 
         assertThatThrownBy(() ->
-            service.rotate(command())
+            service.rotate(
+                command()
+            )
         )
             .isInstanceOf(
                 InvalidRefreshTokenException.class
@@ -408,397 +128,58 @@ class RotateRefreshCredentialsServiceTest {
                 "Refresh token is invalid."
             );
 
-        verifyNoInteractions(
-            familyRepository,
-            userRepository,
-            refreshTokenGeneration,
-            accessTokenGeneration
-        );
-
-        verify(recordRepository, never())
-            .save(
-                any(RefreshTokenRecord.class)
-            );
+        verify(rotationTransaction)
+            .rotate(CURRENT_DIGEST);
     }
 
     @Test
-    void shouldRejectConsumedRefreshToken() {
-        RefreshTokenFamily family =
-            activeFamily();
+    void shouldRejectMalformedCredentialBeforeTransaction() {
+        InvalidRefreshTokenException failure =
+            new InvalidRefreshTokenException();
 
-        RefreshTokenRecord consumedRecord =
-            activeRecord(family)
-                .consume(
-                    EXISTING_SUCCESSOR_ID,
-                    NOW.minusSeconds(1),
-                    family
-                );
-
-        stubLockedSession(
-            family,
-            consumedRecord
-        );
-
-        assertThatThrownBy(() ->
-            service.rotate(command())
-        )
-            .isInstanceOf(
-                InvalidRefreshTokenException.class
-            );
-
-        verifyNoInteractions(
-            userRepository,
-            refreshTokenGeneration,
-            accessTokenGeneration
-        );
-
-        verify(recordRepository, never())
-            .save(
-                any(RefreshTokenRecord.class)
-            );
-    }
-
-    @Test
-    void shouldRejectExpiredRefreshToken() {
-        RefreshTokenFamily family =
-            activeFamily();
-
-        RefreshTokenRecord expiredRecord =
-            RefreshTokenRecord.issue(
-                CURRENT_RECORD_ID,
-                family,
-                CURRENT_DIGEST,
-                CURRENT_ISSUED_AT,
-                NOW
-            );
-
-        stubLockedSession(
-            family,
-            expiredRecord
-        );
-
-        assertThatThrownBy(() ->
-            service.rotate(command())
-        )
-            .isInstanceOf(
-                InvalidRefreshTokenException.class
-            );
-
-        verifyNoInteractions(
-            userRepository,
-            refreshTokenGeneration,
-            accessTokenGeneration
-        );
-    }
-
-    @Test
-    void shouldRejectUnavailableUser() {
-        RefreshTokenFamily family =
-            activeFamily();
-
-        RefreshTokenRecord currentRecord =
-            activeRecord(family);
-
-        stubLockedSession(
-            family,
-            currentRecord
-        );
-
-        when(userRepository.findById(USER_ID))
-            .thenReturn(
-                Optional.of(
-                    suspendedUser()
-                )
-            );
-
-        assertThatThrownBy(() ->
-            service.rotate(command())
-        )
-            .isInstanceOf(
-                InvalidRefreshTokenException.class
-            );
-
-        verifyNoInteractions(
-            refreshTokenGeneration,
-            accessTokenGeneration
-        );
-
-        verify(recordRepository, never())
-            .save(
-                any(RefreshTokenRecord.class)
-            );
-    }
-
-    @Test
-    void shouldStopWhenSuccessorPersistenceFails() {
-        RefreshTokenFamily family =
-            activeFamily();
-
-        RefreshTokenRecord currentRecord =
-            activeRecord(family);
-
-        User user =
-            activeUser();
-
-        stubValidRotation(
-            family,
-            currentRecord,
-            user
-        );
-
-        when(recordRepository.save(
-            any(RefreshTokenRecord.class)
-        ))
-            .thenThrow(
-                new IllegalStateException(
-                    "successor persistence failed"
-                )
-            );
-
-        assertThatThrownBy(() ->
-            service.rotate(command())
-        )
-            .isInstanceOf(
-                IllegalStateException.class
-            )
-            .hasMessage(
-                "successor persistence failed"
-            );
-
-        verify(recordRepository, times(1))
-            .save(
-                any(RefreshTokenRecord.class)
-            );
-
-        verifyNoInteractions(
-            accessTokenGeneration
-        );
-    }
-
-    @Test
-    void shouldStopWhenPredecessorPersistenceFails() {
-        RefreshTokenFamily family =
-            activeFamily();
-
-        RefreshTokenRecord currentRecord =
-            activeRecord(family);
-
-        User user =
-            activeUser();
-
-        stubValidRotation(
-            family,
-            currentRecord,
-            user
-        );
-
-        AtomicInteger saveAttempts =
-            new AtomicInteger();
-
-        when(recordRepository.save(
-            any(RefreshTokenRecord.class)
-        ))
-            .thenAnswer(invocation -> {
-                if (
-                    saveAttempts.getAndIncrement()
-                        == 0
-                ) {
-                    return invocation.getArgument(0);
-                }
-
-                throw new IllegalStateException(
-                    "predecessor persistence failed"
-                );
-            });
-
-        assertThatThrownBy(() ->
-            service.rotate(command())
-        )
-            .isInstanceOf(
-                IllegalStateException.class
-            )
-            .hasMessage(
-                "predecessor persistence failed"
-            );
-
-        verify(recordRepository, times(2))
-            .save(
-                any(RefreshTokenRecord.class)
-            );
-
-        verifyNoInteractions(
-            accessTokenGeneration
-        );
-    }
-
-    @Test
-    void shouldGenerateAccessTokenAfterBothRecordsPersist() {
-        RefreshTokenFamily family =
-            activeFamily();
-
-        RefreshTokenRecord currentRecord =
-            activeRecord(family);
-
-        User user =
-            activeUser();
-
-        stubValidRotation(
-            family,
-            currentRecord,
-            user
-        );
-
-        when(recordRepository.save(
-            any(RefreshTokenRecord.class)
-        ))
-            .thenAnswer(
-                invocation ->
-                    invocation.getArgument(0)
-            );
-
-        when(accessTokenGeneration.generate(user))
-            .thenThrow(
-                new IllegalStateException(
-                    "access-token generation failed"
-                )
-            );
-
-        assertThatThrownBy(() ->
-            service.rotate(command())
-        )
-            .isInstanceOf(
-                IllegalStateException.class
-            )
-            .hasMessage(
-                "access-token generation failed"
-            );
-
-        InOrder order =
-            inOrder(
-                recordRepository,
-                accessTokenGeneration
-            );
-
-        order.verify(
-            recordRepository,
-            times(2)
-        )
-            .save(
-                any(RefreshTokenRecord.class)
-            );
-
-        order.verify(accessTokenGeneration)
-            .generate(user);
-    }
-
-    private void stubValidRotation(
-        RefreshTokenFamily family,
-        RefreshTokenRecord currentRecord,
-        User user
-    ) {
-        stubLockedSession(
-            family,
-            currentRecord
-        );
-
-        when(userRepository.findById(USER_ID))
-            .thenReturn(
-                Optional.of(user)
-            );
-
-        when(refreshTokenGeneration.generate())
-            .thenReturn(
-                new GeneratedRefreshToken(
-                    SUCCESSOR_TOKEN
-                )
-            );
-
-        when(refreshTokenDigest.digest(
-            SUCCESSOR_TOKEN
-        ))
-            .thenReturn(
-                SUCCESSOR_DIGEST
-            );
-    }
-
-    private void stubLockedSession(
-        RefreshTokenFamily family,
-        RefreshTokenRecord currentRecord
-    ) {
         when(refreshTokenDigest.digest(
             CURRENT_TOKEN
         ))
-            .thenReturn(
-                CURRENT_DIGEST
+            .thenThrow(
+                failure
             );
 
-        when(recordRepository
-            .findByDigestForUpdate(
-                CURRENT_DIGEST
-            ))
-            .thenReturn(
-                Optional.of(currentRecord)
+        assertThatThrownBy(() ->
+            service.rotate(
+                command()
+            )
+        )
+            .isSameAs(
+                failure
             );
 
-        when(familyRepository
-            .findByIdForUpdate(
-                FAMILY_ID
-            ))
-            .thenReturn(
-                Optional.of(family)
+        verifyNoInteractions(
+            rotationTransaction
+        );
+    }
+
+    @Test
+    void shouldRequireCommand() {
+        assertThatThrownBy(() ->
+            service.rotate(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "command must not be null"
             );
+
+        verifyNoInteractions(
+            refreshTokenDigest,
+            rotationTransaction
+        );
     }
 
     private static RotateRefreshCredentialsCommand
     command() {
         return new RotateRefreshCredentialsCommand(
             CURRENT_TOKEN
-        );
-    }
-
-    private static RefreshTokenFamily
-    activeFamily() {
-        return RefreshTokenFamily.create(
-            FAMILY_ID,
-            USER_ID,
-            FAMILY_CREATED_AT,
-            FAMILY_EXPIRES_AT
-        );
-    }
-
-    private static RefreshTokenRecord activeRecord(
-        RefreshTokenFamily family
-    ) {
-        return RefreshTokenRecord.issue(
-            CURRENT_RECORD_ID,
-            family,
-            CURRENT_DIGEST,
-            CURRENT_ISSUED_AT,
-            CURRENT_EXPIRES_AT
-        );
-    }
-
-    private static User activeUser() {
-        return user(UserStatus.ACTIVE);
-    }
-
-    private static User suspendedUser() {
-        return user(UserStatus.SUSPENDED);
-    }
-
-    private static User user(
-        UserStatus status
-    ) {
-        return User.rehydrate(
-            USER_ID,
-            EmailAddress.of(
-                "nursena@example.com"
-            ),
-            "hashed-password",
-            UserRole.USER,
-            status,
-            FAMILY_CREATED_AT,
-            FAMILY_CREATED_AT
         );
     }
 

--- a/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsTransactionTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsTransactionTest.java
@@ -1,0 +1,936 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.nursena.payflow.user.application.port.in.RotateRefreshCredentialsResult;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model.User;
+import com.nursena.payflow.user.domain.model.UserRole;
+import com.nursena.payflow.user.domain.model.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
+class RotateRefreshCredentialsTransactionTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "8805681d-d537-42f2-8906-5da1f0666ab7"
+        );
+
+    private static final RefreshTokenFamilyId
+        FAMILY_ID =
+        RefreshTokenFamilyId.of(
+            UUID.fromString(
+                "f89de08d-3035-407d-bbfd-e49eec447177"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        CURRENT_RECORD_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "0d559bfd-05b6-43aa-8822-49b83eea3f1b"
+            )
+        );
+
+    private static final RefreshTokenRecordId
+        EXISTING_SUCCESSOR_ID =
+        RefreshTokenRecordId.of(
+            UUID.fromString(
+                "55667aa8-fd92-4ddb-836b-f83362e5932c"
+            )
+        );
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-28T12:00:00Z"
+        );
+
+    private static final Instant FAMILY_CREATED_AT =
+        NOW.minus(
+            Duration.ofDays(1)
+        );
+
+    private static final Instant FAMILY_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(30)
+        );
+
+    private static final Instant CURRENT_ISSUED_AT =
+        NOW.minus(
+            Duration.ofHours(1)
+        );
+
+    private static final Instant CURRENT_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(6)
+        );
+
+    private static final Instant ACCESS_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofMinutes(15)
+        );
+
+    private static final Instant SUCCESSOR_EXPIRES_AT =
+        NOW.plus(
+            Duration.ofDays(7)
+        );
+
+    private static final String SUCCESSOR_TOKEN =
+        "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8";
+
+    private static final String ACCESS_TOKEN =
+        "rotated.jwt.token";
+
+    private static final RefreshTokenDigest
+        CURRENT_DIGEST =
+        digest((byte) 7);
+
+    private static final RefreshTokenDigest
+        SUCCESSOR_DIGEST =
+        digest((byte) 9);
+
+    @Mock
+    private RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    @Mock
+    private RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    @Mock
+    private UserRepositoryPort userRepository;
+
+    @Mock
+    private RefreshTokenGenerationPort
+        refreshTokenGeneration;
+
+    @Mock
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @Mock
+    private AccessTokenGenerationPort
+        accessTokenGeneration;
+
+    private RefreshSessionLifetimePolicy
+        lifetimePolicy;
+
+    private Clock clock;
+
+    private RotateRefreshCredentialsTransaction
+        transaction;
+
+    @BeforeEach
+    void setUp() {
+        lifetimePolicy =
+            new RefreshSessionLifetimePolicy(
+                Duration.ofDays(7),
+                Duration.ofDays(30)
+            );
+
+        clock =
+            Clock.fixed(
+                NOW,
+                ZoneOffset.UTC
+            );
+
+        transaction =
+            new RotateRefreshCredentialsTransaction(
+                recordRepository,
+                familyRepository,
+                userRepository,
+                refreshTokenGeneration,
+                refreshTokenDigest,
+                accessTokenGeneration,
+                lifetimePolicy,
+                clock
+            );
+    }
+
+    @Test
+    void shouldRotateActiveRefreshCredentials() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(accessTokenGeneration.generate(user))
+            .thenReturn(
+                new GeneratedAccessToken(
+                    ACCESS_TOKEN,
+                    ACCESS_EXPIRES_AT
+                )
+            );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isInstanceOf(
+                RotateRefreshCredentialsOutcome
+                    .Succeeded.class
+            );
+
+        RotateRefreshCredentialsResult result =
+            (
+                (RotateRefreshCredentialsOutcome
+                    .Succeeded) outcome
+            ).result();
+
+        assertThat(result.accessToken())
+            .isEqualTo(
+                ACCESS_TOKEN
+            );
+
+        assertThat(result.expiresAt())
+            .isEqualTo(
+                ACCESS_EXPIRES_AT
+            );
+
+        assertThat(result.refreshToken())
+            .isEqualTo(
+                SUCCESSOR_TOKEN
+            );
+
+        assertThat(
+            result.refreshTokenExpiresAt()
+        )
+            .isEqualTo(
+                SUCCESSOR_EXPIRES_AT
+            );
+
+        ArgumentCaptor<RefreshTokenRecord>
+            recordCaptor =
+            ArgumentCaptor.forClass(
+                RefreshTokenRecord.class
+            );
+
+        verify(recordRepository, times(2))
+            .save(
+                recordCaptor.capture()
+            );
+
+        List<RefreshTokenRecord> savedRecords =
+            recordCaptor.getAllValues();
+
+        RefreshTokenRecord successor =
+            savedRecords.get(0);
+
+        RefreshTokenRecord consumedCurrent =
+            savedRecords.get(1);
+
+        assertThat(successor.familyId())
+            .isEqualTo(
+                FAMILY_ID
+            );
+
+        assertThat(successor.digest())
+            .isEqualTo(
+                SUCCESSOR_DIGEST
+            );
+
+        assertThat(successor.issuedAt())
+            .isEqualTo(
+                NOW
+            );
+
+        assertThat(successor.expiresAt())
+            .isEqualTo(
+                SUCCESSOR_EXPIRES_AT
+            );
+
+        assertThat(successor.isConsumed())
+            .isFalse();
+
+        assertThat(consumedCurrent.id())
+            .isEqualTo(
+                CURRENT_RECORD_ID
+            );
+
+        assertThat(consumedCurrent.consumedAt())
+            .isEqualTo(
+                NOW
+            );
+
+        assertThat(consumedCurrent.successorId())
+            .isEqualTo(
+                successor.id()
+            );
+    }
+
+    @Test
+    void shouldDeclareWriteTransaction()
+        throws NoSuchMethodException {
+
+        Method rotate =
+            RotateRefreshCredentialsTransaction.class
+                .getDeclaredMethod(
+                    "rotate",
+                    RefreshTokenDigest.class
+                );
+
+        Transactional transactional =
+            rotate.getAnnotation(
+                Transactional.class
+            );
+
+        assertThat(transactional)
+            .isNotNull();
+
+        assertThat(transactional.readOnly())
+            .isFalse();
+    }
+
+    @Test
+    void shouldRejectUnknownRefreshToken() {
+        when(recordRepository
+            .findByDigestForUpdate(
+                CURRENT_DIGEST
+            ))
+            .thenReturn(
+                Optional.empty()
+            );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isSameAs(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
+            );
+
+        verifyNoInteractions(
+            familyRepository,
+            userRepository,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldRevokeActiveFamilyWhenConsumedTokenIsReused() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord consumedRecord =
+            consumedRecord(family);
+
+        stubLockedSession(
+            family,
+            consumedRecord
+        );
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isSameAs(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
+            );
+
+        ArgumentCaptor<RefreshTokenFamily>
+            familyCaptor =
+            ArgumentCaptor.forClass(
+                RefreshTokenFamily.class
+            );
+
+        verify(familyRepository)
+            .save(
+                familyCaptor.capture()
+            );
+
+        RefreshTokenFamily revoked =
+            familyCaptor.getValue();
+
+        assertThat(revoked.id())
+            .isEqualTo(
+                FAMILY_ID
+            );
+
+        assertThat(revoked.revokedAt())
+            .isEqualTo(
+                NOW
+            );
+
+        assertThat(revoked.revocationReason())
+            .isEqualTo(
+                RefreshTokenFamilyRevocationReason
+                    .REUSE_DETECTED
+            );
+
+        assertThat(revoked.isActiveAt(NOW))
+            .isFalse();
+
+        verifyNoInteractions(
+            userRepository,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            accessTokenGeneration
+        );
+
+        verify(recordRepository, never())
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+    }
+
+    @Test
+    void shouldPreserveExistingFamilyRevocation() {
+        RefreshTokenFamily activeFamily =
+            activeFamily();
+
+        RefreshTokenRecord consumedRecord =
+            consumedRecord(activeFamily);
+
+        RefreshTokenFamily revokedFamily =
+            activeFamily.revoke(
+                RefreshTokenFamilyRevocationReason
+                    .ADMINISTRATIVE_REVOCATION,
+                NOW.minusSeconds(1)
+            );
+
+        stubLockedSession(
+            revokedFamily,
+            consumedRecord
+        );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isSameAs(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
+            );
+
+        verify(familyRepository, never())
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+
+        verifyNoInteractions(
+            userRepository,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldNotRevokeExpiredFamilyForConsumedToken() {
+        RefreshTokenFamily family =
+            RefreshTokenFamily.create(
+                FAMILY_ID,
+                USER_ID,
+                FAMILY_CREATED_AT,
+                NOW
+            );
+
+        RefreshTokenRecord consumedRecord =
+            RefreshTokenRecord.issue(
+                CURRENT_RECORD_ID,
+                family,
+                CURRENT_DIGEST,
+                CURRENT_ISSUED_AT,
+                NOW
+            )
+                .consume(
+                    EXISTING_SUCCESSOR_ID,
+                    NOW.minusSeconds(1),
+                    family
+                );
+
+        stubLockedSession(
+            family,
+            consumedRecord
+        );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isSameAs(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
+            );
+
+        verify(familyRepository, never())
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+
+        verifyNoInteractions(
+            userRepository,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldRejectExpiredUnconsumedTokenWithoutRevocation() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord expiredRecord =
+            RefreshTokenRecord.issue(
+                CURRENT_RECORD_ID,
+                family,
+                CURRENT_DIGEST,
+                CURRENT_ISSUED_AT,
+                NOW
+            );
+
+        stubLockedSession(
+            family,
+            expiredRecord
+        );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isSameAs(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
+            );
+
+        verify(familyRepository, never())
+            .save(
+                any(RefreshTokenFamily.class)
+            );
+
+        verifyNoInteractions(
+            userRepository,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldRejectUnavailableUser() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        stubLockedSession(
+            family,
+            currentRecord
+        );
+
+        when(userRepository.findById(USER_ID))
+            .thenReturn(
+                Optional.of(
+                    suspendedUser()
+                )
+            );
+
+        RotateRefreshCredentialsOutcome outcome =
+            transaction.rotate(
+                CURRENT_DIGEST
+            );
+
+        assertThat(outcome)
+            .isSameAs(
+                RotateRefreshCredentialsOutcome
+                    .Rejected
+                    .INSTANCE
+            );
+
+        verifyNoInteractions(
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            accessTokenGeneration
+        );
+
+        verify(recordRepository, never())
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+    }
+
+    @Test
+    void shouldStopWhenSuccessorPersistenceFails() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenThrow(
+                new IllegalStateException(
+                    "successor persistence failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            transaction.rotate(
+                CURRENT_DIGEST
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "successor persistence failed"
+            );
+
+        verify(recordRepository, times(1))
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        verifyNoInteractions(
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldStopWhenPredecessorPersistenceFails() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        AtomicInteger saveAttempts =
+            new AtomicInteger();
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(invocation -> {
+                if (
+                    saveAttempts.getAndIncrement()
+                        == 0
+                ) {
+                    return invocation.getArgument(0);
+                }
+
+                throw new IllegalStateException(
+                    "predecessor persistence failed"
+                );
+            });
+
+        assertThatThrownBy(() ->
+            transaction.rotate(
+                CURRENT_DIGEST
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "predecessor persistence failed"
+            );
+
+        verify(recordRepository, times(2))
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        verifyNoInteractions(
+            accessTokenGeneration
+        );
+    }
+
+    @Test
+    void shouldGenerateAccessTokenAfterBothRecordsPersist() {
+        RefreshTokenFamily family =
+            activeFamily();
+
+        RefreshTokenRecord currentRecord =
+            activeRecord(family);
+
+        User user =
+            activeUser();
+
+        stubValidRotation(
+            family,
+            currentRecord,
+            user
+        );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(accessTokenGeneration.generate(user))
+            .thenThrow(
+                new IllegalStateException(
+                    "access-token generation failed"
+                )
+            );
+
+        assertThatThrownBy(() ->
+            transaction.rotate(
+                CURRENT_DIGEST
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "access-token generation failed"
+            );
+
+        InOrder order =
+            inOrder(
+                recordRepository,
+                accessTokenGeneration
+            );
+
+        order.verify(
+            recordRepository,
+            times(2)
+        )
+            .save(
+                any(RefreshTokenRecord.class)
+            );
+
+        order.verify(accessTokenGeneration)
+            .generate(user);
+    }
+
+    private void stubValidRotation(
+        RefreshTokenFamily family,
+        RefreshTokenRecord currentRecord,
+        User user
+    ) {
+        stubLockedSession(
+            family,
+            currentRecord
+        );
+
+        when(userRepository.findById(USER_ID))
+            .thenReturn(
+                Optional.of(user)
+            );
+
+        when(refreshTokenGeneration.generate())
+            .thenReturn(
+                new GeneratedRefreshToken(
+                    SUCCESSOR_TOKEN
+                )
+            );
+
+        when(refreshTokenDigest.digest(
+            SUCCESSOR_TOKEN
+        ))
+            .thenReturn(
+                SUCCESSOR_DIGEST
+            );
+    }
+
+    private void stubLockedSession(
+        RefreshTokenFamily family,
+        RefreshTokenRecord currentRecord
+    ) {
+        when(recordRepository
+            .findByDigestForUpdate(
+                CURRENT_DIGEST
+            ))
+            .thenReturn(
+                Optional.of(currentRecord)
+            );
+
+        when(familyRepository
+            .findByIdForUpdate(
+                FAMILY_ID
+            ))
+            .thenReturn(
+                Optional.of(family)
+            );
+    }
+
+    private static RefreshTokenFamily
+    activeFamily() {
+        return RefreshTokenFamily.create(
+            FAMILY_ID,
+            USER_ID,
+            FAMILY_CREATED_AT,
+            FAMILY_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenRecord activeRecord(
+        RefreshTokenFamily family
+    ) {
+        return RefreshTokenRecord.issue(
+            CURRENT_RECORD_ID,
+            family,
+            CURRENT_DIGEST,
+            CURRENT_ISSUED_AT,
+            CURRENT_EXPIRES_AT
+        );
+    }
+
+    private static RefreshTokenRecord consumedRecord(
+        RefreshTokenFamily family
+    ) {
+        return activeRecord(family)
+            .consume(
+                EXISTING_SUCCESSOR_ID,
+                NOW.minusSeconds(1),
+                family
+            );
+    }
+
+    private static User activeUser() {
+        return user(UserStatus.ACTIVE);
+    }
+
+    private static User suspendedUser() {
+        return user(UserStatus.SUSPENDED);
+    }
+
+    private static User user(
+        UserStatus status
+    ) {
+        return User.rehydrate(
+            USER_ID,
+            EmailAddress.of(
+                "nursena@example.com"
+            ),
+            "hashed-password",
+            UserRole.USER,
+            status,
+            FAMILY_CREATED_AT,
+            FAMILY_CREATED_AT
+        );
+    }
+
+    private static RefreshTokenDigest digest(
+        byte fillValue
+    ) {
+        byte[] bytes =
+            new byte[
+                RefreshTokenDigest
+                    .SHA_256_LENGTH_BYTES
+            ];
+
+        Arrays.fill(
+            bytes,
+            fillValue
+        );
+
+        return RefreshTokenDigest.of(
+            bytes
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/AuthenticateUserIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/AuthenticateUserIntegrationTest.java
@@ -1,0 +1,425 @@
+package com.nursena.payflow.user.integration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+class AuthenticateUserIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldIssueAndPersistInitialRefreshSession()
+        throws Exception {
+
+        String email =
+            "login-success-"
+                + UUID.randomUUID()
+                + "@example.com";
+
+        String password =
+            "StrongPassword123!";
+
+        registerUser(
+            email,
+            password
+        );
+
+        MvcResult loginResult =
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                new LoginRequest(
+                                    email,
+                                    password
+                                )
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.accessToken"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.tokenType"
+                    ).value("Bearer")
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.expiresAt"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.refreshToken"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.refreshTokenExpiresAt"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.tokenDigest"
+                    ).doesNotExist()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.familyId"
+                    ).doesNotExist()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.recordId"
+                    ).doesNotExist()
+                )
+                .andReturn();
+
+        JsonNode response =
+            objectMapper.readTree(
+                loginResult
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        String refreshToken =
+            response
+                .path("refreshToken")
+                .asText();
+
+        Instant responseRefreshExpiresAt =
+            Instant.parse(
+                response
+                    .path(
+                        "refreshTokenExpiresAt"
+                    )
+                    .asText()
+            );
+
+        assertThat(refreshToken)
+            .hasSize(43);
+
+        UUID userId =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT id
+                FROM users
+                WHERE email = ?
+                """,
+                UUID.class,
+                email
+            );
+
+        assertThat(userId)
+            .isNotNull();
+
+        Integer familyCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                WHERE user_id = ?
+                """,
+                Integer.class,
+                userId
+            );
+
+        Integer recordCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records record
+                JOIN refresh_token_families family
+                  ON family.id = record.family_id
+                WHERE family.user_id = ?
+                """,
+                Integer.class,
+                userId
+            );
+
+        assertThat(familyCount)
+            .isEqualTo(1);
+
+        assertThat(recordCount)
+            .isEqualTo(1);
+
+        PersistedSession persisted =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT
+                    family.created_at
+                        AS family_created_at,
+                    family.expires_at
+                        AS family_expires_at,
+                    family.revoked_at
+                        AS family_revoked_at,
+                    record.token_digest,
+                    record.issued_at
+                        AS record_issued_at,
+                    record.expires_at
+                        AS record_expires_at,
+                    record.consumed_at,
+                    record.successor_id
+                FROM refresh_token_families family
+                JOIN refresh_token_records record
+                  ON record.family_id = family.id
+                WHERE family.user_id = ?
+                """,
+                AuthenticateUserIntegrationTest
+                    ::mapPersistedSession,
+                userId
+            );
+
+        assertThat(persisted)
+            .isNotNull();
+
+        assertThat(
+            persisted.familyCreatedAt()
+        )
+            .isEqualTo(
+                persisted.recordIssuedAt()
+            );
+
+        assertThat(
+            Duration.between(
+                persisted.familyCreatedAt(),
+                persisted.familyExpiresAt()
+            )
+        )
+            .isEqualTo(
+                Duration.ofDays(30)
+            );
+
+        assertThat(
+            Duration.between(
+                persisted.recordIssuedAt(),
+                persisted.recordExpiresAt()
+            )
+        )
+            .isEqualTo(
+                Duration.ofDays(7)
+            );
+
+        assertThat(
+            responseRefreshExpiresAt
+        )
+            .isEqualTo(
+                persisted.recordExpiresAt()
+            );
+
+        assertThat(
+            persisted.tokenDigest()
+        )
+            .containsExactly(
+                refreshTokenDigest
+                    .digest(refreshToken)
+                    .value()
+            );
+
+        assertThat(
+            Arrays.equals(
+                persisted.tokenDigest(),
+                refreshToken.getBytes(UTF_8)
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            persisted.familyRevokedAt()
+        )
+            .isNull();
+
+        assertThat(
+            persisted.consumedAt()
+        )
+            .isNull();
+
+        assertThat(
+            persisted.successorId()
+        )
+            .isNull();
+    }
+
+    private void registerUser(
+        String email,
+        String password
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RegistrationRequest(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+    }
+
+    private static PersistedSession
+    mapPersistedSession(
+        ResultSet resultSet,
+        int rowNumber
+    ) throws SQLException {
+
+        return new PersistedSession(
+            resultSet
+                .getTimestamp(
+                    "family_created_at"
+                )
+                .toInstant(),
+            resultSet
+                .getTimestamp(
+                    "family_expires_at"
+                )
+                .toInstant(),
+            nullableInstant(
+                resultSet,
+                "family_revoked_at"
+            ),
+            resultSet.getBytes(
+                "token_digest"
+            ),
+            resultSet
+                .getTimestamp(
+                    "record_issued_at"
+                )
+                .toInstant(),
+            resultSet
+                .getTimestamp(
+                    "record_expires_at"
+                )
+                .toInstant(),
+            nullableInstant(
+                resultSet,
+                "consumed_at"
+            ),
+            resultSet.getObject(
+                "successor_id",
+                UUID.class
+            )
+        );
+    }
+
+    private static Instant nullableInstant(
+        ResultSet resultSet,
+        String column
+    ) throws SQLException {
+
+        java.sql.Timestamp timestamp =
+            resultSet.getTimestamp(column);
+
+        return timestamp == null
+            ? null
+            : timestamp.toInstant();
+    }
+
+    private record RegistrationRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record LoginRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record PersistedSession(
+        Instant familyCreatedAt,
+        Instant familyExpiresAt,
+        Instant familyRevokedAt,
+        byte[] tokenDigest,
+        Instant recordIssuedAt,
+        Instant recordExpiresAt,
+        Instant consumedAt,
+        UUID successorId
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/AuthenticateUserRollbackIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/AuthenticateUserRollbackIntegrationTest.java
@@ -1,0 +1,375 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+@Import(
+    AuthenticateUserRollbackIntegrationTest
+        .FailureInjectionConfiguration.class
+)
+class AuthenticateUserRollbackIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private FailureInjectingRecordRepository
+        recordRepository;
+
+    @Autowired
+    private FailureInjectingAccessTokenGeneration
+        accessTokenGeneration;
+
+    @BeforeEach
+    void setUp() {
+        recordRepository.reset();
+        accessTokenGeneration.reset();
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldRollbackFamilyWhenInitialRecordPersistenceFails()
+        throws Exception {
+
+        Credentials credentials =
+            registerUniqueUser(
+                "record-failure"
+            );
+
+        recordRepository.failNextSave();
+
+        assertThatThrownBy(() ->
+            authenticate(
+                credentials
+            )
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "initial refresh-token record persistence failed"
+            );
+
+        assertRefreshSessionTablesAreEmpty();
+    }
+
+    @Test
+    void shouldRollbackFamilyAndRecordWhenAccessTokenGenerationFails()
+        throws Exception {
+
+        Credentials credentials =
+            registerUniqueUser(
+                "access-failure"
+            );
+
+        accessTokenGeneration
+            .failNextGeneration();
+
+        assertThatThrownBy(() ->
+            authenticate(
+                credentials
+            )
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "access-token generation failed"
+            );
+
+        assertRefreshSessionTablesAreEmpty();
+    }
+
+    private Credentials registerUniqueUser(
+        String prefix
+    ) throws Exception {
+
+        Credentials credentials =
+            new Credentials(
+                prefix
+                    + "-"
+                    + UUID.randomUUID()
+                    + "@example.com",
+                "StrongPassword123!"
+            );
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            credentials
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+
+        return credentials;
+    }
+
+    private org.springframework.test.web.servlet
+    .ResultActions authenticate(
+        Credentials credentials
+    ) throws Exception {
+
+        return mockMvc.perform(
+            post("/api/v1/auth/login")
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    objectMapper.writeValueAsString(
+                        credentials
+                    )
+                )
+        );
+    }
+
+    private void assertRefreshSessionTablesAreEmpty() {
+        Integer familyCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                """,
+                Integer.class
+            );
+
+        Integer recordCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        assertThat(familyCount)
+            .isZero();
+
+        assertThat(recordCount)
+            .isZero();
+    }
+
+    private record Credentials(
+        String email,
+        String password
+    ) {
+    }
+
+    @TestConfiguration(
+        proxyBeanMethods = false
+    )
+    static class FailureInjectionConfiguration {
+
+        @Bean
+        @Primary
+        FailureInjectingRecordRepository
+        failureInjectingRecordRepository(
+            @Qualifier(
+                "refreshTokenRecordPersistenceAdapter"
+            )
+            RefreshTokenRecordRepositoryPort delegate
+        ) {
+            return new FailureInjectingRecordRepository(
+                delegate
+            );
+        }
+
+        @Bean
+        @Primary
+        FailureInjectingAccessTokenGeneration
+        failureInjectingAccessTokenGeneration(
+            @Qualifier(
+                "jwtAccessTokenGenerationAdapter"
+            )
+            AccessTokenGenerationPort delegate
+        ) {
+            return new FailureInjectingAccessTokenGeneration(
+                delegate
+            );
+        }
+    }
+
+    static final class FailureInjectingRecordRepository
+        implements RefreshTokenRecordRepositoryPort {
+
+        private final RefreshTokenRecordRepositoryPort
+            delegate;
+
+        private final AtomicBoolean failNextSave =
+            new AtomicBoolean();
+
+        FailureInjectingRecordRepository(
+            RefreshTokenRecordRepositoryPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void failNextSave() {
+            failNextSave.set(true);
+        }
+
+        void reset() {
+            failNextSave.set(false);
+        }
+
+        @Override
+        public RefreshTokenRecord save(
+            RefreshTokenRecord record
+        ) {
+            if (
+                failNextSave.compareAndSet(
+                    true,
+                    false
+                )
+            ) {
+                throw new IllegalStateException(
+                    "initial refresh-token "
+                        + "record persistence failed"
+                );
+            }
+
+            return delegate.save(record);
+        }
+
+        @Override
+        public Optional<RefreshTokenRecord>
+        findByDigestForUpdate(
+            RefreshTokenDigest digest
+        ) {
+            return delegate
+                .findByDigestForUpdate(
+                    digest
+                );
+        }
+
+        @Override
+        public Optional<RefreshTokenRecord>
+        findById(
+            RefreshTokenRecordId recordId
+        ) {
+            return delegate.findById(
+                recordId
+            );
+        }
+    }
+
+    static final class FailureInjectingAccessTokenGeneration
+        implements AccessTokenGenerationPort {
+
+        private final AccessTokenGenerationPort
+            delegate;
+
+        private final AtomicBoolean
+            failNextGeneration =
+            new AtomicBoolean();
+
+        FailureInjectingAccessTokenGeneration(
+            AccessTokenGenerationPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void failNextGeneration() {
+            failNextGeneration.set(true);
+        }
+
+        void reset() {
+            failNextGeneration.set(false);
+        }
+
+        @Override
+        public GeneratedAccessToken generate(
+            User user
+        ) {
+            if (
+                failNextGeneration.compareAndSet(
+                    true,
+                    false
+                )
+            ) {
+                throw new IllegalStateException(
+                    "access-token generation failed"
+                );
+            }
+
+            return delegate.generate(user);
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RevokeCurrentRefreshSessionIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RevokeCurrentRefreshSessionIntegrationTest.java
@@ -1,0 +1,519 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+class RevokeCurrentRefreshSessionIntegrationTest {
+
+    private static final String UNKNOWN_CANONICAL_TOKEN =
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldDurablyRevokeActiveCurrentSession()
+        throws Exception {
+
+        InitialCredential initial =
+            issueInitialCredential(
+                "logout-active"
+            );
+
+        UUID familyId =
+            findFamilyId(initial.email());
+
+        assertLogoutNoContent(
+            initial.refreshToken()
+        );
+
+        FamilyRevocation revocation =
+            findFamilyRevocation(familyId);
+
+        assertThat(revocation.revokedAt())
+            .isNotNull();
+
+        assertThat(revocation.reason())
+            .isEqualTo(
+                "CURRENT_SESSION_LOGOUT"
+            );
+
+        assertThat(countFamilies())
+            .isEqualTo(1);
+
+        assertThat(countRecords())
+            .isEqualTo(1);
+
+        assertRefreshTokenRejected(
+            initial.refreshToken()
+        );
+
+        assertThat(
+            findFamilyRevocation(familyId)
+        ).isEqualTo(revocation);
+
+        assertThat(countRecords())
+            .isEqualTo(1);
+    }
+
+    @Test
+    void shouldRevokeFamilyThroughConsumedPredecessor()
+        throws Exception {
+
+        InitialCredential initial =
+            issueInitialCredential(
+                "logout-consumed"
+            );
+
+        UUID familyId =
+            findFamilyId(initial.email());
+
+        String successorToken =
+            rotate(initial.refreshToken());
+
+        assertThat(countRecords())
+            .isEqualTo(2);
+
+        assertLogoutNoContent(
+            initial.refreshToken()
+        );
+
+        FamilyRevocation revocation =
+            findFamilyRevocation(familyId);
+
+        assertThat(revocation.revokedAt())
+            .isNotNull();
+
+        assertThat(revocation.reason())
+            .isEqualTo(
+                "CURRENT_SESSION_LOGOUT"
+            );
+
+        assertRefreshTokenRejected(
+            initial.refreshToken()
+        );
+
+        assertRefreshTokenRejected(
+            successorToken
+        );
+
+        assertThat(
+            findFamilyRevocation(familyId)
+        ).isEqualTo(revocation);
+
+        assertThat(countRecords())
+            .isEqualTo(2);
+    }
+
+    @Test
+    void shouldHideMalformedAndUnknownCredentialState()
+        throws Exception {
+
+        assertLogoutNoContent(
+            "not-canonical"
+        );
+
+        assertLogoutNoContent(
+            UNKNOWN_CANONICAL_TOKEN
+        );
+
+        assertThat(countFamilies())
+            .isZero();
+
+        assertThat(countRecords())
+            .isZero();
+    }
+
+    @Test
+    void shouldPreserveExistingReuseRevocationReason()
+        throws Exception {
+
+        InitialCredential initial =
+            issueInitialCredential(
+                "logout-reuse"
+            );
+
+        UUID familyId =
+            findFamilyId(initial.email());
+
+        String successorToken =
+            rotate(initial.refreshToken());
+
+        assertRefreshTokenRejected(
+            initial.refreshToken()
+        );
+
+        FamilyRevocation reuseRevocation =
+            findFamilyRevocation(familyId);
+
+        assertThat(reuseRevocation.revokedAt())
+            .isNotNull();
+
+        assertThat(reuseRevocation.reason())
+            .isEqualTo("REUSE_DETECTED");
+
+        assertLogoutNoContent(
+            successorToken
+        );
+
+        assertLogoutNoContent(
+            successorToken
+        );
+
+        assertThat(
+            findFamilyRevocation(familyId)
+        ).isEqualTo(reuseRevocation);
+
+        assertThat(countRecords())
+            .isEqualTo(2);
+    }
+
+    private void assertLogoutNoContent(
+        String refreshToken
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/logout")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RefreshRequest(
+                                refreshToken
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isNoContent()
+            )
+            .andExpect(
+                content().string("")
+            );
+    }
+
+    private String rotate(
+        String refreshToken
+    ) throws Exception {
+
+        MvcResult result =
+            mockMvc.perform(
+                    post("/api/v1/auth/refresh")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                new RefreshRequest(
+                                    refreshToken
+                                )
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.refreshToken"
+                    ).isNotEmpty()
+                )
+                .andReturn();
+
+        JsonNode response =
+            objectMapper.readTree(
+                result
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        String successorToken =
+            response
+                .path("refreshToken")
+                .asText();
+
+        assertThat(successorToken)
+            .hasSize(43)
+            .isNotEqualTo(refreshToken);
+
+        return successorToken;
+    }
+
+    private void assertRefreshTokenRejected(
+        String refreshToken
+    ) throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RefreshRequest(
+                                refreshToken
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isUnauthorized()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "REFRESH_TOKEN_INVALID"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.message"
+                ).value(
+                    "Refresh token is invalid."
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.accessToken"
+                ).doesNotExist()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.refreshToken"
+                ).doesNotExist()
+            );
+    }
+
+    private InitialCredential issueInitialCredential(
+        String prefix
+    ) throws Exception {
+
+        String email =
+            prefix
+                + "-"
+                + UUID.randomUUID()
+                + "@example.com";
+
+        String password =
+            "StrongPassword123!";
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new Credentials(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+
+        MvcResult loginResult =
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                new Credentials(
+                                    email,
+                                    password
+                                )
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andReturn();
+
+        JsonNode loginResponse =
+            objectMapper.readTree(
+                loginResult
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        return new InitialCredential(
+            email,
+            loginResponse
+                .path("refreshToken")
+                .asText()
+        );
+    }
+
+    private UUID findFamilyId(
+        String email
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT family.id
+            FROM refresh_token_families family
+            JOIN users user_account
+              ON user_account.id = family.user_id
+            WHERE user_account.email = ?
+            """,
+            UUID.class,
+            email
+        );
+    }
+
+    private FamilyRevocation findFamilyRevocation(
+        UUID familyId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT revoked_at, revocation_reason
+            FROM refresh_token_families
+            WHERE id = ?
+            """,
+            RevokeCurrentRefreshSessionIntegrationTest
+                ::mapFamilyRevocation,
+            familyId
+        );
+    }
+
+    private int countFamilies() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                """,
+                Integer.class
+            );
+
+        return count == null
+            ? 0
+            : count;
+    }
+
+    private int countRecords() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        return count == null
+            ? 0
+            : count;
+    }
+
+    private static FamilyRevocation
+    mapFamilyRevocation(
+        ResultSet resultSet,
+        int rowNumber
+    ) throws SQLException {
+
+        java.sql.Timestamp revokedAt =
+            resultSet.getTimestamp(
+                "revoked_at"
+            );
+
+        return new FamilyRevocation(
+            revokedAt == null
+                ? null
+                : revokedAt.toInstant(),
+            resultSet.getString(
+                "revocation_reason"
+            )
+        );
+    }
+
+    private record Credentials(
+        String email,
+        String password
+    ) {
+    }
+
+    private record RefreshRequest(
+        String refreshToken
+    ) {
+    }
+
+    private record InitialCredential(
+        String email,
+        String refreshToken
+    ) {
+    }
+
+    private record FamilyRevocation(
+        Instant revokedAt,
+        String reason
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsConcurrencyIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsConcurrencyIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
@@ -242,7 +243,7 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
                     Integer.class
                 );
 
-            Integer activeCount =
+            Integer unconsumedCount =
                 jdbcTemplate.queryForObject(
                     """
                     SELECT COUNT(*)
@@ -251,6 +252,11 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
                       AND successor_id IS NULL
                     """,
                     Integer.class
+                );
+
+            FamilyRevocation reuseRevocation =
+                findFamilyRevocation(
+                    initialRefreshToken
                 );
 
             byte[] successorDigest =
@@ -272,8 +278,14 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
             assertThat(consumedCount)
                 .isEqualTo(1);
 
-            assertThat(activeCount)
+            assertThat(unconsumedCount)
                 .isEqualTo(1);
+
+            assertThat(reuseRevocation.revokedAt())
+                .isNotNull();
+
+            assertThat(reuseRevocation.reason())
+                .isEqualTo("REUSE_DETECTED");
 
             assertThat(successorDigest)
                 .containsExactly(
@@ -289,6 +301,27 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
                 )
             )
                 .isFalse();
+
+            MvcResult successorResult =
+                performRefresh(
+                    successorToken
+                );
+
+            assertRefreshRejected(
+                successorResult
+            );
+
+            FamilyRevocation
+                afterSuccessorAttempt =
+                findFamilyRevocation(
+                    initialRefreshToken
+                );
+
+            assertThat(afterSuccessorAttempt)
+                .isEqualTo(reuseRevocation);
+
+            assertThat(countRecords())
+                .isEqualTo(2);
         } finally {
             recordRepository
                 .releaseFirstLookup();
@@ -314,6 +347,95 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
                 )
                 .isTrue();
         }
+    }
+
+    private void assertRefreshRejected(
+        MvcResult result
+    ) throws Exception {
+        assertThat(
+            result
+                .getResponse()
+                .getStatus()
+        )
+            .isEqualTo(401);
+
+        JsonNode response =
+            objectMapper.readTree(
+                result
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        assertThat(
+            response
+                .path("code")
+                .asText()
+        )
+            .isEqualTo(
+                "REFRESH_TOKEN_INVALID"
+            );
+
+        assertThat(
+            response
+                .path("message")
+                .asText()
+        )
+            .isEqualTo(
+                "Refresh token is invalid."
+            );
+
+        assertThat(response.has("accessToken"))
+            .isFalse();
+
+        assertThat(response.has("refreshToken"))
+            .isFalse();
+    }
+
+    private FamilyRevocation findFamilyRevocation(
+        String refreshToken
+    ) {
+        byte[] digest =
+            refreshTokenDigest
+                .digest(refreshToken)
+                .value();
+
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT family.revoked_at,
+                   family.revocation_reason
+            FROM refresh_token_families family
+            JOIN refresh_token_records record
+              ON record.family_id = family.id
+            WHERE record.token_digest = ?
+            """,
+            (resultSet, rowNumber) ->
+                new FamilyRevocation(
+                    resultSet
+                        .getTimestamp(
+                            "revoked_at"
+                        )
+                        .toInstant(),
+                    resultSet.getString(
+                        "revocation_reason"
+                    )
+                ),
+            digest
+        );
+    }
+
+    private int countRecords() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        return count == null
+            ? 0
+            : count;
     }
 
     private String issueInitialRefreshToken()
@@ -389,6 +511,12 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
                     )
             )
             .andReturn();
+    }
+
+    private record FamilyRevocation(
+        Instant revokedAt,
+        String reason
+    ) {
     }
 
     private record Credentials(

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsConcurrencyIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsConcurrencyIntegrationTest.java
@@ -349,6 +349,324 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
         }
     }
 
+    @Test
+    void shouldRejectRotationWhenLogoutHoldsTokenLockFirst()
+        throws Exception {
+
+        String initialRefreshToken =
+            issueInitialRefreshToken();
+
+        recordRepository.holdNextLookup();
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(2);
+
+        Future<MvcResult> logoutFuture =
+            null;
+
+        Future<MvcResult> refreshFuture =
+            null;
+
+        try {
+            logoutFuture =
+                executor.submit(
+                    () ->
+                        performLogout(
+                            initialRefreshToken
+                        )
+                );
+
+            assertThat(
+                recordRepository
+                    .awaitFirstLock()
+            )
+                .as(
+                    "logout should acquire the refresh-token row lock first"
+                )
+                .isTrue();
+
+            refreshFuture =
+                executor.submit(
+                    () ->
+                        performRefresh(
+                            initialRefreshToken
+                        )
+                );
+
+            assertThat(
+                recordRepository
+                    .awaitSecondLookup()
+            )
+                .as(
+                    "rotation should reach the locked digest lookup"
+                )
+                .isTrue();
+
+            Thread.sleep(300);
+
+            assertThat(refreshFuture.isDone())
+                .as(
+                    "rotation must remain blocked while logout holds the row lock"
+                )
+                .isFalse();
+
+            recordRepository.releaseFirstLookup();
+
+            MvcResult logoutResult =
+                logoutFuture.get(
+                    15,
+                    SECONDS
+                );
+
+            MvcResult refreshResult =
+                refreshFuture.get(
+                    15,
+                    SECONDS
+                );
+
+            assertLogoutCompleted(
+                logoutResult
+            );
+
+            assertRefreshRejected(
+                refreshResult
+            );
+
+            FamilyRevocation logoutRevocation =
+                findFamilyRevocation(
+                    initialRefreshToken
+                );
+
+            assertThat(logoutRevocation.revokedAt())
+                .isNotNull();
+
+            assertThat(logoutRevocation.reason())
+                .isEqualTo(
+                    "CURRENT_SESSION_LOGOUT"
+                );
+
+            assertThat(countRecords())
+                .isEqualTo(1);
+
+            assertRefreshRejected(
+                performRefresh(
+                    initialRefreshToken
+                )
+            );
+
+            assertThat(
+                findFamilyRevocation(
+                    initialRefreshToken
+                )
+            ).isEqualTo(logoutRevocation);
+
+            assertThat(countRecords())
+                .isEqualTo(1);
+        } finally {
+            recordRepository
+                .releaseFirstLookup();
+
+            if (logoutFuture != null) {
+                logoutFuture.cancel(true);
+            }
+
+            if (refreshFuture != null) {
+                refreshFuture.cancel(true);
+            }
+
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    SECONDS
+                )
+            )
+                .as(
+                    "logout-first concurrency executor should terminate cleanly"
+                )
+                .isTrue();
+        }
+    }
+
+    @Test
+    void shouldRevokeReturnedSuccessorWhenRotationHoldsTokenLockFirst()
+        throws Exception {
+
+        String initialRefreshToken =
+            issueInitialRefreshToken();
+
+        recordRepository.holdNextLookup();
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(2);
+
+        Future<MvcResult> refreshFuture =
+            null;
+
+        Future<MvcResult> logoutFuture =
+            null;
+
+        try {
+            refreshFuture =
+                executor.submit(
+                    () ->
+                        performRefresh(
+                            initialRefreshToken
+                        )
+                );
+
+            assertThat(
+                recordRepository
+                    .awaitFirstLock()
+            )
+                .as(
+                    "rotation should acquire the refresh-token row lock first"
+                )
+                .isTrue();
+
+            logoutFuture =
+                executor.submit(
+                    () ->
+                        performLogout(
+                            initialRefreshToken
+                        )
+                );
+
+            assertThat(
+                recordRepository
+                    .awaitSecondLookup()
+            )
+                .as(
+                    "logout should reach the locked digest lookup"
+                )
+                .isTrue();
+
+            Thread.sleep(300);
+
+            assertThat(logoutFuture.isDone())
+                .as(
+                    "logout must remain blocked while rotation holds the row lock"
+                )
+                .isFalse();
+
+            recordRepository.releaseFirstLookup();
+
+            MvcResult refreshResult =
+                refreshFuture.get(
+                    15,
+                    SECONDS
+                );
+
+            MvcResult logoutResult =
+                logoutFuture.get(
+                    15,
+                    SECONDS
+                );
+
+            assertThat(
+                refreshResult
+                    .getResponse()
+                    .getStatus()
+            )
+                .isEqualTo(200);
+
+            assertLogoutCompleted(
+                logoutResult
+            );
+
+            JsonNode refreshResponse =
+                objectMapper.readTree(
+                    refreshResult
+                        .getResponse()
+                        .getContentAsByteArray()
+                );
+
+            String successorToken =
+                refreshResponse
+                    .path("refreshToken")
+                    .asText();
+
+            assertThat(successorToken)
+                .isNotBlank()
+                .isNotEqualTo(
+                    initialRefreshToken
+                );
+
+            FamilyRevocation logoutRevocation =
+                findFamilyRevocation(
+                    initialRefreshToken
+                );
+
+            assertThat(logoutRevocation.revokedAt())
+                .isNotNull();
+
+            assertThat(logoutRevocation.reason())
+                .isEqualTo(
+                    "CURRENT_SESSION_LOGOUT"
+                );
+
+            assertThat(countRecords())
+                .isEqualTo(2);
+
+            assertRefreshRejected(
+                performRefresh(
+                    successorToken
+                )
+            );
+
+            assertThat(
+                findFamilyRevocation(
+                    initialRefreshToken
+                )
+            ).isEqualTo(logoutRevocation);
+
+            assertThat(countRecords())
+                .isEqualTo(2);
+        } finally {
+            recordRepository
+                .releaseFirstLookup();
+
+            if (refreshFuture != null) {
+                refreshFuture.cancel(true);
+            }
+
+            if (logoutFuture != null) {
+                logoutFuture.cancel(true);
+            }
+
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    SECONDS
+                )
+            )
+                .as(
+                    "rotation-first concurrency executor should terminate cleanly"
+                )
+                .isTrue();
+        }
+    }
+
+    private void assertLogoutCompleted(
+        MvcResult result
+    ) {
+        assertThat(
+            result
+                .getResponse()
+                .getStatus()
+        )
+            .isEqualTo(204);
+
+        assertThat(
+            result
+                .getResponse()
+                .getContentAsByteArray()
+        ).isEmpty();
+    }
+
     private void assertRefreshRejected(
         MvcResult result
     ) throws Exception {
@@ -499,6 +817,26 @@ class RotateRefreshCredentialsConcurrencyIntegrationTest {
 
         return mockMvc.perform(
                 post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RefreshRequest(
+                                refreshToken
+                            )
+                        )
+                    )
+            )
+            .andReturn();
+    }
+
+    private MvcResult performLogout(
+        String refreshToken
+    ) throws Exception {
+
+        return mockMvc.perform(
+                post("/api/v1/auth/logout")
                     .contentType(
                         MediaType.APPLICATION_JSON
                     )

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsConcurrencyIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsConcurrencyIntegrationTest.java
@@ -1,0 +1,577 @@
+package com.nursena.payflow.user.integration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+@Import(
+    RotateRefreshCredentialsConcurrencyIntegrationTest
+        .BlockingRepositoryConfiguration.class
+)
+class RotateRefreshCredentialsConcurrencyIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @Autowired
+    private BlockingRecordRepository
+        recordRepository;
+
+    @BeforeEach
+    void setUp() {
+        recordRepository.reset();
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldAllowOnlyOneConcurrentRotation()
+        throws Exception {
+
+        String initialRefreshToken =
+            issueInitialRefreshToken();
+
+        recordRepository.holdNextLookup();
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(2);
+
+        Future<MvcResult> firstFuture =
+            null;
+
+        Future<MvcResult> secondFuture =
+            null;
+
+        try {
+            firstFuture =
+                executor.submit(
+                    () ->
+                        performRefresh(
+                            initialRefreshToken
+                        )
+                );
+
+            assertThat(
+                recordRepository
+                    .awaitFirstLock()
+            )
+                .as(
+                    "first request should acquire the refresh-token row lock"
+                )
+                .isTrue();
+
+            secondFuture =
+                executor.submit(
+                    () ->
+                        performRefresh(
+                            initialRefreshToken
+                        )
+                );
+
+            assertThat(
+                recordRepository
+                    .awaitSecondLookup()
+            )
+                .as(
+                    "second request should reach the locked digest lookup"
+                )
+                .isTrue();
+
+            Thread.sleep(300);
+
+            assertThat(
+                secondFuture.isDone()
+            )
+                .as(
+                    "second request must remain blocked while the first transaction holds the row lock"
+                )
+                .isFalse();
+
+            recordRepository.releaseFirstLookup();
+
+            MvcResult firstResult =
+                firstFuture.get(
+                    15,
+                    SECONDS
+                );
+
+            MvcResult secondResult =
+                secondFuture.get(
+                    15,
+                    SECONDS
+                );
+
+            assertThat(
+                firstResult
+                    .getResponse()
+                    .getStatus()
+            )
+                .isEqualTo(200);
+
+            assertThat(
+                secondResult
+                    .getResponse()
+                    .getStatus()
+            )
+                .isEqualTo(401);
+
+            JsonNode successResponse =
+                objectMapper.readTree(
+                    firstResult
+                        .getResponse()
+                        .getContentAsByteArray()
+                );
+
+            JsonNode rejectedResponse =
+                objectMapper.readTree(
+                    secondResult
+                        .getResponse()
+                        .getContentAsByteArray()
+                );
+
+            assertThat(
+                rejectedResponse
+                    .path("code")
+                    .asText()
+            )
+                .isEqualTo(
+                    "REFRESH_TOKEN_INVALID"
+                );
+
+            String successorToken =
+                successResponse
+                    .path("refreshToken")
+                    .asText();
+
+            assertThat(successorToken)
+                .isNotBlank()
+                .isNotEqualTo(
+                    initialRefreshToken
+                );
+
+            Integer recordCount =
+                jdbcTemplate.queryForObject(
+                    """
+                    SELECT COUNT(*)
+                    FROM refresh_token_records
+                    """,
+                    Integer.class
+                );
+
+            Integer consumedCount =
+                jdbcTemplate.queryForObject(
+                    """
+                    SELECT COUNT(*)
+                    FROM refresh_token_records
+                    WHERE consumed_at IS NOT NULL
+                      AND successor_id IS NOT NULL
+                    """,
+                    Integer.class
+                );
+
+            Integer activeCount =
+                jdbcTemplate.queryForObject(
+                    """
+                    SELECT COUNT(*)
+                    FROM refresh_token_records
+                    WHERE consumed_at IS NULL
+                      AND successor_id IS NULL
+                    """,
+                    Integer.class
+                );
+
+            byte[] successorDigest =
+                jdbcTemplate.queryForObject(
+                    """
+                    SELECT token_digest
+                    FROM refresh_token_records
+                    WHERE token_digest = ?
+                    """,
+                    byte[].class,
+                    refreshTokenDigest
+                        .digest(successorToken)
+                        .value()
+                );
+
+            assertThat(recordCount)
+                .isEqualTo(2);
+
+            assertThat(consumedCount)
+                .isEqualTo(1);
+
+            assertThat(activeCount)
+                .isEqualTo(1);
+
+            assertThat(successorDigest)
+                .containsExactly(
+                    refreshTokenDigest
+                        .digest(successorToken)
+                        .value()
+                );
+
+            assertThat(
+                Arrays.equals(
+                    successorDigest,
+                    successorToken.getBytes(UTF_8)
+                )
+            )
+                .isFalse();
+        } finally {
+            recordRepository
+                .releaseFirstLookup();
+
+            if (firstFuture != null) {
+                firstFuture.cancel(true);
+            }
+
+            if (secondFuture != null) {
+                secondFuture.cancel(true);
+            }
+
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    SECONDS
+                )
+            )
+                .as(
+                    "concurrency executor should terminate cleanly"
+                )
+                .isTrue();
+        }
+    }
+
+    private String issueInitialRefreshToken()
+        throws Exception {
+
+        Credentials credentials =
+            new Credentials(
+                "rotation-concurrency-"
+                    + UUID.randomUUID()
+                    + "@example.com",
+                "StrongPassword123!"
+            );
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            credentials
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+
+        MvcResult loginResult =
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                credentials
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andReturn();
+
+        JsonNode response =
+            objectMapper.readTree(
+                loginResult
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        return response
+            .path("refreshToken")
+            .asText();
+    }
+
+    private MvcResult performRefresh(
+        String refreshToken
+    ) throws Exception {
+
+        return mockMvc.perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RefreshRequest(
+                                refreshToken
+                            )
+                        )
+                    )
+            )
+            .andReturn();
+    }
+
+    private record Credentials(
+        String email,
+        String password
+    ) {
+    }
+
+    private record RefreshRequest(
+        String refreshToken
+    ) {
+    }
+
+    @TestConfiguration(
+        proxyBeanMethods = false
+    )
+    static class BlockingRepositoryConfiguration {
+
+        @Bean
+        @Primary
+        BlockingRecordRepository
+        blockingRotationRecordRepository(
+            @Qualifier(
+                "refreshTokenRecordPersistenceAdapter"
+            )
+            RefreshTokenRecordRepositoryPort delegate
+        ) {
+            return new BlockingRecordRepository(
+                delegate
+            );
+        }
+    }
+
+    static final class BlockingRecordRepository
+        implements RefreshTokenRecordRepositoryPort {
+
+        private final RefreshTokenRecordRepositoryPort
+            delegate;
+
+        private final AtomicBoolean holdFirst =
+            new AtomicBoolean();
+
+        private final AtomicInteger lookupCount =
+            new AtomicInteger();
+
+        private volatile CountDownLatch
+            firstLockAcquired =
+            new CountDownLatch(0);
+
+        private volatile CountDownLatch
+            secondLookupStarted =
+            new CountDownLatch(0);
+
+        private volatile CountDownLatch
+            releaseFirst =
+            new CountDownLatch(0);
+
+        BlockingRecordRepository(
+            RefreshTokenRecordRepositoryPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void holdNextLookup() {
+            lookupCount.set(0);
+            holdFirst.set(true);
+
+            firstLockAcquired =
+                new CountDownLatch(1);
+
+            secondLookupStarted =
+                new CountDownLatch(1);
+
+            releaseFirst =
+                new CountDownLatch(1);
+        }
+
+        boolean awaitFirstLock()
+            throws InterruptedException {
+
+            return firstLockAcquired.await(
+                10,
+                SECONDS
+            );
+        }
+
+        boolean awaitSecondLookup()
+            throws InterruptedException {
+
+            return secondLookupStarted.await(
+                10,
+                SECONDS
+            );
+        }
+
+        void releaseFirstLookup() {
+            releaseFirst.countDown();
+        }
+
+        void reset() {
+            holdFirst.set(false);
+            lookupCount.set(0);
+            firstLockAcquired.countDown();
+            secondLookupStarted.countDown();
+            releaseFirst.countDown();
+        }
+
+        @Override
+        public RefreshTokenRecord save(
+            RefreshTokenRecord record
+        ) {
+            return delegate.save(record);
+        }
+
+        @Override
+        public Optional<RefreshTokenRecord>
+        findByDigestForUpdate(
+            RefreshTokenDigest digest
+        ) {
+            int invocation =
+                lookupCount.incrementAndGet();
+
+            if (invocation == 2) {
+                secondLookupStarted
+                    .countDown();
+            }
+
+            Optional<RefreshTokenRecord> result =
+                delegate
+                    .findByDigestForUpdate(
+                        digest
+                    );
+
+            if (
+                invocation == 1
+                    && holdFirst.compareAndSet(
+                        true,
+                        false
+                    )
+            ) {
+                firstLockAcquired
+                    .countDown();
+
+                awaitRelease();
+            }
+
+            return result;
+        }
+
+        @Override
+        public Optional<RefreshTokenRecord>
+        findById(
+            RefreshTokenRecordId recordId
+        ) {
+            return delegate.findById(
+                recordId
+            );
+        }
+
+        private void awaitRelease() {
+            try {
+                boolean released =
+                    releaseFirst.await(
+                        15,
+                        SECONDS
+                    );
+
+                if (!released) {
+                    throw new IllegalStateException(
+                        "first refresh-token lookup was not released"
+                    );
+                }
+            } catch (
+                InterruptedException exception
+            ) {
+                Thread.currentThread()
+                    .interrupt();
+
+                throw new IllegalStateException(
+                    "refresh-token lookup wait was interrupted",
+                    exception
+                );
+            }
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsIntegrationTest.java
@@ -1,0 +1,561 @@
+package com.nursena.payflow.user.integration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+class RotateRefreshCredentialsIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldRotateAndPersistSingleSuccessor()
+        throws Exception {
+
+        InitialCredential initial =
+            issueInitialCredential(
+                "rotation-success"
+            );
+
+        UUID predecessorId =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT record.id
+                FROM refresh_token_records record
+                JOIN refresh_token_families family
+                  ON family.id = record.family_id
+                JOIN users user_account
+                  ON user_account.id = family.user_id
+                WHERE user_account.email = ?
+                """,
+                UUID.class,
+                initial.email()
+            );
+
+        assertThat(predecessorId)
+            .isNotNull();
+
+        MvcResult rotationResult =
+            mockMvc.perform(
+                    post("/api/v1/auth/refresh")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                new RefreshRequest(
+                                    initial.refreshToken()
+                                )
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.accessToken"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.tokenType"
+                    ).value("Bearer")
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.expiresAt"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.refreshToken"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.refreshTokenExpiresAt"
+                    ).isNotEmpty()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.tokenDigest"
+                    ).doesNotExist()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.familyId"
+                    ).doesNotExist()
+                )
+                .andExpect(
+                    jsonPath(
+                        "$.recordId"
+                    ).doesNotExist()
+                )
+                .andReturn();
+
+        JsonNode response =
+            objectMapper.readTree(
+                rotationResult
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        String successorToken =
+            response
+                .path("refreshToken")
+                .asText();
+
+        Instant responseSuccessorExpiresAt =
+            Instant.parse(
+                response
+                    .path(
+                        "refreshTokenExpiresAt"
+                    )
+                    .asText()
+            );
+
+        assertThat(successorToken)
+            .hasSize(43)
+            .isNotEqualTo(
+                initial.refreshToken()
+            );
+
+        RotatedSession persisted =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT
+                    predecessor.id
+                        AS predecessor_id,
+                    predecessor.family_id
+                        AS predecessor_family_id,
+                    predecessor.token_digest
+                        AS predecessor_digest,
+                    predecessor.consumed_at
+                        AS predecessor_consumed_at,
+                    predecessor.successor_id
+                        AS predecessor_successor_id,
+                    successor.id
+                        AS successor_id,
+                    successor.family_id
+                        AS successor_family_id,
+                    successor.token_digest
+                        AS successor_digest,
+                    successor.issued_at
+                        AS successor_issued_at,
+                    successor.expires_at
+                        AS successor_expires_at,
+                    successor.consumed_at
+                        AS successor_consumed_at,
+                    successor.successor_id
+                        AS successor_successor_id
+                FROM refresh_token_records predecessor
+                JOIN refresh_token_records successor
+                  ON successor.id =
+                     predecessor.successor_id
+                 AND successor.family_id =
+                     predecessor.family_id
+                WHERE predecessor.id = ?
+                """,
+                RotateRefreshCredentialsIntegrationTest
+                    ::mapRotatedSession,
+                predecessorId
+            );
+
+        assertThat(persisted)
+            .isNotNull();
+
+        assertThat(
+            persisted.predecessorId()
+        )
+            .isEqualTo(
+                predecessorId
+            );
+
+        assertThat(
+            persisted.predecessorConsumedAt()
+        )
+            .isNotNull()
+            .isEqualTo(
+                persisted.successorIssuedAt()
+            );
+
+        assertThat(
+            persisted.predecessorSuccessorId()
+        )
+            .isEqualTo(
+                persisted.successorId()
+            );
+
+        assertThat(
+            persisted.predecessorFamilyId()
+        )
+            .isEqualTo(
+                persisted.successorFamilyId()
+            );
+
+        assertThat(
+            persisted.successorConsumedAt()
+        )
+            .isNull();
+
+        assertThat(
+            persisted.successorSuccessorId()
+        )
+            .isNull();
+
+        assertThat(
+            responseSuccessorExpiresAt
+        )
+            .isEqualTo(
+                persisted.successorExpiresAt()
+            );
+
+        assertThat(
+            Duration.between(
+                persisted.successorIssuedAt(),
+                persisted.successorExpiresAt()
+            )
+        )
+            .isEqualTo(
+                Duration.ofDays(7)
+            );
+
+        byte[] expectedPredecessorDigest =
+            refreshTokenDigest
+                .digest(
+                    initial.refreshToken()
+                )
+                .value();
+
+        byte[] expectedSuccessorDigest =
+            refreshTokenDigest
+                .digest(successorToken)
+                .value();
+
+        assertThat(
+            persisted.predecessorDigest()
+        )
+            .containsExactly(
+                expectedPredecessorDigest
+            );
+
+        assertThat(
+            persisted.successorDigest()
+        )
+            .containsExactly(
+                expectedSuccessorDigest
+            );
+
+        assertThat(
+            Arrays.equals(
+                persisted.predecessorDigest(),
+                initial
+                    .refreshToken()
+                    .getBytes(UTF_8)
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            Arrays.equals(
+                persisted.successorDigest(),
+                successorToken.getBytes(UTF_8)
+            )
+        )
+            .isFalse();
+
+        Integer familyCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                """,
+                Integer.class
+            );
+
+        Integer recordCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        assertThat(familyCount)
+            .isEqualTo(1);
+
+        assertThat(recordCount)
+            .isEqualTo(2);
+
+        mockMvc.perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RefreshRequest(
+                                initial.refreshToken()
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isUnauthorized()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.code"
+                ).value(
+                    "REFRESH_TOKEN_INVALID"
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.message"
+                ).value(
+                    "Refresh token is invalid."
+                )
+            );
+    }
+
+    private InitialCredential issueInitialCredential(
+        String prefix
+    ) throws Exception {
+
+        String email =
+            prefix
+                + "-"
+                + UUID.randomUUID()
+                + "@example.com";
+
+        String password =
+            "StrongPassword123!";
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new Credentials(
+                                email,
+                                password
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+
+        MvcResult loginResult =
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                new Credentials(
+                                    email,
+                                    password
+                                )
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andReturn();
+
+        JsonNode loginResponse =
+            objectMapper.readTree(
+                loginResult
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        return new InitialCredential(
+            email,
+            loginResponse
+                .path("refreshToken")
+                .asText()
+        );
+    }
+
+    private static RotatedSession
+    mapRotatedSession(
+        ResultSet resultSet,
+        int rowNumber
+    ) throws SQLException {
+
+        return new RotatedSession(
+            resultSet.getObject(
+                "predecessor_id",
+                UUID.class
+            ),
+            resultSet.getObject(
+                "predecessor_family_id",
+                UUID.class
+            ),
+            resultSet.getBytes(
+                "predecessor_digest"
+            ),
+            resultSet
+                .getTimestamp(
+                    "predecessor_consumed_at"
+                )
+                .toInstant(),
+            resultSet.getObject(
+                "predecessor_successor_id",
+                UUID.class
+            ),
+            resultSet.getObject(
+                "successor_id",
+                UUID.class
+            ),
+            resultSet.getObject(
+                "successor_family_id",
+                UUID.class
+            ),
+            resultSet.getBytes(
+                "successor_digest"
+            ),
+            resultSet
+                .getTimestamp(
+                    "successor_issued_at"
+                )
+                .toInstant(),
+            resultSet
+                .getTimestamp(
+                    "successor_expires_at"
+                )
+                .toInstant(),
+            nullableInstant(
+                resultSet,
+                "successor_consumed_at"
+            ),
+            resultSet.getObject(
+                "successor_successor_id",
+                UUID.class
+            )
+        );
+    }
+
+    private static Instant nullableInstant(
+        ResultSet resultSet,
+        String column
+    ) throws SQLException {
+
+        java.sql.Timestamp timestamp =
+            resultSet.getTimestamp(column);
+
+        return timestamp == null
+            ? null
+            : timestamp.toInstant();
+    }
+
+    private record Credentials(
+        String email,
+        String password
+    ) {
+    }
+
+    private record RefreshRequest(
+        String refreshToken
+    ) {
+    }
+
+    private record InitialCredential(
+        String email,
+        String refreshToken
+    ) {
+    }
+
+    private record RotatedSession(
+        UUID predecessorId,
+        UUID predecessorFamilyId,
+        byte[] predecessorDigest,
+        Instant predecessorConsumedAt,
+        UUID predecessorSuccessorId,
+        UUID successorId,
+        UUID successorFamilyId,
+        byte[] successorDigest,
+        Instant successorIssuedAt,
+        Instant successorExpiresAt,
+        Instant successorConsumedAt,
+        UUID successorSuccessorId
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsIntegrationTest.java
@@ -76,7 +76,7 @@ class RotateRefreshCredentialsIntegrationTest {
     }
 
     @Test
-    void shouldRotateAndPersistSingleSuccessor()
+    void shouldRotateOnceAndDurablyRevokeFamilyOnReuse()
         throws Exception {
 
         InitialCredential initial =
@@ -356,6 +356,47 @@ class RotateRefreshCredentialsIntegrationTest {
         assertThat(recordCount)
             .isEqualTo(2);
 
+        assertRefreshTokenRejected(
+            initial.refreshToken()
+        );
+
+        FamilyRevocation reuseRevocation =
+            findFamilyRevocation(
+                persisted.predecessorFamilyId()
+            );
+
+        assertThat(reuseRevocation.revokedAt())
+            .isNotNull()
+            .isAfterOrEqualTo(
+                persisted.predecessorConsumedAt()
+            );
+
+        assertThat(reuseRevocation.reason())
+            .isEqualTo("REUSE_DETECTED");
+
+        assertThat(countRecords())
+            .isEqualTo(2);
+
+        assertRefreshTokenRejected(
+            successorToken
+        );
+
+        FamilyRevocation afterSuccessorAttempt =
+            findFamilyRevocation(
+                persisted.predecessorFamilyId()
+            );
+
+        assertThat(afterSuccessorAttempt)
+            .isEqualTo(reuseRevocation);
+
+        assertThat(countRecords())
+            .isEqualTo(2);
+    }
+
+    private void assertRefreshTokenRejected(
+        String refreshToken
+    ) throws Exception {
+
         mockMvc.perform(
                 post("/api/v1/auth/refresh")
                     .contentType(
@@ -364,7 +405,7 @@ class RotateRefreshCredentialsIntegrationTest {
                     .content(
                         objectMapper.writeValueAsString(
                             new RefreshRequest(
-                                initial.refreshToken()
+                                refreshToken
                             )
                         )
                     )
@@ -385,7 +426,55 @@ class RotateRefreshCredentialsIntegrationTest {
                 ).value(
                     "Refresh token is invalid."
                 )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.accessToken"
+                ).doesNotExist()
+            )
+            .andExpect(
+                jsonPath(
+                    "$.refreshToken"
+                ).doesNotExist()
             );
+    }
+
+    private FamilyRevocation findFamilyRevocation(
+        UUID familyId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT revoked_at, revocation_reason
+            FROM refresh_token_families
+            WHERE id = ?
+            """,
+            (resultSet, rowNumber) ->
+                new FamilyRevocation(
+                    nullableInstant(
+                        resultSet,
+                        "revoked_at"
+                    ),
+                    resultSet.getString(
+                        "revocation_reason"
+                    )
+                ),
+            familyId
+        );
+    }
+
+    private int countRecords() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        return count == null
+            ? 0
+            : count;
     }
 
     private InitialCredential issueInitialCredential(
@@ -540,6 +629,12 @@ class RotateRefreshCredentialsIntegrationTest {
     private record InitialCredential(
         String email,
         String refreshToken
+    ) {
+    }
+
+    private record FamilyRevocation(
+        Instant revokedAt,
+        String reason
     ) {
     }
 

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsRollbackIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsRollbackIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
@@ -17,8 +18,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
 import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
 import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
 import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
 import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
 import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
 import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
 import com.nursena.payflow.user.domain.model.User;
@@ -79,12 +84,17 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
         recordRepository;
 
     @Autowired
+    private FailureInjectingFamilyRepository
+        familyRepository;
+
+    @Autowired
     private FailureInjectingAccessTokenGeneration
         accessTokenGeneration;
 
     @BeforeEach
     void setUp() {
         recordRepository.reset();
+        familyRepository.reset();
         accessTokenGeneration.reset();
 
         jdbcTemplate.update(
@@ -192,6 +202,70 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
         assertInitialSessionUnchanged(
             refreshToken
         );
+    }
+
+    @Test
+    void shouldRollbackWhenReuseRevocationPersistenceFails()
+        throws Exception {
+
+        String initialRefreshToken =
+            issueInitialRefreshToken(
+                "reuse-revocation-failure"
+            );
+
+        org.springframework.test.web.servlet
+        .MvcResult firstRotation =
+            refresh(initialRefreshToken)
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode firstResponse =
+            objectMapper.readTree(
+                firstRotation
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        String successorToken =
+            firstResponse
+                .path("refreshToken")
+                .asText();
+
+        int accessGenerationCountBeforeReuse =
+            accessTokenGeneration
+                .generationCount();
+
+        familyRepository.failAfterNextSave(
+            "family revocation persistence failed"
+        );
+
+        assertThatThrownBy(() ->
+            refresh(initialRefreshToken)
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "family revocation persistence failed"
+            );
+
+        assertFamilyRevocationRolledBack(
+            initialRefreshToken
+        );
+
+        assertThat(
+            accessTokenGeneration
+                .generationCount()
+        )
+            .isEqualTo(
+                accessGenerationCountBeforeReuse
+            );
+
+        refresh(successorToken)
+            .andExpect(status().isOk());
     }
 
     private String issueInitialRefreshToken(
@@ -341,6 +415,93 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
             .isFalse();
     }
 
+    private void assertFamilyRevocationRolledBack(
+        String initialRefreshToken
+    ) {
+        byte[] digest =
+            refreshTokenDigest
+                .digest(initialRefreshToken)
+                .value();
+
+        FamilyState familyState =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT family.revoked_at,
+                       family.revocation_reason
+                FROM refresh_token_families family
+                JOIN refresh_token_records record
+                  ON record.family_id = family.id
+                WHERE record.token_digest = ?
+                """,
+                (resultSet, rowNumber) ->
+                    new FamilyState(
+                        resultSet
+                            .getTimestamp(
+                                "revoked_at"
+                            ),
+                        resultSet.getString(
+                            "revocation_reason"
+                        )
+                    ),
+                digest
+            );
+
+        Integer recordCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        Integer consumedCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                WHERE consumed_at IS NOT NULL
+                  AND successor_id IS NOT NULL
+                """,
+                Integer.class
+            );
+
+        Integer unconsumedCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                WHERE consumed_at IS NULL
+                  AND successor_id IS NULL
+                """,
+                Integer.class
+            );
+
+        assertThat(familyState)
+            .isNotNull();
+
+        assertThat(familyState.revokedAt())
+            .isNull();
+
+        assertThat(familyState.reason())
+            .isNull();
+
+        assertThat(recordCount)
+            .isEqualTo(2);
+
+        assertThat(consumedCount)
+            .isEqualTo(1);
+
+        assertThat(unconsumedCount)
+            .isEqualTo(1);
+    }
+
+    private record FamilyState(
+        java.sql.Timestamp revokedAt,
+        String reason
+    ) {
+    }
+
     private record Credentials(
         String email,
         String password
@@ -367,6 +528,20 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
             RefreshTokenRecordRepositoryPort delegate
         ) {
             return new FailureInjectingRecordRepository(
+                delegate
+            );
+        }
+
+        @Bean
+        @Primary
+        FailureInjectingFamilyRepository
+        failureInjectingRotationFamilyRepository(
+            @Qualifier(
+                "refreshTokenFamilyPersistenceAdapter"
+            )
+            RefreshTokenFamilyRepositoryPort delegate
+        ) {
+            return new FailureInjectingFamilyRepository(
                 delegate
             );
         }
@@ -460,6 +635,82 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
         }
     }
 
+    static final class FailureInjectingFamilyRepository
+        implements RefreshTokenFamilyRepositoryPort {
+
+        private final RefreshTokenFamilyRepositoryPort
+            delegate;
+
+        private final AtomicBoolean
+            failAfterNextSave =
+            new AtomicBoolean();
+
+        private volatile String failureMessage =
+            "";
+
+        FailureInjectingFamilyRepository(
+            RefreshTokenFamilyRepositoryPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void failAfterNextSave(
+            String message
+        ) {
+            failureMessage = message;
+            failAfterNextSave.set(true);
+        }
+
+        void reset() {
+            failAfterNextSave.set(false);
+            failureMessage = "";
+        }
+
+        @Override
+        public RefreshTokenFamily save(
+            RefreshTokenFamily family
+        ) {
+            RefreshTokenFamily saved =
+                delegate.save(family);
+
+            if (
+                failAfterNextSave.compareAndSet(
+                    true,
+                    false
+                )
+            ) {
+                throw new IllegalStateException(
+                    failureMessage
+                );
+            }
+
+            return saved;
+        }
+
+        @Override
+        public Optional<RefreshTokenFamily>
+        findByIdForUpdate(
+            RefreshTokenFamilyId familyId
+        ) {
+            return delegate.findByIdForUpdate(
+                familyId
+            );
+        }
+
+        @Override
+        public int revokeAllActiveByUserId(
+            UUID userId,
+            Instant revokedAt,
+            RefreshTokenFamilyRevocationReason reason
+        ) {
+            return delegate.revokeAllActiveByUserId(
+                userId,
+                revokedAt,
+                reason
+            );
+        }
+    }
+
     static final class FailureInjectingAccessTokenGeneration
         implements AccessTokenGenerationPort {
 
@@ -469,6 +720,10 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
         private final AtomicBoolean
             failNextGeneration =
             new AtomicBoolean();
+
+        private final AtomicInteger
+            generationCount =
+            new AtomicInteger();
 
         FailureInjectingAccessTokenGeneration(
             AccessTokenGenerationPort delegate
@@ -482,12 +737,19 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
 
         void reset() {
             failNextGeneration.set(false);
+            generationCount.set(0);
+        }
+
+        int generationCount() {
+            return generationCount.get();
         }
 
         @Override
         public GeneratedAccessToken generate(
             User user
         ) {
+            generationCount.incrementAndGet();
+
             if (
                 failNextGeneration.compareAndSet(
                     true,

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsRollbackIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsRollbackIntegrationTest.java
@@ -205,6 +205,56 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
     }
 
     @Test
+    void shouldRollbackWhenCurrentSessionLogoutRevocationPersistenceFails()
+        throws Exception {
+
+        String refreshToken =
+            issueInitialRefreshToken(
+                "logout-revocation-failure"
+            );
+
+        int accessGenerationCountBeforeLogout =
+            accessTokenGeneration
+                .generationCount();
+
+        familyRepository.failAfterNextSave(
+            "current-session logout revocation persistence failed"
+        );
+
+        assertThatThrownBy(() ->
+            logout(refreshToken)
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "current-session logout revocation persistence failed"
+            );
+
+        assertInitialSessionUnchanged(
+            refreshToken
+        );
+
+        assertFamilyRemainsActive(
+            refreshToken
+        );
+
+        assertThat(
+            accessTokenGeneration
+                .generationCount()
+        )
+            .isEqualTo(
+                accessGenerationCountBeforeLogout
+            );
+
+        refresh(refreshToken)
+            .andExpect(status().isOk());
+    }
+
+    @Test
     void shouldRollbackWhenReuseRevocationPersistenceFails()
         throws Exception {
 
@@ -344,6 +394,66 @@ class RotateRefreshCredentialsRollbackIntegrationTest {
                     )
                 )
         );
+    }
+
+    private org.springframework.test.web.servlet
+    .ResultActions logout(
+        String refreshToken
+    ) throws Exception {
+
+        return mockMvc.perform(
+            post("/api/v1/auth/logout")
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    objectMapper.writeValueAsString(
+                        new RefreshRequest(
+                            refreshToken
+                        )
+                    )
+                )
+        );
+    }
+
+    private void assertFamilyRemainsActive(
+        String refreshToken
+    ) {
+        byte[] digest =
+            refreshTokenDigest
+                .digest(refreshToken)
+                .value();
+
+        FamilyState familyState =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT family.revoked_at,
+                       family.revocation_reason
+                FROM refresh_token_families family
+                JOIN refresh_token_records record
+                  ON record.family_id = family.id
+                WHERE record.token_digest = ?
+                """,
+                (resultSet, rowNumber) ->
+                    new FamilyState(
+                        resultSet.getTimestamp(
+                            "revoked_at"
+                        ),
+                        resultSet.getString(
+                            "revocation_reason"
+                        )
+                    ),
+                digest
+            );
+
+        assertThat(familyState)
+            .isNotNull();
+
+        assertThat(familyState.revokedAt())
+            .isNull();
+
+        assertThat(familyState.reason())
+            .isNull();
     }
 
     private void assertInitialSessionUnchanged(

--- a/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsRollbackIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RotateRefreshCredentialsRollbackIntegrationTest.java
@@ -1,0 +1,505 @@
+package com.nursena.payflow.user.integration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+@Import(
+    RotateRefreshCredentialsRollbackIntegrationTest
+        .FailureInjectionConfiguration.class
+)
+class RotateRefreshCredentialsRollbackIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    @Autowired
+    private FailureInjectingRecordRepository
+        recordRepository;
+
+    @Autowired
+    private FailureInjectingAccessTokenGeneration
+        accessTokenGeneration;
+
+    @BeforeEach
+    void setUp() {
+        recordRepository.reset();
+        accessTokenGeneration.reset();
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldRollbackWhenSuccessorPersistenceFails()
+        throws Exception {
+
+        String refreshToken =
+            issueInitialRefreshToken(
+                "successor-failure"
+            );
+
+        recordRepository.failOnSaveAttempt(
+            1,
+            "successor persistence failed"
+        );
+
+        assertThatThrownBy(() ->
+            refresh(refreshToken)
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "successor persistence failed"
+            );
+
+        assertInitialSessionUnchanged(
+            refreshToken
+        );
+    }
+
+    @Test
+    void shouldRollbackWhenPredecessorPersistenceFails()
+        throws Exception {
+
+        String refreshToken =
+            issueInitialRefreshToken(
+                "predecessor-failure"
+            );
+
+        recordRepository.failOnSaveAttempt(
+            2,
+            "predecessor persistence failed"
+        );
+
+        assertThatThrownBy(() ->
+            refresh(refreshToken)
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "predecessor persistence failed"
+            );
+
+        assertInitialSessionUnchanged(
+            refreshToken
+        );
+    }
+
+    @Test
+    void shouldRollbackWhenAccessTokenGenerationFails()
+        throws Exception {
+
+        String refreshToken =
+            issueInitialRefreshToken(
+                "access-failure"
+            );
+
+        accessTokenGeneration
+            .failNextGeneration();
+
+        assertThatThrownBy(() ->
+            refresh(refreshToken)
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "access-token generation failed"
+            );
+
+        assertInitialSessionUnchanged(
+            refreshToken
+        );
+    }
+
+    private String issueInitialRefreshToken(
+        String prefix
+    ) throws Exception {
+
+        Credentials credentials =
+            new Credentials(
+                prefix
+                    + "-"
+                    + UUID.randomUUID()
+                    + "@example.com",
+                "StrongPassword123!"
+            );
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            credentials
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+
+        org.springframework.test.web.servlet
+        .MvcResult loginResult =
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .contentType(
+                            MediaType.APPLICATION_JSON
+                        )
+                        .content(
+                            objectMapper.writeValueAsString(
+                                credentials
+                            )
+                        )
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andReturn();
+
+        JsonNode response =
+            objectMapper.readTree(
+                loginResult
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        return response
+            .path("refreshToken")
+            .asText();
+    }
+
+    private org.springframework.test.web.servlet
+    .ResultActions refresh(
+        String refreshToken
+    ) throws Exception {
+
+        return mockMvc.perform(
+            post("/api/v1/auth/refresh")
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    objectMapper.writeValueAsString(
+                        new RefreshRequest(
+                            refreshToken
+                        )
+                    )
+                )
+        );
+    }
+
+    private void assertInitialSessionUnchanged(
+        String refreshToken
+    ) {
+        byte[] digest =
+            refreshTokenDigest
+                .digest(refreshToken)
+                .value();
+
+        Integer familyCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                """,
+                Integer.class
+            );
+
+        Integer recordCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                """,
+                Integer.class
+            );
+
+        Integer activeOriginalCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_records
+                WHERE token_digest = ?
+                  AND consumed_at IS NULL
+                  AND successor_id IS NULL
+                """,
+                Integer.class,
+                digest
+            );
+
+        byte[] persistedDigest =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT token_digest
+                FROM refresh_token_records
+                """,
+                byte[].class
+            );
+
+        assertThat(familyCount)
+            .isEqualTo(1);
+
+        assertThat(recordCount)
+            .isEqualTo(1);
+
+        assertThat(activeOriginalCount)
+            .isEqualTo(1);
+
+        assertThat(persistedDigest)
+            .containsExactly(digest);
+
+        assertThat(
+            Arrays.equals(
+                persistedDigest,
+                refreshToken.getBytes(UTF_8)
+            )
+        )
+            .isFalse();
+    }
+
+    private record Credentials(
+        String email,
+        String password
+    ) {
+    }
+
+    private record RefreshRequest(
+        String refreshToken
+    ) {
+    }
+
+    @TestConfiguration(
+        proxyBeanMethods = false
+    )
+    static class FailureInjectionConfiguration {
+
+        @Bean
+        @Primary
+        FailureInjectingRecordRepository
+        failureInjectingRotationRecordRepository(
+            @Qualifier(
+                "refreshTokenRecordPersistenceAdapter"
+            )
+            RefreshTokenRecordRepositoryPort delegate
+        ) {
+            return new FailureInjectingRecordRepository(
+                delegate
+            );
+        }
+
+        @Bean
+        @Primary
+        FailureInjectingAccessTokenGeneration
+        failureInjectingRotationAccessTokenGeneration(
+            @Qualifier(
+                "jwtAccessTokenGenerationAdapter"
+            )
+            AccessTokenGenerationPort delegate
+        ) {
+            return new FailureInjectingAccessTokenGeneration(
+                delegate
+            );
+        }
+    }
+
+    static final class FailureInjectingRecordRepository
+        implements RefreshTokenRecordRepositoryPort {
+
+        private final RefreshTokenRecordRepositoryPort
+            delegate;
+
+        private final AtomicInteger saveAttempts =
+            new AtomicInteger();
+
+        private volatile int failureAttempt =
+            -1;
+
+        private volatile String failureMessage =
+            "";
+
+        FailureInjectingRecordRepository(
+            RefreshTokenRecordRepositoryPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void failOnSaveAttempt(
+            int attempt,
+            String message
+        ) {
+            saveAttempts.set(0);
+            failureAttempt = attempt;
+            failureMessage = message;
+        }
+
+        void reset() {
+            saveAttempts.set(0);
+            failureAttempt = -1;
+            failureMessage = "";
+        }
+
+        @Override
+        public RefreshTokenRecord save(
+            RefreshTokenRecord record
+        ) {
+            int attempt =
+                saveAttempts.incrementAndGet();
+
+            if (attempt == failureAttempt) {
+                throw new IllegalStateException(
+                    failureMessage
+                );
+            }
+
+            return delegate.save(record);
+        }
+
+        @Override
+        public Optional<RefreshTokenRecord>
+        findByDigestForUpdate(
+            RefreshTokenDigest digest
+        ) {
+            return delegate
+                .findByDigestForUpdate(
+                    digest
+                );
+        }
+
+        @Override
+        public Optional<RefreshTokenRecord>
+        findById(
+            RefreshTokenRecordId recordId
+        ) {
+            return delegate.findById(
+                recordId
+            );
+        }
+    }
+
+    static final class FailureInjectingAccessTokenGeneration
+        implements AccessTokenGenerationPort {
+
+        private final AccessTokenGenerationPort
+            delegate;
+
+        private final AtomicBoolean
+            failNextGeneration =
+            new AtomicBoolean();
+
+        FailureInjectingAccessTokenGeneration(
+            AccessTokenGenerationPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        void failNextGeneration() {
+            failNextGeneration.set(true);
+        }
+
+        void reset() {
+            failNextGeneration.set(false);
+        }
+
+        @Override
+        public GeneratedAccessToken generate(
+            User user
+        ) {
+            if (
+                failNextGeneration.compareAndSet(
+                    true,
+                    false
+                )
+            ) {
+                throw new IllegalStateException(
+                    "access-token generation failed"
+                );
+            }
+
+            return delegate.generate(user);
+        }
+    }
+}


### PR DESCRIPTION
## Release summary

This pull request promotes the completed PayFlow v0.8.0 work from `develop` to `main`.

### Refresh-session security

- durable opaque refresh-token families and records in PostgreSQL
- SHA-256 digest-only credential persistence
- secure refresh-token generation and login issuance
- single-use refresh-token rotation
- family-wide revocation on consumed-token reuse
- public current-session logout with state-independent `204 No Content`
- rollback guarantees for persistence failures
- deterministic logout-versus-rotation behavior through pessimistic row locking

### Release preparation

- set the Maven project version to `0.8.0`
- add `CHANGELOG.md` with the completed v0.8.0 milestone work
- document Flyway migration `V14__create_refresh_token_sessions.sql`
- preserve README as version-neutral documentation

### Verification

- `./mvnw clean verify`
- 170 XML test reports
- 808 tests
- 0 failures
- 0 errors
- 0 skipped
- UTF-8 without BOM and LF line endings
- Git whitespace and high-confidence secret checks passed

### Merge and publication plan

- merge this PR into `main` with a merge commit
- create annotated tag `v0.8.0` on the verified main merge commit
- publish the GitHub Release from the changelog notes
- merge the release result back into `develop`
