### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify-and-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Validate tag and release metadata
+        id: metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+          TAG="${GITHUB_REF_NAME}"
+          EXPECTED_TAG="v${VERSION}"
+          NOTES_FILE="docs/releases/${TAG}.md"
+
+          if [[ "${TAG}" != "${EXPECTED_TAG}" ]]; then
+            echo "Tag ${TAG} does not match Maven version ${VERSION}." >&2
+            exit 1
+          fi
+
+          if [[ ! -f "${NOTES_FILE}" ]]; then
+            echo "Release notes were not found: ${NOTES_FILE}" >&2
+            exit 1
+          fi
+
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "notes_file=${NOTES_FILE}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify
+        run: mvn -B -ntp clean verify
+
+      - name: Prepare release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ steps.metadata.outputs.version }}"
+          JAR_NAME="payflow-${VERSION}.jar"
+          JAR_PATH="target/${JAR_NAME}"
+          CHECKSUM_PATH="target/${JAR_NAME}.sha256"
+
+          if [[ ! -f "${JAR_PATH}" ]]; then
+            echo "Release JAR was not found: ${JAR_PATH}" >&2
+            exit 1
+          fi
+
+          (
+            cd target
+            sha256sum "${JAR_NAME}" > "${JAR_NAME}.sha256"
+          )
+
+          test -s "${CHECKSUM_PATH}"
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: payflow-${{ steps.metadata.outputs.version }}
+          path: |
+            target/payflow-${{ steps.metadata.outputs.version }}.jar
+            target/payflow-${{ steps.metadata.outputs.version }}.jar.sha256
+          if-no-files-found: error
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ steps.metadata.outputs.version }}"
+          JAR_PATH="target/payflow-${VERSION}.jar"
+          CHECKSUM_PATH="${JAR_PATH}.sha256"
+
+          gh release create "${GITHUB_REF_NAME}"             "${JAR_PATH}#PayFlow ${VERSION} executable JAR"             "${CHECKSUM_PATH}#SHA-256 checksum"             --repo "${GITHUB_REPOSITORY}"             --title "PayFlow ${GITHUB_REF_NAME}"             --notes-file "${{ steps.metadata.outputs.notes_file }}"             --verify-tag

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Completed capabilities include:
 - operator-only, paginated command-audit queries and chronological command timelines
 - Prometheus metrics, Grafana dashboards, and alert rules for Kafka consumer failures
 
-OpenAPI documentation and executable Postman workflows cover the implemented API. The v0.9.0 development line includes refresh-token issuance and rotation, current-session and all-session logout, and Redis-backed login protection with real PostgreSQL and Redis acceptance coverage. See the [roadmap](docs/roadmap.md).
+OpenAPI documentation and executable Postman workflows cover the implemented API. The v0.9.0 release candidate includes refresh-token issuance and rotation, current-session and all-session logout, and Redis-backed login protection with real PostgreSQL and Redis acceptance coverage. See the [v0.9.0 release notes](docs/releases/v0.9.0.md) and the [roadmap](docs/roadmap.md).
 
 ## Implemented API
 

