### PR TITLE
feat(auth): add Redis-backed login rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This keeps domain rules independent from Spring and infrastructure while avoidin
 
 ## Current status
 
-The repository foundation, identity flow, wallet management, transactional transfer processing, Kafka delivery pipeline, secure dead-letter operations control plane, and durable refresh-session persistence foundation are implemented.
+The repository foundation, identity flow, revocable refresh sessions, Redis-backed login protection, wallet management, transactional transfer processing, Kafka delivery pipeline, and secure dead-letter operations control plane are implemented.
 
 Completed capabilities include:
 
@@ -55,7 +55,10 @@ Completed capabilities include:
 - secure-by-default Spring Security configuration
 - user registration with normalized email addresses
 - BCrypt password hashing
-- user login with RSA-signed JWT access tokens
+- user login with RSA-signed JWT access tokens and opaque refresh credentials
+- Redis-backed fixed-window login limits by normalized identity and direct client peer
+- atomic Lua counter updates with explicit TTL, `429 Retry-After`, and fail-closed `503`
+- low-cardinality login-protection metrics and credential-free security events
 - refresh-session architecture and threat model with explicit rotation and reuse-detection boundaries
 - refresh-token family and record domain/application contracts
 - PostgreSQL refresh-session persistence with SHA-256 digest-only token storage
@@ -98,14 +101,17 @@ Completed capabilities include:
 - operator-only, paginated command-audit queries and chronological command timelines
 - Prometheus metrics, Grafana dashboards, and alert rules for Kafka consumer failures
 
-OpenAPI documentation and the executable Postman collection cover the implemented API. PayFlow v0.7.0 establishes the architecture, domain contracts, and PostgreSQL persistence foundation for secure refresh-token rotation. Public refresh-token issuance, rotation, and revocation endpoints are intentionally deferred to a later release. See the [roadmap](docs/roadmap.md).
+OpenAPI documentation and executable Postman workflows cover the implemented API. The v0.9.0 development line includes refresh-token issuance and rotation, current-session and all-session logout, and Redis-backed login protection with real PostgreSQL and Redis acceptance coverage. See the [roadmap](docs/roadmap.md).
 
 ## Implemented API
 
 | Method | Endpoint | Authentication | Description |
 |---|---|---|---|
 | `POST` | `/api/v1/auth/register` | Public | Registers a new user and stores a BCrypt password hash. |
-| `POST` | `/api/v1/auth/login` | Public | Authenticates a user and returns an RSA-signed JWT access token. |
+| `POST` | `/api/v1/auth/login` | Public | Applies Redis-backed login protection and returns access and refresh credentials. |
+| `POST` | `/api/v1/auth/refresh` | Public | Atomically rotates an active opaque refresh credential. |
+| `POST` | `/api/v1/auth/logout` | Public | Idempotently revokes the refresh-token family represented by the submitted credential. |
+| `POST` | `/api/v1/auth/logout-all` | Bearer JWT | Revokes every active refresh session owned by the authenticated user. |
 | `GET` | `/api/v1/users/me` | Bearer JWT | Returns the authenticated user's safe profile fields. |
 | `POST` | `/api/v1/wallets` | Bearer JWT | Opens a zero-balance wallet for the authenticated user. |
 | `GET` | `/api/v1/wallets/me` | Bearer JWT | Returns the authenticated user's wallet summary. |
@@ -120,6 +126,24 @@ OpenAPI documentation and the executable Postman collection cover the implemente
 | `GET` | `/api/v1/operations/kafka/dead-letter-command-audits/{commandId}` | Bearer JWT with `role=ADMIN` | Returns the chronological audit timeline for one operator command. |
 | `GET` | `/api/v1/system/health` | Configuration-dependent | Exposes the application health status. |
 
+### Redis-backed login protection
+
+`POST /api/v1/auth/login` evaluates normalized-identity and direct-client counters
+in one Redis Lua script before user lookup or password verification. The default
+policy allows five attempts per identity and twenty attempts per client in a
+fixed fifteen-minute window.
+
+Excessive attempts return `429 LOGIN_RATE_LIMIT_EXCEEDED` with a positive
+`Retry-After` header. Redis decision or reset failures return fail-closed
+`503 LOGIN_RATE_LIMIT_UNAVAILABLE`. Error responses remain generic and do not
+reveal whether an identity exists.
+
+A successful login resets only the identity counter; the client counter retains
+its original expiration. Redis keys contain SHA-256 digests rather than raw
+identity or client values.
+
+See [Redis-Backed Login Rate Limiting](docs/login-rate-limiting.md) for policy,
+configuration, metrics, reverse-proxy trust boundaries, and operational checks.
 ### Simulated wallet top-up
 
 ```http
@@ -227,6 +251,7 @@ Import:
 
 - `postman/PayFlow.postman_collection.json`
 - `postman/PayFlow.local.postman_environment.json`
+- `postman/PayFlow.login-rate-limit.postman_collection.json` for the separate, deliberately disruptive security workflow
 
 Select the **PayFlow Local** environment and run the standard application workflow folders in this order:
 
@@ -420,7 +445,7 @@ Transfers and ledger writes require strong relational constraints, transactional
 
 ### Why Redis?
 
-Redis will support bounded, explicitly expiring concerns such as login rate limiting, short-lived wallet summaries, and selected idempotency lookups. PostgreSQL remains the source of truth for durable financial and refresh-session lifecycle state.
+Redis stores bounded, explicitly expiring login-attempt counters. Atomic Lua execution keeps identity and client decisions consistent across application instances, while PostgreSQL remains the source of truth for durable financial and refresh-session lifecycle state.
 
 ### Why Kafka?
 

--- a/docs/adr/0010-redis-login-rate-limiting.md
+++ b/docs/adr/0010-redis-login-rate-limiting.md
@@ -1,0 +1,290 @@
+# ADR 0010: Use Redis-backed login rate limiting
+
+- Status: Accepted
+- Date: 2026-07-30
+
+## Context
+
+PayFlow exposes the public authentication endpoint:
+
+```text
+POST /api/v1/auth/login
+```
+
+Login performs account lookup and BCrypt password verification. Repeated requests
+can therefore be used for password brute force, credential stuffing, targeted
+account abuse, and resource exhaustion.
+
+PayFlow already includes Spring Data Redis and a Redis service in the local
+development environment. The protection must work consistently across
+application instances, remain atomic under concurrency, avoid storing raw
+identifiers, and preserve the existing invalid-credentials contract.
+
+## Decision
+
+PayFlow will protect login with a Redis-backed fixed-window rate limiter.
+
+Two independent dimensions will be evaluated before account lookup and password
+verification:
+
+1. normalized login identity
+2. network peer address
+
+Both dimensions must admit the request.
+
+Initial defaults:
+
+- identity limit: 5 attempts per 15-minute window
+- client-address limit: 20 attempts per 15-minute window
+- the sixth identity attempt is rejected
+- the twenty-first client-address attempt is rejected
+
+Limits and durations are configuration properties.
+
+## Atomic Redis operation
+
+One Lua script will atomically:
+
+1. increment the identity counter
+2. set its expiration when first created
+3. increment the client-address counter
+4. set its expiration when first created
+5. read remaining TTL values
+6. return admission state, blocking dimensions, and retry delay
+
+The adapter will execute one singleton `DefaultRedisScript` through
+`StringRedisTemplate`.
+
+This prevents:
+
+- increments without expiration
+- partial updates between dimensions
+- threshold bypass through concurrent requests
+- inconsistent retry-delay calculation
+
+Denied attempts do not extend the active fixed window.
+
+## Counter lifecycle
+
+Failed authentication retains both counters.
+
+Successful authentication deletes only the identity counter. The client-address
+counter remains so one source cannot avoid network-level protection by
+successfully authenticating one account.
+
+A request rejected by the limiter does not perform:
+
+- user lookup
+- BCrypt password verification
+- token generation
+- refresh-session persistence
+
+## Redis keys and sensitive data
+
+Raw email addresses and raw client addresses must not appear in Redis keys.
+
+The Redis adapter will:
+
+1. normalize the email using the existing `EmailAddress` value object
+2. normalize the network peer address
+3. calculate SHA-256 for each normalized value
+4. encode the digest as lowercase hexadecimal
+5. place only the digest in the key
+
+Key namespaces:
+
+```text
+payflow:security:login:identity:<sha256>
+payflow:security:login:client:<sha256>
+```
+
+Redis keys and values must not contain:
+
+- passwords or password hashes
+- access or refresh tokens
+- raw email addresses
+- raw client addresses
+
+Digests must not be exposed through responses, logs, metrics, traces, or audit
+records.
+
+## Client-address trust boundary
+
+The first implementation will use `HttpServletRequest.getRemoteAddr()`.
+
+Application code will not directly trust:
+
+```text
+X-Forwarded-For
+Forwarded
+X-Real-IP
+```
+
+Forwarded-header processing requires a separate production deployment decision
+with an explicit trusted-proxy boundary.
+
+## HTTP contract
+
+When either dimension is blocked, PayFlow returns:
+
+```text
+HTTP 429 Too Many Requests
+```
+
+The centralized API error contains:
+
+```text
+code: LOGIN_RATE_LIMIT_EXCEEDED
+message: Too many login attempts. Try again later.
+path: /api/v1/auth/login
+```
+
+The response includes:
+
+```text
+Retry-After: <whole seconds>
+```
+
+The delay is the longest remaining TTL among blocked dimensions, with a minimum
+of one second.
+
+The response does not disclose whether the account exists, which dimension was
+blocked, current counts, configured limits, or Redis keys.
+
+## Redis outage behavior
+
+The default behavior is fail-closed.
+
+When Redis cannot provide a reliable admission decision, PayFlow skips password
+verification and returns:
+
+```text
+HTTP 503 Service Unavailable
+```
+
+The API error code is:
+
+```text
+LOGIN_RATE_LIMIT_UNAVAILABLE
+```
+
+The response does not expose Redis commands, hosts, topology, exception
+messages, or connection details.
+
+An explicitly configured fail-open production mode is outside this increment.
+
+## Metrics and security events
+
+The implementation will publish bounded Micrometer counters:
+
+```text
+payflow.auth.login.rate_limit.decisions
+payflow.auth.login.rate_limit.redis.failures
+```
+
+Allowed tags are limited to bounded values such as:
+
+```text
+outcome=allowed|blocked
+dimension=none|identity|client|both
+operation=evaluate|reset
+```
+
+Metrics and security events must not contain email addresses, client addresses,
+digests, user IDs, passwords, credentials, Redis keys, or exception messages.
+
+## Application boundaries
+
+The user module defines a framework-independent output port for login
+rate-limiting decisions.
+
+The Redis adapter owns:
+
+- Redis key construction
+- SHA-256 identifier hashing
+- Lua execution
+- result parsing
+- Redis exception translation
+
+Authentication orchestration owns:
+
+- identity normalization
+- evaluation before authentication
+- identity-counter reset after successful authentication
+- translation of decisions into application exceptions
+
+The web adapter owns:
+
+- transport-peer extraction
+- HTTP 429 and 503 responses
+- `Retry-After`
+- OpenAPI documentation
+
+The application layer does not depend directly on servlet, Redis, Lua, or
+Micrometer types.
+
+## Configuration
+
+Initial configuration namespace:
+
+```yaml
+payflow:
+  security:
+    login-rate-limit:
+      enabled: true
+      window: 15m
+      identity-limit: 5
+      client-limit: 20
+```
+
+Production configuration enables the limiter.
+
+General tests disable it so unrelated authentication tests do not silently
+depend on Redis. Dedicated integration tests enable it and use an isolated Redis
+Testcontainer.
+
+## Testing requirements
+
+The increment must cover:
+
+- configuration validation
+- deterministic hashing and raw-identifier exclusion
+- first-attempt expiration
+- atomic identity and client increments
+- exact threshold behavior
+- identity-only, client-only, and combined blocking
+- retry-delay calculation
+- successful-login identity reset
+- failed-login counter retention
+- concurrent admission behavior
+- automatic expiration
+- Redis failure translation
+- HTTP 429 and `Retry-After`
+- HTTP 503 fail-closed behavior
+- OpenAPI documentation
+- absence of credential data in responses
+- complete Maven verification
+
+## Consequences
+
+Benefits:
+
+- limits are shared across application instances
+- decisions are atomic
+- counters expire automatically
+- blocked requests avoid expensive password verification
+- raw identities are not stored
+- metrics remain low-cardinality
+- Redis outage behavior is deterministic
+
+Costs:
+
+- Redis becomes required for login availability
+- fixed windows permit boundary bursts
+- identity limits may temporarily affect a legitimate user
+- a reverse proxy may appear as the peer until trusted-proxy handling is defined
+- additional integration and concurrency tests are required
+
+The fixed-window trade-off is accepted for PayFlow v0.9.0. Sliding-window or
+token-bucket algorithms may be considered later if production traffic requires
+smoother admission behavior.

--- a/docs/login-rate-limiting.md
+++ b/docs/login-rate-limiting.md
@@ -1,0 +1,189 @@
+# Redis-Backed Login Rate Limiting
+
+PayFlow protects `POST /api/v1/auth/login` with distributed, fixed-window
+counters stored in Redis. The protection is intentionally limited to login;
+refresh, logout, and authenticated business endpoints are outside this policy.
+
+## Security goals
+
+The implementation is designed to:
+
+- reduce automated brute-force and credential-stuffing attempts
+- apply the same policy across multiple application instances
+- avoid revealing whether a login identity exists
+- keep raw emails, passwords, tokens, and client addresses out of Redis keys,
+  logs, and metric labels
+- fail closed when the protection decision cannot be made safely
+
+## Policy
+
+Two counters are evaluated atomically for every login attempt:
+
+| Dimension | Default threshold | Key input |
+|---|---:|---|
+| Identity | 5 attempts per 15 minutes | Normalized email address |
+| Client | 20 attempts per 15 minutes | Direct servlet peer address |
+
+The first five attempts for one identity are evaluated normally. The sixth
+attempt in the same window is blocked. The first twenty attempts for one client
+are evaluated normally; the twenty-first is blocked.
+
+A successful login deletes only the identity counter. The client counter
+remains until its original fixed-window expiration. This prevents one valid
+credential from erasing the broader client-abuse signal.
+
+## Redis model
+
+Identity and client values are normalized and SHA-256 hashed before they are
+placed in Redis keys. The Lua script performs the following work atomically:
+
+1. increment both counters
+2. assign expiration when a key is created
+3. preserve the original fixed-window expiration on later attempts
+4. determine the blocked dimension
+5. return the longest relevant TTL as `Retry-After`
+
+PostgreSQL remains the system of record. Redis stores only short-lived abuse
+control counters.
+
+## HTTP contracts
+
+### Below threshold
+
+Invalid credentials continue to return the generic response:
+
+```http
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+```
+
+```json
+{
+  "code": "INVALID_CREDENTIALS",
+  "message": "Email or password is incorrect."
+}
+```
+
+The response does not disclose whether the identity exists.
+
+### Threshold exceeded
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 734
+Content-Type: application/json
+```
+
+```json
+{
+  "code": "LOGIN_RATE_LIMIT_EXCEEDED",
+  "message": "Too many login attempts. Try again later.",
+  "violations": []
+}
+```
+
+`Retry-After` is expressed as positive whole seconds and is derived from the
+active Redis TTL.
+
+### Redis unavailable
+
+A Redis command failure produces a fail-closed response:
+
+```http
+HTTP/1.1 503 Service Unavailable
+Content-Type: application/json
+```
+
+```json
+{
+  "code": "LOGIN_RATE_LIMIT_UNAVAILABLE",
+  "message": "Login protection is temporarily unavailable.",
+  "violations": []
+}
+```
+
+Authentication does not continue when the limiter cannot evaluate or reset its
+state safely.
+
+## Configuration
+
+| Environment variable | Default | Purpose |
+|---|---|---|
+| `LOGIN_RATE_LIMIT_ENABLED` | `true` | Enables login protection |
+| `LOGIN_RATE_LIMIT_WINDOW` | `15m` | Fixed-window duration |
+| `LOGIN_RATE_LIMIT_IDENTITY_LIMIT` | `5` | Allowed attempts per identity |
+| `LOGIN_RATE_LIMIT_CLIENT_LIMIT` | `20` | Allowed attempts per client |
+| `REDIS_HOST` | `localhost` | Redis host |
+| `REDIS_PORT` | `6379` | Redis port |
+
+Threshold and window changes should be reviewed as security-policy changes.
+Avoid values that create an easy denial-of-service path for shared networks.
+
+## Client-address trust boundary
+
+The controller currently uses the direct servlet peer address and does not
+parse arbitrary `X-Forwarded-For` values. This avoids trusting attacker-supplied
+forwarding headers.
+
+When PayFlow is deployed behind a reverse proxy, the platform must establish a
+trusted forwarding boundary before client-based thresholds are treated as
+end-user IP limits. Without that boundary, requests may be grouped by the proxy
+address. Do not enable unrestricted forwarded-header trust.
+
+## Metrics and logs
+
+Prometheus metrics:
+
+- `payflow.auth.login.rate_limit.decisions`
+  - `outcome=allowed|blocked`
+  - `dimension=none|identity|client|both`
+- `payflow.auth.login.rate_limit.redis.failures`
+  - `operation=evaluate|reset`
+
+Security log events identify only the event type, blocked dimension, and request
+path. They must not include raw identity values, passwords, tokens, or client
+addresses.
+
+## Local verification
+
+Start infrastructure and the application:
+
+```powershell
+docker compose up -d postgres redis kafka
+.\mvnw.cmd spring-boot:run
+```
+
+Import and run the complete dedicated Postman collection:
+
+```text
+postman/PayFlow.login-rate-limit.postman_collection.json
+```
+
+Run it separately from the normal PayFlow workflow because it intentionally
+consumes login attempts.
+
+Automated verification:
+
+```powershell
+.\mvnw.cmd -Dtest=RedisLoginRateLimitAdapterIntegrationTest,LoginRateLimitHttpIntegrationTest,LoginRateLimitUnavailableHttpIntegrationTest test
+```
+
+The full project gate remains:
+
+```powershell
+.\mvnw.cmd clean verify
+```
+
+## Operational checks
+
+When investigating unexpected `429` responses:
+
+1. confirm the configured identity and client thresholds
+2. inspect the `Retry-After` value rather than retrying continuously
+3. verify whether traffic is arriving through a shared proxy or NAT boundary
+4. review only low-cardinality limiter metrics and safe security events
+5. never inspect or export raw credentials for diagnosis
+
+When Redis is unavailable, restore Redis connectivity and verify health before
+retrying login traffic. Bypassing the limiter during an outage changes the
+security contract and requires a separate, explicit operational decision.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,18 +2,15 @@
 
 ## Current delivery focus
 
-PayFlow v0.6.0 is published and the active development line uses
-`0.7.0-SNAPSHOT`.
+PayFlow v0.8.0 is the latest tagged baseline. The active development line uses
+`0.9.0-SNAPSHOT`.
 
-The v0.7.0 increment focuses on identity and session security. The goal is to
-extend the existing RSA-signed access-token authentication with revocable,
-rotating refresh-token sessions and bounded Redis-backed login protection.
+The v0.9.0 increment focuses on distributed Redis-backed login protection and
+release readiness for the completed refresh-session security lifecycle. PayFlow
+remains a modular monolith. PostgreSQL is the system of record; Redis is used
+only for bounded, explicitly expiring abuse-control state.
 
-The project remains a modular monolith. PostgreSQL remains the system of record,
-Redis is used only for explicitly bounded and expiring concerns, and public API
-changes must preserve stable security and error contracts.
-
-## Delivered baseline through v0.6.0
+## Delivered platform baseline
 
 ### Repository and architecture
 
@@ -22,179 +19,149 @@ changes must preserve stable security and error contracts.
 - [x] Inward-facing domain, application, and adapter dependencies
 - [x] PostgreSQL, Redis, and Kafka local infrastructure
 - [x] Flyway-managed database schema
-- [x] CI, Dependabot, pull request, and issue templates
+- [x] CI, Dependabot, pull-request, and issue templates
 - [x] Conventional Commits and protected pull-request workflow
-- [x] Tagged GitHub releases with executable JAR and SHA-256 assets
+- [x] Tagged releases with executable JAR and SHA-256 assets
 
-### Identity and authorization
+### Identity, authorization, and sessions
 
 - [x] User registration with normalized email addresses
 - [x] BCrypt password hashing
-- [x] User login
 - [x] RSA-signed JWT access tokens
-- [x] Authenticated current-user profile
-- [x] Stable authentication and authorization error handling
+- [x] Opaque refresh credentials persisted only as SHA-256 digests
+- [x] Atomic refresh-token rotation
+- [x] Concurrent rotation protection
+- [x] Refresh-token reuse detection and family revocation
+- [x] Current-session logout
+- [x] Authenticated all-session logout
+- [x] Durable all-session revocation across application restarts
+- [x] Stable authentication and authorization error contracts
 - [x] ADMIN-derived `PAYFLOW_OPERATIONS` authorization boundary
