### PR TITLE
chore(release): complete v0.10.0 housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Completed capabilities include:
 - operator-only, paginated command-audit queries and chronological command timelines
 - Prometheus metrics, Grafana dashboards, and alert rules for Kafka consumer failures
 
-OpenAPI documentation and executable Postman workflows cover the implemented API. PayFlow v0.9.0 is the latest published release. The v0.10.0 release candidate packages spoofing-resistant effective client-address resolution behind explicitly trusted reverse proxies, safe fallback behavior, bounded observability, and executable operational contracts. See the [v0.10.0 release notes](docs/releases/v0.10.0.md), the [trusted client-context ADR](docs/adr/0011-trusted-client-context.md), and the [roadmap](docs/roadmap.md).
+OpenAPI documentation and executable Postman workflows cover the implemented API. PayFlow v0.10.0 is the latest published release, including spoofing-resistant effective client-address resolution behind explicitly trusted reverse proxies, safe fallback behavior, bounded observability, and executable operational contracts. The v0.11.0 development line is open for the next explicitly scoped increment. See the [v0.10.0 release notes](docs/releases/v0.10.0.md), the [trusted client-context ADR](docs/adr/0011-trusted-client-context.md), and the [roadmap](docs/roadmap.md).
 
 ## Implemented API
 

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -120,6 +120,15 @@ Verify the artifact on PowerShell:
 Get-Content .\payflow-0.10.0.jar.sha256
 ```
 
+## Publication verification
+
+- release-preparation PR: `#104`
+- release merge commit: `9dad6bdf0b8d1e166ba6454a6d791561cc30b671`
+- annotated tag: `v0.10.0`
+- release workflow run: `30675532483`
+- executable JAR size: `98,655,970` bytes
+- verified SHA-256: `174D7F51D27F19B0A45B281869FF86BD9DC52F59B41B20B479827B92102D957B`
+
 ## Full changelog
 
 `v0.9.0...v0.10.0`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,13 +2,13 @@
 
 ## Current delivery focus
 
-PayFlow v0.9.0 is the latest tagged release. The v0.10.0 release candidate uses
-the Maven version `0.10.0`.
+PayFlow v0.10.0 is the latest tagged release. The active development line uses
+`0.11.0-SNAPSHOT`.
 
-The v0.10.0 increment focuses on trusted client-address resolution behind
-explicitly configured reverse proxies. The goal is to make client-scoped
-security controls deployment-aware without trusting attacker-supplied
-forwarding headers.
+The v0.10.0 trusted client-context increment is released and independently
+verified. The current focus is post-release stabilization and selection of the
+next v0.11.0 increment through a dedicated issue with explicit scope, threat
+model, acceptance criteria, and rollback boundaries.
 
 PayFlow remains a modular monolith. PostgreSQL is the system of record; Redis is
 used only for bounded, explicitly expiring abuse-control state.
@@ -78,7 +78,7 @@ used only for bounded, explicitly expiring abuse-control state.
 - [x] Publish and verify `payflow-0.9.0.jar.sha256`
 - [x] Publish the GitHub Release
 
-## v0.10.0 — Trusted Client Context
+## v0.10.0 — Released: Trusted Client Context
 
 ### Product outcome
 
@@ -133,11 +133,17 @@ that identity by supplying forwarding headers.
 - [x] Update architecture diagrams where the trust boundary is shown
 - [x] Pass protected-branch CI and review checks
 - [x] Prepare v0.10.0 release notes