--- a/docs/releases/v0.9.0.md
+++ b/docs/releases/v0.9.0.md
@@ -1,0 +1,98 @@
+# PayFlow v0.9.0
+
+PayFlow v0.9.0 completes the authentication-session security lifecycle and adds
+distributed Redis-backed protection to the public login endpoint.
+
+PayFlow remains an educational simulated digital-wallet backend. It does not
+process real money and is not certified for production financial use.
+
+## Highlights
+
+### Refresh-session security
+
+- access and opaque refresh credentials are issued together
+- refresh credentials are persisted only as SHA-256 digests
+- refresh-token rotation executes atomically
+- concurrent refresh attempts are serialized safely
+- confirmed token reuse revokes the complete refresh family
+- current-session logout is idempotent
+- authenticated all-session logout survives application restarts
+
+### Redis-backed login protection
+
+- normalized identity and direct servlet peer counters
+- fixed fifteen-minute windows with secure default thresholds
+- SHA-256-hashed Redis key material
+- atomic identity/client updates through a Lua script
+- fixed-window TTL that is not refreshed by later attempts
+- generic invalid-credential responses below the threshold
+- `429 LOGIN_RATE_LIMIT_EXCEEDED` with positive `Retry-After`
+- fail-closed `503 LOGIN_RATE_LIMIT_UNAVAILABLE`
+- successful-login reset of the identity counter only
+- bounded metric tags and credential-free security events
+
+### Verification
+
+- complete Maven verification suite: 880 tests
+- real PostgreSQL refresh-session integration coverage
+- real Redis threshold, expiration, and reset coverage
+- concurrent Redis Lua atomicity verification
+- HTTP `429`, `Retry-After`, and Redis-outage `503` coverage
+- OpenAPI, Postman, roadmap, migration, and persistence contracts
+- JaCoCo report generation across 289 classes
+- protected pull-request CI completed successfully in PR #99
+
+### Documentation and tooling
+
+- root README aligned with the v0.9.0 authentication contract
+- dedicated login-rate-limit operations guide
+- credential-free Postman identity-threshold workflow
+- v0.9.0 delivery roadmap and contract test
+- tag-triggered GitHub Release workflow
+- executable Spring Boot JAR and SHA-256 release assets
+
+## Configuration
+
+Login protection defaults:
+
+| Environment variable | Default |
+|---|---:|
+| `LOGIN_RATE_LIMIT_ENABLED` | `true` |
+| `LOGIN_RATE_LIMIT_WINDOW` | `15m` |
+| `LOGIN_RATE_LIMIT_IDENTITY_LIMIT` | `5` |
+| `LOGIN_RATE_LIMIT_CLIENT_LIMIT` | `20` |
+| `REDIS_HOST` | `localhost` |
+| `REDIS_PORT` | `6379` |
+
+Threshold and window changes are security-policy changes and should be reviewed
+accordingly.
+
+## Upgrade notes
+
+1. Back up the PostgreSQL database before applying migrations.
+2. Start PostgreSQL, Redis, and Kafka.
+3. Run the v0.9.0 executable JAR with the required JWT key configuration.
+4. Allow Flyway to apply pending refresh-session migrations.
+5. Verify Redis connectivity before enabling login traffic.
+6. Confirm reverse-proxy client-address trust boundaries before relying on the
+   client dimension as an end-user IP limit.
+
+No generalized API rate limit, OAuth provider, multi-factor authentication,
+password recovery, or unrestricted forwarded-header trust is introduced in this
+release.
+
+## Release assets
+
+- `payflow-0.9.0.jar`
+- `payflow-0.9.0.jar.sha256`
+
+Verify the artifact on PowerShell:
+
+```powershell
+(Get-FileHash .\payflow-0.9.0.jar -Algorithm SHA256).Hash
+Get-Content .\payflow-0.9.0.jar.sha256
+```
+
+## Full changelog
+
+`v0.8.0...v0.9.0`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,13 +2,13 @@
 
 ## Current delivery focus
 
-PayFlow v0.8.0 is the latest tagged baseline. The active development line uses
-`0.9.0-SNAPSHOT`.
+PayFlow v0.8.0 is the latest tagged baseline. The v0.9.0 release candidate uses
+the Maven version `0.9.0`.
 
-The v0.9.0 increment focuses on distributed Redis-backed login protection and
-release readiness for the completed refresh-session security lifecycle. PayFlow
-remains a modular monolith. PostgreSQL is the system of record; Redis is used
-only for bounded, explicitly expiring abuse-control state.
+The v0.9.0 increment delivers distributed Redis-backed login protection and
+completes the refresh-session security lifecycle. PayFlow remains a modular
+monolith. PostgreSQL is the system of record; Redis is used only for bounded,
+explicitly expiring abuse-control state.
 
 ## Delivered platform baseline
 
@@ -113,11 +113,12 @@ fail-closed behavior when Redis cannot make a safe decision.
 
 ### Increment 5 — Pull request and release readiness
 
-- [ ] Synchronize the feature branch with the latest `origin/main`
-- [ ] Open the pull request linked to issue #98
-- [ ] Pass protected-branch CI and review checks
-- [ ] Merge through the protected pull-request workflow
-- [ ] Publish v0.9.0 release notes
+- [x] Synchronize the feature branch with the latest `origin/main`
+- [x] Open the pull request linked to issue #98
+- [x] Pass protected-branch CI and review checks
+- [x] Merge through the protected pull-request workflow
+- [x] Prepare v0.9.0 release notes
+- [x] Add a tag-triggered release workflow
 - [ ] Publish the executable JAR and SHA-256 checksum
 - [ ] Tag the verified release commit as `v0.9.0`
 
@@ -149,9 +150,12 @@ The release is ready only when:
 - [x] plaintext refresh tokens and authentication credentials are excluded from persistence and logs
 - [x] OpenAPI and Postman contracts match the implementation
 - [x] all local automated tests pass
-- [ ] the pull request is approved and merged
-- [ ] protected-branch CI passes on the merge candidate
-- [ ] release notes, executable JAR, and SHA-256 checksum are published
+- [x] the feature pull request is merged
+- [x] protected-branch CI passes on the merge candidate
+- [x] release notes are prepared
+- [ ] the v0.9.0 tag is published
+- [ ] the executable JAR and SHA-256 checksum are published
+- [ ] the GitHub Release is published
 
 ## Future candidates
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.9.0</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 

