### PR TITLE
chore: start v0.9.0 development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.8.0</version>
+    <version>0.9.0-SNAPSHOT</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 


### PR DESCRIPTION
## Summary

Open the PayFlow v0.9.0 development cycle after the completed v0.8.0 release.

### Change

- update the root Maven project version from `0.8.0` to `0.9.0-SNAPSHOT`
- keep the change isolated to `pom.xml`
- preserve the established feature-to-develop squash workflow

### Verification

- `./mvnw clean verify`
- 170 XML test reports
- 808 tests
- 0 failures
- 0 errors
- 0 skipped
- UTF-8 without BOM and LF line endings
- Git whitespace and high-confidence secret checks passed

Tracks #93