-- [ ] Merge v0.10.0 release preparation through a protected pull request
-- [ ] Tag the verified release commit as `v0.10.0`
-- [ ] Publish `payflow-0.10.0.jar`
-- [ ] Publish and verify `payflow-0.10.0.jar.sha256`
-- [ ] Publish the GitHub Release
+- [x] Merge v0.10.0 release preparation through protected PR #104
+- [x] Tag merge commit `9dad6bdf0b8d1e166ba6454a6d791561cc30b671` as `v0.10.0`
+- [x] Publish `payflow-0.10.0.jar`
+- [x] Publish and verify `payflow-0.10.0.jar.sha256`
+- [x] Publish the GitHub Release
+
+### Publication record
+
+- release workflow run: `30675532483`
+- executable JAR size: `98,655,970` bytes
+- verified SHA-256: `174D7F51D27F19B0A45B281869FF86BD9DC52F59B41B20B479827B92102D957B`
 
 ## Explicit v0.10.0 non-goals
 
@@ -170,14 +176,14 @@ The release is ready only when:
 - [x] OpenAPI and operations documentation match the implementation
 - [x] protected-branch CI passes for the feature merge
 - [x] v0.10.0 release notes are prepared
-- [ ] the release-preparation pull request is merged
-- [ ] the v0.10.0 tag is published
-- [ ] the executable JAR and SHA-256 checksum are published
-- [ ] the GitHub Release is published
+- [x] the release-preparation pull request is merged
+- [x] the v0.10.0 tag is published
+- [x] the executable JAR and SHA-256 checksum are published
+- [x] the GitHub Release is published
 
 ## Future candidates
 
-Potential increments after v0.10.0 include:
+Potential v0.11.0 increments include:
 
 - structured JSON logging and request correlation
 - signing-key rotation and external key-management integration

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.10.0</version>
+    <version>0.11.0-SNAPSHOT</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 