--- a/src/test/java/com/nursena/payflow/configuration/ReleaseWorkflowContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/ReleaseWorkflowContractTest.java
@@ -1,0 +1,80 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class ReleaseWorkflowContractTest {
+
+    private static final Path WORKFLOW_PATH =
+        Path.of(
+            ".github",
+            "workflows",
+            "release.yml"
+        );
+
+    private static final Path RELEASE_NOTES_PATH =
+        Path.of(
+            "docs",
+            "releases",
+            "v0.9.0.md"
+        );
+
+    @Test
+    void shouldDefineVerifiedTagReleaseWorkflow()
+        throws IOException {
+
+        String workflow =
+            Files.readString(WORKFLOW_PATH);
+
+        assertThat(workflow)
+            .contains(
+                "name: Release",
+                "tags:",
+                "'v[0-9]+.[0-9]+.[0-9]+'",
+                "permissions:",
+                "contents: write",
+                "actions/checkout@v6",
+                "actions/setup-java@v5",
+                "mvn -B -ntp clean verify",
+                "sha256sum",
+                "actions/upload-artifact@v7",
+                "gh release create",
+                "--verify-tag",
+                "docs/releases/${TAG}.md"
+            )
+            .doesNotContain(
+                "pull_request_target",
+                "secrets.GITHUB_TOKEN",
+                "curl ",
+                "wget "
+            );
+    }
+
+    @Test
+    void shouldProvideVersionedReleaseNotesAndAssets()
+        throws IOException {
+
+        String releaseNotes =
+            Files.readString(RELEASE_NOTES_PATH);
+
+        assertThat(releaseNotes)
+            .contains(
+                "# PayFlow v0.9.0",
+                "Refresh-session security",
+                "Redis-backed login protection",
+                "880 tests",
+                "payflow-0.9.0.jar",
+                "payflow-0.9.0.jar.sha256",
+                "`v0.8.0...v0.9.0`"
+            )
+            .doesNotContain(
+                "0.9.0-SNAPSHOT",
+                "real money processing"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
@@ -22,7 +22,7 @@ class RoadmapContractTest {
         Path.of("docs", "roadmap.md");
 
     @Test
-    void shouldAlignRoadmapWithActiveMavenDevelopmentVersion()
+    void shouldAlignRoadmapWithReleaseVersion()
         throws Exception {
 
         String projectVersion =
@@ -32,21 +32,23 @@ class RoadmapContractTest {
             Files.readString(ROADMAP_PATH);
 
         assertThat(projectVersion)
-            .isEqualTo("0.9.0-SNAPSHOT");
+            .isEqualTo("0.9.0");
 
         assertThat(roadmap)
             .contains(
-                "`" + projectVersion + "`",
+                "Maven version `" + projectVersion + "`",
                 "## v0.9.0 — Redis-Backed Login Protection",
                 "- [x] Verify identity and client thresholds with real Redis",
                 "- [x] Verify HTTP `429` and `Retry-After`",
                 "- [x] Verify Redis outage produces fail-closed HTTP `503`",
-                "- [x] Add a dedicated, credential-free Postman verification collection",
-                "- [ ] Open the pull request linked to issue #98",
-                "- [ ] Tag the verified release commit as `v0.9.0`"
+                "- [x] Open the pull request linked to issue #98",
+                "- [x] Merge through the protected pull-request workflow",
+                "- [x] Prepare v0.9.0 release notes",
+                "- [ ] Tag the verified release commit as `v0.9.0`",
+                "- [ ] the GitHub Release is published"
             )
             .doesNotContain(
-                "active development line uses\n`0.7.0-SNAPSHOT`",
+                "0.9.0-SNAPSHOT",
                 "## v0.7.0 — Identity and Session Security"
             );
     }


### PR DESCRIPTION
## Summary

Prepares PayFlow v0.9.0 for a protected release-tag workflow.

## Changes

- sets the Maven project version to `0.9.0`
- adds versioned v0.9.0 release notes
- adds a tag-triggered GitHub Release workflow
- verifies the tag matches the Maven project version
- runs `mvn clean verify` before publishing
- generates `payflow-0.9.0.jar` and its SHA-256 checksum
- uploads workflow artifacts and GitHub Release assets
- aligns README and roadmap release status
- adds roadmap and release-workflow contract coverage

## Verification

- Tests run: 882, Failures: 0, Errors: 0, Skipped: 0
- executable JAR generated successfully
- local JAR SHA-256: `C141EDADC3189DB61061907CFD40DD53ED23B3235D481C56855F74FC7278FADF`
- `git diff --check` passed before and after verification

## Release boundary

This pull request does not create the `v0.9.0` tag and does not publish a GitHub Release. After merge and green protected-branch CI, the verified merge commit will be tagged separately.

## Scope

- Base: `main`
- Head: `chore/release-v0.9.0` at `4aa8b7642988e7af2d7fb83509bef95aa7091b5a`
- Changed paths: 7