### PR TITLE
chore(release): prepare v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Completed capabilities include:
 - operator-only, paginated command-audit queries and chronological command timelines
 - Prometheus metrics, Grafana dashboards, and alert rules for Kafka consumer failures
 
-OpenAPI documentation and executable Postman workflows cover the implemented API. PayFlow v0.9.0 is the latest published release. The v0.10.0 development line now implements spoofing-resistant effective client-address resolution behind explicitly trusted reverse proxies, including safe fallback behavior and bounded observability. See the [trusted client-context ADR](docs/adr/0011-trusted-client-context.md), the [v0.9.0 release notes](docs/releases/v0.9.0.md), and the [roadmap](docs/roadmap.md).
+OpenAPI documentation and executable Postman workflows cover the implemented API. PayFlow v0.9.0 is the latest published release. The v0.10.0 release candidate packages spoofing-resistant effective client-address resolution behind explicitly trusted reverse proxies, safe fallback behavior, bounded observability, and executable operational contracts. See the [v0.10.0 release notes](docs/releases/v0.10.0.md), the [trusted client-context ADR](docs/adr/0011-trusted-client-context.md), and the [roadmap](docs/roadmap.md).
 
 ## Implemented API
 

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -1,0 +1,125 @@
+# PayFlow v0.10.0
+
+PayFlow v0.10.0 adds a spoofing-resistant client-context boundary for
+deployments behind explicitly trusted reverse proxies.
+
+PayFlow remains an educational simulated digital-wallet backend. It does not
+process real money and is not certified for production financial use.
+
+## Highlights
+
+### Trusted reverse-proxy configuration
+
+- secure default with no trusted proxy networks
+- literal-only IPv4 and IPv6 parsing without DNS resolution
+- startup validation for trusted CIDRs
+- rejection of host-bit CIDRs, duplicates, trust-all `/0` ranges, and excessive
+  network counts
+- bounded forwarding-header length and proxy-hop configuration
+
+### Effective client-address resolution
+
+- direct network peer decides whether forwarding metadata may be trusted
+- `Forwarded` takes precedence over `X-Forwarded-For`
+- a malformed preferred `Forwarded` value never downgrades to
+  `X-Forwarded-For`
+- trusted chains are traversed from right to left
+- the first untrusted address becomes the effective client
+- IPv4, IPv6, and mixed-address chains are normalized deterministically
+- malformed, obfuscated, oversized, and excessive-hop input falls back safely
+  to the direct peer
+
+### Login-protection integration
+
+- normalized effective client replaces direct-peer coupling in the login
+  controller
+- existing identity and client counter semantics remain unchanged
+- spoofed forwarding values from untrusted peers do not affect Redis keys
+- trusted proxy requests are grouped by effective client
+- generic `401`, stable `429`, and fail-closed `503` contracts remain unchanged
+- Redis key material continues to use SHA-256 digests rather than raw addresses
+
+### Bounded observability
+
+- Micrometer counter `payflow.security.client_context.decisions`
+- bounded `source` and `outcome` dimensions
+- fixed matrix of 21 metric series
+- observer API accepts no client address, servlet request, or header value
+- raw client addresses and forwarding values are excluded from metric labels
+  and logs
+
+## Verification
+
+- trusted-proxy configuration and domain tests
+- forwarding parser and chain-resolution tests
+- IPv4, IPv6, mixed-chain, malformed-input, oversized-input, and excessive-hop
+  coverage
+- Redis HTTP acceptance tests for trusted effective-client grouping and
+  untrusted-header spoofing resistance
+- bounded metric cardinality and privacy tests
+- executable roadmap and documentation contracts
+- complete Maven verification at every committed feature checkpoint
+- protected pull-request CI completed successfully in PR #103
+
+The focused checkpoint suites overlap and should not be added together as a
+single project test count.
+
+## Documentation
+
+- ADR 0011 for the trusted client-context decision
+- deployment and login-protection operations guidance
+- reverse-proxy configuration example
+- architecture responsibility and trust-boundary documentation
+- trust-boundary architecture diagram
+- executable documentation contract tests
+
+## Configuration
+
+| Environment variable | Default | Purpose |
+|---|---:|---|
+| `TRUSTED_PROXY_CIDRS` | empty | Comma-separated direct-peer IPv4 or IPv6 CIDRs allowed to influence client identity |
+| `FORWARDED_HEADER_MAX_LENGTH` | `4096` | Maximum combined selected forwarding-header length |
+| `FORWARDED_MAX_HOPS` | `16` | Maximum accepted forwarding-chain elements |
+| `LOGIN_RATE_LIMIT_ENABLED` | `true` | Enables Redis-backed login protection |
+| `LOGIN_RATE_LIMIT_WINDOW` | `15m` | Fixed login-attempt window |
+| `LOGIN_RATE_LIMIT_IDENTITY_LIMIT` | `5` | Allowed attempts per normalized identity |
+| `LOGIN_RATE_LIMIT_CLIENT_LIMIT` | `20` | Allowed attempts per effective client |
+
+An empty trusted-proxy list is the secure default. Configure only the network
+peers that connect directly to PayFlow. Do not configure public client ranges,
+`0.0.0.0/0`, or `::/0`.
+
+## Upgrade notes
+
+1. Back up PostgreSQL before applying migrations.
+2. Start PostgreSQL, Redis, and Kafka.
+3. Review the reverse-proxy topology before setting `TRUSTED_PROXY_CIDRS`.
+4. Keep `TRUSTED_PROXY_CIDRS` empty when PayFlow is reached directly.
+5. Configure one supported forwarding representation consistently across the
+   controlled proxy chain.
+6. Deploy the v0.10.0 executable JAR with the existing JWT key configuration.
+7. Verify Redis connectivity and monitor client-context decision outcomes before
+   enabling login traffic.
+8. Confirm that raw addresses do not appear in application logs or metric
+   labels.
+
+No database migration, login request-body change, OpenAPI schema change,
+generalized API rate limit, unrestricted forwarded-header trust, GeoIP
+inference, device fingerprinting, OAuth provider, multi-factor authentication,
+or password recovery is introduced in this release.
+
+## Release assets
+
+- `payflow-0.10.0.jar`
+- `payflow-0.10.0.jar.sha256`
+
+Verify the artifact on PowerShell:
+
+```powershell
+(Get-FileHash .\payflow-0.10.0.jar -Algorithm SHA256).Hash
+Get-Content .\payflow-0.10.0.jar.sha256
+```
+
+## Full changelog
+
+`v0.9.0...v0.10.0`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,8 +2,8 @@
 
 ## Current delivery focus
 