--- a/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
@@ -22,7 +22,7 @@ class RoadmapContractTest {
         Path.of("docs", "roadmap.md");
 
     @Test
-    void shouldAlignRoadmapWithReleaseCandidateVersion()
+    void shouldAlignRoadmapWithPublishedReleaseAndNextDevelopmentVersion()
         throws Exception {
 
         String projectVersion =
@@ -32,14 +32,14 @@ class RoadmapContractTest {
             Files.readString(ROADMAP_PATH);
 
         assertThat(projectVersion)
-            .isEqualTo("0.10.0");
+            .isEqualTo("0.11.0-SNAPSHOT");
 
         assertThat(roadmap)
             .contains(
-                "PayFlow v0.9.0 is the latest tagged release",
+                "PayFlow v0.10.0 is the latest tagged release",
                 "`" + projectVersion + "`",
                 "## v0.9.0 — Released",
-                "## v0.10.0 — Trusted Client Context",
+                "## v0.10.0 — Released: Trusted Client Context",
                 "- [x] Open the v0.10.0 implementation issue",
                 "- [x] Define trusted-proxy CIDR configuration",
                 "- [x] Validate IPv4 and IPv6 network ranges at startup",
@@ -82,22 +82,25 @@ class RoadmapContractTest {
                 "- [x] OpenAPI and operations documentation match the implementation",
                 "- [x] Pass protected-branch CI and review checks",
                 "- [x] Prepare v0.10.0 release notes",
-                "- [ ] Merge v0.10.0 release preparation through a protected pull request",
-                "- [ ] Tag the verified release commit as `v0.10.0`",
-                "- [ ] Publish `payflow-0.10.0.jar`",
-                "- [ ] Publish and verify `payflow-0.10.0.jar.sha256`",
-                "- [ ] Publish the GitHub Release",
+                "- [x] Merge v0.10.0 release preparation through protected PR #104",
+                "- [x] Tag merge commit `9dad6bdf0b8d1e166ba6454a6d791561cc30b671` as `v0.10.0`",
+                "- [x] Publish `payflow-0.10.0.jar`",
+                "- [x] Publish and verify `payflow-0.10.0.jar.sha256`",
+                "- [x] Publish the GitHub Release",
                 "- [x] protected-branch CI passes for the feature merge",
                 "- [x] v0.10.0 release notes are prepared",
-                "- [ ] the release-preparation pull request is merged",
-                "- [ ] the v0.10.0 tag is published",
-                "- [ ] the executable JAR and SHA-256 checksum are published",
-                "- [ ] the GitHub Release is published"
+                "- [x] the release-preparation pull request is merged",
+                "- [x] the v0.10.0 tag is published",
+                "- [x] the executable JAR and SHA-256 checksum are published",
+                "- [x] the GitHub Release is published",
+                "release workflow run: `30675532483`",
+                "verified SHA-256: `174D7F51D27F19B0A45B281869FF86BD9DC52F59B41B20B479827B92102D957B`"
             )
             .doesNotContain(
                 "0.9.0-SNAPSHOT",
                 "0.10.0-SNAPSHOT",
                 "The v0.9.0 release candidate",
+                "The v0.10.0 release candidate",
                 "## v0.7.0 — Identity and Session Security"
             );
     }

--- a/src/test/java/com/nursena/payflow/configuration/TrustedClientContextDocumentationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/TrustedClientContextDocumentationContractTest.java
@@ -175,7 +175,7 @@ class TrustedClientContextDocumentationContractTest {
     }
 
     @Test
-    void shouldTrackReleasePreparationAndPublicationGates()
+    void shouldRecordCompletedTrustedClientReleaseGates()
         throws IOException {
 
         String roadmap =
@@ -188,17 +188,15 @@ class TrustedClientContextDocumentationContractTest {
                 "- [x] OpenAPI and operations documentation match the implementation",
                 "- [x] Pass protected-branch CI and review checks",
                 "- [x] Prepare v0.10.0 release notes",
-                "- [ ] Merge v0.10.0 release preparation through a protected pull request",
-                "- [ ] Tag the verified release commit as `v0.10.0`",
-                "- [ ] Publish `payflow-0.10.0.jar`",
-                "- [ ] Publish and verify `payflow-0.10.0.jar.sha256`",
-                "- [ ] Publish the GitHub Release",
-                "- [x] protected-branch CI passes for the feature merge",
-                "- [x] v0.10.0 release notes are prepared",
-                "- [ ] the release-preparation pull request is merged",
-                "- [ ] the v0.10.0 tag is published",
-                "- [ ] the executable JAR and SHA-256 checksum are published",
-                "- [ ] the GitHub Release is published"
+                "- [x] Merge v0.10.0 release preparation through protected PR #104",
+                "- [x] Tag merge commit `9dad6bdf0b8d1e166ba6454a6d791561cc30b671` as `v0.10.0`",
+                "- [x] Publish `payflow-0.10.0.jar`",
+                "- [x] Publish and verify `payflow-0.10.0.jar.sha256`",
+                "- [x] Publish the GitHub Release",
+                "- [x] the release-preparation pull request is merged",
+                "- [x] the v0.10.0 tag is published",
+                "- [x] the executable JAR and SHA-256 checksum are published",
+                "- [x] the GitHub Release is published"
             );
     }
 }

--- a/src/test/java/com/nursena/payflow/configuration/V010ReleasePreparationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V010ReleasePreparationContractTest.java
@@ -44,17 +44,18 @@ class V010ReleasePreparationContractTest {
         );
 
     @Test
-    void shouldUseReleaseCandidateVersion()
+    void shouldUseNextDevelopmentVersionAfterPublishedRelease()
         throws Exception {
 
         assertThat(readProjectVersion())
-            .isEqualTo("0.10.0");
+            .isEqualTo("0.11.0-SNAPSHOT");
 
         assertThat(
             Files.readString(README_PATH)
         )
             .contains(
-                "v0.10.0 release candidate",
+                "v0.10.0 is the latest published release",
+                "v0.11.0 development line",
                 "docs/releases/v0.10.0.md"
             );
 
@@ -62,12 +63,12 @@ class V010ReleasePreparationContractTest {
             Files.readString(ROADMAP_PATH)
         )
             .contains(
-                "The v0.10.0 release candidate uses",
-                "the Maven version `0.10.0`",
-                "- [x] Prepare v0.10.0 release notes"
+                "PayFlow v0.10.0 is the latest tagged release",
+                "`0.11.0-SNAPSHOT`",
+                "## v0.10.0 — Released: Trusted Client Context"
             )
             .doesNotContain(
-                "0.10.0-SNAPSHOT"
+                "The v0.10.0 release candidate uses"
             );
     }
 
@@ -93,22 +94,34 @@ class V010ReleasePreparationContractTest {
     }
 
     @Test
-    void shouldKeepPublicationCriteriaOpen()
+    void shouldRecordCompletedPublicationCriteria()
         throws IOException {
 
-        assertThat(
-            Files.readString(ROADMAP_PATH)
-        )
+        String roadmap =
+            Files.readString(ROADMAP_PATH);
+
+        String releaseNotes =
+            Files.readString(RELEASE_NOTES_PATH);
+
+        assertThat(roadmap)
             .contains(
-                "- [ ] Merge v0.10.0 release preparation through a protected pull request",
-                "- [ ] Tag the verified release commit as `v0.10.0`",
-                "- [ ] Publish `payflow-0.10.0.jar`",
-                "- [ ] Publish and verify `payflow-0.10.0.jar.sha256`",
-                "- [ ] Publish the GitHub Release",
-                "- [ ] the release-preparation pull request is merged",
-                "- [ ] the v0.10.0 tag is published",
-                "- [ ] the executable JAR and SHA-256 checksum are published",
-                "- [ ] the GitHub Release is published"
+                "- [x] Merge v0.10.0 release preparation through protected PR #104",
+                "- [x] Tag merge commit `9dad6bdf0b8d1e166ba6454a6d791561cc30b671` as `v0.10.0`",
+                "- [x] Publish `payflow-0.10.0.jar`",
+                "- [x] Publish and verify `payflow-0.10.0.jar.sha256`",
+                "- [x] Publish the GitHub Release",
+                "- [x] the release-preparation pull request is merged",
+                "- [x] the v0.10.0 tag is published",
+                "- [x] the executable JAR and SHA-256 checksum are published",
+                "- [x] the GitHub Release is published"
+            );
+
+        assertThat(releaseNotes)
+            .contains(
+                "## Publication verification",
+                "release-preparation PR: `#104`",
+                "release workflow run: `30675532483`",
+                "verified SHA-256: `174D7F51D27F19B0A45B281869FF86BD9DC52F59B41B20B479827B92102D957B`"
             );
     }
 


### PR DESCRIPTION
## Summary

- records v0.10.0 as the latest published release
- closes the v0.10.0 publication gates in the roadmap
- records PR #104, release merge commit, workflow run, artifact size, and verified SHA-256
- starts the next development line at `0.11.0-SNAPSHOT`
- updates executable documentation and release lifecycle contracts

## Verification

- `mvn clean verify`
- 949 tests passed
- 202 Surefire XML reports
- 0 failures
- 0 errors
- generated `payflow-0.11.0-SNAPSHOT.jar`
- artifact size: 98,656,105 bytes
- working tree clean

## Release provenance

- release tag: `v0.10.0`
- release merge commit: `9dad6bdf0b8d1e166ba6454a6d791561cc30b671`
- release workflow run: `30675532483`
- published artifact: `payflow-0.10.0.jar`
- verified SHA-256: `174D7F51D27F19B0A45B281869FF86BD9DC52F59B41B20B479827B92102D957B`

## Scope

Exactly seven files are changed:

- `README.md`
- `docs/releases/v0.10.0.md`
- `docs/roadmap.md`
- `pom.xml`
- `RoadmapContractTest.java`
- `TrustedClientContextDocumentationContractTest.java`
- `V010ReleasePreparationContractTest.java`

## Merge gate

- [x] local full verification passed
- [x] branch contains exactly one commit
- [x] branch is based on the v0.10.0 release merge commit
- [x] branch and remote HEAD match
- [x] working tree is clean
- [ ] protected-branch CI passes
- [ ] pull request is mergeable
- [ ] review requirements are satisfied