### PR TITLE
feat(auth): add all-session refresh logout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.8.0</version>
+    <version>0.9.0-SNAPSHOT</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 

--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -62,6 +62,7 @@ public class SecurityConfiguration {
                 .authenticated()
                 .requestMatchers(
                     POST,
+                    "/api/v1/auth/logout-all",
                     "/api/v1/wallets",
                     "/api/v1/wallets/me/top-ups",
                     "/api/v1/transfers"

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RevokeAllRefreshSessionsController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RevokeAllRefreshSessionsController.java
@@ -1,0 +1,117 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import com.nursena.payflow.user.application.port.in.RevokeAllRefreshSessionsCommand;
+import com.nursena.payflow.user.application.port.in.RevokeAllRefreshSessionsUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+    name = "Authentication",
+    description =
+        "Public and authenticated user-session operations."
+)
+@RestController
+@RequestMapping("/api/v1/auth")
+public class RevokeAllRefreshSessionsController {
+
+    private final RevokeAllRefreshSessionsUseCase
+        revokeAllRefreshSessionsUseCase;
+
+    public RevokeAllRefreshSessionsController(
+        RevokeAllRefreshSessionsUseCase
+            revokeAllRefreshSessionsUseCase
+    ) {
+        this.revokeAllRefreshSessionsUseCase =
+            Objects.requireNonNull(
+                revokeAllRefreshSessionsUseCase,
+                "revokeAllRefreshSessionsUseCase "
+                    + "must not be null"
+            );
+    }
+
+    @Operation(
+        operationId = "revokeAllRefreshSessions",
+        summary = "Log out every refresh session",
+        description =
+            "Revokes every active refresh-token family "
+                + "owned by the authenticated user. "
+                + "Existing access tokens remain valid "
+                + "until their normal expiration."
+    )
+    @SecurityRequirement(
+        name =
+            OpenApiConfiguration
+                .BEARER_AUTH_SCHEME
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description =
+                "All active refresh sessions were "
+                    + "revoked, or no active session "
+                    + "required mutation."
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description =
+                "A valid access token is required."
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description =
+                "The revocation transaction could not "
+                    + "be completed."
+        )
+    })
+    @PostMapping("/logout-all")
+    public ResponseEntity<Void> logoutAll(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal
+        Jwt jwt
+    ) {
+        UUID userId =
+            authenticatedUserId(jwt);
+
+        revokeAllRefreshSessionsUseCase.revoke(
+            new RevokeAllRefreshSessionsCommand(
+                userId
+            )
+        );
+
+        return ResponseEntity
+            .noContent()
+            .build();
+    }
+
+    private static UUID authenticatedUserId(
+        Jwt jwt
+    ) {
+        Jwt checkedJwt =
+            Objects.requireNonNull(
+                jwt,
+                "jwt must not be null"
+            );
+
+        String subject =
+            Objects.requireNonNull(
+                checkedJwt.getSubject(),
+                "jwt subject must not be null"
+            );
+
+        return UUID.fromString(subject);
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RevokeAllRefreshSessionsCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RevokeAllRefreshSessionsCommand.java
@@ -1,0 +1,22 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record RevokeAllRefreshSessionsCommand(
+    UUID userId
+) {
+
+    public RevokeAllRefreshSessionsCommand {
+        Objects.requireNonNull(
+            userId,
+            "userId must not be null"
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "RevokeAllRefreshSessionsCommand"
+            + "[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RevokeAllRefreshSessionsUseCase.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RevokeAllRefreshSessionsUseCase.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.user.application.port.in;
+
+public interface RevokeAllRefreshSessionsUseCase {
+
+    void revoke(
+        RevokeAllRefreshSessionsCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/RevokeAllRefreshSessionsService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RevokeAllRefreshSessionsService.java
@@ -1,0 +1,68 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.port.in.RevokeAllRefreshSessionsCommand;
+import com.nursena.payflow.user.application.port.in.RevokeAllRefreshSessionsUseCase;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RevokeAllRefreshSessionsService
+    implements RevokeAllRefreshSessionsUseCase {
+
+    private final RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    private final Clock clock;
+
+    public RevokeAllRefreshSessionsService(
+        RefreshTokenFamilyRepositoryPort
+            familyRepository,
+        Clock clock
+    ) {
+        this.familyRepository =
+            Objects.requireNonNull(
+                familyRepository,
+                "familyRepository must not be null"
+            );
+
+        this.clock =
+            Objects.requireNonNull(
+                clock,
+                "clock must not be null"
+            );
+    }
+
+    @Override
+    @Transactional
+    public void revoke(
+        RevokeAllRefreshSessionsCommand command
+    ) {
+        RevokeAllRefreshSessionsCommand
+            checkedCommand =
+            Objects.requireNonNull(
+                command,
+                "command must not be null"
+            );
+
+        Instant revokedAt =
+            clock.instant()
+                .truncatedTo(
+                    ChronoUnit.MICROS
+                );
+
+        familyRepository
+            .revokeAllActiveByUserId(
+                checkedCommand.userId(),
+                revokedAt,
+                RefreshTokenFamilyRevocationReason
+                    .ALL_SESSIONS_LOGOUT
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/AuthenticatedApiDocumentationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/AuthenticatedApiDocumentationTest.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import com.nursena.payflow.user.adapter.in.web.CurrentUserProfileController;
+import com.nursena.payflow.user.adapter.in.web.RevokeAllRefreshSessionsController;
 import com.nursena.payflow.wallet.adapter.in.web.GetCurrentWalletController;
 import com.nursena.payflow.wallet.adapter.in.web.OpenWalletController;
 import com.nursena.payflow.wallet.adapter.in.web.OpenWalletRequest;
@@ -125,6 +126,29 @@ class AuthenticatedApiDocumentationTest {
         );
     }
 
+    @Test
+    void shouldDocumentAllSessionLogout()
+        throws NoSuchMethodException {
+
+        Method method =
+            RevokeAllRefreshSessionsController
+                .class
+                .getDeclaredMethod(
+                    "logoutAll",
+                    Jwt.class
+                );
+
+        assertAuthenticatedDocumentation(
+            RevokeAllRefreshSessionsController
+                .class,
+            method,
+            "Authentication",
+            "revokeAllRefreshSessions",
+            "204",
+            "401",
+            "500"
+        );
+    }
     private static void assertAuthenticatedDocumentation(
         Class<?> controllerType,
         Method method,

--- a/src/test/java/com/nursena/payflow/configuration/SecurityConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/SecurityConfigurationTest.java
@@ -62,6 +62,42 @@ class SecurityConfigurationTest {
     }
 
     @Test
+    void shouldRejectAnonymousAllSessionLogout()
+        throws Exception {
+
+        mockMvc.perform(
+                post(
+                    "/api/v1/auth/logout-all"
+                )
+            )
+            .andExpect(
+                status().isUnauthorized()
+            );
+    }
+
+    @Test
+    void shouldPermitAuthenticatedAllSessionLogoutMatcher()
+        throws Exception {
+
+        mockDecodedJwt(
+            "user-token",
+            "USER"
+        );
+
+        mockMvc.perform(
+                post(
+                    "/api/v1/auth/logout-all"
+                )
+                    .header(
+                        AUTHORIZATION,
+                        bearer("user-token")
+                    )
+            )
+            .andExpect(
+                status().isNotFound()
+            );
+    }
+    @Test
     void shouldPermitAnonymousRequestToPrometheusEndpoint()
         throws Exception {
 

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -52,6 +52,9 @@ class OpenApiJsonContractIntegrationTest {
     private static final String LOGOUT_PATH =
         "/api/v1/auth/logout";
 
+    private static final String LOGOUT_ALL_PATH =
+        "/api/v1/auth/logout-all";
+
     private static final String USER_PROFILE_PATH =
         "/api/v1/users/me";
 
@@ -188,6 +191,7 @@ class OpenApiJsonContractIntegrationTest {
             LOGIN_PATH,
             REFRESH_PATH,
             LOGOUT_PATH,
+            LOGOUT_ALL_PATH,
             USER_PROFILE_PATH,
             WALLETS_PATH,
             CURRENT_WALLET_PATH,

--- a/src/test/java/com/nursena/payflow/configuration/integration/RevokeAllRefreshSessionsOpenApiIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/RevokeAllRefreshSessionsOpenApiIntegrationTest.java
@@ -1,0 +1,157 @@
+package com.nursena.payflow.configuration.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.configuration.OpenApiConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class RevokeAllRefreshSessionsOpenApiIntegrationTest {
+
+    private static final String LOGOUT_ALL_PATH =
+        "/api/v1/auth/logout-all";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private JsonNode operation;
+
+    @BeforeEach
+    void loadOperation() throws Exception {
+        MvcResult result =
+            mockMvc.perform(
+                    get("/v3/api-docs")
+                )
+                .andExpect(
+                    status().isOk()
+                )
+                .andExpect(
+                    content()
+                        .contentTypeCompatibleWith(
+                            MediaType.APPLICATION_JSON
+                        )
+                )
+                .andReturn();
+
+        JsonNode openApi =
+            objectMapper.readTree(
+                result
+                    .getResponse()
+                    .getContentAsByteArray()
+            );
+
+        operation =
+            openApi
+                .path("paths")
+                .path(LOGOUT_ALL_PATH)
+                .path("post");
+    }
+
+    @Test
+    void shouldExposeAuthenticatedNoContentContract() {
+        assertThat(operation.isObject())
+            .isTrue();
+
+        assertThat(
+            operation
+                .path("operationId")
+                .asText()
+        )
+            .isEqualTo(
+                "revokeAllRefreshSessions"
+            );
+
+        assertThat(
+            operation
+                .path("security")
+                .get(0)
+                .has(
+                    OpenApiConfiguration
+                        .BEARER_AUTH_SCHEME
+                )
+        )
+            .isTrue();
+
+        assertThat(
+            operation.has("requestBody")
+        )
+            .isFalse();
+
+        Set<String> responseCodes =
+            new LinkedHashSet<>();
+
+        operation
+            .path("responses")
+            .fieldNames()
+            .forEachRemaining(
+                responseCodes::add
+            );
+
+        assertThat(responseCodes)
+            .containsExactlyInAnyOrder(
+                "204",
+                "401",
+                "500"
+            );
+    }
+
+    @Test
+    void shouldExposeNoCredentialOrIdentitySchema() {
+        assertThat(
+            operation
+                .path("responses")
+                .path("204")
+                .has("content")
+        )
+            .isFalse();
+
+        assertThat(
+            operation
+                .path("responses")
+                .path("401")
+                .has("content")
+        )
+            .isFalse();
+
+        assertThat(
+            operation.toString()
+        )
+            .doesNotContain(
+                "userId",
+                "refreshToken",
+                "tokenDigest",
+                "sessionCount"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/RevokeAllRefreshSessionsControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/RevokeAllRefreshSessionsControllerTest.java
@@ -1,0 +1,145 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.user.application.port.in.RevokeAllRefreshSessionsUseCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    RevokeAllRefreshSessionsController.class
+)
+@Import(SecurityConfiguration.class)
+class RevokeAllRefreshSessionsControllerTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "95000000-0000-0000-0000-000000000003"
+        );
+
+    private static final UUID REQUEST_USER_ID =
+        UUID.fromString(
+            "95000000-0000-0000-0000-000000000004"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RevokeAllRefreshSessionsUseCase
+        revokeAllRefreshSessionsUseCase;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldRevokeAllSessionsForAuthenticatedSubject()
+        throws Exception {
+
+        mockMvc.perform(
+                authenticatedLogoutAllRequest()
+            )
+            .andExpect(
+                status().isNoContent()
+            )
+            .andExpect(
+                content().string("")
+            );
+
+        verify(
+            revokeAllRefreshSessionsUseCase
+        ).revoke(
+            argThat(command ->
+                USER_ID.equals(
+                    command.userId()
+                )
+            )
+        );
+    }
+
+    @Test
+    void shouldRejectAnonymousRequest()
+        throws Exception {
+
+        mockMvc.perform(
+                post(
+                    "/api/v1/auth/logout-all"
+                )
+            )
+            .andExpect(
+                status().isUnauthorized()
+            );
+
+        verifyNoInteractions(
+            revokeAllRefreshSessionsUseCase
+        );
+    }
+
+    @Test
+    void shouldIgnoreRequestControlledUserId()
+        throws Exception {
+
+        mockMvc.perform(
+                authenticatedLogoutAllRequest()
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        """
+                        {
+                          "userId": "%s"
+                        }
+                        """
+                            .formatted(
+                                REQUEST_USER_ID
+                            )
+                    )
+            )
+            .andExpect(
+                status().isNoContent()
+            );
+
+        verify(
+            revokeAllRefreshSessionsUseCase
+        ).revoke(
+            argThat(command ->
+                USER_ID.equals(
+                    command.userId()
+                )
+                    && !REQUEST_USER_ID.equals(
+                        command.userId()
+                    )
+            )
+        );
+    }
+
+    private static org.springframework.test.web
+    .servlet.request.MockHttpServletRequestBuilder
+    authenticatedLogoutAllRequest() {
+        return post(
+            "/api/v1/auth/logout-all"
+        )
+            .with(
+                jwt().jwt(token ->
+                    token.subject(
+                        USER_ID.toString()
+                    )
+                )
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/port/in/RevokeAllRefreshSessionsCommandTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/in/RevokeAllRefreshSessionsCommandTest.java
@@ -1,0 +1,60 @@
+package com.nursena.payflow.user.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class RevokeAllRefreshSessionsCommandTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "95000000-0000-0000-0000-000000000001"
+        );
+
+    @Test
+    void shouldRetainAuthenticatedUserId() {
+        RevokeAllRefreshSessionsCommand command =
+            new RevokeAllRefreshSessionsCommand(
+                USER_ID
+            );
+
+        assertThat(command.userId())
+            .isEqualTo(USER_ID);
+    }
+
+    @Test
+    void shouldRejectNullUserId() {
+        assertThatThrownBy(
+            () ->
+                new RevokeAllRefreshSessionsCommand(
+                    null
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "userId must not be null"
+            );
+    }
+
+    @Test
+    void shouldRedactUserIdFromStringRepresentation() {
+        RevokeAllRefreshSessionsCommand command =
+            new RevokeAllRefreshSessionsCommand(
+                USER_ID
+            );
+
+        assertThat(command.toString())
+            .isEqualTo(
+                "RevokeAllRefreshSessionsCommand"
+                    + "[redacted]"
+            )
+            .doesNotContain(
+                USER_ID.toString()
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/RevokeAllRefreshSessionsServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RevokeAllRefreshSessionsServiceTest.java
@@ -1,0 +1,178 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.RevokeAllRefreshSessionsCommand;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RevokeAllRefreshSessionsServiceTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "95000000-0000-0000-0000-000000000002"
+        );
+
+    private static final Instant NOW =
+        Instant.parse(
+            "2026-07-30T10:15:30.123456789Z"
+        );
+
+    private static final Instant REVOKED_AT =
+        Instant.parse(
+            "2026-07-30T10:15:30.123456Z"
+        );
+
+    @Mock
+    private RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    private Clock clock;
+
+    private RevokeAllRefreshSessionsService service;
+
+    @BeforeEach
+    void setUp() {
+        clock =
+            Clock.fixed(
+                NOW,
+                ZoneOffset.UTC
+            );
+
+        service =
+            new RevokeAllRefreshSessionsService(
+                familyRepository,
+                clock
+            );
+    }
+
+    @Test
+    void shouldRevokeEveryActiveFamilyForUser() {
+        when(
+            familyRepository
+                .revokeAllActiveByUserId(
+                    USER_ID,
+                    REVOKED_AT,
+                    RefreshTokenFamilyRevocationReason
+                        .ALL_SESSIONS_LOGOUT
+                )
+        )
+            .thenReturn(3);
+
+        service.revoke(
+            command()
+        );
+
+        verify(familyRepository)
+            .revokeAllActiveByUserId(
+                USER_ID,
+                REVOKED_AT,
+                RefreshTokenFamilyRevocationReason
+                    .ALL_SESSIONS_LOGOUT
+            );
+    }
+
+    @Test
+    void shouldRemainIdempotentWhenNoActiveFamilyExists() {
+        when(
+            familyRepository
+                .revokeAllActiveByUserId(
+                    USER_ID,
+                    REVOKED_AT,
+                    RefreshTokenFamilyRevocationReason
+                        .ALL_SESSIONS_LOGOUT
+                )
+        )
+            .thenReturn(0);
+
+        assertThatCode(
+            () ->
+                service.revoke(
+                    command()
+                )
+        )
+            .doesNotThrowAnyException();
+
+        verify(familyRepository)
+            .revokeAllActiveByUserId(
+                USER_ID,
+                REVOKED_AT,
+                RefreshTokenFamilyRevocationReason
+                    .ALL_SESSIONS_LOGOUT
+            );
+    }
+
+    @Test
+    void shouldRejectNullCommandWithoutPersistenceAccess() {
+        assertThatThrownBy(
+            () ->
+                service.revoke(null)
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "command must not be null"
+            );
+
+        verifyNoInteractions(
+            familyRepository
+        );
+    }
+
+    @Test
+    void shouldRejectNullRepository() {
+        assertThatThrownBy(
+            () ->
+                new RevokeAllRefreshSessionsService(
+                    null,
+                    clock
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "familyRepository must not be null"
+            );
+    }
+
+    @Test
+    void shouldRejectNullClock() {
+        assertThatThrownBy(
+            () ->
+                new RevokeAllRefreshSessionsService(
+                    familyRepository,
+                    null
+                )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "clock must not be null"
+            );
+    }
+
+    private static RevokeAllRefreshSessionsCommand
+    command() {
+        return new RevokeAllRefreshSessionsCommand(
+            USER_ID
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RevokeAllRefreshSessionsIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RevokeAllRefreshSessionsIntegrationTest.java
@@ -1,0 +1,431 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class RevokeAllRefreshSessionsIntegrationTest {
+
+    private static final String PASSWORD =
+        "StrongPassword123!";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldRevokeOnlyActiveFamiliesOwnedBySubject()
+        throws Exception {
+
+        UUID userId =
+            registerUser("all-session-owner");
+
+        UUID otherUserId =
+            registerUser("all-session-other");
+
+        Instant now =
+            Instant.now()
+                .truncatedTo(
+                    ChronoUnit.MICROS
+                );
+
+        UUID firstActiveId =
+            insertFamily(
+                userId,
+                now.minusSeconds(3600),
+                now.plusSeconds(86400),
+                null,
+                null
+            );
+
+        UUID secondActiveId =
+            insertFamily(
+                userId,
+                now.minusSeconds(1800),
+                now.plusSeconds(172800),
+                null,
+                null
+            );
+
+        UUID expiredId =
+            insertFamily(
+                userId,
+                now.minusSeconds(7200),
+                now.minusSeconds(1),
+                null,
+                null
+            );
+
+        UUID futureId =
+            insertFamily(
+                userId,
+                now.plusSeconds(3600),
+                now.plusSeconds(86400),
+                null,
+                null
+            );
+
+        Instant earlierRevokedAt =
+            now.minusSeconds(600);
+
+        UUID previouslyRevokedId =
+            insertFamily(
+                userId,
+                now.minusSeconds(7200),
+                now.plusSeconds(86400),
+                earlierRevokedAt,
+                "CURRENT_SESSION_LOGOUT"
+            );
+
+        UUID otherUserActiveId =
+            insertFamily(
+                otherUserId,
+                now.minusSeconds(3600),
+                now.plusSeconds(86400),
+                null,
+                null
+            );
+
+        performLogoutAll(userId);
+
+        assertRevokedWithAllSessionsReason(
+            firstActiveId
+        );
+
+        assertRevokedWithAllSessionsReason(
+            secondActiveId
+        );
+
+        assertUnrevoked(expiredId);
+        assertUnrevoked(futureId);
+        assertUnrevoked(otherUserActiveId);
+
+        FamilyState previouslyRevoked =
+            familyState(previouslyRevokedId);
+
+        assertThat(
+            previouslyRevoked.revokedAt()
+        )
+            .isEqualTo(
+                earlierRevokedAt
+            );
+
+        assertThat(
+            previouslyRevoked.reason()
+        )
+            .isEqualTo(
+                "CURRENT_SESSION_LOGOUT"
+            );
+    }
+
+    @Test
+    void shouldRemainIdempotentAndPreserveFirstMutation()
+        throws Exception {
+
+        UUID userId =
+            registerUser("all-session-idempotent");
+
+        Instant now =
+            Instant.now()
+                .truncatedTo(
+                    ChronoUnit.MICROS
+                );
+
+        UUID familyId =
+            insertFamily(
+                userId,
+                now.minusSeconds(3600),
+                now.plusSeconds(86400),
+                null,
+                null
+            );
+
+        performLogoutAll(userId);
+
+        FamilyState first =
+            familyState(familyId);
+
+        performLogoutAll(userId);
+
+        FamilyState second =
+            familyState(familyId);
+
+        assertThat(first.revokedAt())
+            .isNotNull();
+
+        assertThat(second.revokedAt())
+            .isEqualTo(
+                first.revokedAt()
+            );
+
+        assertThat(second.reason())
+            .isEqualTo(
+                "ALL_SESSIONS_LOGOUT"
+            );
+    }
+
+    @Test
+    void shouldReturnNoContentWhenNoFamilyExists()
+        throws Exception {
+
+        UUID userId =
+            registerUser("all-session-empty");
+
+        performLogoutAll(userId);
+
+        Integer familyCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM refresh_token_families
+                WHERE user_id = ?
+                """,
+                Integer.class,
+                userId
+            );
+
+        assertThat(familyCount)
+            .isZero();
+    }
+
+    private void performLogoutAll(
+        UUID userId
+    ) throws Exception {
+
+        mockMvc.perform(
+                post(
+                    "/api/v1/auth/logout-all"
+                )
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                userId.toString()
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isNoContent()
+            )
+            .andExpect(
+                content().string("")
+            );
+    }
+
+    private UUID registerUser(
+        String prefix
+    ) throws Exception {
+
+        String email =
+            prefix
+                + "-"
+                + UUID.randomUUID()
+                + "@example.com";
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RegistrationRequest(
+                                email,
+                                PASSWORD
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+
+        UUID userId =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT id
+                FROM users
+                WHERE email = ?
+                """,
+                UUID.class,
+                email
+            );
+
+        assertThat(userId)
+            .isNotNull();
+
+        return userId;
+    }
+
+    private UUID insertFamily(
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt,
+        Instant revokedAt,
+        String reason
+    ) {
+        UUID familyId =
+            UUID.randomUUID();
+
+        int inserted =
+            jdbcTemplate.update(
+                """
+                INSERT INTO refresh_token_families (
+                    id,
+                    user_id,
+                    created_at,
+                    expires_at,
+                    revoked_at,
+                    revocation_reason
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                familyId,
+                userId,
+                Timestamp.from(createdAt),
+                Timestamp.from(expiresAt),
+                revokedAt == null
+                    ? null
+                    : Timestamp.from(revokedAt),
+                reason
+            );
+
+        assertThat(inserted)
+            .isEqualTo(1);
+
+        return familyId;
+    }
+
+    private void assertRevokedWithAllSessionsReason(
+        UUID familyId
+    ) {
+        FamilyState state =
+            familyState(familyId);
+
+        assertThat(state.revokedAt())
+            .isNotNull();
+
+        assertThat(state.reason())
+            .isEqualTo(
+                "ALL_SESSIONS_LOGOUT"
+            );
+    }
+
+    private void assertUnrevoked(
+        UUID familyId
+    ) {
+        FamilyState state =
+            familyState(familyId);
+
+        assertThat(state.revokedAt())
+            .isNull();
+
+        assertThat(state.reason())
+            .isNull();
+    }
+
+    private FamilyState familyState(
+        UUID familyId
+    ) {
+        FamilyState state =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT
+                    id,
+                    revoked_at,
+                    revocation_reason
+                FROM refresh_token_families
+                WHERE id = ?
+                """,
+                (resultSet, rowNumber) -> {
+                    Timestamp revokedAt =
+                        resultSet.getTimestamp(
+                            "revoked_at"
+                        );
+
+                    return new FamilyState(
+                        resultSet.getObject(
+                            "id",
+                            UUID.class
+                        ),
+                        revokedAt == null
+                            ? null
+                            : revokedAt.toInstant(),
+                        resultSet.getString(
+                            "revocation_reason"
+                        )
+                    );
+                },
+                familyId
+            );
+
+        assertThat(state)
+            .isNotNull();
+
+        return state;
+    }
+
+    private record RegistrationRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record FamilyState(
+        UUID id,
+        Instant revokedAt,
+        String reason
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RevokeAllRefreshSessionsRollbackIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RevokeAllRefreshSessionsRollbackIntegrationTest.java
@@ -1,0 +1,366 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Import(
+    RevokeAllRefreshSessionsRollbackIntegrationTest
+        .FailureInjectionConfiguration.class
+)
+class RevokeAllRefreshSessionsRollbackIntegrationTest {
+
+    private static final String PASSWORD =
+        "StrongPassword123!";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private FailureInjectingFamilyRepository
+        familyRepository;
+
+    @BeforeEach
+    void setUp() {
+        familyRepository.reset();
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldRollbackEveryFamilyWhenPersistenceFails()
+        throws Exception {
+
+        UUID userId =
+            registerUser();
+
+        Instant now =
+            Instant.now();
+
+        UUID firstFamilyId =
+            insertActiveFamily(
+                userId,
+                now.minusSeconds(3600),
+                now.plusSeconds(86400)
+            );
+
+        UUID secondFamilyId =
+            insertActiveFamily(
+                userId,
+                now.minusSeconds(1800),
+                now.plusSeconds(172800)
+            );
+
+        familyRepository
+            .failAfterNextBulkRevocation();
+
+        assertThatThrownBy(() ->
+            mockMvc.perform(
+                post(
+                    "/api/v1/auth/logout-all"
+                )
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                userId.toString()
+                            )
+                        )
+                    )
+            )
+        )
+            .isInstanceOf(
+                jakarta.servlet.ServletException.class
+            )
+            .hasRootCauseInstanceOf(
+                IllegalStateException.class
+            )
+            .hasRootCauseMessage(
+                "all-session revocation persistence failed"
+            );
+
+        assertFamilyUnrevoked(firstFamilyId);
+        assertFamilyUnrevoked(secondFamilyId);
+    }
+
+    private UUID registerUser()
+        throws Exception {
+
+        String email =
+            "all-session-rollback-"
+                + UUID.randomUUID()
+                + "@example.com";
+
+        mockMvc.perform(
+                post("/api/v1/auth/register")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RegistrationRequest(
+                                email,
+                                PASSWORD
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+
+        UUID userId =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT id
+                FROM users
+                WHERE email = ?
+                """,
+                UUID.class,
+                email
+            );
+
+        assertThat(userId)
+            .isNotNull();
+
+        return userId;
+    }
+
+    private UUID insertActiveFamily(
+        UUID userId,
+        Instant createdAt,
+        Instant expiresAt
+    ) {
+        UUID familyId =
+            UUID.randomUUID();
+
+        int inserted =
+            jdbcTemplate.update(
+                """
+                INSERT INTO refresh_token_families (
+                    id,
+                    user_id,
+                    created_at,
+                    expires_at,
+                    revoked_at,
+                    revocation_reason
+                )
+                VALUES (?, ?, ?, ?, NULL, NULL)
+                """,
+                familyId,
+                userId,
+                Timestamp.from(createdAt),
+                Timestamp.from(expiresAt)
+            );
+
+        assertThat(inserted)
+            .isEqualTo(1);
+
+        return familyId;
+    }
+
+    private void assertFamilyUnrevoked(
+        UUID familyId
+    ) {
+        FamilyState state =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT
+                    revoked_at,
+                    revocation_reason
+                FROM refresh_token_families
+                WHERE id = ?
+                """,
+                (resultSet, rowNumber) -> {
+                    Timestamp revokedAt =
+                        resultSet.getTimestamp(
+                            "revoked_at"
+                        );
+
+                    return new FamilyState(
+                        revokedAt == null
+                            ? null
+                            : revokedAt.toInstant(),
+                        resultSet.getString(
+                            "revocation_reason"
+                        )
+                    );
+                },
+                familyId
+            );
+
+        assertThat(state)
+            .isNotNull();
+
+        assertThat(state.revokedAt())
+            .isNull();
+
+        assertThat(state.reason())
+            .isNull();
+    }
+
+    private record RegistrationRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record FamilyState(
+        Instant revokedAt,
+        String reason
+    ) {
+    }
+
+    @TestConfiguration(
+        proxyBeanMethods = false
+    )
+    static class FailureInjectionConfiguration {
+
+        @Bean
+        @Primary
+        FailureInjectingFamilyRepository
+        failureInjectingFamilyRepository(
+            @Qualifier(
+                "refreshTokenFamilyPersistenceAdapter"
+            )
+            RefreshTokenFamilyRepositoryPort delegate
+        ) {
+            return new FailureInjectingFamilyRepository(
+                delegate
+            );
+        }
+    }
+
+    static final class FailureInjectingFamilyRepository
+        implements RefreshTokenFamilyRepositoryPort {
+
+        private final RefreshTokenFamilyRepositoryPort
+            delegate;
+
+        private final AtomicBoolean
+            failAfterNextBulkRevocation =
+            new AtomicBoolean();
+
+        FailureInjectingFamilyRepository(
+            RefreshTokenFamilyRepositoryPort delegate
+        ) {
+            this.delegate =
+                delegate;
+        }
+
+        void failAfterNextBulkRevocation() {
+            failAfterNextBulkRevocation.set(
+                true
+            );
+        }
+
+        void reset() {
+            failAfterNextBulkRevocation.set(
+                false
+            );
+        }
+
+        @Override
+        public RefreshTokenFamily save(
+            RefreshTokenFamily family
+        ) {
+            return delegate.save(family);
+        }
+
+        @Override
+        public Optional<RefreshTokenFamily>
+        findByIdForUpdate(
+            RefreshTokenFamilyId familyId
+        ) {
+            return delegate.findByIdForUpdate(
+                familyId
+            );
+        }
+
+        @Override
+        public int revokeAllActiveByUserId(
+            UUID userId,
+            Instant revokedAt,
+            RefreshTokenFamilyRevocationReason
+                reason
+        ) {
+            int affected =
+                delegate.revokeAllActiveByUserId(
+                    userId,
+                    revokedAt,
+                    reason
+                );
+
+            if (
+                failAfterNextBulkRevocation
+                    .compareAndSet(
+                        true,
+                        false
+                    )
+            ) {
+                throw new IllegalStateException(
+                    "all-session revocation "
+                        + "persistence failed"
+                );
+            }
+
+            return affected;
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Allow an authenticated user to revoke every active refresh-token session owned by their identity.

## Implementation

- add POST /api/v1/auth/logout-all
- derive the target user exclusively from the authenticated JWT subject
- transactionally revoke all active refresh-token families owned by that user
- preserve already issued access tokens until their normal expiration
- keep the operation idempotent when no active family exists
- expose the endpoint through the authenticated OpenAPI contract

## Verification

- security matcher tests
- controller and command tests
- application service tests
- OpenAPI contract integration tests
- PostgreSQL persistence integration tests
- ownership and active-session filtering tests
- idempotency tests
- transaction rollback integration test
- full Maven verification

## Release gate

- Tests: 828
- Failures: 0
- Errors: 0
- Skipped: 0
- Build: SUCCESS
- Artifact: 	arget/payflow-0.9.0-SNAPSHOT.jar

## Security semantics

This operation revokes refresh-token families. Access tokens issued before the operation remain valid until their configured expiration.