-PayFlow v0.9.0 is the latest tagged release. The active development line uses
-`0.10.0-SNAPSHOT`.
+PayFlow v0.9.0 is the latest tagged release. The v0.10.0 release candidate uses
+the Maven version `0.10.0`.
 
 The v0.10.0 increment focuses on trusted client-address resolution behind
 explicitly configured reverse proxies. The goal is to make client-scoped
@@ -131,8 +131,13 @@ that identity by supplying forwarding headers.
 - [x] Update deployment and login-protection documentation
 - [x] Add reverse-proxy configuration examples
 - [x] Update architecture diagrams where the trust boundary is shown
-- [ ] Pass protected-branch CI and review checks
-- [ ] Publish v0.10.0 release notes and artifacts
+- [x] Pass protected-branch CI and review checks
+- [x] Prepare v0.10.0 release notes
+- [ ] Merge v0.10.0 release preparation through a protected pull request
+- [ ] Tag the verified release commit as `v0.10.0`
+- [ ] Publish `payflow-0.10.0.jar`
+- [ ] Publish and verify `payflow-0.10.0.jar.sha256`
+- [ ] Publish the GitHub Release
 
 ## Explicit v0.10.0 non-goals
 
@@ -163,8 +168,12 @@ The release is ready only when:
 - [x] focused unit, integration, and acceptance tests pass
 - [x] the complete Maven suite passes
 - [x] OpenAPI and operations documentation match the implementation