-- [x] Authentication and operations-security integration tests
 
-### Wallets, transfers, and ledger
+### Wallets, transfers, ledger, and events
 
 - [x] One wallet per authenticated user
-- [x] Current-wallet retrieval
-- [x] Simulated wallet top-up
+- [x] Simulated top-up and current-wallet retrieval
 - [x] Optimistic locking and PostgreSQL concurrency verification
-- [x] Authenticated wallet-to-wallet transfers
-- [x] Source identity derived from the JWT subject
+- [x] Authenticated, atomic wallet-to-wallet transfers
 - [x] Source-wallet-scoped idempotency
-- [x] Atomic source debit and target credit
 - [x] Immutable double-entry ledger persistence
-- [x] Transaction rollback verification
-- [x] Concurrent duplicate-transfer verification
+- [x] Transaction rollback and concurrent duplicate verification
 - [x] Paginated and filterable transaction history
-- [x] Deterministic transaction ordering
-- [x] Endpoint-to-database integration tests
-
-### Event-driven delivery and operations
-
-- [x] Transactional outbox persistence
-- [x] Versioned `wallet.transfer.completed` event
-- [x] Leased and retryable Kafka publication
+- [x] Transactional outbox and retryable Kafka publication
 - [x] Idempotent event consumption
-- [x] Kafka integration tests
-- [x] Durable dead-letter intake
-- [x] Replay lineage and controlled replay lifecycle
-- [x] Explicit discard lifecycle
-- [x] Operator-only dead-letter query and command APIs
-- [x] Append-only replay and discard command auditing
-- [x] Paginated audit investigation queries
-- [x] Chronological command timelines
-- [x] Safe-field response allowlists
+- [x] Durable dead-letter intake, replay, and discard lifecycle
+- [x] Append-only operator command auditing
 
 ### Documentation and observability
 
 - [x] OpenAPI contracts and examples
-- [x] Executable Postman collection
-- [x] Prometheus metrics for Kafka delivery failures
-- [x] Provisioned Grafana dashboards
-- [x] Operational alert rules
+- [x] Executable standard Postman workflow
+- [x] Dedicated login rate-limit Postman workflow
+- [x] Prometheus metrics, Grafana dashboards, and alert rules
 - [x] Architecture and ER diagram sources
-- [x] Release notes and upgrade guidance
+- [x] Security and operations documentation
 
-## v0.7.0 — Identity and Session Security
+## v0.9.0 — Redis-Backed Login Protection
 
 ### Product outcome
 
-Authenticated users can maintain revocable sessions without receiving
-long-lived bearer access tokens. Refresh-token rotation limits replay windows,
-token-family reuse detection provides an incident response boundary, and login
-rate limiting reduces automated credential attacks.
+Login attempts are evaluated consistently across application instances without
+revealing whether an account exists. The implementation uses bounded fixed
+windows, hashed Redis keys, atomic Lua updates, low-cardinality metrics, and
+fail-closed behavior when Redis cannot make a safe decision.
 
-No plaintext refresh token, password, JWT, authorization header, or equivalent
-credential may be persisted, logged, returned through administrative APIs, or
-included in metrics.
+### Increment 1 — Redis foundation
 
-### Increment 1 — Architecture and security contracts
+- [x] Define identity and client rate-limit ports and domain contracts
+- [x] Add validated configuration properties with secure defaults
+- [x] Hash normalized identity and client values before key construction
+- [x] Implement atomic Redis Lua evaluation
+- [x] Apply expiration only when a fixed-window key is created
+- [x] Add bounded metric tags and credential-free security events
 
-- [ ] Record the refresh-session architecture and threat model in an ADR
-- [ ] Define access-token and refresh-token responsibilities
-- [ ] Define token-family lifecycle states and invariants
-- [ ] Define expiration, rotation, revocation, and reuse-detection semantics
-- [ ] Define stable public error codes and HTTP outcomes
-- [ ] Define safe logging, metric, and audit-field allowlists
-- [ ] Define clock and token-generation ports for deterministic tests
+### Increment 2 — Authentication integration
 
-### Increment 2 — Durable refresh-session persistence
+- [x] Apply the limiter before user lookup and password verification
+- [x] Preserve generic invalid-credential responses below the threshold
+- [x] Return stable `429 LOGIN_RATE_LIMIT_EXCEEDED`
+- [x] Derive a positive `Retry-After` value from Redis TTL
+- [x] Reset only the identity counter after successful login
+- [x] Preserve the client counter until its original expiration
+- [x] Return fail-closed `503 LOGIN_RATE_LIMIT_UNAVAILABLE`
+- [x] Keep direct servlet peer addressing as the explicit trust boundary
 
-- [ ] Add a Flyway migration for refresh-token families and token records
-- [ ] Persist only cryptographic token hashes
-- [ ] Store family, user, creation, expiration, replacement, and revocation metadata
-- [ ] Enforce database constraints for family and rotation invariants
-- [ ] Add indexes for active-token lookup and user-session revocation
-- [ ] Add PostgreSQL repository integration tests
-- [ ] Verify that plaintext credentials never enter persistence
+### Increment 3 — Verification
 
-### Increment 3 — Token issuance and atomic rotation
+- [x] Unit-test configuration, hashing, decisions, metrics, and error mapping
+- [x] Verify identity and client thresholds with real Redis
+- [x] Verify fixed-window expiration is not refreshed
+- [x] Verify identity-only reset after successful authentication
+- [x] Verify atomic Lua behavior under concurrent requests
+- [x] Verify HTTP `429` and `Retry-After`
+- [x] Verify Redis outage produces fail-closed HTTP `503`
+- [x] Run the complete Maven verification suite
 
-- [ ] Extend successful login with an access and refresh token pair
-- [ ] Add a refresh endpoint with an explicit request contract
-- [ ] Rotate refresh tokens exactly once
-- [ ] Replace the consumed token atomically
-- [ ] Reject expired, revoked, malformed, and unknown tokens deterministically
-- [ ] Handle concurrent refresh requests without issuing multiple valid successors
-- [ ] Add endpoint-to-database integration and concurrency tests
+### Increment 4 — Public and operational contracts
 
-### Increment 4 — Reuse detection and session revocation
+- [x] Update OpenAPI authentication responses
+- [x] Add a dedicated, credential-free Postman verification collection
+- [x] Add Postman collection contract tests
+- [x] Document thresholds, TTL, metrics, logs, and outage behavior
+- [x] Document reverse-proxy and forwarded-address trust boundaries
+- [x] Update the root project documentation
 
-- [ ] Detect reuse of an already rotated refresh token
-- [ ] Revoke the complete token family after confirmed reuse
-- [ ] Add current-session logout
-- [ ] Add all-session logout for the authenticated user
-- [ ] Keep logout behavior idempotent
-- [ ] Add safe security metrics for rotation, rejection, reuse, and revocation
-- [ ] Verify that operational data exposes no token material
+### Increment 5 — Pull request and release readiness
 
-### Increment 5 — Redis-backed login protection
+- [ ] Synchronize the feature branch with the latest `origin/main`
+- [ ] Open the pull request linked to issue #98
+- [ ] Pass protected-branch CI and review checks
+- [ ] Merge through the protected pull-request workflow
+- [ ] Publish v0.9.0 release notes
+- [ ] Publish the executable JAR and SHA-256 checksum
+- [ ] Tag the verified release commit as `v0.9.0`
 
-- [ ] Define a bounded login-attempt policy
-- [ ] Apply limits using normalized login identity and trusted client context
-- [ ] Use atomic Redis operations with explicit expiration
-- [ ] Return a stable `429 Too Many Requests` contract
-- [ ] Avoid revealing whether an account exists
-- [ ] Define safe behavior when Redis is unavailable
-- [ ] Add Redis integration, expiration, and concurrency tests
-
-### Increment 6 — Public contracts and release readiness
-
-- [ ] Update OpenAPI authentication contracts and examples
-- [ ] Update the executable Postman authentication workflow
-- [ ] Document refresh, logout, reuse, and rate-limit behavior
-- [ ] Add regression tests for existing access-token-only endpoints
-- [ ] Verify authentication responses exclude credential internals
-- [ ] Run full Maven, security, migration, and API-contract verification
-- [ ] Publish v0.7.0 release notes, JAR, and SHA-256 checksum
-
-## Explicit v0.7.0 non-goals
-
-The following work is valuable but is not part of the v0.7.0 commitment:
+## Explicit v0.9.0 non-goals
 
 - external OAuth or OpenID Connect identity providers
 - social login
 - multi-factor authentication
 - password-reset and email-verification workflows
-- browser or mobile user interfaces
 - device fingerprinting
 - generalized API-wide rate limiting
 - production KMS or HSM integration
+- unrestricted trust of forwarded client-address headers
 - microservice extraction
 - wallet-summary caching
 - unrelated dependency modernization
 
-These items require separate milestones and threat models rather than being
-silently added to the session-security increment.
+These items require separate issues, milestones, and threat models rather than
+being silently added to the login-protection increment.
 
-## v0.7.0 release exit criteria
+## v0.9.0 release exit criteria
 
 The release is ready only when:
 
-- [ ] all committed v0.7.0 issues are closed
-- [ ] database migrations are backward-safe and verified with PostgreSQL
-- [ ] refresh-token rotation is atomic under concurrent requests
-- [ ] confirmed token reuse revokes the complete family
-- [ ] current-session and all-session logout behavior is verified
-- [ ] login rate limiting is verified against Redis
-- [ ] no plaintext refresh token or other credential is persisted or logged
-- [ ] OpenAPI and Postman contracts match the implementation
-- [ ] all automated tests and pull-request checks pass
-- [ ] release documentation, executable JAR, and SHA-256 checksum are published
+- [x] refresh-token rotation is atomic under concurrent requests
+- [x] confirmed token reuse revokes the complete family
+- [x] current-session and all-session logout behavior is verified
+- [x] login rate limiting is verified against real Redis
+- [x] plaintext refresh tokens and authentication credentials are excluded from persistence and logs
+- [x] OpenAPI and Postman contracts match the implementation
+- [x] all local automated tests pass
+- [ ] the pull request is approved and merged
+- [ ] protected-branch CI passes on the merge candidate
+- [ ] release notes, executable JAR, and SHA-256 checksum are published
 
 ## Future candidates
 
-Potential increments after v0.7.0 include:
+Potential increments after v0.9.0 include:
 
 - signing-key rotation and external key-management integration
+- trusted reverse-proxy client-address resolution
 - structured JSON logging and request correlation
-- performance and load-test scenarios
-- cache strategy and invalidation verification
+- load and performance verification
 - password recovery and verified-email workflows
 - multi-factor authentication
 - broader operational-security dashboards
+- generalized API abuse protection

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>

--- a/postman/PayFlow.login-rate-limit.postman_collection.json
+++ b/postman/PayFlow.login-rate-limit.postman_collection.json
@@ -1,0 +1,401 @@
+{
+  "info": {
+    "_postman_id": "8ab283ab-ebb9-4728-a8b0-dee607126686",
+    "name": "PayFlow Login Rate-Limit Verification",
+    "description": "Dedicated, deliberately disruptive verification workflow for the Redis-backed PayFlow login identity threshold. Run separately from the standard application workflow. No real credentials are included.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080",
+      "type": "string"
+    },
+    {
+      "key": "rateLimitEmail",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "Identity Threshold",
+      "description": "Run this complete folder in order. Attempt 1 creates a unique unregistered identity. Attempts 1-5 expect 401 INVALID_CREDENTIALS; attempt 6 expects 429 LOGIN_RATE_LIMIT_EXCEEDED with Retry-After.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "if (pm.info.requestName === 'Failed Login Attempt 1') {",
+              "  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1000000)}`;",
+              "  pm.collectionVariables.set('rateLimitEmail', `rate-limit-${suffix}@example.com`);",
+              "}",
+              "",
+              "if (!pm.collectionVariables.get('rateLimitEmail')) {",
+              "  throw new Error('Run the complete Identity Threshold folder from attempt 1.');",
+              "}"
+            ]
+          }
+        }
+      ],
+      "item": [
+        {
+          "name": "Failed Login Attempt 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"attempt remains below the identity threshold\", function () {",
+                  "  pm.response.to.have.status(401);",
+                  "});",
+                  "",
+                  "const response = pm.response.json();",
+                  "pm.test(\"invalid-credential contract remains generic\", function () {",
+                  "  pm.expect(response.code).to.eql('INVALID_CREDENTIALS');",
+                  "  pm.expect(response.message).to.eql('Email or password is incorrect.');",
+                  "  pm.expect(response.violations).to.eql([]);",
+                  "  pm.expect(response).not.to.have.property('userId');",
+                  "  pm.expect(response).not.to.have.property('userExists');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{rateLimitEmail}}\",\n  \"password\": \"WrongPassword123!\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            },
+            "description": "Uses an intentionally unregistered identity so the first five attempts return the same generic invalid-credential response and the sixth attempt is blocked by the identity rate limit."
+          },
+          "response": []
+        },
+        {
+          "name": "Failed Login Attempt 2",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"attempt remains below the identity threshold\", function () {",
+                  "  pm.response.to.have.status(401);",
+                  "});",
+                  "",
+                  "const response = pm.response.json();",
+                  "pm.test(\"invalid-credential contract remains generic\", function () {",
+                  "  pm.expect(response.code).to.eql('INVALID_CREDENTIALS');",
+                  "  pm.expect(response.message).to.eql('Email or password is incorrect.');",
+                  "  pm.expect(response.violations).to.eql([]);",
+                  "  pm.expect(response).not.to.have.property('userId');",
+                  "  pm.expect(response).not.to.have.property('userExists');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{rateLimitEmail}}\",\n  \"password\": \"WrongPassword123!\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            },
+            "description": "Uses an intentionally unregistered identity so the first five attempts return the same generic invalid-credential response and the sixth attempt is blocked by the identity rate limit."
+          },
+          "response": []
+        },
+        {
+          "name": "Failed Login Attempt 3",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"attempt remains below the identity threshold\", function () {",
+                  "  pm.response.to.have.status(401);",
+                  "});",
+                  "",
+                  "const response = pm.response.json();",
+                  "pm.test(\"invalid-credential contract remains generic\", function () {",
+                  "  pm.expect(response.code).to.eql('INVALID_CREDENTIALS');",
+                  "  pm.expect(response.message).to.eql('Email or password is incorrect.');",
+                  "  pm.expect(response.violations).to.eql([]);",
+                  "  pm.expect(response).not.to.have.property('userId');",
+                  "  pm.expect(response).not.to.have.property('userExists');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{rateLimitEmail}}\",\n  \"password\": \"WrongPassword123!\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            },
+            "description": "Uses an intentionally unregistered identity so the first five attempts return the same generic invalid-credential response and the sixth attempt is blocked by the identity rate limit."
+          },
+          "response": []
+        },
+        {
+          "name": "Failed Login Attempt 4",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"attempt remains below the identity threshold\", function () {",
+                  "  pm.response.to.have.status(401);",
+                  "});",
+                  "",
+                  "const response = pm.response.json();",
+                  "pm.test(\"invalid-credential contract remains generic\", function () {",
+                  "  pm.expect(response.code).to.eql('INVALID_CREDENTIALS');",
+                  "  pm.expect(response.message).to.eql('Email or password is incorrect.');",
+                  "  pm.expect(response.violations).to.eql([]);",
+                  "  pm.expect(response).not.to.have.property('userId');",
+                  "  pm.expect(response).not.to.have.property('userExists');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{rateLimitEmail}}\",\n  \"password\": \"WrongPassword123!\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            },
+            "description": "Uses an intentionally unregistered identity so the first five attempts return the same generic invalid-credential response and the sixth attempt is blocked by the identity rate limit."
+          },
+          "response": []
+        },
+        {
+          "name": "Failed Login Attempt 5",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"attempt remains below the identity threshold\", function () {",
+                  "  pm.response.to.have.status(401);",
+                  "});",
+                  "",
+                  "const response = pm.response.json();",
+                  "pm.test(\"invalid-credential contract remains generic\", function () {",
+                  "  pm.expect(response.code).to.eql('INVALID_CREDENTIALS');",
+                  "  pm.expect(response.message).to.eql('Email or password is incorrect.');",
+                  "  pm.expect(response.violations).to.eql([]);",
+                  "  pm.expect(response).not.to.have.property('userId');",
+                  "  pm.expect(response).not.to.have.property('userExists');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{rateLimitEmail}}\",\n  \"password\": \"WrongPassword123!\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            },
+            "description": "Uses an intentionally unregistered identity so the first five attempts return the same generic invalid-credential response and the sixth attempt is blocked by the identity rate limit."
+          },
+          "response": []
+        },
+        {
+          "name": "Failed Login Attempt 6",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"rate limit returns 429\", function () {",
+                  "  pm.response.to.have.status(429);",
+                  "});",
+                  "",
+                  "const retryAfter = pm.response.headers.get('Retry-After');",
+                  "pm.test(\"Retry-After is a positive whole number\", function () {",
+                  "  pm.expect(retryAfter).to.match(/^[1-9]\\d*$/);",
+                  "});",
+                  "",
+                  "const response = pm.response.json();",
+                  "pm.test(\"rate-limit error contract is stable\", function () {",
+                  "  pm.expect(response.code).to.eql('LOGIN_RATE_LIMIT_EXCEEDED');",
+                  "  pm.expect(response.message).to.eql('Too many login attempts. Try again later.');",
+                  "  pm.expect(response.violations).to.eql([]);",
+                  "  pm.expect(response).not.to.have.property('userId');",
+                  "  pm.expect(response).not.to.have.property('userExists');",
+                  "});",
+                  "",
+                  "pm.collectionVariables.unset('rateLimitEmail');"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{rateLimitEmail}}\",\n  \"password\": \"WrongPassword123!\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            },
+            "description": "Uses an intentionally unregistered identity so the first five attempts return the same generic invalid-credential response and the sixth attempt is blocked by the identity rate limit."
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/postman/README.md
+++ b/postman/README.md
@@ -1,15 +1,19 @@
 # PayFlow Postman Collection
 
-This collection provides an executable local workflow for the PayFlow simulated digital-wallet API plus manually gated Kafka dead-letter operations and command-audit investigation.
+The Postman assets provide an executable local workflow for the PayFlow simulated digital-wallet API, manually gated Kafka dead-letter operations, and a separate deliberately disruptive login rate-limit verification workflow.
 
 ## Import
 
-Import both files into Postman:
+Import the standard workflow assets:
 
 - `PayFlow.postman_collection.json`
 - `PayFlow.local.postman_environment.json`
 
 Select the **PayFlow Local** environment.
+
+Import `PayFlow.login-rate-limit.postman_collection.json` separately when
+verifying the Redis-backed identity threshold. The dedicated collection has its
+own safe collection variables and does not require committed credentials.
 
 ## Prerequisites
 
@@ -46,6 +50,30 @@ Run **Operations** separately. It is not part of the unattended application work
 
 The public registration and login workflow does not grant operations authority automatically.
 
+## Login rate-limit workflow
+
+Run **PayFlow Login Rate-Limit Verification** separately from the normal
+application workflow. It intentionally consumes login attempts.
+
+1. Ensure Redis and the application are running with the default identity limit
+   of five attempts.
+2. Run the complete **Identity Threshold** folder in order.
+3. Attempt 1 generates a unique unregistered email address.
+4. Attempts 1 through 5 verify the generic `401 INVALID_CREDENTIALS` contract.
+5. Attempt 6 verifies `429 LOGIN_RATE_LIMIT_EXCEEDED` and a positive
+   `Retry-After` header.
+
+The workflow uses no real account and clears its generated collection variable
+after the blocked attempt. Rerun the folder from attempt 1 rather than sending
+individual requests out of order.
+
+To verify fail-closed behavior manually, stop Redis after the application has
+started and send a login request. The expected response is
+`503 LOGIN_RATE_LIMIT_UNAVAILABLE`. Restore Redis before running the standard
+authentication workflow.
+
+See [`../docs/login-rate-limiting.md`](../docs/login-rate-limiting.md) for the
+complete security and operations contract.
 ## Operations workflow
 
 1. Obtain an admin JWT from a trusted local identity or test setup.