-- [ ] protected-branch CI passes
-- [ ] v0.10.0 release assets and checksum are published
+- [x] protected-branch CI passes for the feature merge
+- [x] v0.10.0 release notes are prepared
+- [ ] the release-preparation pull request is merged
+- [ ] the v0.10.0 tag is published
+- [ ] the executable JAR and SHA-256 checksum are published
+- [ ] the GitHub Release is published
 
 ## Future candidates
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.10.0-SNAPSHOT</version>
+    <version>0.10.0</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 

--- a/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
@@ -22,7 +22,7 @@ class RoadmapContractTest {
         Path.of("docs", "roadmap.md");
 
     @Test
-    void shouldAlignRoadmapWithNextDevelopmentVersion()
+    void shouldAlignRoadmapWithReleaseCandidateVersion()
         throws Exception {
 
         String projectVersion =
@@ -32,7 +32,7 @@ class RoadmapContractTest {
             Files.readString(ROADMAP_PATH);
 
         assertThat(projectVersion)
-            .isEqualTo("0.10.0-SNAPSHOT");
+            .isEqualTo("0.10.0");
 
         assertThat(roadmap)
             .contains(
@@ -80,13 +80,23 @@ class RoadmapContractTest {
                 "- [x] focused unit, integration, and acceptance tests pass",
                 "- [x] the complete Maven suite passes",
                 "- [x] OpenAPI and operations documentation match the implementation",
-                "- [ ] Pass protected-branch CI and review checks",
-                "- [ ] Publish v0.10.0 release notes and artifacts",
-                "- [ ] protected-branch CI passes",
-                "- [ ] v0.10.0 release assets and checksum are published"
+                "- [x] Pass protected-branch CI and review checks",
+                "- [x] Prepare v0.10.0 release notes",
+                "- [ ] Merge v0.10.0 release preparation through a protected pull request",
+                "- [ ] Tag the verified release commit as `v0.10.0`",
+                "- [ ] Publish `payflow-0.10.0.jar`",
+                "- [ ] Publish and verify `payflow-0.10.0.jar.sha256`",
+                "- [ ] Publish the GitHub Release",
+                "- [x] protected-branch CI passes for the feature merge",
+                "- [x] v0.10.0 release notes are prepared",
+                "- [ ] the release-preparation pull request is merged",
+                "- [ ] the v0.10.0 tag is published",
+                "- [ ] the executable JAR and SHA-256 checksum are published",
+                "- [ ] the GitHub Release is published"
             )
             .doesNotContain(
                 "0.9.0-SNAPSHOT",
+                "0.10.0-SNAPSHOT",
                 "The v0.9.0 release candidate",
                 "## v0.7.0 — Identity and Session Security"
             );

--- a/src/test/java/com/nursena/payflow/configuration/TrustedClientContextDocumentationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/TrustedClientContextDocumentationContractTest.java
@@ -175,7 +175,7 @@ class TrustedClientContextDocumentationContractTest {
     }
 
     @Test
-    void shouldKeepCiAndReleaseWorkOpen()
+    void shouldTrackReleasePreparationAndPublicationGates()
         throws IOException {
 
         String roadmap =
@@ -186,10 +186,19 @@ class TrustedClientContextDocumentationContractTest {
                 "- [x] Add an ADR for the proxy trust model",
                 "- [x] Run the complete Maven verification suite",
                 "- [x] OpenAPI and operations documentation match the implementation",
-                "- [ ] Pass protected-branch CI and review checks",
-                "- [ ] Publish v0.10.0 release notes and artifacts",
-                "- [ ] protected-branch CI passes",
-                "- [ ] v0.10.0 release assets and checksum are published"
+                "- [x] Pass protected-branch CI and review checks",
+                "- [x] Prepare v0.10.0 release notes",
+                "- [ ] Merge v0.10.0 release preparation through a protected pull request",
+                "- [ ] Tag the verified release commit as `v0.10.0`",
+                "- [ ] Publish `payflow-0.10.0.jar`",
+                "- [ ] Publish and verify `payflow-0.10.0.jar.sha256`",
+                "- [ ] Publish the GitHub Release",
+                "- [x] protected-branch CI passes for the feature merge",
+                "- [x] v0.10.0 release notes are prepared",
+                "- [ ] the release-preparation pull request is merged",
+                "- [ ] the v0.10.0 tag is published",
+                "- [ ] the executable JAR and SHA-256 checksum are published",
+                "- [ ] the GitHub Release is published"
             );
     }
 }

--- a/src/test/java/com/nursena/payflow/configuration/V010ReleasePreparationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V010ReleasePreparationContractTest.java
@@ -1,0 +1,213 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+class V010ReleasePreparationContractTest {
+
+    private static final Path POM_PATH =
+        Path.of("pom.xml");
+
+    private static final Path README_PATH =
+        Path.of("README.md");
+
+    private static final Path ROADMAP_PATH =
+        Path.of(
+            "docs",
+            "roadmap.md"
+        );
+
+    private static final Path RELEASE_NOTES_PATH =
+        Path.of(
+            "docs",
+            "releases",
+            "v0.10.0.md"
+        );
+
+    private static final Path WORKFLOW_DIRECTORY =
+        Path.of(
+            ".github",
+            "workflows"
+        );
+
+    @Test
+    void shouldUseReleaseCandidateVersion()
+        throws Exception {
+
+        assertThat(readProjectVersion())
+            .isEqualTo("0.10.0");
+
+        assertThat(
+            Files.readString(README_PATH)
+        )
+            .contains(
+                "v0.10.0 release candidate",
+                "docs/releases/v0.10.0.md"
+            );
+
+        assertThat(
+            Files.readString(ROADMAP_PATH)
+        )
+            .contains(
+                "The v0.10.0 release candidate uses",
+                "the Maven version `0.10.0`",
+                "- [x] Prepare v0.10.0 release notes"
+            )
+            .doesNotContain(
+                "0.10.0-SNAPSHOT"
+            );
+    }
+
+    @Test
+    void shouldDocumentReleaseScopeAndAssets()
+        throws IOException {
+
+        assertThat(
+            Files.readString(RELEASE_NOTES_PATH)
+        )
+            .contains(
+                "# PayFlow v0.10.0",
+                "## Highlights",
+                "### Effective client-address resolution",
+                "### Login-protection integration",
+                "### Bounded observability",
+                "## Upgrade notes",
+                "## Release assets",
+                "`payflow-0.10.0.jar`",
+                "`payflow-0.10.0.jar.sha256`",
+                "`v0.9.0...v0.10.0`"
+            );
+    }
+
+    @Test
+    void shouldKeepPublicationCriteriaOpen()
+        throws IOException {
+
+        assertThat(
+            Files.readString(ROADMAP_PATH)
+        )
+            .contains(
+                "- [ ] Merge v0.10.0 release preparation through a protected pull request",
+                "- [ ] Tag the verified release commit as `v0.10.0`",
+                "- [ ] Publish `payflow-0.10.0.jar`",
+                "- [ ] Publish and verify `payflow-0.10.0.jar.sha256`",
+                "- [ ] Publish the GitHub Release",
+                "- [ ] the release-preparation pull request is merged",
+                "- [ ] the v0.10.0 tag is published",
+                "- [ ] the executable JAR and SHA-256 checksum are published",
+                "- [ ] the GitHub Release is published"
+            );
+    }
+
+    @Test
+    void shouldHaveTagTriggeredReleaseWorkflow()
+        throws IOException {
+
+        List<String> workflows;
+
+        try (Stream<Path> paths =
+            Files.list(WORKFLOW_DIRECTORY)) {
+
+            workflows =
+                paths
+                    .filter(Files::isRegularFile)
+                    .map(
+                        V010ReleasePreparationContractTest
+                            ::readUnchecked
+                    )
+                    .toList();
+        }
+
+        assertThat(workflows)
+            .anySatisfy(
+                workflow ->
+                    assertThat(workflow)
+                        .contains(
+                            "name: Release",
+                            "tags:",
+                            "v[0-9]+.[0-9]+.[0-9]+",
+                            "contents: write",
+                            "mvn -B -ntp clean verify",
+                            "sha256sum",
+                            "actions/upload-artifact@v7",
+                            "gh release create",
+                            "--verify-tag"
+                        )
+            );
+    }
+
+    private static String readUnchecked(
+        Path path
+    ) {
+        try {
+            return Files.readString(path);
+        }
+        catch (IOException exception) {
+            throw new UncheckedIOException(
+                exception
+            );
+        }
+    }
+
+    private static String readProjectVersion()
+        throws Exception {
+
+        DocumentBuilderFactory factory =
+            DocumentBuilderFactory.newInstance();
+
+        factory.setFeature(
+            "http://apache.org/xml/features/disallow-doctype-decl",
+            true
+        );
+
+        try (InputStream input =
+            Files.newInputStream(POM_PATH)) {
+
+            Element project =
+                factory
+                    .newDocumentBuilder()
+                    .parse(input)
+                    .getDocumentElement();
+
+            NodeList children =
+                project.getChildNodes();
+
+            for (int index = 0;
+                index < children.getLength();
+                index++) {
+
+                Node child =
+                    children.item(index);
+
+                if (
+                    child.getNodeType()
+                        == Node.ELEMENT_NODE
+                        && "version".equals(
+                            child.getNodeName()
+                        )
+                ) {
+                    return child
+                        .getTextContent()
+                        .trim();
+                }
+            }
+        }
+
+        throw new IOException(
+            "Project version was not found in pom.xml"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- set the Maven project version to `0.10.0`
- add versioned v0.10.0 release notes and upgrade guidance
- align README and roadmap with the release-candidate lifecycle
- add executable release-preparation contracts
- update documentation contracts after the trusted client-context feature merge
- retain the existing tag-triggered GitHub Release workflow unchanged

## Verification

- full `mvn clean verify` passed
- 949 tests passed across 202 Surefire reports
- executable artifact produced: `payflow-0.10.0.jar`
- artifact size: 98,656,077 bytes
- local SHA-256 verification passed
- SHA-256: `38C58BBBC3D0FA0D66F0F34A1AF334D95943DEBD30689DAB78B20D68D759A94D`
- `git diff --check` passed
- release branch is clean and pushed

## Release workflow

- semantic-version tag trigger
- tag and Maven-version consistency validation
- complete Maven verification before publication
- executable JAR and SHA-256 generation
- GitHub Actions artifact upload
- GitHub Release publication with verified tag

## Publication gates

- [x] release candidate version is `0.10.0`
- [x] release notes are prepared
- [x] complete local verification passes
- [x] release branch is pushed
- [ ] protected-branch CI passes for this PR
- [ ] review approval is recorded when required
- [ ] this release-preparation PR is merged
- [ ] merge commit is tagged as `v0.10.0`
- [ ] tag-triggered release workflow succeeds
- [ ] JAR and SHA-256 are attached to the GitHub Release
- [ ] published checksum is verified

## Important

This PR does not create the `v0.10.0` tag or publish the GitHub Release. Publication begins only after this PR is merged and the verified merge commit is tagged.