--- a/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
+++ b/src/main/java/com/nursena/payflow/configuration/OpenApiExamples.java
@@ -144,6 +144,30 @@ public final class OpenApiExamples {
         }
         """;
 
+    public static final String LOGIN_RATE_LIMIT_EXCEEDED =
+        """
+        {
+          "timestamp": "2026-07-30T12:00:00Z",
+          "status": 429,
+          "code": "LOGIN_RATE_LIMIT_EXCEEDED",
+          "message": "Too many login attempts. Try again later.",
+          "path": "/api/v1/auth/login",
+          "violations": []
+        }
+        """;
+
+    public static final String LOGIN_RATE_LIMIT_UNAVAILABLE =
+        """
+        {
+          "timestamp": "2026-07-30T12:00:00Z",
+          "status": 503,
+          "code": "LOGIN_RATE_LIMIT_UNAVAILABLE",
+          "message": "Login protection is temporarily unavailable.",
+          "path": "/api/v1/auth/login",
+          "violations": []
+        }
+        """;
+
     public static final String USER_ACCOUNT_UNAVAILABLE =
         """
         {

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserController.java
@@ -1,36 +1,53 @@
+
 package com.nursena.payflow.user.adapter.in.web;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType
+    .APPLICATION_JSON_VALUE;
+
+import java.util.Objects;
 
 import com.nursena.payflow.common.api.ApiError;
 import com.nursena.payflow.configuration.OpenApiExamples;
-import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
-import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
-import com.nursena.payflow.user.application.port.in.AuthenticateUserUseCase;
+import com.nursena.payflow.user.application.port.in
+    .AuthenticateUserCommand;
+import com.nursena.payflow.user.application.port.in
+    .AuthenticateUserResult;
+import com.nursena.payflow.user.application.port.in
+    .AuthenticateUserUseCase;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.responses
+    .ApiResponse;
+import io.swagger.v3.oas.annotations.responses
+    .ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation
+    .RequestBody;
+import org.springframework.web.bind.annotation
+    .RequestMapping;
+import org.springframework.web.bind.annotation
+    .RestController;
 
 @Tag(
     name = "Authentication",
     description =
-        "Public user registration and authentication operations."
+        "Public user registration and "
+            + "authentication operations."
 )
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthenticateUserController {
 
-    private static final String TOKEN_TYPE = "Bearer";
+    private static final String TOKEN_TYPE =
+        "Bearer";
 
     private final AuthenticateUserUseCase
         authenticateUserUseCase;
@@ -39,16 +56,21 @@ public class AuthenticateUserController {
         AuthenticateUserUseCase authenticateUserUseCase
     ) {
         this.authenticateUserUseCase =
-            authenticateUserUseCase;
+            Objects.requireNonNull(
+                authenticateUserUseCase,
+                "authenticateUserUseCase "
+                    + "must not be null"
+            );
     }
 
     @Operation(
         operationId = "authenticateUser",
         summary = "Authenticate a user",
         description =
-            "Validates user credentials and returns "
-                + "an RSA-signed JWT access token and "
-                + "an opaque refresh token."
+            "Applies distributed login protection, "
+                + "validates user credentials, and "
+                + "returns an RSA-signed JWT access "
+                + "token with an opaque refresh token."
     )
     @ApiResponses({
         @ApiResponse(
@@ -98,7 +120,8 @@ public class AuthenticateUserController {
         @ApiResponse(
             responseCode = "403",
             description =
-                "The user account cannot be authenticated.",
+                "The user account cannot "
+                    + "be authenticated.",
             content = @Content(
                 mediaType = APPLICATION_JSON_VALUE,
                 schema = @Schema(
@@ -110,18 +133,65 @@ public class AuthenticateUserController {
                             .USER_ACCOUNT_UNAVAILABLE
                 )
             )
+        ),
+        @ApiResponse(
+            responseCode = "429",
+            description =
+                "The login rate limit was exceeded.",
+            headers = @Header(
+                name = "Retry-After",
+                description =
+                    "Whole seconds until another "
+                        + "login attempt may be made.",
+                schema = @Schema(
+                    type = "integer",
+                    format = "int64",
+                    minimum = "1"
+                )
+            ),
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .LOGIN_RATE_LIMIT_EXCEEDED
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "503",
+            description =
+                "Login protection is temporarily "
+                    + "unavailable.",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(
+                    implementation = ApiError.class
+                ),
+                examples = @ExampleObject(
+                    value =
+                        OpenApiExamples
+                            .LOGIN_RATE_LIMIT_UNAVAILABLE
+                )
+            )
         )
     })
     @PostMapping("/login")
     public ResponseEntity<AuthenticateUserResponse>
     authenticate(
         @Valid @RequestBody
-        AuthenticateUserRequest request
+        AuthenticateUserRequest request,
+        @Parameter(hidden = true)
+        HttpServletRequest servletRequest
     ) {
         AuthenticateUserCommand command =
             new AuthenticateUserCommand(
                 request.email(),
-                request.password()
+                request.password(),
+                servletRequest.getRemoteAddr()
             );
 
         AuthenticateUserResult result =

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/UserAuthenticationExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/UserAuthenticationExceptionHandler.java
@@ -1,19 +1,33 @@
+
 package com.nursena.payflow.user.adapter.in.web;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 
 import com.nursena.payflow.common.api.ApiError;
-import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
-import com.nursena.payflow.user.domain.exception.InvalidRefreshTokenException;
-import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
+import com.nursena.payflow.user.application.exception
+    .LoginRateLimitExceededException;
+import com.nursena.payflow.user.application.exception
+    .LoginRateLimitUnavailableException;
+import com.nursena.payflow.user.domain.exception
+    .InvalidCredentialsException;
+import com.nursena.payflow.user.domain.exception
+    .InvalidRefreshTokenException;
+import com.nursena.payflow.user.domain.exception
+    .UserAccountUnavailableException;
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.annotation
+    .ExceptionHandler;
+import org.springframework.web.bind.annotation
+    .RestControllerAdvice;
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RestControllerAdvice(
@@ -24,7 +38,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 )
 public class UserAuthenticationExceptionHandler {
 
-    @ExceptionHandler(InvalidCredentialsException.class)
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(
+            UserAuthenticationExceptionHandler.class
+        );
+
+    @ExceptionHandler(
+        InvalidCredentialsException.class
+    )
     ResponseEntity<ApiError> handleInvalidCredentials(
         InvalidCredentialsException exception,
         HttpServletRequest request
@@ -37,7 +58,9 @@ public class UserAuthenticationExceptionHandler {
         );
     }
 
-    @ExceptionHandler(UserAccountUnavailableException.class)
+    @ExceptionHandler(
+        UserAccountUnavailableException.class
+    )
     ResponseEntity<ApiError> handleUnavailableAccount(
         UserAccountUnavailableException exception,
         HttpServletRequest request
@@ -65,13 +88,94 @@ public class UserAuthenticationExceptionHandler {
         );
     }
 
-    private ResponseEntity<ApiError> buildResponse(
+    @ExceptionHandler(
+        LoginRateLimitExceededException.class
+    )
+    ResponseEntity<ApiError> handleRateLimitExceeded(
+        LoginRateLimitExceededException exception,
+        HttpServletRequest request
+    ) {
+        LOGGER.warn(
+            "security_event=login_rate_limit_blocked "
+                + "dimension={} path={}",
+            exception
+                .getBlockedDimension()
+                .name()
+                .toLowerCase(
+                    Locale.ROOT
+                ),
+            request.getRequestURI()
+        );
+
+        return ResponseEntity
+            .status(
+                HttpStatus.TOO_MANY_REQUESTS
+            )
+            .header(
+                HttpHeaders.RETRY_AFTER,
+                Long.toString(
+                    exception
+                        .getRetryAfter()
+                        .toSeconds()
+                )
+            )
+            .body(
+                errorBody(
+                    HttpStatus.TOO_MANY_REQUESTS,
+                    exception.getCode(),
+                    exception.getMessage(),
+                    request
+                )
+            );
+    }
+
+    @ExceptionHandler(
+        LoginRateLimitUnavailableException.class
+    )
+    ResponseEntity<ApiError> handleRateLimitUnavailable(
+        LoginRateLimitUnavailableException exception,
+        HttpServletRequest request
+    ) {
+        LOGGER.warn(
+            "security_event=login_rate_limit_unavailable "
+                + "path={}",
+            request.getRequestURI()
+        );
+
+        return buildResponse(
+            HttpStatus.SERVICE_UNAVAILABLE,
+            exception.getCode(),
+            exception.getMessage(),
+            request
+        );
+    }
+
+    private static ResponseEntity<ApiError>
+    buildResponse(
         HttpStatus status,
         String code,
         String message,
         HttpServletRequest request
     ) {
-        ApiError body = new ApiError(
+        return ResponseEntity
+            .status(status)
+            .body(
+                errorBody(
+                    status,
+                    code,
+                    message,
+                    request
+                )
+            );
+    }
+
+    private static ApiError errorBody(
+        HttpStatus status,
+        String code,
+        String message,
+        HttpServletRequest request
+    ) {
+        return new ApiError(
             Instant.now(),
             status.value(),
             code,
@@ -79,9 +183,5 @@ public class UserAuthenticationExceptionHandler {
             request.getRequestURI(),
             List.of()
         );
-
-        return ResponseEntity
-            .status(status)
-            .body(body);
     }
 }

--- a/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitConfiguration.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitConfiguration.java
@@ -1,0 +1,98 @@
+package com.nursena.payflow.user.adapter.out.ratelimit;
+
+import java.util.List;
+
+import com.nursena.payflow.user.application.port.out.LoginRateLimitPort;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(
+    LoginRateLimitProperties.class
+)
+class LoginRateLimitConfiguration {
+
+    private static final String SCRIPT = """
+        local window_seconds = tonumber(ARGV[1])
+        local identity_limit = tonumber(ARGV[2])
+        local client_limit = tonumber(ARGV[3])
+
+        local identity_count = redis.call('INCR', KEYS[1])
+        if identity_count == 1 then
+            redis.call('EXPIRE', KEYS[1], window_seconds)
+        end
+
+        local client_count = redis.call('INCR', KEYS[2])
+        if client_count == 1 then
+            redis.call('EXPIRE', KEYS[2], window_seconds)
+        end
+
+        local identity_ttl = redis.call('TTL', KEYS[1])
+        if identity_ttl < 0 then
+            redis.call('EXPIRE', KEYS[1], window_seconds)
+            identity_ttl = window_seconds
+        end
+
+        local client_ttl = redis.call('TTL', KEYS[2])
+        if client_ttl < 0 then
+            redis.call('EXPIRE', KEYS[2], window_seconds)
+            client_ttl = window_seconds
+        end
+
+        local identity_blocked = 0
+        if identity_count > identity_limit then
+            identity_blocked = 1
+        end
+
+        local client_blocked = 0
+        if client_count > client_limit then
+            client_blocked = 1
+        end
+
+        local retry_after = 0
+        if identity_blocked == 1 then
+            retry_after = identity_ttl
+        end
+
+        if client_blocked == 1
+            and client_ttl > retry_after then
+            retry_after = client_ttl
+        end
+
+        return {
+            identity_blocked,
+            client_blocked,
+            retry_after
+        }
+        """;
+
+    @Bean
+    @SuppressWarnings({
+        "unchecked",
+        "rawtypes"
+    })
+    RedisScript<List<Long>>
+    loginRateLimitScript() {
+        return (RedisScript) new DefaultRedisScript<>(
+            SCRIPT,
+            List.class
+        );
+    }
+
+    @Bean
+    LoginRateLimitPort loginRateLimitPort(
+        StringRedisTemplate redisTemplate,
+        RedisScript<List<Long>> loginRateLimitScript,
+        LoginRateLimitProperties properties
+    ) {
+        return new RedisLoginRateLimitAdapter(
+            redisTemplate,
+            loginRateLimitScript,
+            properties
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitConfiguration.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitConfiguration.java
@@ -1,13 +1,18 @@
+
 package com.nursena.payflow.user.adapter.out.ratelimit;
 
 import java.util.List;
 
-import com.nursena.payflow.user.application.port.out.LoginRateLimitPort;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitPort;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.context.properties
+    .EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script
+    .DefaultRedisScript;
 import org.springframework.data.redis.core.script.RedisScript;
 
 @Configuration(proxyBeanMethods = false)
@@ -84,15 +89,26 @@ class LoginRateLimitConfiguration {
     }
 
     @Bean
+    LoginRateLimitMetrics loginRateLimitMetrics(
+        MeterRegistry meterRegistry
+    ) {
+        return new LoginRateLimitMetrics(
+            meterRegistry
+        );
+    }
+
+    @Bean
     LoginRateLimitPort loginRateLimitPort(
         StringRedisTemplate redisTemplate,
         RedisScript<List<Long>> loginRateLimitScript,
-        LoginRateLimitProperties properties
+        LoginRateLimitProperties properties,
+        LoginRateLimitMetrics metrics
     ) {
         return new RedisLoginRateLimitAdapter(
             redisTemplate,
             loginRateLimitScript,
-            properties
+            properties,
+            metrics
         );
     }
 }

--- a/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitKeyFactory.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitKeyFactory.java
@@ -1,0 +1,84 @@
+package com.nursena.payflow.user.adapter.out.ratelimit;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Locale;
+import java.util.Objects;
+
+import com.nursena.payflow.user.domain.model.EmailAddress;
+
+final class LoginRateLimitKeyFactory {
+
+    private static final String IDENTITY_PREFIX =
+        "payflow:security:login:identity:";
+
+    private static final String CLIENT_PREFIX =
+        "payflow:security:login:client:";
+
+    private LoginRateLimitKeyFactory() {
+    }
+
+    static String identityKey(
+        EmailAddress identity
+    ) {
+        Objects.requireNonNull(
+            identity,
+            "identity must not be null"
+        );
+
+        return IDENTITY_PREFIX
+            + sha256(identity.value());
+    }
+
+    static String clientKey(
+        String clientAddress
+    ) {
+        Objects.requireNonNull(
+            clientAddress,
+            "clientAddress must not be null"
+        );
+
+        String normalizedAddress =
+            clientAddress
+                .trim()
+                .toLowerCase(Locale.ROOT);
+
+        if (normalizedAddress.isBlank()) {
+            throw new IllegalArgumentException(
+                "clientAddress must not be blank"
+            );
+        }
+
+        return CLIENT_PREFIX
+            + sha256(normalizedAddress);
+    }
+
+    private static String sha256(
+        String value
+    ) {
+        try {
+            MessageDigest digest =
+                MessageDigest.getInstance(
+                    "SHA-256"
+                );
+
+            return HexFormat.of()
+                .formatHex(
+                    digest.digest(
+                        value.getBytes(
+                            StandardCharsets.UTF_8
+                        )
+                    )
+                );
+        } catch (
+            NoSuchAlgorithmException exception
+        ) {
+            throw new IllegalStateException(
+                "SHA-256 is not available",
+                exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitMetrics.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitMetrics.java
@@ -1,0 +1,120 @@
+
+package com.nursena.payflow.user.adapter.out.ratelimit;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDecision;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+final class LoginRateLimitMetrics {
+
+    static final String DECISIONS_METRIC =
+        "payflow.auth.login.rate_limit.decisions";
+
+    static final String REDIS_FAILURES_METRIC =
+        "payflow.auth.login.rate_limit.redis.failures";
+
+    private static final String OUTCOME_TAG =
+        "outcome";
+
+    private static final String DIMENSION_TAG =
+        "dimension";
+
+    private static final String OPERATION_TAG =
+        "operation";
+
+    private final MeterRegistry meterRegistry;
+
+    LoginRateLimitMetrics(
+        MeterRegistry meterRegistry
+    ) {
+        this.meterRegistry =
+            Objects.requireNonNull(
+                meterRegistry,
+                "meterRegistry must not be null"
+            );
+    }
+
+    void recordDecision(
+        LoginRateLimitDecision decision
+    ) {
+        LoginRateLimitDecision validatedDecision =
+            Objects.requireNonNull(
+                decision,
+                "decision must not be null"
+            );
+
+        Counter.builder(
+                DECISIONS_METRIC
+            )
+            .description(
+                "Number of Redis-backed login "
+                    + "rate-limit decisions."
+            )
+            .baseUnit("decisions")
+            .tags(
+                OUTCOME_TAG,
+                validatedDecision.isAllowed()
+                    ? "allowed"
+                    : "blocked",
+                DIMENSION_TAG,
+                dimensionName(
+                    validatedDecision
+                )
+            )
+            .register(
+                meterRegistry
+            )
+            .increment();
+    }
+
+    void recordRedisFailure(
+        String operation
+    ) {
+        Counter.builder(
+                REDIS_FAILURES_METRIC
+            )
+            .description(
+                "Number of Redis failures while "
+                    + "enforcing login rate limits."
+            )
+            .baseUnit("failures")
+            .tag(
+                OPERATION_TAG,
+                validateOperation(operation)
+            )
+            .register(
+                meterRegistry
+            )
+            .increment();
+    }
+
+    private static String dimensionName(
+        LoginRateLimitDecision decision
+    ) {
+        return decision
+            .blockedDimension()
+            .name()
+            .toLowerCase(
+                Locale.ROOT
+            );
+    }
+
+    private static String validateOperation(
+        String value
+    ) {
+        if (
+            !"evaluate".equals(value)
+                && !"reset".equals(value)
+        ) {
+            throw new IllegalArgumentException(
+                "operation must be evaluate or reset"
+            );
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitProperties.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitProperties.java
@@ -1,0 +1,54 @@
+package com.nursena.payflow.user.adapter.out.ratelimit;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(
+    prefix = "payflow.security.login-rate-limit"
+)
+public record LoginRateLimitProperties(
+    boolean enabled,
+    Duration window,
+    int identityLimit,
+    int clientLimit
+) {
+
+    private static final Duration MINIMUM_WINDOW =
+        Duration.ofSeconds(1);
+
+    public LoginRateLimitProperties {
+        Objects.requireNonNull(
+            window,
+            "window must not be null"
+        );
+
+        if (window.compareTo(MINIMUM_WINDOW) < 0) {
+            throw new IllegalArgumentException(
+                "window must be at least one second"
+            );
+        }
+
+        requirePositive(
+            identityLimit,
+            "identityLimit"
+        );
+
+        requirePositive(
+            clientLimit,
+            "clientLimit"
+        );
+    }
+
+    private static void requirePositive(
+        int value,
+        String propertyName
+    ) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(
+                propertyName + " must be positive"
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/RedisLoginRateLimitAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/RedisLoginRateLimitAdapter.java
@@ -1,0 +1,236 @@
+package com.nursena.payflow.user.adapter.out.ratelimit;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.exception.LoginRateLimitUnavailableException;
+import com.nursena.payflow.user.application.port.out.LoginRateLimitDecision;
+import com.nursena.payflow.user.application.port.out.LoginRateLimitDimension;
+import com.nursena.payflow.user.application.port.out.LoginRateLimitPort;
+import com.nursena.payflow.user.application.port.out.LoginRateLimitRequest;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+
+final class RedisLoginRateLimitAdapter
+    implements LoginRateLimitPort {
+
+    private static final int RESULT_SIZE = 3;
+
+    private static final int IDENTITY_BLOCKED_INDEX = 0;
+
+    private static final int CLIENT_BLOCKED_INDEX = 1;
+
+    private static final int RETRY_AFTER_INDEX = 2;
+
+    private final StringRedisTemplate redisTemplate;
+
+    private final RedisScript<List<Long>> script;
+
+    private final LoginRateLimitProperties properties;
+
+    RedisLoginRateLimitAdapter(
+        StringRedisTemplate redisTemplate,
+        RedisScript<List<Long>> script,
+        LoginRateLimitProperties properties
+    ) {
+        this.redisTemplate =
+            Objects.requireNonNull(
+                redisTemplate,
+                "redisTemplate must not be null"
+            );
+
+        this.script =
+            Objects.requireNonNull(
+                script,
+                "script must not be null"
+            );
+
+        this.properties =
+            Objects.requireNonNull(
+                properties,
+                "properties must not be null"
+            );
+    }
+
+    @Override
+    public LoginRateLimitDecision evaluate(
+        LoginRateLimitRequest request
+    ) {
+        Objects.requireNonNull(
+            request,
+            "request must not be null"
+        );
+
+        if (!properties.enabled()) {
+            return LoginRateLimitDecision.allowed();
+        }
+
+        List<String> keys =
+            List.of(
+                LoginRateLimitKeyFactory.identityKey(
+                    request.identity()
+                ),
+                LoginRateLimitKeyFactory.clientKey(
+                    request.clientAddress()
+                )
+            );
+
+        try {
+            List<Long> result =
+                redisTemplate.execute(
+                    script,
+                    keys,
+                    Long.toString(
+                        properties.window().toSeconds()
+                    ),
+                    Integer.toString(
+                        properties.identityLimit()
+                    ),
+                    Integer.toString(
+                        properties.clientLimit()
+                    )
+                );
+
+            return parseDecision(result);
+        } catch (
+            LoginRateLimitUnavailableException exception
+        ) {
+            throw exception;
+        } catch (
+            RuntimeException exception
+        ) {
+            throw new LoginRateLimitUnavailableException(
+                exception
+            );
+        }
+    }
+
+    @Override
+    public void resetIdentity(
+        EmailAddress identity
+    ) {
+        Objects.requireNonNull(
+            identity,
+            "identity must not be null"
+        );
+
+        if (!properties.enabled()) {
+            return;
+        }
+
+        try {
+            Boolean deleted =
+                redisTemplate.delete(
+                    LoginRateLimitKeyFactory
+                        .identityKey(identity)
+                );
+
+            if (deleted == null) {
+                throw new IllegalStateException(
+                    "Redis delete returned no result"
+                );
+            }
+        } catch (
+            RuntimeException exception
+        ) {
+            throw new LoginRateLimitUnavailableException(
+                exception
+            );
+        }
+    }
+
+    private static LoginRateLimitDecision parseDecision(
+        List<Long> result
+    ) {
+        if (
+            result == null
+                || result.size() != RESULT_SIZE
+        ) {
+            throw unavailableResult();
+        }
+
+        boolean identityBlocked =
+            numericValue(
+                result.get(
+                    IDENTITY_BLOCKED_INDEX
+                )
+            ) == 1L;
+
+        boolean clientBlocked =
+            numericValue(
+                result.get(
+                    CLIENT_BLOCKED_INDEX
+                )
+            ) == 1L;
+
+        long retryAfterSeconds =
+            numericValue(
+                result.get(
+                    RETRY_AFTER_INDEX
+                )
+            );
+
+        if (
+            !identityBlocked
+                && !clientBlocked
+        ) {
+            return LoginRateLimitDecision.allowed();
+        }
+
+        LoginRateLimitDimension dimension =
+            blockedDimension(
+                identityBlocked,
+                clientBlocked
+            );
+
+        return LoginRateLimitDecision.blocked(
+            dimension,
+            Duration.ofSeconds(
+                Math.max(
+                    1L,
+                    retryAfterSeconds
+                )
+            )
+        );
+    }
+
+    private static long numericValue(
+        Long value
+    ) {
+        if (value == null) {
+            throw unavailableResult();
+        }
+
+        return value;
+    }
+
+    private static LoginRateLimitDimension
+    blockedDimension(
+        boolean identityBlocked,
+        boolean clientBlocked
+    ) {
+        if (
+            identityBlocked
+                && clientBlocked
+        ) {
+            return LoginRateLimitDimension.BOTH;
+        }
+
+        if (identityBlocked) {
+            return LoginRateLimitDimension.IDENTITY;
+        }
+
+        return LoginRateLimitDimension.CLIENT;
+    }
+
+    private static LoginRateLimitUnavailableException
+    unavailableResult() {
+        return new LoginRateLimitUnavailableException(
+            new IllegalStateException(
+                "Redis script returned an invalid result"
+            )
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/RedisLoginRateLimitAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/ratelimit/RedisLoginRateLimitAdapter.java
@@ -1,14 +1,20 @@
+
 package com.nursena.payflow.user.adapter.out.ratelimit;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 
-import com.nursena.payflow.user.application.exception.LoginRateLimitUnavailableException;
-import com.nursena.payflow.user.application.port.out.LoginRateLimitDecision;
-import com.nursena.payflow.user.application.port.out.LoginRateLimitDimension;
-import com.nursena.payflow.user.application.port.out.LoginRateLimitPort;
-import com.nursena.payflow.user.application.port.out.LoginRateLimitRequest;
+import com.nursena.payflow.user.application.exception
+    .LoginRateLimitUnavailableException;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDecision;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDimension;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitPort;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitRequest;
 import com.nursena.payflow.user.domain.model.EmailAddress;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
@@ -18,11 +24,14 @@ final class RedisLoginRateLimitAdapter
 
     private static final int RESULT_SIZE = 3;
 
-    private static final int IDENTITY_BLOCKED_INDEX = 0;
+    private static final int
+        IDENTITY_BLOCKED_INDEX = 0;
 
-    private static final int CLIENT_BLOCKED_INDEX = 1;
+    private static final int
+        CLIENT_BLOCKED_INDEX = 1;
 
-    private static final int RETRY_AFTER_INDEX = 2;
+    private static final int
+        RETRY_AFTER_INDEX = 2;
 
     private final StringRedisTemplate redisTemplate;
 
@@ -30,10 +39,13 @@ final class RedisLoginRateLimitAdapter
 
     private final LoginRateLimitProperties properties;
 
+    private final LoginRateLimitMetrics metrics;
+
     RedisLoginRateLimitAdapter(
         StringRedisTemplate redisTemplate,
         RedisScript<List<Long>> script,
-        LoginRateLimitProperties properties
+        LoginRateLimitProperties properties,
+        LoginRateLimitMetrics metrics
     ) {
         this.redisTemplate =
             Objects.requireNonNull(
@@ -51,6 +63,12 @@ final class RedisLoginRateLimitAdapter
             Objects.requireNonNull(
                 properties,
                 "properties must not be null"
+            );
+
+        this.metrics =
+            Objects.requireNonNull(
+                metrics,
+                "metrics must not be null"
             );
     }
 
@@ -93,14 +111,27 @@ final class RedisLoginRateLimitAdapter
                     )
                 );
 
-            return parseDecision(result);
+            LoginRateLimitDecision decision =
+                parseDecision(result);
+
+            metrics.recordDecision(decision);
+
+            return decision;
         } catch (
             LoginRateLimitUnavailableException exception
         ) {
+            metrics.recordRedisFailure(
+                "evaluate"
+            );
+
             throw exception;
         } catch (
             RuntimeException exception
         ) {
+            metrics.recordRedisFailure(
+                "evaluate"
+            );
+
             throw new LoginRateLimitUnavailableException(
                 exception
             );
@@ -135,6 +166,10 @@ final class RedisLoginRateLimitAdapter
         } catch (
             RuntimeException exception
         ) {
+            metrics.recordRedisFailure(
+                "reset"
+            );
+
             throw new LoginRateLimitUnavailableException(
                 exception
             );

--- a/src/main/java/com/nursena/payflow/user/application/exception/LoginRateLimitExceededException.java
+++ b/src/main/java/com/nursena/payflow/user/application/exception/LoginRateLimitExceededException.java
@@ -1,0 +1,99 @@
+
+package com.nursena.payflow.user.application.exception;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDimension;
+
+public final class LoginRateLimitExceededException
+    extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String CODE =
+        "LOGIN_RATE_LIMIT_EXCEEDED";
+
+    private static final String MESSAGE =
+        "Too many login attempts. Try again later.";
+
+    private final LoginRateLimitDimension
+        blockedDimension;
+
+    private final Duration retryAfter;
+
+    public LoginRateLimitExceededException(
+        LoginRateLimitDimension blockedDimension,
+        Duration retryAfter
+    ) {
+        super(MESSAGE);
+
+        this.blockedDimension =
+            validateBlockedDimension(
+                blockedDimension
+            );
+
+        this.retryAfter =
+            validateRetryAfter(
+                retryAfter
+            );
+    }
+
+    public String getCode() {
+        return CODE;
+    }
+
+    public LoginRateLimitDimension
+    getBlockedDimension() {
+        return blockedDimension;
+    }
+
+    public Duration getRetryAfter() {
+        return retryAfter;
+    }
+
+    private static LoginRateLimitDimension
+    validateBlockedDimension(
+        LoginRateLimitDimension value
+    ) {
+        LoginRateLimitDimension validatedValue =
+            Objects.requireNonNull(
+                value,
+                "blockedDimension must not be null"
+            );
+
+        if (
+            validatedValue
+                == LoginRateLimitDimension.NONE
+        ) {
+            throw new IllegalArgumentException(
+                "blockedDimension must not be NONE"
+            );
+        }
+
+        return validatedValue;
+    }
+
+    private static Duration validateRetryAfter(
+        Duration value
+    ) {
+        Duration validatedValue =
+            Objects.requireNonNull(
+                value,
+                "retryAfter must not be null"
+            );
+
+        if (
+            validatedValue.compareTo(
+                Duration.ofSeconds(1)
+            ) < 0
+        ) {
+            throw new IllegalArgumentException(
+                "retryAfter must be at least one second"
+            );
+        }
+
+        return validatedValue;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/exception/LoginRateLimitUnavailableException.java
+++ b/src/main/java/com/nursena/payflow/user/application/exception/LoginRateLimitUnavailableException.java
@@ -1,0 +1,26 @@
+package com.nursena.payflow.user.application.exception;
+
+public final class LoginRateLimitUnavailableException
+    extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String CODE =
+        "LOGIN_RATE_LIMIT_UNAVAILABLE";
+
+    private static final String MESSAGE =
+        "Login protection is temporarily unavailable.";
+
+    public LoginRateLimitUnavailableException(
+        Throwable cause
+    ) {
+        super(
+            MESSAGE,
+            cause
+        );
+    }
+
+    public String getCode() {
+        return CODE;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/AuthenticateUserCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/AuthenticateUserCommand.java
@@ -1,17 +1,28 @@
+
 package com.nursena.payflow.user.application.port.in;
 
 import java.util.Objects;
 
 public record AuthenticateUserCommand(
     String email,
-    String rawPassword
+    String rawPassword,
+    String clientAddress
 ) {
 
     public AuthenticateUserCommand {
-        Objects.requireNonNull(email, "email must not be null");
+        Objects.requireNonNull(
+            email,
+            "email must not be null"
+        );
+
         Objects.requireNonNull(
             rawPassword,
             "rawPassword must not be null"
+        );
+
+        Objects.requireNonNull(
+            clientAddress,
+            "clientAddress must not be null"
         );
 
         if (rawPassword.isBlank()) {
@@ -19,5 +30,16 @@ public record AuthenticateUserCommand(
                 "rawPassword must not be blank"
             );
         }
+
+        if (clientAddress.isBlank()) {
+            throw new IllegalArgumentException(
+                "clientAddress must not be blank"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AuthenticateUserCommand[redacted]";
     }
 }

--- a/src/main/java/com/nursena/payflow/user/application/port/out/LoginRateLimitDecision.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/LoginRateLimitDecision.java
@@ -1,0 +1,65 @@
+package com.nursena.payflow.user.application.port.out;
+
+import java.time.Duration;
+import java.util.Objects;
+
+public record LoginRateLimitDecision(
+    LoginRateLimitDimension blockedDimension,
+    Duration retryAfter
+) {
+
+    public LoginRateLimitDecision {
+        Objects.requireNonNull(
+            blockedDimension,
+            "blockedDimension must not be null"
+        );
+
+        Objects.requireNonNull(
+            retryAfter,
+            "retryAfter must not be null"
+        );
+
+        if (blockedDimension == LoginRateLimitDimension.NONE) {
+            if (!retryAfter.isZero()) {
+                throw new IllegalArgumentException(
+                    "allowed decision retryAfter must be zero"
+                );
+            }
+        } else if (
+            retryAfter.isZero()
+                || retryAfter.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                "blocked decision retryAfter must be positive"
+            );
+        }
+    }
+
+    public static LoginRateLimitDecision allowed() {
+        return new LoginRateLimitDecision(
+            LoginRateLimitDimension.NONE,
+            Duration.ZERO
+        );
+    }
+
+    public static LoginRateLimitDecision blocked(
+        LoginRateLimitDimension dimension,
+        Duration retryAfter
+    ) {
+        if (dimension == LoginRateLimitDimension.NONE) {
+            throw new IllegalArgumentException(
+                "blocked dimension must not be NONE"
+            );
+        }
+
+        return new LoginRateLimitDecision(
+            dimension,
+            retryAfter
+        );
+    }
+
+    public boolean isAllowed() {
+        return blockedDimension
+            == LoginRateLimitDimension.NONE;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/LoginRateLimitDimension.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/LoginRateLimitDimension.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.user.application.port.out;
+
+public enum LoginRateLimitDimension {
+    NONE,
+    IDENTITY,
+    CLIENT,
+    BOTH
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/LoginRateLimitPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/LoginRateLimitPort.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.user.application.port.out;
+
+import com.nursena.payflow.user.domain.model.EmailAddress;
+
+public interface LoginRateLimitPort {
+
+    LoginRateLimitDecision evaluate(
+        LoginRateLimitRequest request
+    );
+
+    void resetIdentity(
+        EmailAddress identity
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/LoginRateLimitRequest.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/LoginRateLimitRequest.java
@@ -1,0 +1,29 @@
+package com.nursena.payflow.user.application.port.out;
+
+import java.util.Objects;
+
+import com.nursena.payflow.user.domain.model.EmailAddress;
+
+public record LoginRateLimitRequest(
+    EmailAddress identity,
+    String clientAddress
+) {
+
+    public LoginRateLimitRequest {
+        Objects.requireNonNull(
+            identity,
+            "identity must not be null"
+        );
+
+        Objects.requireNonNull(
+            clientAddress,
+            "clientAddress must not be null"
+        );
+
+        if (clientAddress.isBlank()) {
+            throw new IllegalArgumentException(
+                "clientAddress must not be blank"
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/AuthenticateUserService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/AuthenticateUserService.java
@@ -1,3 +1,4 @@
+
 package com.nursena.payflow.user.application.service;
 
 import java.time.Clock;
@@ -6,43 +7,89 @@ import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.UUID;
 
-import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
-import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
-import com.nursena.payflow.user.application.port.in.AuthenticateUserUseCase;
-import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
-import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
-import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
-import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenGenerationPort;
-import com.nursena.payflow.user.application.port.out.RefreshTokenRecordRepositoryPort;
-import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
-import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
-import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
+import com.nursena.payflow.user.application.exception
+    .LoginRateLimitExceededException;
+import com.nursena.payflow.user.application.port.in
+    .AuthenticateUserCommand;
+import com.nursena.payflow.user.application.port.in
+    .AuthenticateUserResult;
+import com.nursena.payflow.user.application.port.in
+    .AuthenticateUserUseCase;
+import com.nursena.payflow.user.application.port.out
+    .AccessTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out
+    .GeneratedAccessToken;
+import com.nursena.payflow.user.application.port.out
+    .GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDecision;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitPort;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitRequest;
+import com.nursena.payflow.user.application.port.out
+    .PasswordVerificationPort;
+import com.nursena.payflow.user.application.port.out
+    .RefreshTokenDigestPort;
+import com.nursena.payflow.user.application.port.out
+    .RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out
+    .RefreshTokenGenerationPort;
+import com.nursena.payflow.user.application.port.out
+    .RefreshTokenRecordRepositoryPort;
+import com.nursena.payflow.user.application.port.out
+    .UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception
+    .InvalidCredentialsException;
+import com.nursena.payflow.user.domain.exception
+    .UserAccountUnavailableException;
 import com.nursena.payflow.user.domain.model.EmailAddress;
-import com.nursena.payflow.user.domain.model.RefreshTokenDigest;
-import com.nursena.payflow.user.domain.model.RefreshTokenFamily;
-import com.nursena.payflow.user.domain.model.RefreshTokenFamilyId;
-import com.nursena.payflow.user.domain.model.RefreshTokenRecord;
-import com.nursena.payflow.user.domain.model.RefreshTokenRecordId;
+import com.nursena.payflow.user.domain.model
+    .RefreshTokenDigest;
+import com.nursena.payflow.user.domain.model
+    .RefreshTokenFamily;
+import com.nursena.payflow.user.domain.model
+    .RefreshTokenFamilyId;
+import com.nursena.payflow.user.domain.model
+    .RefreshTokenRecord;
+import com.nursena.payflow.user.domain.model
+    .RefreshTokenRecordId;
 import com.nursena.payflow.user.domain.model.User;
-import com.nursena.payflow.user.domain.model.UserStatus;
+import com.nursena.payflow.user.domain.model
+    .UserStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation
+    .Transactional;
 
 @Service
 public class AuthenticateUserService
     implements AuthenticateUserUseCase {
 
     private final UserRepositoryPort userRepository;
-    private final PasswordVerificationPort passwordVerification;
-    private final RefreshTokenGenerationPort refreshTokenGeneration;
-    private final RefreshTokenDigestPort refreshTokenDigest;
-    private final RefreshTokenFamilyRepositoryPort familyRepository;
-    private final RefreshTokenRecordRepositoryPort recordRepository;
-    private final AccessTokenGenerationPort accessTokenGeneration;
-    private final RefreshSessionLifetimePolicy lifetimePolicy;
+
+    private final PasswordVerificationPort
+        passwordVerification;
+
+    private final RefreshTokenGenerationPort
+        refreshTokenGeneration;
+
+    private final RefreshTokenDigestPort
+        refreshTokenDigest;
+
+    private final RefreshTokenFamilyRepositoryPort
+        familyRepository;
+
+    private final RefreshTokenRecordRepositoryPort
+        recordRepository;
+
+    private final AccessTokenGenerationPort
+        accessTokenGeneration;
+
+    private final LoginRateLimitPort loginRateLimit;
+
+    private final RefreshSessionLifetimePolicy
+        lifetimePolicy;
+
     private final Clock clock;
 
     public AuthenticateUserService(
@@ -53,6 +100,7 @@ public class AuthenticateUserService
         RefreshTokenFamilyRepositoryPort familyRepository,
         RefreshTokenRecordRepositoryPort recordRepository,
         AccessTokenGenerationPort accessTokenGeneration,
+        LoginRateLimitPort loginRateLimit,
         RefreshSessionLifetimePolicy lifetimePolicy,
         Clock clock
     ) {
@@ -98,6 +146,12 @@ public class AuthenticateUserService
                 "accessTokenGeneration must not be null"
             );
 
+        this.loginRateLimit =
+            Objects.requireNonNull(
+                loginRateLimit,
+                "loginRateLimit must not be null"
+            );
+
         this.lifetimePolicy =
             Objects.requireNonNull(
                 lifetimePolicy,
@@ -116,17 +170,32 @@ public class AuthenticateUserService
     public AuthenticateUserResult authenticate(
         AuthenticateUserCommand command
     ) {
-        EmailAddress email =
-            EmailAddress.of(command.email());
-
-        User user = userRepository.findByEmail(email)
-            .orElseThrow(
-                InvalidCredentialsException::new
+        AuthenticateUserCommand validatedCommand =
+            Objects.requireNonNull(
+                command,
+                "command must not be null"
             );
+
+        EmailAddress email =
+            EmailAddress.of(
+                validatedCommand.email()
+            );
+
+        enforceRateLimit(
+            email,
+            validatedCommand.clientAddress()
+        );
+
+        User user =
+            userRepository
+                .findByEmail(email)
+                .orElseThrow(
+                    InvalidCredentialsException::new
+                );
 
         boolean passwordMatches =
             passwordVerification.matches(
-                command.rawPassword(),
+                validatedCommand.rawPassword(),
                 user.passwordHash()
             );
 
@@ -135,7 +204,8 @@ public class AuthenticateUserService
         }
 
         if (user.status() != UserStatus.ACTIVE) {
-            throw new UserAccountUnavailableException();
+            throw new
+                UserAccountUnavailableException();
         }
 
         Instant issuedAt =
@@ -144,7 +214,8 @@ public class AuthenticateUserService
                     ChronoUnit.MICROS
                 );
 
-        GeneratedRefreshToken generatedRefreshToken =
+        GeneratedRefreshToken
+            generatedRefreshToken =
             refreshTokenGeneration.generate();
 
         RefreshTokenDigest digest =
@@ -199,11 +270,34 @@ public class AuthenticateUserService
                 user
             );
 
+        loginRateLimit.resetIdentity(email);
+
         return new AuthenticateUserResult(
             accessToken.value(),
             accessToken.expiresAt(),
             generatedRefreshToken.value(),
             savedRecord.expiresAt()
         );
+    }
+
+    private void enforceRateLimit(
+        EmailAddress email,
+        String clientAddress
+    ) {
+        LoginRateLimitDecision decision =
+            loginRateLimit.evaluate(
+                new LoginRateLimitRequest(
+                    email,
+                    clientAddress
+                )
+            );
+
+        if (!decision.isAllowed()) {
+            throw new
+                LoginRateLimitExceededException(
+                decision.blockedDimension(),
+                decision.retryAfter()
+            );
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,11 @@ payflow:
     refresh-session:
       refresh-token-ttl: ${REFRESH_TOKEN_TTL:7d}
       family-ttl: ${REFRESH_TOKEN_FAMILY_TTL:30d}
+    login-rate-limit:
+      enabled: ${LOGIN_RATE_LIMIT_ENABLED:true}
+      window: ${LOGIN_RATE_LIMIT_WINDOW:15m}
+      identity-limit: ${LOGIN_RATE_LIMIT_IDENTITY_LIMIT:5}
+      client-limit: ${LOGIN_RATE_LIMIT_CLIENT_LIMIT:20}
   outbox:
     kafka:
       send-timeout: ${OUTBOX_KAFKA_SEND_TIMEOUT:10s}

--- a/src/test/java/com/nursena/payflow/configuration/LoginRateLimitPostmanCollectionContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/LoginRateLimitPostmanCollectionContractTest.java
@@ -1,0 +1,261 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class LoginRateLimitPostmanCollectionContractTest {
+
+    private static final Path COLLECTION_PATH =
+        Path.of(
+            "postman",
+            "PayFlow.login-rate-limit.postman_collection.json"
+        );
+
+    private static final String FOLDER_NAME =
+        "Identity Threshold";
+
+    private static final String LOGIN_URL =
+        "{{baseUrl}}/api/v1/auth/login";
+
+    private final ObjectMapper objectMapper =
+        new ObjectMapper();
+
+    @Test
+    void shouldExposeIdentityThresholdWorkflow()
+        throws IOException {
+
+        JsonNode collection =
+            objectMapper.readTree(
+                COLLECTION_PATH.toFile()
+            );
+
+        JsonNode folder =
+            findNamedItem(
+                collection.path("item"),
+                FOLDER_NAME
+            );
+
+        assertThat(
+            eventScript(folder, "prerequest")
+        )
+            .contains(
+                "Failed Login Attempt 1",
+                "Date.now()",
+                "rateLimitEmail"
+            )
+            .doesNotContain(
+                "accessToken",
+                "refreshToken",
+                "passwordHash"
+            );
+
+        List<JsonNode> attempts =
+            StreamSupport.stream(
+                    folder
+                        .path("item")
+                        .spliterator(),
+                    false
+                )
+                .toList();
+
+        assertThat(attempts)
+            .extracting(
+                attempt ->
+                    attempt.path("name").asText()
+            )
+            .containsExactly(
+                "Failed Login Attempt 1",
+                "Failed Login Attempt 2",
+                "Failed Login Attempt 3",
+                "Failed Login Attempt 4",
+                "Failed Login Attempt 5",
+                "Failed Login Attempt 6"
+            );
+
+        for (int index = 0; index < 5; index++) {
+            JsonNode attempt = attempts.get(index);
+
+            assertLoginRequest(attempt);
+
+            assertThat(
+                eventScript(attempt, "test")
+            )
+                .contains(
+                    "pm.response.to.have.status(401)",
+                    "INVALID_CREDENTIALS",
+                    "Email or password is incorrect.",
+                    "pm.expect(response).not.to.have.property('userExists')"
+                )
+                .doesNotContain(
+                    "emailExists"
+                );
+        }
+
+        JsonNode blockedAttempt =
+            attempts.get(5);
+
+        assertLoginRequest(blockedAttempt);
+
+        assertThat(
+            eventScript(blockedAttempt, "test")
+        )
+            .contains(
+                "pm.response.to.have.status(429)",
+                "Retry-After",
+                "LOGIN_RATE_LIMIT_EXCEEDED",
+                "Too many login attempts. Try again later.",
+                "pm.collectionVariables.unset('rateLimitEmail')",
+                "pm.expect(response).not.to.have.property('userExists')"
+            )
+            .doesNotContain(
+                "emailExists"
+            );
+    }
+
+    @Test
+    void shouldKeepCollectionVariablesCredentialFree()
+        throws IOException {
+
+        JsonNode collection =
+            objectMapper.readTree(
+                COLLECTION_PATH.toFile()
+            );
+
+        Map<String, String> variables =
+            StreamSupport.stream(
+                    collection
+                        .path("variable")
+                        .spliterator(),
+                    false
+                )
+                .collect(
+                    Collectors.toMap(
+                        variable ->
+                            variable.path("key").asText(),
+                        variable ->
+                            variable.path("value").asText(),
+                        (left, right) -> right,
+                        LinkedHashMap::new
+                    )
+                );
+
+        assertThat(variables)
+            .containsEntry(
+                "baseUrl",
+                "http://localhost:8080"
+            )
+            .containsEntry(
+                "rateLimitEmail",
+                ""
+            )
+            .doesNotContainKeys(
+                "accessToken",
+                "refreshToken",
+                "password",
+                "operatorAccessToken"
+            );
+    }
+
+    private static void assertLoginRequest(
+        JsonNode item
+    ) {
+        JsonNode request =
+            item.path("request");
+
+        assertThat(
+            request.path("method").asText()
+        )
+            .isEqualTo("POST");
+
+        assertThat(
+            request
+                .path("url")
+                .path("raw")
+                .asText()
+        )
+            .isEqualTo(LOGIN_URL);
+
+        String body =
+            request
+                .path("body")
+                .path("raw")
+                .asText();
+
+        assertThat(body)
+            .contains(
+                "{{rateLimitEmail}}",
+                "WrongPassword123!"
+            )
+            .doesNotContain(
+                "accessToken",
+                "refreshToken"
+            );
+    }
+
+    private static String eventScript(
+        JsonNode item,
+        String listen
+    ) {
+        return StreamSupport.stream(
+                item.path("event").spliterator(),
+                false
+            )
+            .filter(event ->
+                listen.equals(
+                    event.path("listen").asText()
+                )
+            )
+            .findFirst()
+            .map(event ->
+                StreamSupport.stream(
+                        event
+                            .path("script")
+                            .path("exec")
+                            .spliterator(),
+                        false
+                    )
+                    .map(JsonNode::asText)
+                    .collect(
+                        Collectors.joining("\n")
+                    )
+            )
+            .orElseThrow(() ->
+                new AssertionError(
+                    "Missing " + listen + " script"
+                )
+            );
+    }
+
+    private static JsonNode findNamedItem(
+        JsonNode items,
+        String expectedName
+    ) {
+        return StreamSupport.stream(
+                items.spliterator(),
+                false
+            )
+            .filter(item ->
+                expectedName.equals(
+                    item.path("name").asText()
+                )
+            )
+            .findFirst()
+            .orElseThrow(() ->
+                new AssertionError(
+                    "Missing Postman item: "
+                        + expectedName
+                )
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/PublicApiDocumentationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/PublicApiDocumentationTest.java
@@ -11,6 +11,7 @@ import com.nursena.payflow.user.adapter.in.web.AuthenticateUserRequest;
 import com.nursena.payflow.user.adapter.in.web.RegisterUserController;
 import com.nursena.payflow.user.adapter.in.web.RegisterUserRequest;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -65,7 +66,8 @@ class PublicApiDocumentationTest {
             AuthenticateUserController.class
                 .getDeclaredMethod(
                     "authenticate",
-                    AuthenticateUserRequest.class
+                    AuthenticateUserRequest.class,
+                    HttpServletRequest.class
                 );
 
         assertDocumentation(
@@ -76,7 +78,9 @@ class PublicApiDocumentationTest {
             "200",
             "400",
             "401",
-            "403"
+            "403",
+            "429",
+            "503"
         );
     }
 

--- a/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
@@ -1,0 +1,102 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+class RoadmapContractTest {
+
+    private static final Path POM_PATH =
+        Path.of("pom.xml");
+
+    private static final Path ROADMAP_PATH =
+        Path.of("docs", "roadmap.md");
+
+    @Test
+    void shouldAlignRoadmapWithActiveMavenDevelopmentVersion()
+        throws Exception {
+
+        String projectVersion =
+            readProjectVersion();
+
+        String roadmap =
+            Files.readString(ROADMAP_PATH);
+
+        assertThat(projectVersion)
+            .isEqualTo("0.9.0-SNAPSHOT");
+
+        assertThat(roadmap)
+            .contains(
+                "`" + projectVersion + "`",
+                "## v0.9.0 — Redis-Backed Login Protection",
+                "- [x] Verify identity and client thresholds with real Redis",
+                "- [x] Verify HTTP `429` and `Retry-After`",
+                "- [x] Verify Redis outage produces fail-closed HTTP `503`",
+                "- [x] Add a dedicated, credential-free Postman verification collection",
+                "- [ ] Open the pull request linked to issue #98",
+                "- [ ] Tag the verified release commit as `v0.9.0`"
+            )
+            .doesNotContain(
+                "active development line uses\n`0.7.0-SNAPSHOT`",
+                "## v0.7.0 — Identity and Session Security"
+            );
+    }
+
+    private static String readProjectVersion()
+        throws Exception {
+
+        DocumentBuilderFactory factory =
+            DocumentBuilderFactory.newInstance();
+
+        factory.setFeature(
+            "http://apache.org/xml/features/disallow-doctype-decl",
+            true
+        );
+
+        try (InputStream input =
+            Files.newInputStream(POM_PATH)) {
+
+            Element project =
+                factory
+                    .newDocumentBuilder()
+                    .parse(input)
+                    .getDocumentElement();
+
+            NodeList children =
+                project.getChildNodes();
+
+            for (int index = 0;
+                index < children.getLength();
+                index++) {
+
+                Node child =
+                    children.item(index);
+
+                if (
+                    child.getNodeType()
+                        == Node.ELEMENT_NODE
+                        && "version".equals(
+                            child.getNodeName()
+                        )
+                ) {
+                    return child
+                        .getTextContent()
+                        .trim();
+                }
+            }
+        }
+
+        throw new IOException(
+            "Project version was not found in pom.xml"
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -241,8 +241,28 @@ class OpenApiJsonContractIntegrationTest {
             "200",
             "400",
             "401",
-            "403"
+            "403",
+            "429",
+            "503"
         );
+
+        JsonNode retryAfterHeader =
+            login
+                .path("responses")
+                .path("429")
+                .path("headers")
+                .path("Retry-After");
+
+        assertThat(retryAfterHeader.isObject())
+            .isTrue();
+
+        assertThat(
+            retryAfterHeader
+                .path("schema")
+                .path("minimum")
+                .asInt()
+        )
+            .isEqualTo(1);
 
         JsonNode refresh =
             operation(

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserControllerTest.java
@@ -1,29 +1,52 @@
+
 package com.nursena.payflow.user.adapter.in.web;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request
+    .MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.status;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.time.Instant;
 
-import com.nursena.payflow.configuration.SecurityConfiguration;
-import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
-import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
-import com.nursena.payflow.user.application.port.in.AuthenticateUserUseCase;
-import com.nursena.payflow.user.domain.exception.InvalidCredentialsException;
-import com.nursena.payflow.user.domain.exception.UserAccountUnavailableException;
+import com.nursena.payflow.configuration
+    .SecurityConfiguration;
+import com.nursena.payflow.user.application.exception
+    .LoginRateLimitExceededException;
+import com.nursena.payflow.user.application.exception
+    .LoginRateLimitUnavailableException;
+import com.nursena.payflow.user.application.port.in
+    .AuthenticateUserCommand;
+import com.nursena.payflow.user.application.port.in
+    .AuthenticateUserResult;
+import com.nursena.payflow.user.application.port.in
+    .AuthenticateUserUseCase;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDimension;
+import com.nursena.payflow.user.domain.exception
+    .InvalidCredentialsException;
+import com.nursena.payflow.user.domain.exception
+    .UserAccountUnavailableException;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.beans.factory.annotation
+    .Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet
+    .WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito
+    .MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(AuthenticateUserController.class)
@@ -32,6 +55,9 @@ import org.springframework.test.web.servlet.MockMvc;
     UserAuthenticationExceptionHandler.class
 })
 class AuthenticateUserControllerTest {
+
+    private static final String CLIENT_ADDRESS =
+        "203.0.113.10";
 
     private static final Instant ACCESS_EXPIRES_AT =
         Instant.parse(
@@ -70,16 +96,10 @@ class AuthenticateUserControllerTest {
             );
 
         mockMvc.perform(
-                post("/api/v1/auth/login")
-                    .contentType(
-                        MediaType.APPLICATION_JSON
-                    )
-                    .content("""
-                        {
-                          "email": "nursena@example.com",
-                          "password": "StrongPassword123!"
-                        }
-                        """)
+                loginRequest(
+                    "nursena@example.com",
+                    "StrongPassword123!"
+                )
             )
             .andExpect(
                 status().isOk()
@@ -138,6 +158,10 @@ class AuthenticateUserControllerTest {
                             .equals(
                                 "StrongPassword123!"
                             )
+                        && command.clientAddress()
+                            .equals(
+                                CLIENT_ADDRESS
+                            )
                 )
             );
     }
@@ -168,16 +192,10 @@ class AuthenticateUserControllerTest {
         throws Exception {
 
         mockMvc.perform(
-                post("/api/v1/auth/login")
-                    .contentType(
-                        MediaType.APPLICATION_JSON
-                    )
-                    .content("""
-                        {
-                          "email": "not-an-email",
-                          "password": "StrongPassword123!"
-                        }
-                        """)
+                loginRequest(
+                    "not-an-email",
+                    "StrongPassword123!"
+                )
             )
             .andExpect(
                 status().isBadRequest()
@@ -208,16 +226,10 @@ class AuthenticateUserControllerTest {
             );
 
         mockMvc.perform(
-                post("/api/v1/auth/login")
-                    .contentType(
-                        MediaType.APPLICATION_JSON
-                    )
-                    .content("""
-                        {
-                          "email": "nursena@example.com",
-                          "password": "WrongPassword123!"
-                        }
-                        """)
+                loginRequest(
+                    "nursena@example.com",
+                    "WrongPassword123!"
+                )
             )
             .andExpect(
                 status().isUnauthorized()
@@ -257,16 +269,10 @@ class AuthenticateUserControllerTest {
             );
 
         mockMvc.perform(
-                post("/api/v1/auth/login")
-                    .contentType(
-                        MediaType.APPLICATION_JSON
-                    )
-                    .content("""
-                        {
-                          "email": "nursena@example.com",
-                          "password": "StrongPassword123!"
-                        }
-                        """)
+                loginRequest(
+                    "nursena@example.com",
+                    "StrongPassword123!"
+                )
             )
             .andExpect(
                 status().isForbidden()
@@ -282,7 +288,8 @@ class AuthenticateUserControllerTest {
                 jsonPath(
                     "$.message"
                 ).value(
-                    "User account is not available for authentication."
+                    "User account is not available "
+                        + "for authentication."
                 )
             )
             .andExpect(
@@ -292,5 +299,146 @@ class AuthenticateUserControllerTest {
                     "/api/v1/auth/login"
                 )
             );
+    }
+
+    @Test
+    void shouldReturnTooManyRequestsWithRetryAfter()
+        throws Exception {
+
+        when(authenticateUserUseCase.authenticate(
+            any(AuthenticateUserCommand.class)
+        ))
+            .thenThrow(
+                new LoginRateLimitExceededException(
+                    LoginRateLimitDimension.IDENTITY,
+                    Duration.ofSeconds(420)
+                )
+            );
+
+        mockMvc.perform(
+                loginRequest(
+                    "nursena@example.com",
+                    "WrongPassword123!"
+                )
+            )
+            .andExpect(
+                status().isTooManyRequests()
+            )
+            .andExpect(
+                header().string(
+                    HttpHeaders.RETRY_AFTER,
+                    "420"
+                )
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value(429)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "LOGIN_RATE_LIMIT_EXCEEDED"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Too many login attempts. "
+                            + "Try again later."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/auth/login"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.violations")
+                    .isEmpty()
+            );
+    }
+
+    @Test
+    void shouldFailClosedWhenLoginProtectionIsUnavailable()
+        throws Exception {
+
+        when(authenticateUserUseCase.authenticate(
+            any(AuthenticateUserCommand.class)
+        ))
+            .thenThrow(
+                new LoginRateLimitUnavailableException(
+                    new IllegalStateException(
+                        "redis-host:6379 unavailable"
+                    )
+                )
+            );
+
+        mockMvc.perform(
+                loginRequest(
+                    "nursena@example.com",
+                    "StrongPassword123!"
+                )
+            )
+            .andExpect(
+                status().isServiceUnavailable()
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value(503)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "LOGIN_RATE_LIMIT_UNAVAILABLE"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Login protection is "
+                            + "temporarily unavailable."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/auth/login"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.violations")
+                    .isEmpty()
+            );
+    }
+
+    private static org.springframework.test.web.servlet
+        .request.MockHttpServletRequestBuilder
+    loginRequest(
+        String email,
+        String password
+    ) {
+        String body =
+            """
+            {
+              "email": "%s",
+              "password": "%s"
+            }
+            """.formatted(
+                email,
+                password
+            );
+
+        return post("/api/v1/auth/login")
+            .with(request -> {
+                request.setRemoteAddr(
+                    CLIENT_ADDRESS
+                );
+                return request;
+            })
+            .contentType(
+                MediaType.APPLICATION_JSON
+            )
+            .content(body);
     }
 }

--- a/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitConfigurationTest.java
@@ -1,0 +1,104 @@
+package com.nursena.payflow.user.adapter.out.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
+
+import com.nursena.payflow.user.application.port.out.LoginRateLimitPort;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+
+class LoginRateLimitConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+        new ApplicationContextRunner()
+            .withBean(
+                StringRedisTemplate.class,
+                () -> new StringRedisTemplate(
+                    mock(
+                        RedisConnectionFactory.class
+                    )
+                )
+            )
+            .withUserConfiguration(
+                LoginRateLimitConfiguration.class
+            );
+
+    @Test
+    void shouldBindPropertiesAndExposeBeans() {
+        contextRunner
+            .withPropertyValues(
+                "payflow.security.login-rate-limit."
+                    + "enabled=true",
+                "payflow.security.login-rate-limit."
+                    + "window=15m",
+                "payflow.security.login-rate-limit."
+                    + "identity-limit=5",
+                "payflow.security.login-rate-limit."
+                    + "client-limit=20"
+            )
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed()
+                    .hasSingleBean(
+                        LoginRateLimitProperties.class
+                    )
+                    .hasSingleBean(
+                        LoginRateLimitPort.class
+                    )
+                    .hasSingleBean(
+                        RedisScript.class
+                    );
+
+                LoginRateLimitProperties properties =
+                    context.getBean(
+                        LoginRateLimitProperties.class
+                    );
+
+                assertThat(properties.enabled())
+                    .isTrue();
+
+                assertThat(properties.window())
+                    .isEqualTo(
+                        Duration.ofMinutes(15)
+                    );
+
+                RedisScript<?> script =
+                    context.getBean(
+                        RedisScript.class
+                    );
+
+                assertThat(
+                    script.getScriptAsString()
+                )
+                    .contains(
+                        "redis.call('INCR'",
+                        "redis.call('EXPIRE'",
+                        "redis.call('TTL'"
+                    );
+            });
+    }
+
+    @Test
+    void shouldRejectInvalidConfiguration() {
+        contextRunner
+            .withPropertyValues(
+                "payflow.security.login-rate-limit."
+                    + "enabled=true",
+                "payflow.security.login-rate-limit."
+                    + "window=500ms",
+                "payflow.security.login-rate-limit."
+                    + "identity-limit=5",
+                "payflow.security.login-rate-limit."
+                    + "client-limit=20"
+            )
+            .run(context ->
+                assertThat(context)
+                    .hasFailed()
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitConfigurationTest.java
@@ -1,16 +1,26 @@
+
 package com.nursena.payflow.user.adapter.out.ratelimit;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions
+    .assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.time.Duration;
 
-import com.nursena.payflow.user.application.port.out.LoginRateLimitPort;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitPort;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple
+    .SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.boot.test.context.runner
+    .ApplicationContextRunner;
+import org.springframework.data.redis.connection
+    .RedisConnectionFactory;
+import org.springframework.data.redis.core
+    .StringRedisTemplate;
+import org.springframework.data.redis.core.script
+    .RedisScript;
 
 class LoginRateLimitConfigurationTest {
 
@@ -18,11 +28,16 @@ class LoginRateLimitConfigurationTest {
         new ApplicationContextRunner()
             .withBean(
                 StringRedisTemplate.class,
-                () -> new StringRedisTemplate(
-                    mock(
-                        RedisConnectionFactory.class
+                () ->
+                    new StringRedisTemplate(
+                        mock(
+                            RedisConnectionFactory.class
+                        )
                     )
-                )
+            )
+            .withBean(
+                MeterRegistry.class,
+                SimpleMeterRegistry::new
             )
             .withUserConfiguration(
                 LoginRateLimitConfiguration.class
@@ -49,6 +64,9 @@ class LoginRateLimitConfigurationTest {
                     )
                     .hasSingleBean(
                         LoginRateLimitPort.class
+                    )
+                    .hasSingleBean(
+                        LoginRateLimitMetrics.class
                     )
                     .hasSingleBean(
                         RedisScript.class

--- a/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitKeyFactoryTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitKeyFactoryTest.java
@@ -1,0 +1,80 @@
+package com.nursena.payflow.user.adapter.out.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import org.junit.jupiter.api.Test;
+
+class LoginRateLimitKeyFactoryTest {
+
+    private static final String HEX_DIGEST_PATTERN =
+        "[0-9a-f]{64}";
+
+    @Test
+    void shouldBuildDeterministicNormalizedIdentityKey() {
+        String firstKey =
+            LoginRateLimitKeyFactory.identityKey(
+                EmailAddress.of(
+                    "  NURSENA@EXAMPLE.COM  "
+                )
+            );
+
+        String secondKey =
+            LoginRateLimitKeyFactory.identityKey(
+                EmailAddress.of(
+                    "nursena@example.com"
+                )
+            );
+
+        assertThat(firstKey)
+            .isEqualTo(secondKey)
+            .startsWith(
+                "payflow:security:login:"
+                    + "identity:"
+            )
+            .doesNotContain(
+                "nursena@example.com"
+            );
+
+        assertThat(
+            firstKey.substring(
+                firstKey.lastIndexOf(':') + 1
+            )
+        )
+            .matches(
+                HEX_DIGEST_PATTERN
+            );
+    }
+
+    @Test
+    void shouldBuildNormalizedClientKey() {
+        String firstKey =
+            LoginRateLimitKeyFactory.clientKey(
+                " 2001:DB8::1 "
+            );
+
+        String secondKey =
+            LoginRateLimitKeyFactory.clientKey(
+                "2001:db8::1"
+            );
+
+        assertThat(firstKey)
+            .isEqualTo(secondKey)
+            .startsWith(
+                "payflow:security:login:"
+                    + "client:"
+            )
+            .doesNotContain(
+                "2001:db8::1"
+            );
+
+        assertThat(
+            firstKey.substring(
+                firstKey.lastIndexOf(':') + 1
+            )
+        )
+            .matches(
+                HEX_DIGEST_PATTERN
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitMetricsTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitMetricsTest.java
@@ -1,0 +1,161 @@
+
+package com.nursena.payflow.user.adapter.out.ratelimit;
+
+import static org.assertj.core.api.Assertions
+    .assertThat;
+import static org.assertj.core.api.Assertions
+    .assertThatThrownBy;
+
+import java.time.Duration;
+
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDecision;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDimension;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple
+    .SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LoginRateLimitMetricsTest {
+
+    private SimpleMeterRegistry meterRegistry;
+
+    private LoginRateLimitMetrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry =
+            new SimpleMeterRegistry();
+
+        metrics =
+            new LoginRateLimitMetrics(
+                meterRegistry
+            );
+    }
+
+    @AfterEach
+    void tearDown() {
+        meterRegistry.close();
+    }
+
+    @Test
+    void shouldRecordAllowedAndBlockedDecisions() {
+        metrics.recordDecision(
+            LoginRateLimitDecision.allowed()
+        );
+
+        metrics.recordDecision(
+            LoginRateLimitDecision.blocked(
+                LoginRateLimitDimension.BOTH,
+                Duration.ofSeconds(30)
+            )
+        );
+
+        assertCounter(
+            LoginRateLimitMetrics.DECISIONS_METRIC,
+            "outcome",
+            "allowed",
+            "dimension",
+            "none",
+            1.0
+        );
+
+        assertCounter(
+            LoginRateLimitMetrics.DECISIONS_METRIC,
+            "outcome",
+            "blocked",
+            "dimension",
+            "both",
+            1.0
+        );
+    }
+
+    @Test
+    void shouldRecordBoundedRedisFailureOperations() {
+        metrics.recordRedisFailure(
+            "evaluate"
+        );
+
+        metrics.recordRedisFailure(
+            "reset"
+        );
+
+        assertCounter(
+            LoginRateLimitMetrics
+                .REDIS_FAILURES_METRIC,
+            "operation",
+            "evaluate",
+            1.0
+        );
+
+        assertCounter(
+            LoginRateLimitMetrics
+                .REDIS_FAILURES_METRIC,
+            "operation",
+            "reset",
+            1.0
+        );
+    }
+
+    @Test
+    void shouldRejectUnexpectedOperationTag() {
+        assertThatThrownBy(() ->
+            metrics.recordRedisFailure(
+                "email:nursena@example.com"
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "operation must be evaluate or reset"
+            );
+    }
+
+    private void assertCounter(
+        String metricName,
+        String firstTagName,
+        String firstTagValue,
+        String secondTagName,
+        String secondTagValue,
+        double expectedCount
+    ) {
+        Counter counter =
+            meterRegistry
+                .get(metricName)
+                .tag(
+                    firstTagName,
+                    firstTagValue
+                )
+                .tag(
+                    secondTagName,
+                    secondTagValue
+                )
+                .counter();
+
+        assertThat(counter.count())
+            .isEqualTo(expectedCount);
+    }
+
+    private void assertCounter(
+        String metricName,
+        String tagName,
+        String tagValue,
+        double expectedCount
+    ) {
+        Counter counter =
+            meterRegistry
+                .get(metricName)
+                .tag(
+                    tagName,
+                    tagValue
+                )
+                .counter();
+
+        assertThat(counter.count())
+            .isEqualTo(expectedCount);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitPropertiesTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/LoginRateLimitPropertiesTest.java
@@ -1,0 +1,125 @@
+package com.nursena.payflow.user.adapter.out.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class LoginRateLimitPropertiesTest {
+
+    @Test
+    void shouldRetainValidConfiguration() {
+        LoginRateLimitProperties properties =
+            new LoginRateLimitProperties(
+                true,
+                Duration.ofMinutes(15),
+                5,
+                20
+            );
+
+        assertThat(properties.enabled())
+            .isTrue();
+
+        assertThat(properties.window())
+            .isEqualTo(
+                Duration.ofMinutes(15)
+            );
+
+        assertThat(properties.identityLimit())
+            .isEqualTo(5);
+
+        assertThat(properties.clientLimit())
+            .isEqualTo(20);
+    }
+
+    @Test
+    void shouldRequireWindow() {
+        assertThatThrownBy(() ->
+            new LoginRateLimitProperties(
+                true,
+                null,
+                5,
+                20
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "window must not be null"
+            );
+    }
+
+    @Test
+    void shouldRejectSubSecondWindow() {
+        assertThatThrownBy(() ->
+            new LoginRateLimitProperties(
+                true,
+                Duration.ofMillis(999),
+                5,
+                20
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "window must be at least one second"
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonPositiveLimits")
+    void shouldRejectNonPositiveIdentityLimit(
+        int invalidLimit
+    ) {
+        assertThatThrownBy(() ->
+            new LoginRateLimitProperties(
+                true,
+                Duration.ofMinutes(15),
+                invalidLimit,
+                20
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "identityLimit must be positive"
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonPositiveLimits")
+    void shouldRejectNonPositiveClientLimit(
+        int invalidLimit
+    ) {
+        assertThatThrownBy(() ->
+            new LoginRateLimitProperties(
+                true,
+                Duration.ofMinutes(15),
+                5,
+                invalidLimit
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "clientLimit must be positive"
+            );
+    }
+
+    private static Stream<Integer>
+    nonPositiveLimits() {
+        return Stream.of(
+            0,
+            -1
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/RedisLoginRateLimitAdapterIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/RedisLoginRateLimitAdapterIntegrationTest.java
@@ -1,0 +1,637 @@
+package com.nursena.payflow.user.adapter.out.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDecision;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDimension;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitRequest;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import io.micrometer.core.instrument.simple
+    .SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection
+    .RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce
+    .LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class RedisLoginRateLimitAdapterIntegrationTest {
+
+    private static final int REDIS_PORT = 6379;
+
+    private static final EmailAddress IDENTITY =
+        EmailAddress.of(
+            "nursena@example.com"
+        );
+
+    private static final String CLIENT_ADDRESS =
+        "203.0.113.10";
+
+    @Container
+    private static final GenericContainer<?> REDIS =
+        new GenericContainer<>(
+            DockerImageName.parse(
+                "redis:8-alpine"
+            )
+        )
+            .withExposedPorts(REDIS_PORT);
+
+    private LettuceConnectionFactory connectionFactory;
+
+    private StringRedisTemplate redisTemplate;
+
+    private SimpleMeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        RedisStandaloneConfiguration configuration =
+            new RedisStandaloneConfiguration(
+                REDIS.getHost(),
+                REDIS.getMappedPort(
+                    REDIS_PORT
+                )
+            );
+
+        connectionFactory =
+            new LettuceConnectionFactory(
+                configuration
+            );
+
+        connectionFactory.afterPropertiesSet();
+        connectionFactory.start();
+
+        redisTemplate =
+            new StringRedisTemplate(
+                connectionFactory
+            );
+
+        redisTemplate.afterPropertiesSet();
+
+        meterRegistry =
+            new SimpleMeterRegistry();
+
+        flushRedis();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (meterRegistry != null) {
+            meterRegistry.close();
+        }
+
+        if (connectionFactory != null) {
+            connectionFactory.destroy();
+        }
+    }
+
+    @Test
+    void shouldApplyIdentityThresholdWithoutRefreshingTtl()
+        throws Exception {
+
+        RedisLoginRateLimitAdapter adapter =
+            adapter(
+                Duration.ofSeconds(8),
+                2,
+                100
+            );
+
+        LoginRateLimitRequest request =
+            request(
+                IDENTITY,
+                CLIENT_ADDRESS
+            );
+
+        assertThat(
+            adapter.evaluate(request)
+                .isAllowed()
+        )
+            .isTrue();
+
+        String identityKey =
+            LoginRateLimitKeyFactory
+                .identityKey(IDENTITY);
+
+        String clientKey =
+            LoginRateLimitKeyFactory
+                .clientKey(CLIENT_ADDRESS);
+
+        Long firstTtl =
+            redisTemplate.getExpire(
+                identityKey,
+                TimeUnit.SECONDS
+            );
+
+        assertThat(firstTtl)
+            .isBetween(1L, 8L);
+
+        Thread.sleep(1_500L);
+
+        assertThat(
+            adapter.evaluate(request)
+                .isAllowed()
+        )
+            .isTrue();
+
+        Long secondTtl =
+            redisTemplate.getExpire(
+                identityKey,
+                TimeUnit.SECONDS
+            );
+
+        assertThat(secondTtl)
+            .isPositive()
+            .isLessThan(firstTtl);
+
+        LoginRateLimitDecision blocked =
+            adapter.evaluate(request);
+
+        assertThat(blocked.isAllowed())
+            .isFalse();
+
+        assertThat(
+            blocked.blockedDimension()
+        )
+            .isEqualTo(
+                LoginRateLimitDimension.IDENTITY
+            );
+
+        Long currentTtl =
+            redisTemplate.getExpire(
+                identityKey,
+                TimeUnit.SECONDS
+            );
+
+        assertThat(
+            blocked.retryAfter().toSeconds()
+        )
+            .isBetween(
+                Math.max(
+                    1L,
+                    currentTtl - 1L
+                ),
+                currentTtl + 1L
+            );
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(identityKey)
+        )
+            .isEqualTo("3");
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(clientKey)
+        )
+            .isEqualTo("3");
+    }
+
+    @Test
+    void shouldBlockClientAcrossDistinctIdentities() {
+        RedisLoginRateLimitAdapter adapter =
+            adapter(
+                Duration.ofSeconds(30),
+                100,
+                3
+            );
+
+        for (
+            int attempt = 1;
+            attempt <= 3;
+            attempt++
+        ) {
+            assertThat(
+                adapter.evaluate(
+                    request(
+                        EmailAddress.of(
+                            "client-attempt-"
+                                + attempt
+                                + "@example.com"
+                        ),
+                        CLIENT_ADDRESS
+                    )
+                ).isAllowed()
+            )
+                .isTrue();
+        }
+
+        LoginRateLimitDecision blocked =
+            adapter.evaluate(
+                request(
+                    EmailAddress.of(
+                        "client-attempt-4@example.com"
+                    ),
+                    CLIENT_ADDRESS
+                )
+            );
+
+        assertThat(blocked.isAllowed())
+            .isFalse();
+
+        assertThat(
+            blocked.blockedDimension()
+        )
+            .isEqualTo(
+                LoginRateLimitDimension.CLIENT
+            );
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(
+                    LoginRateLimitKeyFactory
+                        .clientKey(
+                            CLIENT_ADDRESS
+                        )
+                )
+        )
+            .isEqualTo("4");
+    }
+
+    @Test
+    void shouldResetOnlyIdentityCounter() {
+        RedisLoginRateLimitAdapter adapter =
+            adapter(
+                Duration.ofSeconds(30),
+                5,
+                20
+            );
+
+        LoginRateLimitRequest request =
+            request(
+                IDENTITY,
+                CLIENT_ADDRESS
+            );
+
+        adapter.evaluate(request);
+        adapter.evaluate(request);
+
+        String identityKey =
+            LoginRateLimitKeyFactory
+                .identityKey(IDENTITY);
+
+        String clientKey =
+            LoginRateLimitKeyFactory
+                .clientKey(CLIENT_ADDRESS);
+
+        adapter.resetIdentity(IDENTITY);
+
+        assertThat(
+            redisTemplate.hasKey(
+                identityKey
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(clientKey)
+        )
+            .isEqualTo("2");
+
+        assertThat(
+            redisTemplate.getExpire(
+                clientKey,
+                TimeUnit.SECONDS
+            )
+        )
+            .isPositive();
+
+        assertThat(
+            adapter.evaluate(request)
+                .isAllowed()
+        )
+            .isTrue();
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(identityKey)
+        )
+            .isEqualTo("1");
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(clientKey)
+        )
+            .isEqualTo("3");
+    }
+
+    @Test
+    void shouldOpenANewWindowAfterExpiration()
+        throws Exception {
+
+        RedisLoginRateLimitAdapter adapter =
+            adapter(
+                Duration.ofSeconds(2),
+                1,
+                10
+            );
+
+        LoginRateLimitRequest request =
+            request(
+                IDENTITY,
+                CLIENT_ADDRESS
+            );
+
+        assertThat(
+            adapter.evaluate(request)
+                .isAllowed()
+        )
+            .isTrue();
+
+        assertThat(
+            adapter.evaluate(request)
+                .isAllowed()
+        )
+            .isFalse();
+
+        String identityKey =
+            LoginRateLimitKeyFactory
+                .identityKey(IDENTITY);
+
+        String clientKey =
+            LoginRateLimitKeyFactory
+                .clientKey(CLIENT_ADDRESS);
+
+        awaitExpiration(
+            identityKey,
+            clientKey
+        );
+
+        assertThat(
+            adapter.evaluate(request)
+                .isAllowed()
+        )
+            .isTrue();
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(identityKey)
+        )
+            .isEqualTo("1");
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(clientKey)
+        )
+            .isEqualTo("1");
+    }
+
+    @Test
+    void shouldApplyLuaAtomicallyUnderConcurrentLoad()
+        throws Exception {
+
+        int operationCount = 32;
+
+        RedisLoginRateLimitAdapter adapter =
+            adapter(
+                Duration.ofSeconds(30),
+                5,
+                100
+            );
+
+        LoginRateLimitRequest request =
+            request(
+                IDENTITY,
+                CLIENT_ADDRESS
+            );
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(
+                operationCount
+            );
+
+        CountDownLatch ready =
+            new CountDownLatch(
+                operationCount
+            );
+
+        CountDownLatch start =
+            new CountDownLatch(1);
+
+        List<Future<LoginRateLimitDecision>>
+            futures =
+            new ArrayList<>();
+
+        try {
+            for (
+                int index = 0;
+                index < operationCount;
+                index++
+            ) {
+                futures.add(
+                    executor.submit(
+                        () -> {
+                            ready.countDown();
+
+                            if (
+                                !start.await(
+                                    10,
+                                    TimeUnit.SECONDS
+                                )
+                            ) {
+                                throw new
+                                    IllegalStateException(
+                                    "Concurrent login "
+                                        + "rate-limit start "
+                                        + "timed out."
+                                );
+                            }
+
+                            return adapter.evaluate(
+                                request
+                            );
+                        }
+                    )
+                );
+            }
+
+            assertThat(
+                ready.await(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            )
+                .isTrue();
+
+            start.countDown();
+
+            long allowedCount = 0;
+            long blockedCount = 0;
+
+            for (
+                Future<LoginRateLimitDecision>
+                    future
+                : futures
+            ) {
+                LoginRateLimitDecision decision =
+                    future.get(
+                        10,
+                        TimeUnit.SECONDS
+                    );
+
+                if (decision.isAllowed()) {
+                    allowedCount++;
+                } else {
+                    blockedCount++;
+
+                    assertThat(
+                        decision.blockedDimension()
+                    )
+                        .isEqualTo(
+                            LoginRateLimitDimension
+                                .IDENTITY
+                        );
+                }
+            }
+
+            assertThat(allowedCount)
+                .isEqualTo(5);
+
+            assertThat(blockedCount)
+                .isEqualTo(
+                    operationCount - 5L
+                );
+
+            assertThat(
+                redisTemplate.opsForValue()
+                    .get(
+                        LoginRateLimitKeyFactory
+                            .identityKey(
+                                IDENTITY
+                            )
+                    )
+            )
+                .isEqualTo(
+                    Integer.toString(
+                        operationCount
+                    )
+                );
+
+            assertThat(
+                redisTemplate.opsForValue()
+                    .get(
+                        LoginRateLimitKeyFactory
+                            .clientKey(
+                                CLIENT_ADDRESS
+                            )
+                    )
+            )
+                .isEqualTo(
+                    Integer.toString(
+                        operationCount
+                    )
+                );
+        } finally {
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            )
+                .isTrue();
+        }
+    }
+
+    private RedisLoginRateLimitAdapter adapter(
+        Duration window,
+        int identityLimit,
+        int clientLimit
+    ) {
+        return new RedisLoginRateLimitAdapter(
+            redisTemplate,
+            new LoginRateLimitConfiguration()
+                .loginRateLimitScript(),
+            new LoginRateLimitProperties(
+                true,
+                window,
+                identityLimit,
+                clientLimit
+            ),
+            new LoginRateLimitMetrics(
+                meterRegistry
+            )
+        );
+    }
+
+    private void flushRedis() {
+        redisTemplate.execute(
+            (RedisCallback<Void>) connection -> {
+                connection
+                    .serverCommands()
+                    .flushDb();
+
+                return null;
+            }
+        );
+    }
+
+    private void awaitExpiration(
+        String... keys
+    ) throws Exception {
+        long deadline =
+            System.nanoTime()
+                + Duration.ofSeconds(6)
+                .toNanos();
+
+        while (
+            System.nanoTime() < deadline
+        ) {
+            boolean anyKeyPresent = false;
+
+            for (String key : keys) {
+                if (
+                    Boolean.TRUE.equals(
+                        redisTemplate.hasKey(
+                            key
+                        )
+                    )
+                ) {
+                    anyKeyPresent = true;
+                    break;
+                }
+            }
+
+            if (!anyKeyPresent) {
+                return;
+            }
+
+            Thread.sleep(50L);
+        }
+
+        throw new AssertionError(
+            "Redis login rate-limit keys "
+                + "did not expire in time."
+        );
+    }
+
+    private static LoginRateLimitRequest request(
+        EmailAddress identity,
+        String clientAddress
+    ) {
+        return new LoginRateLimitRequest(
+            identity,
+            clientAddress
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/RedisLoginRateLimitAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/RedisLoginRateLimitAdapterTest.java
@@ -1,0 +1,313 @@
+package com.nursena.payflow.user.adapter.out.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.List;
+
+import com.nursena.payflow.user.application.exception.LoginRateLimitUnavailableException;
+import com.nursena.payflow.user.application.port.out.LoginRateLimitDecision;
+import com.nursena.payflow.user.application.port.out.LoginRateLimitDimension;
+import com.nursena.payflow.user.application.port.out.LoginRateLimitRequest;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+
+class RedisLoginRateLimitAdapterTest {
+
+    private static final EmailAddress IDENTITY =
+        EmailAddress.of(
+            "nursena@example.com"
+        );
+
+    private static final LoginRateLimitProperties
+        ENABLED_PROPERTIES =
+        new LoginRateLimitProperties(
+            true,
+            Duration.ofMinutes(15),
+            5,
+            20
+        );
+
+    private RecordingStringRedisTemplate
+        redisTemplate;
+
+    private RedisLoginRateLimitAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate =
+            new RecordingStringRedisTemplate();
+
+        adapter =
+            new RedisLoginRateLimitAdapter(
+                redisTemplate,
+                script(),
+                ENABLED_PROPERTIES
+            );
+    }
+
+    @Test
+    void shouldAllowRequestAndUseHashedKeys() {
+        redisTemplate.scriptResult =
+            List.of(
+                0L,
+                0L,
+                0L
+            );
+
+        LoginRateLimitDecision decision =
+            adapter.evaluate(
+                request()
+            );
+
+        assertThat(decision.isAllowed())
+            .isTrue();
+
+        assertThat(redisTemplate.executions)
+            .isEqualTo(1);
+
+        assertThat(redisTemplate.keys)
+            .hasSize(2)
+            .allSatisfy(key ->
+                assertThat(key)
+                    .doesNotContain(
+                        "nursena@example.com",
+                        "127.0.0.1"
+                    )
+            );
+
+        assertThat(redisTemplate.arguments)
+            .containsExactly(
+                "900",
+                "5",
+                "20"
+            );
+    }
+
+    @Test
+    void shouldMapIdentityBlockingDecision() {
+        redisTemplate.scriptResult =
+            List.of(
+                1L,
+                0L,
+                840L
+            );
+
+        LoginRateLimitDecision decision =
+            adapter.evaluate(
+                request()
+            );
+
+        assertThat(decision.isAllowed())
+            .isFalse();
+
+        assertThat(decision.blockedDimension())
+            .isEqualTo(
+                LoginRateLimitDimension.IDENTITY
+            );
+
+        assertThat(decision.retryAfter())
+            .isEqualTo(
+                Duration.ofSeconds(840)
+            );
+    }
+
+    @Test
+    void shouldMapCombinedBlockingDecision() {
+        redisTemplate.scriptResult =
+            List.of(
+                1L,
+                1L,
+                900L
+            );
+
+        LoginRateLimitDecision decision =
+            adapter.evaluate(
+                request()
+            );
+
+        assertThat(decision.blockedDimension())
+            .isEqualTo(
+                LoginRateLimitDimension.BOTH
+            );
+
+        assertThat(decision.retryAfter())
+            .isEqualTo(
+                Duration.ofMinutes(15)
+            );
+    }
+
+    @Test
+    void shouldSkipRedisWhenDisabled() {
+        RedisLoginRateLimitAdapter disabledAdapter =
+            new RedisLoginRateLimitAdapter(
+                redisTemplate,
+                script(),
+                new LoginRateLimitProperties(
+                    false,
+                    Duration.ofMinutes(15),
+                    5,
+                    20
+                )
+            );
+
+        LoginRateLimitDecision decision =
+            disabledAdapter.evaluate(
+                request()
+            );
+
+        disabledAdapter.resetIdentity(
+            IDENTITY
+        );
+
+        assertThat(decision.isAllowed())
+            .isTrue();
+
+        assertThat(redisTemplate.executions)
+            .isZero();
+
+        assertThat(redisTemplate.deletedKey)
+            .isNull();
+    }
+
+    @Test
+    void shouldTranslateRedisEvaluationFailure() {
+        IllegalStateException redisFailure =
+            new IllegalStateException(
+                "redis-host:6379 unavailable"
+            );
+
+        redisTemplate.executeFailure =
+            redisFailure;
+
+        assertThatThrownBy(() ->
+            adapter.evaluate(
+                request()
+            )
+        )
+            .isInstanceOf(
+                LoginRateLimitUnavailableException.class
+            )
+            .hasMessage(
+                "Login protection is "
+                    + "temporarily unavailable."
+            )
+            .hasCause(redisFailure)
+            .hasMessageNotContaining(
+                "redis-host"
+            );
+    }
+
+    @Test
+    void shouldRejectMalformedScriptResult() {
+        redisTemplate.scriptResult =
+            List.of(
+                0L,
+                0L
+            );
+
+        assertThatThrownBy(() ->
+            adapter.evaluate(
+                request()
+            )
+        )
+            .isInstanceOf(
+                LoginRateLimitUnavailableException.class
+            )
+            .hasMessage(
+                "Login protection is "
+                    + "temporarily unavailable."
+            );
+    }
+
+    @Test
+    void shouldResetOnlyHashedIdentityKey() {
+        adapter.resetIdentity(
+            IDENTITY
+        );
+
+        assertThat(redisTemplate.deletedKey)
+            .startsWith(
+                "payflow:security:login:"
+                    + "identity:"
+            )
+            .doesNotContain(
+                "nursena@example.com"
+            );
+    }
+
+    @SuppressWarnings({
+        "unchecked",
+        "rawtypes"
+    })
+    private static RedisScript<List<Long>> script() {
+        return (RedisScript) new DefaultRedisScript<>(
+            "return {0, 0, 0}",
+            List.class
+        );
+    }
+
+    private static LoginRateLimitRequest request() {
+        return new LoginRateLimitRequest(
+            IDENTITY,
+            "127.0.0.1"
+        );
+    }
+
+    private static final class
+    RecordingStringRedisTemplate
+        extends StringRedisTemplate {
+
+        private List<?> scriptResult =
+            List.of(
+                0L,
+                0L,
+                0L
+            );
+
+        private RuntimeException executeFailure;
+
+        private int executions;
+
+        private List<String> keys;
+
+        private Object[] arguments;
+
+        private String deletedKey;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T execute(
+            RedisScript<T> script,
+            List<String> keys,
+            Object... args
+        ) {
+            executions++;
+
+            if (executeFailure != null) {
+                throw executeFailure;
+            }
+
+            this.keys =
+                List.copyOf(keys);
+
+            this.arguments =
+                args.clone();
+
+            return (T) scriptResult;
+        }
+
+        @Override
+        public Boolean delete(
+            String key
+        ) {
+            deletedKey = key;
+            return true;
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/RedisLoginRateLimitAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/ratelimit/RedisLoginRateLimitAdapterTest.java
@@ -1,21 +1,34 @@
+
 package com.nursena.payflow.user.adapter.out.ratelimit;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions
+    .assertThat;
+import static org.assertj.core.api.Assertions
+    .assertThatThrownBy;
 
 import java.time.Duration;
 import java.util.List;
 
-import com.nursena.payflow.user.application.exception.LoginRateLimitUnavailableException;
-import com.nursena.payflow.user.application.port.out.LoginRateLimitDecision;
-import com.nursena.payflow.user.application.port.out.LoginRateLimitDimension;
-import com.nursena.payflow.user.application.port.out.LoginRateLimitRequest;
+import com.nursena.payflow.user.application.exception
+    .LoginRateLimitUnavailableException;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDecision;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDimension;
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitRequest;
 import com.nursena.payflow.user.domain.model.EmailAddress;
+import io.micrometer.core.instrument.simple
+    .SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
-import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.data.redis.core
+    .StringRedisTemplate;
+import org.springframework.data.redis.core.script
+    .DefaultRedisScript;
+import org.springframework.data.redis.core.script
+    .RedisScript;
 
 class RedisLoginRateLimitAdapterTest {
 
@@ -36,6 +49,10 @@ class RedisLoginRateLimitAdapterTest {
     private RecordingStringRedisTemplate
         redisTemplate;
 
+    private SimpleMeterRegistry meterRegistry;
+
+    private LoginRateLimitMetrics metrics;
+
     private RedisLoginRateLimitAdapter adapter;
 
     @BeforeEach
@@ -43,12 +60,26 @@ class RedisLoginRateLimitAdapterTest {
         redisTemplate =
             new RecordingStringRedisTemplate();
 
+        meterRegistry =
+            new SimpleMeterRegistry();
+
+        metrics =
+            new LoginRateLimitMetrics(
+                meterRegistry
+            );
+
         adapter =
             new RedisLoginRateLimitAdapter(
                 redisTemplate,
                 script(),
-                ENABLED_PROPERTIES
+                ENABLED_PROPERTIES,
+                metrics
             );
+    }
+
+    @AfterEach
+    void tearDown() {
+        meterRegistry.close();
     }
 
     @Test
@@ -87,6 +118,12 @@ class RedisLoginRateLimitAdapterTest {
                 "5",
                 "20"
             );
+
+        assertDecisionCount(
+            "allowed",
+            "none",
+            1.0
+        );
     }
 
     @Test
@@ -115,6 +152,12 @@ class RedisLoginRateLimitAdapterTest {
             .isEqualTo(
                 Duration.ofSeconds(840)
             );
+
+        assertDecisionCount(
+            "blocked",
+            "identity",
+            1.0
+        );
     }
 
     @Test
@@ -140,10 +183,16 @@ class RedisLoginRateLimitAdapterTest {
             .isEqualTo(
                 Duration.ofMinutes(15)
             );
+
+        assertDecisionCount(
+            "blocked",
+            "both",
+            1.0
+        );
     }
 
     @Test
-    void shouldSkipRedisWhenDisabled() {
+    void shouldSkipRedisAndMetricsWhenDisabled() {
         RedisLoginRateLimitAdapter disabledAdapter =
             new RedisLoginRateLimitAdapter(
                 redisTemplate,
@@ -153,7 +202,8 @@ class RedisLoginRateLimitAdapterTest {
                     Duration.ofMinutes(15),
                     5,
                     20
-                )
+                ),
+                metrics
             );
 
         LoginRateLimitDecision decision =
@@ -173,10 +223,18 @@ class RedisLoginRateLimitAdapterTest {
 
         assertThat(redisTemplate.deletedKey)
             .isNull();
+
+        assertThat(
+            meterRegistry.find(
+                LoginRateLimitMetrics
+                    .DECISIONS_METRIC
+            ).counter()
+        )
+            .isNull();
     }
 
     @Test
-    void shouldTranslateRedisEvaluationFailure() {
+    void shouldTranslateAndMeasureRedisEvaluationFailure() {
         IllegalStateException redisFailure =
             new IllegalStateException(
                 "redis-host:6379 unavailable"
@@ -201,10 +259,15 @@ class RedisLoginRateLimitAdapterTest {
             .hasMessageNotContaining(
                 "redis-host"
             );
+
+        assertRedisFailureCount(
+            "evaluate",
+            1.0
+        );
     }
 
     @Test
-    void shouldRejectMalformedScriptResult() {
+    void shouldRejectMalformedScriptResultAndMeasureFailure() {
         redisTemplate.scriptResult =
             List.of(
                 0L,
@@ -223,6 +286,11 @@ class RedisLoginRateLimitAdapterTest {
                 "Login protection is "
                     + "temporarily unavailable."
             );
+
+        assertRedisFailureCount(
+            "evaluate",
+            1.0
+        );
     }
 
     @Test
@@ -239,6 +307,77 @@ class RedisLoginRateLimitAdapterTest {
             .doesNotContain(
                 "nursena@example.com"
             );
+    }
+
+    @Test
+    void shouldTranslateAndMeasureRedisResetFailure() {
+        IllegalStateException redisFailure =
+            new IllegalStateException(
+                "redis reset failed"
+            );
+
+        redisTemplate.deleteFailure =
+            redisFailure;
+
+        assertThatThrownBy(() ->
+            adapter.resetIdentity(
+                IDENTITY
+            )
+        )
+            .isInstanceOf(
+                LoginRateLimitUnavailableException.class
+            )
+            .hasCause(redisFailure);
+
+        assertRedisFailureCount(
+            "reset",
+            1.0
+        );
+    }
+
+    private void assertDecisionCount(
+        String outcome,
+        String dimension,
+        double expectedCount
+    ) {
+        assertThat(
+            meterRegistry
+                .get(
+                    LoginRateLimitMetrics
+                        .DECISIONS_METRIC
+                )
+                .tag(
+                    "outcome",
+                    outcome
+                )
+                .tag(
+                    "dimension",
+                    dimension
+                )
+                .counter()
+                .count()
+        )
+            .isEqualTo(expectedCount);
+    }
+
+    private void assertRedisFailureCount(
+        String operation,
+        double expectedCount
+    ) {
+        assertThat(
+            meterRegistry
+                .get(
+                    LoginRateLimitMetrics
+                        .REDIS_FAILURES_METRIC
+                )
+                .tag(
+                    "operation",
+                    operation
+                )
+                .counter()
+                .count()
+        )
+            .isEqualTo(expectedCount);
     }
 
     @SuppressWarnings({
@@ -271,6 +410,8 @@ class RedisLoginRateLimitAdapterTest {
             );
 
         private RuntimeException executeFailure;
+
+        private RuntimeException deleteFailure;
 
         private int executions;
 
@@ -306,6 +447,10 @@ class RedisLoginRateLimitAdapterTest {
         public Boolean delete(
             String key
         ) {
+            if (deleteFailure != null) {
+                throw deleteFailure;
+            }
+
             deletedKey = key;
             return true;
         }

--- a/src/test/java/com/nursena/payflow/user/application/exception/LoginRateLimitExceededExceptionTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/exception/LoginRateLimitExceededExceptionTest.java
@@ -1,0 +1,62 @@
+
+package com.nursena.payflow.user.application.exception;
+
+import static org.assertj.core.api.Assertions
+    .assertThat;
+import static org.assertj.core.api.Assertions
+    .assertThatThrownBy;
+
+import java.time.Duration;
+
+import com.nursena.payflow.user.application.port.out
+    .LoginRateLimitDimension;
+import org.junit.jupiter.api.Test;
+
+class LoginRateLimitExceededExceptionTest {
+
+    @Test
+    void shouldExposeSafeRateLimitState() {
+        LoginRateLimitExceededException exception =
+            new LoginRateLimitExceededException(
+                LoginRateLimitDimension.CLIENT,
+                Duration.ofSeconds(45)
+            );
+
+        assertThat(exception.getCode())
+            .isEqualTo(
+                "LOGIN_RATE_LIMIT_EXCEEDED"
+            );
+
+        assertThat(exception.getMessage())
+            .isEqualTo(
+                "Too many login attempts. "
+                    + "Try again later."
+            );
+
+        assertThat(exception.getBlockedDimension())
+            .isEqualTo(
+                LoginRateLimitDimension.CLIENT
+            );
+
+        assertThat(exception.getRetryAfter())
+            .isEqualTo(
+                Duration.ofSeconds(45)
+            );
+    }
+
+    @Test
+    void shouldRejectNoneDimension() {
+        assertThatThrownBy(() ->
+            new LoginRateLimitExceededException(
+                LoginRateLimitDimension.NONE,
+                Duration.ofSeconds(1)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "blockedDimension must not be NONE"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/port/in/AuthenticateUserCommandTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/in/AuthenticateUserCommandTest.java
@@ -1,0 +1,74 @@
+
+package com.nursena.payflow.user.application.port.in;
+
+import static org.assertj.core.api.Assertions
+    .assertThat;
+import static org.assertj.core.api.Assertions
+    .assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class AuthenticateUserCommandTest {
+
+    @Test
+    void shouldRetainAuthenticationInput() {
+        AuthenticateUserCommand command =
+            new AuthenticateUserCommand(
+                "nursena@example.com",
+                "StrongPassword123!",
+                "203.0.113.10"
+            );
+
+        assertThat(command.email())
+            .isEqualTo(
+                "nursena@example.com"
+            );
+
+        assertThat(command.rawPassword())
+            .isEqualTo(
+                "StrongPassword123!"
+            );
+
+        assertThat(command.clientAddress())
+            .isEqualTo(
+                "203.0.113.10"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankClientAddress() {
+        assertThatThrownBy(() ->
+            new AuthenticateUserCommand(
+                "nursena@example.com",
+                "StrongPassword123!",
+                " "
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "clientAddress must not be blank"
+            );
+    }
+
+    @Test
+    void shouldRedactPasswordAndClientAddress() {
+        AuthenticateUserCommand command =
+            new AuthenticateUserCommand(
+                "nursena@example.com",
+                "StrongPassword123!",
+                "203.0.113.10"
+            );
+
+        assertThat(command.toString())
+            .isEqualTo(
+                "AuthenticateUserCommand[redacted]"
+            )
+            .doesNotContain(
+                "StrongPassword123!",
+                "203.0.113.10",
+                "nursena@example.com"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/port/out/LoginRateLimitDecisionTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/out/LoginRateLimitDecisionTest.java
@@ -1,0 +1,83 @@
+package com.nursena.payflow.user.application.port.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class LoginRateLimitDecisionTest {
+
+    @Test
+    void shouldCreateAllowedDecision() {
+        LoginRateLimitDecision decision =
+            LoginRateLimitDecision.allowed();
+
+        assertThat(decision.isAllowed())
+            .isTrue();
+
+        assertThat(decision.blockedDimension())
+            .isEqualTo(
+                LoginRateLimitDimension.NONE
+            );
+
+        assertThat(decision.retryAfter())
+            .isZero();
+    }
+
+    @Test
+    void shouldCreateBlockedDecision() {
+        LoginRateLimitDecision decision =
+            LoginRateLimitDecision.blocked(
+                LoginRateLimitDimension.IDENTITY,
+                Duration.ofMinutes(3)
+            );
+
+        assertThat(decision.isAllowed())
+            .isFalse();
+
+        assertThat(decision.blockedDimension())
+            .isEqualTo(
+                LoginRateLimitDimension.IDENTITY
+            );
+
+        assertThat(decision.retryAfter())
+            .isEqualTo(
+                Duration.ofMinutes(3)
+            );
+    }
+
+    @Test
+    void shouldRejectNoneAsBlockedDimension() {
+        assertThatThrownBy(() ->
+            LoginRateLimitDecision.blocked(
+                LoginRateLimitDimension.NONE,
+                Duration.ofSeconds(1)
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "blocked dimension must not be NONE"
+            );
+    }
+
+    @Test
+    void shouldRejectNonPositiveBlockedRetryDelay() {
+        assertThatThrownBy(() ->
+            LoginRateLimitDecision.blocked(
+                LoginRateLimitDimension.CLIENT,
+                Duration.ZERO
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "blocked decision retryAfter "
+                    + "must be positive"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/port/out/LoginRateLimitRequestTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/out/LoginRateLimitRequestTest.java
@@ -1,0 +1,64 @@
+package com.nursena.payflow.user.application.port.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import org.junit.jupiter.api.Test;
+
+class LoginRateLimitRequestTest {
+
+    @Test
+    void shouldRetainIdentityAndClientAddress() {
+        EmailAddress identity =
+            EmailAddress.of(
+                "nursena@example.com"
+            );
+
+        LoginRateLimitRequest request =
+            new LoginRateLimitRequest(
+                identity,
+                "127.0.0.1"
+            );
+
+        assertThat(request.identity())
+            .isEqualTo(identity);
+
+        assertThat(request.clientAddress())
+            .isEqualTo("127.0.0.1");
+    }
+
+    @Test
+    void shouldRequireIdentity() {
+        assertThatThrownBy(() ->
+            new LoginRateLimitRequest(
+                null,
+                "127.0.0.1"
+            )
+        )
+            .isInstanceOf(
+                NullPointerException.class
+            )
+            .hasMessage(
+                "identity must not be null"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankClientAddress() {
+        assertThatThrownBy(() ->
+            new LoginRateLimitRequest(
+                EmailAddress.of(
+                    "nursena@example.com"
+                ),
+                "  "
+            )
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "clientAddress must not be blank"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/AuthenticateUserServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/AuthenticateUserServiceTest.java
@@ -3,7 +3,9 @@ package com.nursena.payflow.user.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -18,11 +20,19 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.nursena.payflow.user.application.exception
+    .LoginRateLimitExceededException;
+import com.nursena.payflow.user.application.exception
+    .LoginRateLimitUnavailableException;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserCommand;
 import com.nursena.payflow.user.application.port.in.AuthenticateUserResult;
 import com.nursena.payflow.user.application.port.out.AccessTokenGenerationPort;
 import com.nursena.payflow.user.application.port.out.GeneratedAccessToken;
 import com.nursena.payflow.user.application.port.out.GeneratedRefreshToken;
+import com.nursena.payflow.user.application.port.out.LoginRateLimitDecision;
+import com.nursena.payflow.user.application.port.out.LoginRateLimitDimension;
+import com.nursena.payflow.user.application.port.out.LoginRateLimitPort;
+import com.nursena.payflow.user.application.port.out.LoginRateLimitRequest;
 import com.nursena.payflow.user.application.port.out.PasswordVerificationPort;
 import com.nursena.payflow.user.application.port.out.RefreshTokenDigestPort;
 import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
@@ -108,6 +118,9 @@ class AuthenticateUserServiceTest {
     @Mock
     private AccessTokenGenerationPort accessTokenGeneration;
 
+    @Mock
+    private LoginRateLimitPort loginRateLimit;
+
     private RefreshSessionLifetimePolicy lifetimePolicy;
     private Clock clock;
     private AuthenticateUserService authenticateUserService;
@@ -126,6 +139,16 @@ class AuthenticateUserServiceTest {
                 ZoneOffset.UTC
             );
 
+        lenient()
+            .when(
+                loginRateLimit.evaluate(
+                    any(LoginRateLimitRequest.class)
+                )
+            )
+            .thenReturn(
+                LoginRateLimitDecision.allowed()
+            );
+
         authenticateUserService =
             new AuthenticateUserService(
                 userRepository,
@@ -135,6 +158,7 @@ class AuthenticateUserServiceTest {
                 familyRepository,
                 recordRepository,
                 accessTokenGeneration,
+                loginRateLimit,
                 lifetimePolicy,
                 clock
             );
@@ -204,7 +228,8 @@ class AuthenticateUserServiceTest {
             authenticateUserService.authenticate(
                 new AuthenticateUserCommand(
                     "  NURSENA@EXAMPLE.COM  ",
-                    RAW_PASSWORD
+                    RAW_PASSWORD,
+                    "203.0.113.10"
                 )
             );
 
@@ -331,6 +356,18 @@ class AuthenticateUserServiceTest {
                 RAW_PASSWORD,
                 PASSWORD_HASH
             );
+
+        verify(loginRateLimit)
+            .evaluate(
+                argThat(request ->
+                    request.identity().equals(email)
+                        && request.clientAddress()
+                            .equals("203.0.113.10")
+                )
+            );
+
+        verify(loginRateLimit)
+            .resetIdentity(email);
     }
 
     @Test
@@ -380,7 +417,8 @@ class AuthenticateUserServiceTest {
             authenticateUserService.authenticate(
                 new AuthenticateUserCommand(
                     "unknown@example.com",
-                    RAW_PASSWORD
+                    RAW_PASSWORD,
+                    "203.0.113.10"
                 )
             )
         )
@@ -429,7 +467,8 @@ class AuthenticateUserServiceTest {
             authenticateUserService.authenticate(
                 new AuthenticateUserCommand(
                     "nursena@example.com",
-                    "IncorrectPassword123!"
+                    "IncorrectPassword123!",
+                    "203.0.113.10"
                 )
             )
         )
@@ -471,7 +510,8 @@ class AuthenticateUserServiceTest {
             authenticateUserService.authenticate(
                 new AuthenticateUserCommand(
                     "nursena@example.com",
-                    RAW_PASSWORD
+                    RAW_PASSWORD,
+                    "203.0.113.10"
                 )
             )
         )
@@ -642,6 +682,199 @@ class AuthenticateUserServiceTest {
             .generate(user);
     }
 
+    @Test
+    void shouldRejectBlockedAttemptBeforeUserLookup() {
+        when(
+            loginRateLimit.evaluate(
+                any(LoginRateLimitRequest.class)
+            )
+        )
+            .thenReturn(
+                LoginRateLimitDecision.blocked(
+                    LoginRateLimitDimension.BOTH,
+                    Duration.ofSeconds(420)
+                )
+            );
+
+        assertThatThrownBy(() ->
+            authenticateUserService.authenticate(
+                command()
+            )
+        )
+            .isInstanceOf(
+                LoginRateLimitExceededException.class
+            )
+            .hasMessage(
+                "Too many login attempts. "
+                    + "Try again later."
+            )
+            .satisfies(exception -> {
+                LoginRateLimitExceededException
+                    rateLimitException =
+                    (LoginRateLimitExceededException)
+                        exception;
+
+                assertThat(
+                    rateLimitException
+                        .getBlockedDimension()
+                )
+                    .isEqualTo(
+                        LoginRateLimitDimension.BOTH
+                    );
+
+                assertThat(
+                    rateLimitException
+                        .getRetryAfter()
+                )
+                    .isEqualTo(
+                        Duration.ofSeconds(420)
+                    );
+            });
+
+        verifyNoInteractions(
+            userRepository,
+            passwordVerification,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            familyRepository,
+            recordRepository,
+            accessTokenGeneration
+        );
+
+        verify(loginRateLimit, never())
+            .resetIdentity(
+                any(EmailAddress.class)
+            );
+    }
+
+    @Test
+    void shouldFailClosedBeforeUserLookupWhenLimiterIsUnavailable() {
+        LoginRateLimitUnavailableException failure =
+            new LoginRateLimitUnavailableException(
+                new IllegalStateException(
+                    "redis unavailable"
+                )
+            );
+
+        when(
+            loginRateLimit.evaluate(
+                any(LoginRateLimitRequest.class)
+            )
+        )
+            .thenThrow(failure);
+
+        assertThatThrownBy(() ->
+            authenticateUserService.authenticate(
+                command()
+            )
+        )
+            .isSameAs(failure);
+
+        verifyNoInteractions(
+            userRepository,
+            passwordVerification,
+            refreshTokenGeneration,
+            refreshTokenDigest,
+            familyRepository,
+            recordRepository,
+            accessTokenGeneration
+        );
+
+        verify(loginRateLimit, never())
+            .resetIdentity(
+                any(EmailAddress.class)
+            );
+    }
+
+    @Test
+    void shouldRetainIdentityCounterAfterInvalidCredentials() {
+        EmailAddress email =
+            EmailAddress.of(
+                "nursena@example.com"
+            );
+
+        when(userRepository.findByEmail(email))
+            .thenReturn(
+                Optional.empty()
+            );
+
+        assertThatThrownBy(() ->
+            authenticateUserService.authenticate(
+                command()
+            )
+        )
+            .isInstanceOf(
+                InvalidCredentialsException.class
+            );
+
+        verify(loginRateLimit, never())
+            .resetIdentity(email);
+    }
+
+    @Test
+    void shouldPropagateIdentityResetFailureAfterCredentialIssuance() {
+        User user =
+            activeUser(
+                EmailAddress.of(
+                    "nursena@example.com"
+                )
+            );
+
+        stubValidAuthentication(user);
+
+        when(familyRepository.save(
+            any(RefreshTokenFamily.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(recordRepository.save(
+            any(RefreshTokenRecord.class)
+        ))
+            .thenAnswer(
+                invocation ->
+                    invocation.getArgument(0)
+            );
+
+        when(accessTokenGeneration.generate(user))
+            .thenReturn(
+                new GeneratedAccessToken(
+                    ACCESS_TOKEN,
+                    ACCESS_EXPIRES_AT
+                )
+            );
+
+        LoginRateLimitUnavailableException failure =
+            new LoginRateLimitUnavailableException(
+                new IllegalStateException(
+                    "redis reset failed"
+                )
+            );
+
+        org.mockito.Mockito.doThrow(failure)
+            .when(loginRateLimit)
+            .resetIdentity(
+                user.email()
+            );
+
+        assertThatThrownBy(() ->
+            authenticateUserService.authenticate(
+                command()
+            )
+        )
+            .isSameAs(failure);
+
+        verify(accessTokenGeneration)
+            .generate(user);
+
+        verify(loginRateLimit)
+            .resetIdentity(
+                user.email()
+            );
+    }
+
     private void stubValidAuthentication(
         User user
     ) {
@@ -676,7 +909,8 @@ class AuthenticateUserServiceTest {
     private static AuthenticateUserCommand command() {
         return new AuthenticateUserCommand(
             "nursena@example.com",
-            RAW_PASSWORD
+            RAW_PASSWORD,
+            "203.0.113.10"
         );
     }
 

--- a/src/test/java/com/nursena/payflow/user/integration/LoginRateLimitHttpIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/LoginRateLimitHttpIntegrationTest.java
@@ -1,0 +1,559 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request
+    .MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet
+    .AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request
+    .RequestPostProcessor;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.login-rate-limit.enabled=true",
+        "payflow.security.login-rate-limit.window=30s",
+        "payflow.security.login-rate-limit.identity-limit=2",
+        "payflow.security.login-rate-limit.client-limit=3",
+        "payflow.security.refresh-session.refresh-token-ttl=7d",
+        "payflow.security.refresh-session.family-ttl=30d"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+class LoginRateLimitHttpIntegrationTest {
+
+    private static final int REDIS_PORT = 6379;
+
+    private static final String LOGIN_PATH =
+        "/api/v1/auth/login";
+
+    private static final String REGISTER_PATH =
+        "/api/v1/auth/register";
+
+    private static final String PASSWORD =
+        "StrongPassword123!";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Container
+    private static final GenericContainer<?> REDIS =
+        new GenericContainer<>(
+            DockerImageName.parse(
+                "redis:8-alpine"
+            )
+        )
+            .withExposedPorts(REDIS_PORT);
+
+    @DynamicPropertySource
+    static void redisProperties(
+        DynamicPropertyRegistry registry
+    ) {
+        registry.add(
+            "spring.data.redis.host",
+            REDIS::getHost
+        );
+
+        registry.add(
+            "spring.data.redis.port",
+            () ->
+                REDIS.getMappedPort(
+                    REDIS_PORT
+                )
+        );
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @BeforeEach
+    void cleanState() {
+        redisTemplate.execute(
+            (RedisCallback<Void>) connection -> {
+                connection
+                    .serverCommands()
+                    .flushDb();
+
+                return null;
+            }
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldReturn429WithRedisRetryAfterForIdentityLimit()
+        throws Exception {
+
+        String email =
+            uniqueEmail(
+                "identity-limit"
+            );
+
+        String clientAddress =
+            "203.0.113.21";
+
+        performLogin(
+            email,
+            "WrongPassword123!",
+            clientAddress
+        )
+            .andExpect(
+                status().isUnauthorized()
+            );
+
+        performLogin(
+            email,
+            "WrongPassword123!",
+            clientAddress
+        )
+            .andExpect(
+                status().isUnauthorized()
+            );
+
+        MvcResult blocked =
+            performLogin(
+                email,
+                "WrongPassword123!",
+                clientAddress
+            )
+                .andExpect(
+                    status()
+                        .isTooManyRequests()
+                )
+                .andExpect(
+                    header().exists(
+                        "Retry-After"
+                    )
+                )
+                .andExpect(
+                    jsonPath("$.status")
+                        .value(429)
+                )
+                .andExpect(
+                    jsonPath("$.code")
+                        .value(
+                            "LOGIN_RATE_LIMIT_EXCEEDED"
+                        )
+                )
+                .andExpect(
+                    jsonPath("$.message")
+                        .value(
+                            "Too many login attempts. "
+                                + "Try again later."
+                        )
+                )
+                .andExpect(
+                    jsonPath("$.path")
+                        .value(LOGIN_PATH)
+                )
+                .andReturn();
+
+        String identityKey =
+            identityKey(email);
+
+        String clientKey =
+            clientKey(clientAddress);
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(identityKey)
+        )
+            .isEqualTo("3");
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(clientKey)
+        )
+            .isEqualTo("3");
+
+        assertRetryAfterMatchesRedisTtl(
+            blocked,
+            identityKey
+        );
+    }
+
+    @Test
+    void shouldEnforceClientLimitAcrossDistinctIdentities()
+        throws Exception {
+
+        String clientAddress =
+            "203.0.113.22";
+
+        for (
+            int attempt = 1;
+            attempt <= 3;
+            attempt++
+        ) {
+            performLogin(
+                uniqueEmail(
+                    "client-limit-" + attempt
+                ),
+                "WrongPassword123!",
+                clientAddress
+            )
+                .andExpect(
+                    status().isUnauthorized()
+                );
+        }
+
+        String blockedEmail =
+            uniqueEmail(
+                "client-limit-4"
+            );
+
+        MvcResult blocked =
+            performLogin(
+                blockedEmail,
+                "WrongPassword123!",
+                clientAddress
+            )
+                .andExpect(
+                    status()
+                        .isTooManyRequests()
+                )
+                .andExpect(
+                    header().exists(
+                        "Retry-After"
+                    )
+                )
+                .andExpect(
+                    jsonPath("$.code")
+                        .value(
+                            "LOGIN_RATE_LIMIT_EXCEEDED"
+                        )
+                )
+                .andReturn();
+
+        String clientKey =
+            clientKey(clientAddress);
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(clientKey)
+        )
+            .isEqualTo("4");
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(
+                    identityKey(
+                        blockedEmail
+                    )
+                )
+        )
+            .isEqualTo("1");
+
+        assertRetryAfterMatchesRedisTtl(
+            blocked,
+            clientKey
+        );
+    }
+
+    @Test
+    void shouldResetIdentityAfterSuccessfulLoginOnly()
+        throws Exception {
+
+        String email =
+            uniqueEmail(
+                "successful-reset"
+            );
+
+        String clientAddress =
+            "203.0.113.23";
+
+        registerUser(
+            email,
+            PASSWORD
+        );
+
+        performLogin(
+            email,
+            "WrongPassword123!",
+            clientAddress
+        )
+            .andExpect(
+                status().isUnauthorized()
+            );
+
+        String identityKey =
+            identityKey(email);
+
+        String clientKey =
+            clientKey(clientAddress);
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(identityKey)
+        )
+            .isEqualTo("1");
+
+        performLogin(
+            email,
+            PASSWORD,
+            clientAddress
+        )
+            .andExpect(
+                status().isOk()
+            )
+            .andExpect(
+                jsonPath("$.accessToken")
+                    .isNotEmpty()
+            )
+            .andExpect(
+                jsonPath("$.refreshToken")
+                    .isNotEmpty()
+            );
+
+        assertThat(
+            redisTemplate.hasKey(
+                identityKey
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            redisTemplate.opsForValue()
+                .get(clientKey)
+        )
+            .isEqualTo("2");
+
+        assertThat(
+            redisTemplate.getExpire(
+                clientKey,
+                TimeUnit.SECONDS
+            )
+        )
+            .isPositive();
+    }
+
+    private ResultActions performLogin(
+        String email,
+        String password,
+        String clientAddress
+    ) throws Exception {
+        return mockMvc.perform(
+            post(LOGIN_PATH)
+                .with(
+                    remoteAddress(
+                        clientAddress
+                    )
+                )
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    objectMapper
+                        .writeValueAsString(
+                            new LoginRequest(
+                                email,
+                                password
+                            )
+                        )
+                )
+        );
+    }
+
+    private void registerUser(
+        String email,
+        String password
+    ) throws Exception {
+        mockMvc.perform(
+                post(REGISTER_PATH)
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper
+                            .writeValueAsString(
+                                new RegistrationRequest(
+                                    email,
+                                    password
+                                )
+                            )
+                    )
+            )
+            .andExpect(
+                status().isCreated()
+            );
+    }
+
+    private void assertRetryAfterMatchesRedisTtl(
+        MvcResult result,
+        String key
+    ) {
+        long retryAfter =
+            Long.parseLong(
+                result
+                    .getResponse()
+                    .getHeader(
+                        "Retry-After"
+                    )
+            );
+
+        Long currentTtl =
+            redisTemplate.getExpire(
+                key,
+                TimeUnit.SECONDS
+            );
+
+        assertThat(retryAfter)
+            .isPositive()
+            .isLessThanOrEqualTo(30L);
+
+        assertThat(currentTtl)
+            .isPositive();
+
+        assertThat(retryAfter)
+            .isBetween(
+                currentTtl,
+                currentTtl + 2L
+            );
+    }
+
+    private static RequestPostProcessor
+    remoteAddress(
+        String address
+    ) {
+        return request -> {
+            request.setRemoteAddr(address);
+            return request;
+        };
+    }
+
+    private static String identityKey(
+        String email
+    ) {
+        return key(
+            "payflow:security:login:identity:",
+            email
+                .trim()
+                .toLowerCase(
+                    Locale.ROOT
+                )
+        );
+    }
+
+    private static String clientKey(
+        String clientAddress
+    ) {
+        return key(
+            "payflow:security:login:client:",
+            clientAddress
+                .trim()
+                .toLowerCase(
+                    Locale.ROOT
+                )
+        );
+    }
+
+    private static String key(
+        String prefix,
+        String value
+    ) {
+        try {
+            MessageDigest digest =
+                MessageDigest.getInstance(
+                    "SHA-256"
+                );
+
+            return prefix
+                + HexFormat.of()
+                    .formatHex(
+                        digest.digest(
+                            value.getBytes(
+                                StandardCharsets.UTF_8
+                            )
+                        )
+                    );
+        } catch (
+            NoSuchAlgorithmException exception
+        ) {
+            throw new IllegalStateException(
+                "SHA-256 is not available",
+                exception
+            );
+        }
+    }
+
+    private static String uniqueEmail(
+        String prefix
+    ) {
+        return prefix
+            + "-"
+            + UUID.randomUUID()
+            + "@example.com";
+    }
+
+    private record RegistrationRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record LoginRequest(
+        String email,
+        String password
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/LoginRateLimitUnavailableHttpIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/LoginRateLimitUnavailableHttpIntegrationTest.java
@@ -1,0 +1,94 @@
+package com.nursena.payflow.user.integration;
+
+import static org.springframework.test.web.servlet.request
+    .MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet
+    .AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+    properties = {
+        "payflow.security.login-rate-limit.enabled=true",
+        "payflow.security.login-rate-limit.window=30s",
+        "payflow.security.login-rate-limit.identity-limit=2",
+        "payflow.security.login-rate-limit.client-limit=3",
+        "spring.data.redis.host=127.0.0.1",
+        "spring.data.redis.port=1",
+        "spring.data.redis.connect-timeout=250ms",
+        "spring.data.redis.timeout=250ms"
+    }
+)
+@AutoConfigureMockMvc
+@Testcontainers
+class LoginRateLimitUnavailableHttpIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldFailClosedWith503WhenRedisIsUnavailable()
+        throws Exception {
+
+        mockMvc.perform(
+                post("/api/v1/auth/login")
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        """
+                        {
+                          "email": "redis-down@example.com",
+                          "password": "WrongPassword123!"
+                        }
+                        """
+                    )
+            )
+            .andExpect(
+                status().isServiceUnavailable()
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value(503)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "LOGIN_RATE_LIMIT_UNAVAILABLE"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "Login protection is "
+                            + "temporarily unavailable."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/auth/login"
+                    )
+            );
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+
+payflow.security.login-rate-limit.enabled=false


### PR DESCRIPTION
## Summary

Adds distributed Redis-backed protection to `POST /api/v1/auth/login` and completes the v0.9.0 authentication-security increment.

## Security design

- evaluates normalized identity and direct servlet peer dimensions
- hashes rate-limit key material before storing it in Redis
- updates identity and client counters atomically with Lua
- preserves fixed-window TTL instead of refreshing it per request
- returns generic authentication failures without account enumeration
- returns `429 LOGIN_RATE_LIMIT_EXCEEDED` with `Retry-After`
- fails closed with `503 LOGIN_RATE_LIMIT_UNAVAILABLE` when Redis cannot make a safe decision
- resets only the identity counter after successful authentication
- keeps metrics low-cardinality and logs credential-free

## Verification

- full Maven suite: **880 tests passed**
- real Redis identity and client threshold coverage
- fixed-window TTL and expiration coverage
- concurrent Lua atomicity coverage
- successful-login identity-reset coverage
- HTTP `429` and `Retry-After` coverage
- Redis outage HTTP `503` coverage
- OpenAPI, Postman, and roadmap contract coverage
- JaCoCo report generated for 289 classes

## Documentation

- root README updated
- dedicated Redis login-protection operations guide added
- separate credential-free Postman verification collection added
- v0.9.0 delivery roadmap aligned with the Maven project version

## Scope

- Changed files: 43
- Base: `main` at `dc2b02f9a62ffcfb443f35c8a5e5f000f4810d8b`
- Head: `feat/auth-login-rate-limiting` at `8730649905a8dc8f9c497c79bec59e0215a688a7`

## Commit history

```text
8730649 docs(project): align v0.9.0 delivery roadmap
9d26fda docs(auth): document Redis login rate limiting
ea7306a test(auth): add Redis login rate-limit acceptance coverage
c5d1fca feat(auth): integrate login rate limiting
51ba335 feat(auth): add Redis login rate-limit foundation
```

## Diff summary

```text
 README.md                                          |  35 +-
 docs/adr/0010-redis-login-rate-limiting.md         | 290 ++++++++++
 docs/login-rate-limiting.md                        | 189 ++++++
 docs/roadmap.md                                    | 241 ++++----
 pom.xml                                            |   5 +
 ...ayFlow.login-rate-limit.postman_collection.json | 401 +++++++++++++
 postman/README.md                                  |  32 +-
 .../payflow/configuration/OpenApiExamples.java     |  24 +
 .../adapter/in/web/AuthenticateUserController.java | 106 +++-
 .../in/web/UserAuthenticationExceptionHandler.java | 126 +++-
 .../out/ratelimit/LoginRateLimitConfiguration.java | 114 ++++
 .../out/ratelimit/LoginRateLimitKeyFactory.java    |  84 +++
 .../out/ratelimit/LoginRateLimitMetrics.java       | 120 ++++
 .../out/ratelimit/LoginRateLimitProperties.java    |  54 ++
 .../out/ratelimit/RedisLoginRateLimitAdapter.java  | 271 +++++++++
 .../exception/LoginRateLimitExceededException.java |  99 ++++
 .../LoginRateLimitUnavailableException.java        |  26 +
 .../port/in/AuthenticateUserCommand.java           |  26 +-
 .../port/out/LoginRateLimitDecision.java           |  65 +++
 .../port/out/LoginRateLimitDimension.java          |   8 +
 .../application/port/out/LoginRateLimitPort.java   |  14 +
 .../port/out/LoginRateLimitRequest.java            |  29 +
 .../service/AuthenticateUserService.java           | 166 ++++--
 src/main/resources/application.yml                 |   5 +
 ...oginRateLimitPostmanCollectionContractTest.java | 261 +++++++++
 .../configuration/PublicApiDocumentationTest.java  |   8 +-
 .../payflow/configuration/RoadmapContractTest.java | 102 ++++
 .../OpenApiJsonContractIntegrationTest.java        |  22 +-
 .../in/web/AuthenticateUserControllerTest.java     | 256 +++++++--
 .../ratelimit/LoginRateLimitConfigurationTest.java | 122 ++++
 .../ratelimit/LoginRateLimitKeyFactoryTest.java    |  80 +++
 .../out/ratelimit/LoginRateLimitMetricsTest.java   | 161 ++++++
 .../ratelimit/LoginRateLimitPropertiesTest.java    | 125 ++++
 .../RedisLoginRateLimitAdapterIntegrationTest.java | 637 +++++++++++++++++++++
 .../ratelimit/RedisLoginRateLimitAdapterTest.java  | 458 +++++++++++++++
 .../LoginRateLimitExceededExceptionTest.java       |  62 ++
 .../port/in/AuthenticateUserCommandTest.java       |  74 +++
 .../port/out/LoginRateLimitDecisionTest.java       |  83 +++
 .../port/out/LoginRateLimitRequestTest.java        |  64 +++
 .../service/AuthenticateUserServiceTest.java       | 244 +++++++-
 .../LoginRateLimitHttpIntegrationTest.java         | 559 ++++++++++++++++++
 ...ginRateLimitUnavailableHttpIntegrationTest.java |  94 +++
 src/test/resources/application.properties          |   2 +
 43 files changed, 5669 insertions(+), 275 deletions(-)
```

Closes #98