### PR TITLE
feat(observability): add structured logging and request correlation

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,0 +1,110 @@
+name: Docker Smoke
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docker-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      GRAFANA_ADMIN_PASSWORD: payflow-smoke-local-only
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate Docker Compose
+        run: docker compose config --quiet
+
+      - name: Start production-profile stack
+        shell: bash
+        run: |
+          cat > /tmp/payflow-smoke.override.yml <<'YAML'
+          services:
+            app:
+              environment:
+                SPRING_PROFILES_ACTIVE: production
+          YAML
+
+          docker compose \
+            -f compose.yml \
+            -f /tmp/payflow-smoke.override.yml \
+            --profile app \
+            up -d --build postgres redis kafka app
+
+      - name: Verify health, correlation, and JSON completion log
+        shell: bash
+        run: |
+          healthy=false
+
+          for attempt in $(seq 1 75); do
+            if curl \
+              --fail \
+              --silent \
+              --show-error \
+              --dump-header /tmp/payflow-headers.txt \
+              --output /tmp/payflow-health.json \
+              http://localhost:8080/api/v1/system/health; then
+              healthy=true
+              break
+            fi
+
+            sleep 2
+          done
+
+          test "$healthy" = "true"
+          test -s /tmp/payflow-health.json
+
+          correlation_id="$(
+            awk '
+              BEGIN { IGNORECASE = 1 }
+              /^X-Correlation-ID:/ {
+                sub(/\r$/, "", $2)
+                print $2
+              }
+            ' /tmp/payflow-headers.txt
+          )"
+
+          test -n "$correlation_id"
+          test "${#correlation_id}" -le 64
+
+          docker compose \
+            -f compose.yml \
+            -f /tmp/payflow-smoke.override.yml \
+            --profile app \
+            logs --no-color app \
+            > /tmp/payflow-app.log
+
+          grep -F '"event":"http.request.completed"' /tmp/payflow-app.log
+          grep -F "\"correlationId\":\"$correlation_id\"" /tmp/payflow-app.log
+          grep -F '"http.route":"/api/v1/system/health"' /tmp/payflow-app.log
+          grep -F '"outcome":"SUCCESS"' /tmp/payflow-app.log
+
+      - name: Print stack logs on failure
+        if: failure()
+        run: |
+          docker compose \
+            -f compose.yml \
+            -f /tmp/payflow-smoke.override.yml \
+            --profile app \
+            ps
+
+          docker compose \
+            -f compose.yml \
+            -f /tmp/payflow-smoke.override.yml \
+            --profile app \
+            logs --no-color
+
+      - name: Tear down
+        if: always()
+        run: |
+          docker compose \
+            -f compose.yml \
+            -f /tmp/payflow-smoke.override.yml \
+            --profile app \
+            down -v --remove-orphans

--- a/README.md
+++ b/README.md
@@ -106,8 +106,13 @@ Completed capabilities include:
 
 OpenAPI documentation and executable Postman workflows cover the implemented API. PayFlow v0.10.0 is the latest published release, including spoofing-resistant effective client-address resolution behind explicitly trusted reverse proxies, safe fallback behavior, bounded observability, and executable operational contracts. The v0.11.0 development line is open for the next explicitly scoped increment. See the [v0.10.0 release notes](docs/releases/v0.10.0.md), the [trusted client-context ADR](docs/adr/0011-trusted-client-context.md), and the [roadmap](docs/roadmap.md).
 
-## Implemented API
+## Structured logging
 
+PayFlow supports single-line JSON logs through the `structured-logging` and `production` Spring profiles. HTTP requests emit one bounded completion event containing the correlation ID, route template, method, status, duration, and outcome without logging bodies, query strings, authorization headers, cookies, raw URI paths, or financial/user data.
+
+See the [structured logging operations guide](docs/operations/structured-logging.md) for activation, field contracts, redaction boundaries, and verification commands.
+
+## Implemented API
 | Method | Endpoint | Authentication | Description |
 |---|---|---|---|
 | `POST` | `/api/v1/auth/register` | Public | Registers a new user and stores a BCrypt password hash. |

--- a/README.md
+++ b/README.md
@@ -112,8 +112,13 @@ PayFlow supports single-line JSON logs through the `structured-logging` and `pro
 
 See the [structured logging operations guide](docs/operations/structured-logging.md) for activation, field contracts, redaction boundaries, and verification commands.
 
-## Implemented API
-| Method | Endpoint | Authentication | Description |
+## v0.11.0 release candidate
+
+PayFlow v0.10.0 remains the latest published release. The v0.11.0 observability increment is submitted for protected pull-request review with trustworthy request correlation, structured JSON logs, bounded completion events, centralized redaction, OpenAPI/Postman contracts, and Docker smoke verification.
+
+See the [v0.11.0 release candidate notes](docs/releases/v0.11.0.md), the [structured logging operations guide](docs/operations/structured-logging.md), the [v0.10.0 release notes](docs/releases/v0.10.0.md), and the [roadmap](docs/roadmap.md).
+
+## Implemented API| Method | Endpoint | Authentication | Description |
 |---|---|---|---|
 | `POST` | `/api/v1/auth/register` | Public | Registers a new user and stores a BCrypt password hash. |
 | `POST` | `/api/v1/auth/login` | Public | Applies Redis-backed login protection and returns access and refresh credentials. |

--- a/docs/operations/structured-logging.md
+++ b/docs/operations/structured-logging.md
@@ -1,0 +1,106 @@
+# Structured logging operations guide
+
+PayFlow emits human-readable console logs by default and single-line JSON logs when either the `structured-logging` or `production` Spring profile is active.
+
+## Activation
+
+PowerShell:
+
+```powershell
+$env:SPRING_PROFILES_ACTIVE = "structured-logging"
+mvn spring-boot:run
+```
+
+Docker or another process manager:
+
+```text
+SPRING_PROFILES_ACTIVE=production
+```
+
+The JSON encoder writes one object per UNIX-delimited line. This makes the output safe for container log collectors and line-oriented ingestion pipelines.
+
+## Stable fields
+
+Every structured log can contain the common fields below:
+
+| Field | Meaning |
+|---|---|
+| `timestamp` | Encoder-generated event timestamp |
+| `service` | Spring application name |
+| `schemaVersion` | Structured-log contract version |
+| `level` | Log severity |
+| `logger` | Logger name |
+| `thread` | Request-processing thread |
+| `message` | Human-readable event message |
+| `correlationId` | Effective trusted request correlation identifier |
+| `exception` | Bounded exception representation when explicitly logged |
+
+A completed HTTP request emits exactly one `http.request.completed` event with these bounded fields:
+
+| Field | Meaning |
+|---|---|
+| `event` | Always `http.request.completed` |
+| `http.method` | Normalized HTTP method or `UNKNOWN` |
+| `http.route` | Spring MVC route template or `UNMATCHED` |
+| `http.status_code` | Effective response status |
+| `duration_ms` | Non-negative elapsed request time |
+| `outcome` | `SUCCESS`, `CLIENT_ERROR`, or `SERVER_ERROR` |
+
+`http.route` uses Spring MVC's best matching route pattern after request dispatch. It never falls back to the raw request URI. Requests without a resolved route use the fixed value `UNMATCHED`.
+
+## Security boundaries
+
+The completion event is deliberately smaller than the HTTP request.
+
+- Query strings are never logged.
+- Request and response bodies are never logged.
+- Authorization and cookie headers are never logged.
+- Raw URI paths and path-variable values are never logged.
+- User identifiers, email addresses, wallet identifiers, transfer identifiers, amounts, balances, and idempotency keys are not completion-event fields.
+- Unrecognized or unsafe methods use `UNKNOWN`.
+- Missing or unsafe route patterns use `UNMATCHED`.
+- Completion events do not include the handled application exception and therefore do not duplicate exception stack traces.
+
+The JSON encoder also masks known credential fields and bearer/JWT values with `[REDACTED]`.
+
+## Example
+
+```json
+{
+  "timestamp": "2026-08-02T01:30:00.000Z",
+  "service": "payflow",
+  "schemaVersion": 1,
+  "level": "INFO",
+  "logger": "com.nursena.payflow.observability.logging.Slf4jRequestCompletionLogger",
+  "thread": "http-nio-8080-exec-1",
+  "message": "HTTP request completed: method=POST, route=/api/v1/transfers, status=201, durationMs=24, outcome=SUCCESS.",
+  "correlationId": "request-123",
+  "event": "http.request.completed",
+  "http.method": "POST",
+  "http.route": "/api/v1/transfers",
+  "http.status_code": "201",
+  "duration_ms": "24",
+  "outcome": "SUCCESS"
+}
+```
+
+## Outcome rules
+
+- Statuses below `400` are `SUCCESS`.
+- Statuses from `400` through `499` are `CLIENT_ERROR`.
+- Statuses from `500` through `599` are `SERVER_ERROR`.
+- An exception that escapes the request chain is always `SERVER_ERROR`; its effective status is logged as `500` when the response has not already selected a server-error status.
+
+## Verification
+
+Run the focused observability contracts:
+
+```powershell
+mvn -B -ntp -Dtest=HttpRequestOutcomeTest,Slf4jRequestCompletionLoggerTest,RequestCompletionHttpIntegrationTest,RequestCorrelationFilterTest,RequestCorrelationHttpIntegrationTest,StructuredLoggingConfigurationContractTest,StructuredJsonEncodingTest test
+```
+
+Run the complete suite before merging:
+
+```powershell
+mvn -B -ntp clean test
+```

--- a/docs/operations/structured-logging.md
+++ b/docs/operations/structured-logging.md
@@ -91,8 +91,34 @@ The JSON encoder also masks known credential fields and bearer/JWT values with `
 - Statuses from `500` through `599` are `SERVER_ERROR`.
 - An exception that escapes the request chain is always `SERVER_ERROR`; its effective status is logged as `500` when the response has not already selected a server-error status.
 
-## Verification
+## Correlation API contract
 
+Every API response advertises `X-Correlation-ID` through the generated OpenAPI document. The header is required in the response contract, has a maximum length of 64 characters, and follows the same allowlisted character policy enforced at runtime.
+
+The standard Postman collection verifies the header after every request, checks the 64-character upper bound, and stores the effective value in the active environment as `correlationId`.
+
+## Synchronous and asynchronous boundaries
+
+The servlet MDC contract is intentionally synchronous. It starts when `RequestCorrelationFilter` accepts or generates the effective identifier and ends in that filter's `finally` block.
+
+Thread pools, scheduled jobs, transactional outbox publication, Kafka consumers, retries, and dead-letter processing do not inherit servlet MDC implicitly. PayFlow does not treat a request correlation ID as a business identifier, authentication credential, transaction identifier, idempotency key, or Kafka partition key.
+
+A future asynchronous propagation design must be an explicit event-schema decision with bounded validation, compatibility rules, consumer cleanup, and dedicated tests. Until that work is delivered, asynchronous processing uses its existing bounded event, transaction, command, and audit identifiers.
+
+## Exception and stack-trace policy
+
+Stack traces are emitted only when application code explicitly logs a throwable. The request-completion event never includes a throwable and therefore does not duplicate centralized exception logging.
+
+Both structured production logs and local plain logs use the same application logging calls. In structured profiles, exception output is bounded by the configured shortened throwable converter:
+
+- maximum depth per throwable: 30
+- maximum encoded exception length: 8192 characters
+- root cause first
+- shortened class names
+
+No profile enables request bodies, response bodies, query strings, credentials, cookies, authorization headers, raw financial payloads, or unbounded exception data.
+
+## Verification
 Run the focused observability contracts:
 
 ```powershell

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -1,0 +1,72 @@
+# PayFlow v0.11.0 release candidate notes
+
+PayFlow v0.11.0 introduces a bounded observability foundation for request diagnosis. These notes describe the feature branch submitted for protected pull-request review; v0.10.0 remains the latest published release until the separate release gate completes.
+
+## Added
+
+- Strict `X-Correlation-ID` validation with a maximum length of 64 characters and a constrained character allowlist.
+- Server-generated UUID identifiers when the inbound value is absent, duplicated, malformed, oversized, or newline-bearing.
+- Correlation IDs in response headers and centralized API error bodies.
+- Request-lifetime MDC setup and guaranteed cleanup.
+- Single-line JSON logging for the `structured-logging` and `production` profiles.
+- Stable structured fields for service, schema version, severity, logger, thread, message, correlation ID, and bounded exception output.
+- Exactly one `http.request.completed` event for each synchronous HTTP request.
+- Bounded request fields for method, Spring MVC route template, effective status, duration, and outcome.
+- Global OpenAPI response-header documentation for `X-Correlation-ID`.
+- Executable Postman verification of the effective response correlation header.
+- Docker smoke verification for production-profile JSON logs and response correlation.
+- Operations guidance for activation, field contracts, redaction, synchronous boundaries, asynchronous boundaries, and exception policy.
+
+## Security
+
+- Correlation identifiers cannot contain line breaks or uncontrolled characters.
+- Duplicate inbound correlation headers are rejected and replaced.
+- Access tokens, refresh tokens, passwords, authorization values, API keys, client secrets, private keys, bearer credentials, and JWT-like values are masked with `[REDACTED]`.
+- Structured and non-structured argument expansion is disabled.
+- Query strings, raw URI paths, path-variable values, request bodies, response bodies, cookies, user identifiers, wallet identifiers, transfer identifiers, balances, amounts, and idempotency keys are excluded from request-completion fields.
+- Unresolved routes use the fixed `UNMATCHED` value.
+- Unrecognized methods use the fixed `UNKNOWN` value.
+- Correlation IDs remain log context and are not introduced as high-cardinality metric labels.
+- Servlet MDC is not implicitly propagated into scheduled, outbox, Kafka, retry, or dead-letter execution.
+
+## Operational contract
+
+Production-oriented profiles write one JSON object per UNIX-delimited line. Request completion events contain:
+
+- `event`
+- `correlationId`
+- `http.method`
+- `http.route`
+- `http.status_code`
+- `duration_ms`
+- `outcome`
+
+Exception output is emitted only for explicit throwable logging and is bounded to a maximum encoded length of 8192 characters with a maximum depth of 30 frames per throwable.
+
+## Verification baseline
+
+The protected pull request requires:
+
+- focused observability acceptance tests
+- `mvn -B -ntp clean verify`
+- valid Docker Compose configuration
+- Docker image construction
+- application startup with PostgreSQL, Redis, and Kafka
+- public health-response verification
+- response `X-Correlation-ID` verification
+- production-profile JSON completion-event verification
+- clean repository and sensitive-data checks
+
+## Compatibility and boundaries
+
+- No database migration is included.
+- No public request or response payload is changed except the previously introduced `correlationId` field in centralized API errors.
+- The response correlation header is additive.
+- Existing authentication, wallet, transfer, outbox, Kafka, and operations authorization contracts remain unchanged.
+- Asynchronous request-correlation propagation is deliberately out of scope and must be introduced through a future versioned event contract.
+
+## Related work
+
+- Issue: [#107](https://github.com/nursena-pc/payflow/issues/107)
+- Operations guide: [`docs/operations/structured-logging.md`](../operations/structured-logging.md)
+- Previous release: [`v0.10.0`](v0.10.0.md)

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,8 @@
     <properties>
         <java.version>21</java.version>
         <springdoc.version>2.8.17</springdoc.version>
+
+        <logstash-logback-encoder.version>8.1</logstash-logback-encoder.version>
     </properties>
 
     <dependencies>
@@ -54,6 +56,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>${logstash-logback-encoder.version}</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/postman/PayFlow.postman_collection.json
+++ b/postman/PayFlow.postman_collection.json
@@ -1,1394 +1,1433 @@
 {
-  "info": {
-    "_postman_id": "9c519cd7-2f77-464b-a5b6-308f7167afb1",
-    "name": "PayFlow API",
-    "description": "Executable local workflow for the PayFlow simulated digital-wallet API, including manually gated Kafka dead-letter operations. No real money is processed.",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-  },
-  "event": [
-    {
-      "listen": "prerequest",
-      "script": {
-        "type": "text/javascript",
-        "exec": [
-          "if (!pm.environment.get('baseUrl')) pm.environment.set('baseUrl', 'http://localhost:8080');",
-          "if (!pm.environment.get('topUpAmount')) pm.environment.set('topUpAmount', '300.00');",
-          "if (!pm.environment.get('transferAmount')) pm.environment.set('transferAmount', '125.50');"
-        ]
-      }
-    }
-  ],
-  "item": [
-    {
-      "name": "System",
-      "item": [
-        {
-          "name": "Health Check",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "auth": {
-              "type": "noauth"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/system/health",
-              "host": [
-                "{{baseUrl}}"
+    "info":  {
+                 "_postman_id":  "9c519cd7-2f77-464b-a5b6-308f7167afb1",
+                 "name":  "PayFlow API",
+                 "description":  "Executable local workflow for the PayFlow simulated digital-wallet API, including manually gated Kafka dead-letter operations. No real money is processed.",
+                 "schema":  "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+             },
+    "event":  [
+                  {
+                      "listen":  "prerequest",
+                      "script":  {
+                                     "type":  "text/javascript",
+                                     "exec":  [
+                                                  "if (!pm.environment.get(\u0027baseUrl\u0027)) pm.environment.set(\u0027baseUrl\u0027, \u0027http://localhost:8080\u0027);",
+                                                  "if (!pm.environment.get(\u0027topUpAmount\u0027)) pm.environment.set(\u0027topUpAmount\u0027, \u0027300.00\u0027);",
+                                                  "if (!pm.environment.get(\u0027transferAmount\u0027)) pm.environment.set(\u0027transferAmount\u0027, \u0027125.50\u0027);"
+                                              ]
+                                 }
+                  },
+                  {
+                      "listen":  "test",
+                      "script":  {
+                                     "type":  "text/javascript",
+                                     "exec":  [
+                                                  "pm.test(\u0027Response contains a bounded X-Correlation-ID\u0027, function () {",
+                                                  "    const correlationId = pm.response.headers.get(\u0027X-Correlation-ID\u0027);",
+                                                  "    pm.expect(correlationId).to.be.a(\u0027string\u0027).and.not.empty;",
+                                                  "    pm.expect(correlationId.length).to.be.at.most(64);",
+                                                  "    pm.expect(correlationId).to.match(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/);",
+                                                  "});",
+                                                  "pm.environment.set(\u0027correlationId\u0027, pm.response.headers.get(\u0027X-Correlation-ID\u0027));"
+                                              ]
+                                 }
+                  }
               ],
-              "path": [
-                "api",
-                "v1",
-                "system",
-                "health"
-              ]
-            },
-            "description": "Returns the public PayFlow health response."
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});"
-                ]
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Authentication",
-      "item": [
-        {
-          "name": "Register Source User",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "auth": {
-              "type": "noauth"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/auth/register",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "auth",
-                "register"
-              ]
-            },
-            "description": "Registers a unique source user and saves sourceUserId.",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"email\": \"{{sourceEmail}}\",\n  \"password\": \"{{sourcePassword}}\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            }
-          },
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const suffix = `${Date.now()}-${Math.floor(Math.random() * 100000)}`;",
-                  "pm.environment.set('sourceEmail', `source-${suffix}@example.com`);"
-                ]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "const response = pm.response.json();",
-                  "pm.environment.set('sourceUserId', response.userId);"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Login Source User",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "auth": {
-              "type": "noauth"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/auth/login",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "auth",
-                "login"
-              ]
-            },
-            "description": "Authenticates the source user and saves its JWT.",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"email\": \"{{sourceEmail}}\",\n  \"password\": \"{{sourcePassword}}\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "const response = pm.response.json();",
-                  "pm.environment.set('sourceAccessToken', response.accessToken);",
-                  "pm.environment.set('accessToken', response.accessToken);"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Register Target User",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "auth": {
-              "type": "noauth"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/auth/register",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "auth",
-                "register"
-              ]
-            },
-            "description": "Registers a unique target user and saves targetUserId.",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"email\": \"{{targetEmail}}\",\n  \"password\": \"{{targetPassword}}\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            }
-          },
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const suffix = `${Date.now()}-${Math.floor(Math.random() * 100000)}`;",
-                  "pm.environment.set('targetEmail', `target-${suffix}@example.com`);"
-                ]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "const response = pm.response.json();",
-                  "pm.environment.set('targetUserId', response.userId);"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Login Target User",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "auth": {
-              "type": "noauth"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/auth/login",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "auth",
-                "login"
-              ]
-            },
-            "description": "Authenticates the target user and saves its JWT.",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"email\": \"{{targetEmail}}\",\n  \"password\": \"{{targetPassword}}\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "const response = pm.response.json();",
-                  "pm.environment.set('targetAccessToken', response.accessToken);"
-                ]
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Users",
-      "item": [
-        {
-          "name": "Get Source User Profile",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{sourceAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/users/me",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "users",
-                "me"
-              ]
-            },
-            "description": "Returns the authenticated source user's profile."
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});"
-                ]
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Wallets",
-      "item": [
-        {
-          "name": "Open Source Wallet",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{sourceAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/wallets",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "wallets"
-              ]
-            },
-            "description": "Creates the source wallet and saves sourceWalletId.",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"currency\": \"TRY\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "pm.environment.set('sourceWalletId', pm.response.json().id);"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Open Target Wallet",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{targetAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/wallets",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "wallets"
-              ]
-            },
-            "description": "Creates the target wallet and saves targetWalletId.",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"currency\": \"TRY\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "pm.environment.set('targetWalletId', pm.response.json().id);"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Top Up Source Wallet",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{sourceAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/wallets/me/top-ups",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "wallets",
-                "me",
-                "top-ups"
-              ]
-            },
-            "description": "Credits a simulated amount to the source wallet.",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"amount\": \"{{topUpAmount}}\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get Source Wallet",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{sourceAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/wallets/me",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "wallets",
-                "me"
-              ]
-            },
-            "description": "Returns the source user's wallet."
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "pm.environment.set('sourceWalletId', pm.response.json().id);"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get Target Wallet",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{targetAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/wallets/me",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "wallets",
-                "me"
-              ]
-            },
-            "description": "Returns the target user's wallet."
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "pm.environment.set('targetWalletId', pm.response.json().id);"
-                ]
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Transfers",
-      "item": [
-        {
-          "name": "Create Transfer",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Idempotency-Key",
-                "value": "{{idempotencyKey}}",
-                "type": "text"
-              },
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{sourceAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/transfers",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "transfers"
-              ]
-            },
-            "description": "Creates an idempotent source-to-target transfer with a fresh key.",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"targetWalletId\": \"{{targetWalletId}}\",\n  \"amount\": \"{{transferAmount}}\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            }
-          },
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.environment.set('idempotencyKey', `transfer-${Date.now()}-${Math.floor(Math.random() * 100000)}`);"
-                ]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "const response = pm.response.json();",
-                  "pm.expect(response.status).to.eql('COMPLETED');",
-                  "pm.environment.set('transactionId', response.transactionId);"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Replay Last Transfer",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Idempotency-Key",
-                "value": "{{idempotencyKey}}",
-                "type": "text"
-              },
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{sourceAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/transfers",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "transfers"
-              ]
-            },
-            "description": "Replays the last request with the same key and payload.",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"targetWalletId\": \"{{targetWalletId}}\",\n  \"amount\": \"{{transferAmount}}\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "pm.expect(pm.response.json().transactionId).to.eql(pm.environment.get('transactionId'));"
-                ]
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Transactions",
-      "item": [
-        {
-          "name": "Get Transaction History",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{sourceAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/transactions/me?page={{historyPage}}&size={{historySize}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "transactions",
-                "me"
-              ],
-              "query": [
-                {
-                  "key": "page",
-                  "value": "{{historyPage}}"
-                },
-                {
-                  "key": "size",
-                  "value": "{{historySize}}"
-                }
-              ]
-            },
-            "description": "Returns the default transaction-history page."
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "pm.expect(pm.response.json().items).to.be.an('array');"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get Filtered Outgoing Transactions",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{sourceAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/transactions/me?page={{historyPage}}&size={{historySize}}&direction=OUTGOING&status=COMPLETED&from={{historyFrom}}&to={{historyTo}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "transactions",
-                "me"
-              ],
-              "query": [
-                {
-                  "key": "page",
-                  "value": "{{historyPage}}"
-                },
-                {
-                  "key": "size",
-                  "value": "{{historySize}}"
-                },
-                {
-                  "key": "direction",
-                  "value": "OUTGOING"
-                },
-                {
-                  "key": "status",
-                  "value": "COMPLETED"
-                },
-                {
-                  "key": "from",
-                  "value": "{{historyFrom}}"
-                },
-                {
-                  "key": "to",
-                  "value": "{{historyTo}}"
-                }
-              ]
-            },
-            "description": "Uses direction, status, inclusive from, and exclusive to filters."
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "pm.response.json().items.forEach(function (entry) {",
-                  "    pm.expect(entry.direction).to.eql('OUTGOING');",
-                  "    pm.expect(entry.status).to.eql('COMPLETED');",
-                  "});"
-                ]
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Operations",
-      "description": "Manual operator-only Kafka dead-letter workflow and read-only command-audit investigation. Configure operatorAccessToken with a valid role=ADMIN JWT. Select record and command identifiers deliberately before running requests.",
-      "item": [
-        {
-          "name": "List Kafka Dead-Letter Records",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{operatorAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/operations/kafka/dead-letters?page=0&size=20",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "operations",
-                "kafka",
-                "dead-letters"
-              ],
-              "query": [
-                {
-                  "key": "page",
-                  "value": "0"
-                },
-                {
-                  "key": "size",
-                  "value": "20"
-                },
-                {
-                  "key": "status",
-                  "value": "REPLAY_FAILED",
-                  "description": "Optional status filter. Enable deliberately when needed.",
-                  "disabled": true
-                }
-              ]
-            },
-            "description": "Lists safe Kafka dead-letter operational metadata. The disabled status query can be enabled with RECEIVED, REPLAYING, REPLAYED, REPLAY_FAILED, or DISCARDED."
-          },
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const operatorAccessToken = String(pm.environment.get('operatorAccessToken') || '').trim();",
-                  "if (!operatorAccessToken) {",
-                  "    throw new Error('Set operatorAccessToken to a valid ADMIN JWT before running Operations requests.');",
-                  "}"
-                ]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "const response = pm.response.json();",
-                  "pm.expect(response.items).to.be.an('array');",
-                  "pm.expect(response.page).to.be.a('number');",
-                  "pm.expect(response.size).to.be.a('number');",
-                  "pm.expect(response.totalElements).to.be.a('number');"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get Kafka Dead-Letter Record",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{operatorAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/operations/kafka/dead-letters/{{deadLetterRecordId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "operations",
-                "kafka",
-                "dead-letters",
-                "{{deadLetterRecordId}}"
-              ]
-            },
-            "description": "Returns authorized operational details for the deliberately selected dead-letter record."
-          },
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const operatorAccessToken = String(pm.environment.get('operatorAccessToken') || '').trim();",
-                  "if (!operatorAccessToken) {",
-                  "    throw new Error('Set operatorAccessToken to a valid ADMIN JWT before running Operations requests.');",
-                  "}",
-                  "const deadLetterRecordId = String(pm.environment.get('deadLetterRecordId') || '').trim();",
-                  "const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;",
-                  "if (!uuidPattern.test(deadLetterRecordId)) {",
-                  "    throw new Error('Set deadLetterRecordId to a valid Kafka dead-letter UUID before running this request.');",
-                  "}"
-                ]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "const response = pm.response.json();",
-                  "const expectedId = String(pm.environment.get('deadLetterRecordId')).toLowerCase();",
-                  "pm.expect(String(response.id).toLowerCase()).to.eql(expectedId);",
-                  "pm.expect(response.status).to.be.a('string');",
-                  "pm.expect(response).to.not.have.property('payload');",
-                  "pm.expect(response).to.not.have.property('recordKey');"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Replay Kafka Dead-Letter Record",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{operatorAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/operations/kafka/dead-letters/{{deadLetterRecordId}}/replay",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "operations",
-                "kafka",
-                "dead-letters",
-                "{{deadLetterRecordId}}",
-                "replay"
-              ]
-            },
-            "description": "Replays the deliberately selected claimable record. This mutates lifecycle state and publishes to the original Kafka topic."
-          },
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const operatorAccessToken = String(pm.environment.get('operatorAccessToken') || '').trim();",
-                  "if (!operatorAccessToken) {",
-                  "    throw new Error('Set operatorAccessToken to a valid ADMIN JWT before running Operations requests.');",
-                  "}",
-                  "const deadLetterRecordId = String(pm.environment.get('deadLetterRecordId') || '').trim();",
-                  "const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;",
-                  "if (!uuidPattern.test(deadLetterRecordId)) {",
-                  "    throw new Error('Set deadLetterRecordId to a valid Kafka dead-letter UUID before running this request.');",
-                  "}"
-                ]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "const response = pm.response.json();",
-                  "const expectedId = String(pm.environment.get('deadLetterRecordId')).toLowerCase();",
-                  "pm.expect(String(response.recordId).toLowerCase()).to.eql(expectedId);",
-                  "pm.expect(response.status).to.eql('REPLAYED');"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Discard Kafka Dead-Letter Record",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{operatorAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/operations/kafka/dead-letters/{{deadLetterRecordId}}/discard",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "operations",
-                "kafka",
-                "dead-letters",
-                "{{deadLetterRecordId}}",
-                "discard"
-              ]
-            },
-            "description": "Idempotently discards the deliberately selected eligible record. This mutates lifecycle state and prevents later replay."
-          },
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const operatorAccessToken = String(pm.environment.get('operatorAccessToken') || '').trim();",
-                  "if (!operatorAccessToken) {",
-                  "    throw new Error('Set operatorAccessToken to a valid ADMIN JWT before running Operations requests.');",
-                  "}",
-                  "const deadLetterRecordId = String(pm.environment.get('deadLetterRecordId') || '').trim();",
-                  "const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;",
-                  "if (!uuidPattern.test(deadLetterRecordId)) {",
-                  "    throw new Error('Set deadLetterRecordId to a valid Kafka dead-letter UUID before running this request.');",
-                  "}"
-                ]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 204', function () { pm.response.to.have.status(204); });",
-                  "pm.test('Response body is empty', function () {",
-                  "    pm.expect(pm.response.text()).to.eql('');",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "List Kafka Dead-Letter Command Audits",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{operatorAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/operations/kafka/dead-letter-command-audits?page={{auditPage}}&size={{auditSize}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "operations",
-                "kafka",
-                "dead-letter-command-audits"
-              ],
-              "query": [
-                {
-                  "key": "page",
-                  "value": "{{auditPage}}"
-                },
-                {
-                  "key": "size",
-                  "value": "{{auditSize}}"
-                },
-                {
-                  "key": "commandId",
-                  "value": "{{auditCommandId}}",
-                  "description": "Optional command UUID filter. Enable deliberately when configured.",
-                  "disabled": true
-                },
-                {
-                  "key": "operatorId",
-                  "value": "{{auditOperatorId}}",
-                  "description": "Optional operator UUID filter. Enable deliberately when configured.",
-                  "disabled": true
-                },
-                {
-                  "key": "deadLetterRecordId",
-                  "value": "{{deadLetterRecordId}}",
-                  "description": "Optional dead-letter record UUID filter. Enable deliberately when configured.",
-                  "disabled": true
-                },
-                {
-                  "key": "commandType",
-                  "value": "REPLAY",
-                  "description": "Optional REPLAY or DISCARD filter.",
-                  "disabled": true
-                },
-                {
-                  "key": "stage",
-                  "value": "COMPLETED",
-                  "description": "Optional ATTEMPTED or COMPLETED filter.",
-                  "disabled": true
-                },
-                {
-                  "key": "outcome",
-                  "value": "REPLAYED",
-                  "description": "Optional allowlisted command outcome filter.",
-                  "disabled": true
-                }
-              ]
-            },
-            "description": "Lists safe command-audit entries in occurredAt DESC, id DESC order. Optional filters are disabled by default and must be enabled deliberately."
-          },
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const operatorAccessToken = String(pm.environment.get('operatorAccessToken') || '').trim();",
-                  "if (!operatorAccessToken) {",
-                  "    throw new Error('Set operatorAccessToken to a valid ADMIN JWT before running Operations requests.');",
-                  "}",
-                  "const auditPage = Number(pm.environment.get('auditPage'));",
-                  "const auditSize = Number(pm.environment.get('auditSize'));",
-                  "if (!Number.isInteger(auditPage) || auditPage < 0) {",
-                  "    throw new Error('Set auditPage to a zero-based non-negative integer.');",
-                  "}",
-                  "if (!Number.isInteger(auditSize) || auditSize < 1 || auditSize > 100) {",
-                  "    throw new Error('Set auditSize to an integer between 1 and 100.');",
-                  "}"
-                ]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "const response = pm.response.json();",
-                  "pm.expect(response.items).to.be.an('array');",
-                  "pm.expect(response.page).to.be.a('number');",
-                  "pm.expect(response.size).to.be.a('number');",
-                  "pm.expect(response.totalElements).to.be.a('number');",
-                  "function assertSafeAuditEntry(entry) {",
-                  "    pm.expect(entry).to.not.have.property('payload');",
-                  "    pm.expect(entry).to.not.have.property('recordKey');",
-                  "    pm.expect(entry).to.not.have.property('operatorEmail');",
-                  "    pm.expect(entry).to.not.have.property('exceptionMessage');",
-                  "    pm.expect(entry).to.not.have.property('stackTrace');",
-                  "    pm.expect(entry).to.not.have.property('replayLeaseOwner');",
-                  "}",
-                  "response.items.forEach(assertSafeAuditEntry);"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get Kafka Dead-Letter Command Audit Timeline",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{operatorAccessToken}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/operations/kafka/dead-letter-command-audits/{{auditCommandId}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "operations",
-                "kafka",
-                "dead-letter-command-audits",
-                "{{auditCommandId}}"
-              ]
-            },
-            "description": "Returns the chronological ATTEMPTED and optional COMPLETED entries for the deliberately selected command UUID."
-          },
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const operatorAccessToken = String(pm.environment.get('operatorAccessToken') || '').trim();",
-                  "if (!operatorAccessToken) {",
-                  "    throw new Error('Set operatorAccessToken to a valid ADMIN JWT before running Operations requests.');",
-                  "}",
-                  "const auditCommandId = String(pm.environment.get('auditCommandId') || '').trim();",
-                  "const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;",
-                  "if (!uuidPattern.test(auditCommandId)) {",
-                  "    throw new Error('Set auditCommandId to a valid operator command UUID before running this request.');",
-                  "}"
-                ]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Response is JSON', function () {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json');",
-                  "});",
-                  "const response = pm.response.json();",
-                  "const expectedCommandId = String(pm.environment.get('auditCommandId')).toLowerCase();",
-                  "pm.expect(String(response.commandId).toLowerCase()).to.eql(expectedCommandId);",
-                  "pm.expect(response.complete).to.be.a('boolean');",
-                  "pm.expect(response.entries).to.be.an('array').that.is.not.empty;",
-                  "function assertSafeAuditEntry(entry) {",
-                  "    pm.expect(entry).to.not.have.property('payload');",
-                  "    pm.expect(entry).to.not.have.property('recordKey');",
-                  "    pm.expect(entry).to.not.have.property('operatorEmail');",
-                  "    pm.expect(entry).to.not.have.property('exceptionMessage');",
-                  "    pm.expect(entry).to.not.have.property('stackTrace');",
-                  "    pm.expect(entry).to.not.have.property('replayLeaseOwner');",
-                  "}",
-                  "response.entries.forEach(assertSafeAuditEntry);"
-                ]
-              }
-            }
-          ]
-        }
-      ]
-    }
-  ]
+    "item":  [
+                 {
+                     "name":  "System",
+                     "item":  [
+                                  {
+                                      "name":  "Health Check",
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "noauth"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/system/health",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "system",
+                                                                               "health"
+                                                                           ]
+                                                              },
+                                                      "description":  "Returns the public PayFlow health response."
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "Authentication",
+                     "item":  [
+                                  {
+                                      "name":  "Register Source User",
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json",
+                                                                         "type":  "text"
+                                                                     }
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "noauth"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/auth/register",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "auth",
+                                                                               "register"
+                                                                           ]
+                                                              },
+                                                      "description":  "Registers a unique source user and saves sourceUserId.",
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{\n  \"email\": \"{{sourceEmail}}\",\n  \"password\": \"{{sourcePassword}}\"\n}",
+                                                                   "options":  {
+                                                                                   "raw":  {
+                                                                                               "language":  "json"
+                                                                                           }
+                                                                               }
+                                                               }
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "const suffix = `${Date.now()}-${Math.floor(Math.random() * 100000)}`;",
+                                                                                    "pm.environment.set(\u0027sourceEmail\u0027, `source-${suffix}@example.com`);"
+                                                                                ]
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 201\u0027, function () { pm.response.to.have.status(201); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "const response = pm.response.json();",
+                                                                                    "pm.environment.set(\u0027sourceUserId\u0027, response.userId);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Login Source User",
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json",
+                                                                         "type":  "text"
+                                                                     }
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "noauth"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/auth/login",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "auth",
+                                                                               "login"
+                                                                           ]
+                                                              },
+                                                      "description":  "Authenticates the source user and saves its JWT.",
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{\n  \"email\": \"{{sourceEmail}}\",\n  \"password\": \"{{sourcePassword}}\"\n}",
+                                                                   "options":  {
+                                                                                   "raw":  {
+                                                                                               "language":  "json"
+                                                                                           }
+                                                                               }
+                                                               }
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "const response = pm.response.json();",
+                                                                                    "pm.environment.set(\u0027sourceAccessToken\u0027, response.accessToken);",
+                                                                                    "pm.environment.set(\u0027accessToken\u0027, response.accessToken);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Register Target User",
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json",
+                                                                         "type":  "text"
+                                                                     }
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "noauth"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/auth/register",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "auth",
+                                                                               "register"
+                                                                           ]
+                                                              },
+                                                      "description":  "Registers a unique target user and saves targetUserId.",
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{\n  \"email\": \"{{targetEmail}}\",\n  \"password\": \"{{targetPassword}}\"\n}",
+                                                                   "options":  {
+                                                                                   "raw":  {
+                                                                                               "language":  "json"
+                                                                                           }
+                                                                               }
+                                                               }
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "const suffix = `${Date.now()}-${Math.floor(Math.random() * 100000)}`;",
+                                                                                    "pm.environment.set(\u0027targetEmail\u0027, `target-${suffix}@example.com`);"
+                                                                                ]
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 201\u0027, function () { pm.response.to.have.status(201); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "const response = pm.response.json();",
+                                                                                    "pm.environment.set(\u0027targetUserId\u0027, response.userId);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Login Target User",
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json",
+                                                                         "type":  "text"
+                                                                     }
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "noauth"
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/auth/login",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "auth",
+                                                                               "login"
+                                                                           ]
+                                                              },
+                                                      "description":  "Authenticates the target user and saves its JWT.",
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{\n  \"email\": \"{{targetEmail}}\",\n  \"password\": \"{{targetPassword}}\"\n}",
+                                                                   "options":  {
+                                                                                   "raw":  {
+                                                                                               "language":  "json"
+                                                                                           }
+                                                                               }
+                                                               }
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "const response = pm.response.json();",
+                                                                                    "pm.environment.set(\u0027targetAccessToken\u0027, response.accessToken);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "Users",
+                     "item":  [
+                                  {
+                                      "name":  "Get Source User Profile",
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{sourceAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/users/me",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "users",
+                                                                               "me"
+                                                                           ]
+                                                              },
+                                                      "description":  "Returns the authenticated source user\u0027s profile."
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "Wallets",
+                     "item":  [
+                                  {
+                                      "name":  "Open Source Wallet",
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json",
+                                                                         "type":  "text"
+                                                                     }
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{sourceAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/wallets",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "wallets"
+                                                                           ]
+                                                              },
+                                                      "description":  "Creates the source wallet and saves sourceWalletId.",
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{\n  \"currency\": \"TRY\"\n}",
+                                                                   "options":  {
+                                                                                   "raw":  {
+                                                                                               "language":  "json"
+                                                                                           }
+                                                                               }
+                                                               }
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 201\u0027, function () { pm.response.to.have.status(201); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "pm.environment.set(\u0027sourceWalletId\u0027, pm.response.json().id);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Open Target Wallet",
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json",
+                                                                         "type":  "text"
+                                                                     }
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{targetAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/wallets",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "wallets"
+                                                                           ]
+                                                              },
+                                                      "description":  "Creates the target wallet and saves targetWalletId.",
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{\n  \"currency\": \"TRY\"\n}",
+                                                                   "options":  {
+                                                                                   "raw":  {
+                                                                                               "language":  "json"
+                                                                                           }
+                                                                               }
+                                                               }
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 201\u0027, function () { pm.response.to.have.status(201); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "pm.environment.set(\u0027targetWalletId\u0027, pm.response.json().id);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Top Up Source Wallet",
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json",
+                                                                         "type":  "text"
+                                                                     }
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{sourceAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/wallets/me/top-ups",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "wallets",
+                                                                               "me",
+                                                                               "top-ups"
+                                                                           ]
+                                                              },
+                                                      "description":  "Credits a simulated amount to the source wallet.",
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{\n  \"amount\": \"{{topUpAmount}}\"\n}",
+                                                                   "options":  {
+                                                                                   "raw":  {
+                                                                                               "language":  "json"
+                                                                                           }
+                                                                               }
+                                                               }
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Get Source Wallet",
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{sourceAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/wallets/me",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "wallets",
+                                                                               "me"
+                                                                           ]
+                                                              },
+                                                      "description":  "Returns the source user\u0027s wallet."
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "pm.environment.set(\u0027sourceWalletId\u0027, pm.response.json().id);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Get Target Wallet",
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{targetAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/wallets/me",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "wallets",
+                                                                               "me"
+                                                                           ]
+                                                              },
+                                                      "description":  "Returns the target user\u0027s wallet."
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "pm.environment.set(\u0027targetWalletId\u0027, pm.response.json().id);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "Transfers",
+                     "item":  [
+                                  {
+                                      "name":  "Create Transfer",
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Idempotency-Key",
+                                                                         "value":  "{{idempotencyKey}}",
+                                                                         "type":  "text"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json",
+                                                                         "type":  "text"
+                                                                     }
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{sourceAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/transfers",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "transfers"
+                                                                           ]
+                                                              },
+                                                      "description":  "Creates an idempotent source-to-target transfer with a fresh key.",
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{\n  \"targetWalletId\": \"{{targetWalletId}}\",\n  \"amount\": \"{{transferAmount}}\"\n}",
+                                                                   "options":  {
+                                                                                   "raw":  {
+                                                                                               "language":  "json"
+                                                                                           }
+                                                                               }
+                                                               }
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.environment.set(\u0027idempotencyKey\u0027, `transfer-${Date.now()}-${Math.floor(Math.random() * 100000)}`);"
+                                                                                ]
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 201\u0027, function () { pm.response.to.have.status(201); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "const response = pm.response.json();",
+                                                                                    "pm.expect(response.status).to.eql(\u0027COMPLETED\u0027);",
+                                                                                    "pm.environment.set(\u0027transactionId\u0027, response.transactionId);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Replay Last Transfer",
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+                                                                     {
+                                                                         "key":  "Idempotency-Key",
+                                                                         "value":  "{{idempotencyKey}}",
+                                                                         "type":  "text"
+                                                                     },
+                                                                     {
+                                                                         "key":  "Content-Type",
+                                                                         "value":  "application/json",
+                                                                         "type":  "text"
+                                                                     }
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{sourceAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/transfers",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "transfers"
+                                                                           ]
+                                                              },
+                                                      "description":  "Replays the last request with the same key and payload.",
+                                                      "body":  {
+                                                                   "mode":  "raw",
+                                                                   "raw":  "{\n  \"targetWalletId\": \"{{targetWalletId}}\",\n  \"amount\": \"{{transferAmount}}\"\n}",
+                                                                   "options":  {
+                                                                                   "raw":  {
+                                                                                               "language":  "json"
+                                                                                           }
+                                                                               }
+                                                               }
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 201\u0027, function () { pm.response.to.have.status(201); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "pm.expect(pm.response.json().transactionId).to.eql(pm.environment.get(\u0027transactionId\u0027));"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "Transactions",
+                     "item":  [
+                                  {
+                                      "name":  "Get Transaction History",
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{sourceAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/transactions/me?page={{historyPage}}\u0026size={{historySize}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "transactions",
+                                                                               "me"
+                                                                           ],
+                                                                  "query":  [
+                                                                                {
+                                                                                    "key":  "page",
+                                                                                    "value":  "{{historyPage}}"
+                                                                                },
+                                                                                {
+                                                                                    "key":  "size",
+                                                                                    "value":  "{{historySize}}"
+                                                                                }
+                                                                            ]
+                                                              },
+                                                      "description":  "Returns the default transaction-history page."
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "pm.expect(pm.response.json().items).to.be.an(\u0027array\u0027);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Get Filtered Outgoing Transactions",
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{sourceAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/transactions/me?page={{historyPage}}\u0026size={{historySize}}\u0026direction=OUTGOING\u0026status=COMPLETED\u0026from={{historyFrom}}\u0026to={{historyTo}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "transactions",
+                                                                               "me"
+                                                                           ],
+                                                                  "query":  [
+                                                                                {
+                                                                                    "key":  "page",
+                                                                                    "value":  "{{historyPage}}"
+                                                                                },
+                                                                                {
+                                                                                    "key":  "size",
+                                                                                    "value":  "{{historySize}}"
+                                                                                },
+                                                                                {
+                                                                                    "key":  "direction",
+                                                                                    "value":  "OUTGOING"
+                                                                                },
+                                                                                {
+                                                                                    "key":  "status",
+                                                                                    "value":  "COMPLETED"
+                                                                                },
+                                                                                {
+                                                                                    "key":  "from",
+                                                                                    "value":  "{{historyFrom}}"
+                                                                                },
+                                                                                {
+                                                                                    "key":  "to",
+                                                                                    "value":  "{{historyTo}}"
+                                                                                }
+                                                                            ]
+                                                              },
+                                                      "description":  "Uses direction, status, inclusive from, and exclusive to filters."
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "pm.response.json().items.forEach(function (entry) {",
+                                                                                    "    pm.expect(entry.direction).to.eql(\u0027OUTGOING\u0027);",
+                                                                                    "    pm.expect(entry.status).to.eql(\u0027COMPLETED\u0027);",
+                                                                                    "});"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  }
+                              ]
+                 },
+                 {
+                     "name":  "Operations",
+                     "description":  "Manual operator-only Kafka dead-letter workflow and read-only command-audit investigation. Configure operatorAccessToken with a valid role=ADMIN JWT. Select record and command identifiers deliberately before running requests.",
+                     "item":  [
+                                  {
+                                      "name":  "List Kafka Dead-Letter Records",
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{operatorAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/operations/kafka/dead-letters?page=0\u0026size=20",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "operations",
+                                                                               "kafka",
+                                                                               "dead-letters"
+                                                                           ],
+                                                                  "query":  [
+                                                                                {
+                                                                                    "key":  "page",
+                                                                                    "value":  "0"
+                                                                                },
+                                                                                {
+                                                                                    "key":  "size",
+                                                                                    "value":  "20"
+                                                                                },
+                                                                                {
+                                                                                    "key":  "status",
+                                                                                    "value":  "REPLAY_FAILED",
+                                                                                    "description":  "Optional status filter. Enable deliberately when needed.",
+                                                                                    "disabled":  true
+                                                                                }
+                                                                            ]
+                                                              },
+                                                      "description":  "Lists safe Kafka dead-letter operational metadata. The disabled status query can be enabled with RECEIVED, REPLAYING, REPLAYED, REPLAY_FAILED, or DISCARDED."
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "const operatorAccessToken = String(pm.environment.get(\u0027operatorAccessToken\u0027) || \u0027\u0027).trim();",
+                                                                                    "if (!operatorAccessToken) {",
+                                                                                    "    throw new Error(\u0027Set operatorAccessToken to a valid ADMIN JWT before running Operations requests.\u0027);",
+                                                                                    "}"
+                                                                                ]
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "const response = pm.response.json();",
+                                                                                    "pm.expect(response.items).to.be.an(\u0027array\u0027);",
+                                                                                    "pm.expect(response.page).to.be.a(\u0027number\u0027);",
+                                                                                    "pm.expect(response.size).to.be.a(\u0027number\u0027);",
+                                                                                    "pm.expect(response.totalElements).to.be.a(\u0027number\u0027);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Get Kafka Dead-Letter Record",
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{operatorAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/operations/kafka/dead-letters/{{deadLetterRecordId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "operations",
+                                                                               "kafka",
+                                                                               "dead-letters",
+                                                                               "{{deadLetterRecordId}}"
+                                                                           ]
+                                                              },
+                                                      "description":  "Returns authorized operational details for the deliberately selected dead-letter record."
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "const operatorAccessToken = String(pm.environment.get(\u0027operatorAccessToken\u0027) || \u0027\u0027).trim();",
+                                                                                    "if (!operatorAccessToken) {",
+                                                                                    "    throw new Error(\u0027Set operatorAccessToken to a valid ADMIN JWT before running Operations requests.\u0027);",
+                                                                                    "}",
+                                                                                    "const deadLetterRecordId = String(pm.environment.get(\u0027deadLetterRecordId\u0027) || \u0027\u0027).trim();",
+                                                                                    "const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;",
+                                                                                    "if (!uuidPattern.test(deadLetterRecordId)) {",
+                                                                                    "    throw new Error(\u0027Set deadLetterRecordId to a valid Kafka dead-letter UUID before running this request.\u0027);",
+                                                                                    "}"
+                                                                                ]
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "const response = pm.response.json();",
+                                                                                    "const expectedId = String(pm.environment.get(\u0027deadLetterRecordId\u0027)).toLowerCase();",
+                                                                                    "pm.expect(String(response.id).toLowerCase()).to.eql(expectedId);",
+                                                                                    "pm.expect(response.status).to.be.a(\u0027string\u0027);",
+                                                                                    "pm.expect(response).to.not.have.property(\u0027payload\u0027);",
+                                                                                    "pm.expect(response).to.not.have.property(\u0027recordKey\u0027);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Replay Kafka Dead-Letter Record",
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{operatorAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/operations/kafka/dead-letters/{{deadLetterRecordId}}/replay",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "operations",
+                                                                               "kafka",
+                                                                               "dead-letters",
+                                                                               "{{deadLetterRecordId}}",
+                                                                               "replay"
+                                                                           ]
+                                                              },
+                                                      "description":  "Replays the deliberately selected claimable record. This mutates lifecycle state and publishes to the original Kafka topic."
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "const operatorAccessToken = String(pm.environment.get(\u0027operatorAccessToken\u0027) || \u0027\u0027).trim();",
+                                                                                    "if (!operatorAccessToken) {",
+                                                                                    "    throw new Error(\u0027Set operatorAccessToken to a valid ADMIN JWT before running Operations requests.\u0027);",
+                                                                                    "}",
+                                                                                    "const deadLetterRecordId = String(pm.environment.get(\u0027deadLetterRecordId\u0027) || \u0027\u0027).trim();",
+                                                                                    "const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;",
+                                                                                    "if (!uuidPattern.test(deadLetterRecordId)) {",
+                                                                                    "    throw new Error(\u0027Set deadLetterRecordId to a valid Kafka dead-letter UUID before running this request.\u0027);",
+                                                                                    "}"
+                                                                                ]
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "const response = pm.response.json();",
+                                                                                    "const expectedId = String(pm.environment.get(\u0027deadLetterRecordId\u0027)).toLowerCase();",
+                                                                                    "pm.expect(String(response.recordId).toLowerCase()).to.eql(expectedId);",
+                                                                                    "pm.expect(response.status).to.eql(\u0027REPLAYED\u0027);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Discard Kafka Dead-Letter Record",
+                                      "request":  {
+                                                      "method":  "POST",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{operatorAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/operations/kafka/dead-letters/{{deadLetterRecordId}}/discard",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "operations",
+                                                                               "kafka",
+                                                                               "dead-letters",
+                                                                               "{{deadLetterRecordId}}",
+                                                                               "discard"
+                                                                           ]
+                                                              },
+                                                      "description":  "Idempotently discards the deliberately selected eligible record. This mutates lifecycle state and prevents later replay."
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "const operatorAccessToken = String(pm.environment.get(\u0027operatorAccessToken\u0027) || \u0027\u0027).trim();",
+                                                                                    "if (!operatorAccessToken) {",
+                                                                                    "    throw new Error(\u0027Set operatorAccessToken to a valid ADMIN JWT before running Operations requests.\u0027);",
+                                                                                    "}",
+                                                                                    "const deadLetterRecordId = String(pm.environment.get(\u0027deadLetterRecordId\u0027) || \u0027\u0027).trim();",
+                                                                                    "const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;",
+                                                                                    "if (!uuidPattern.test(deadLetterRecordId)) {",
+                                                                                    "    throw new Error(\u0027Set deadLetterRecordId to a valid Kafka dead-letter UUID before running this request.\u0027);",
+                                                                                    "}"
+                                                                                ]
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 204\u0027, function () { pm.response.to.have.status(204); });",
+                                                                                    "pm.test(\u0027Response body is empty\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.text()).to.eql(\u0027\u0027);",
+                                                                                    "});"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "List Kafka Dead-Letter Command Audits",
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{operatorAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/operations/kafka/dead-letter-command-audits?page={{auditPage}}\u0026size={{auditSize}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "operations",
+                                                                               "kafka",
+                                                                               "dead-letter-command-audits"
+                                                                           ],
+                                                                  "query":  [
+                                                                                {
+                                                                                    "key":  "page",
+                                                                                    "value":  "{{auditPage}}"
+                                                                                },
+                                                                                {
+                                                                                    "key":  "size",
+                                                                                    "value":  "{{auditSize}}"
+                                                                                },
+                                                                                {
+                                                                                    "key":  "commandId",
+                                                                                    "value":  "{{auditCommandId}}",
+                                                                                    "description":  "Optional command UUID filter. Enable deliberately when configured.",
+                                                                                    "disabled":  true
+                                                                                },
+                                                                                {
+                                                                                    "key":  "operatorId",
+                                                                                    "value":  "{{auditOperatorId}}",
+                                                                                    "description":  "Optional operator UUID filter. Enable deliberately when configured.",
+                                                                                    "disabled":  true
+                                                                                },
+                                                                                {
+                                                                                    "key":  "deadLetterRecordId",
+                                                                                    "value":  "{{deadLetterRecordId}}",
+                                                                                    "description":  "Optional dead-letter record UUID filter. Enable deliberately when configured.",
+                                                                                    "disabled":  true
+                                                                                },
+                                                                                {
+                                                                                    "key":  "commandType",
+                                                                                    "value":  "REPLAY",
+                                                                                    "description":  "Optional REPLAY or DISCARD filter.",
+                                                                                    "disabled":  true
+                                                                                },
+                                                                                {
+                                                                                    "key":  "stage",
+                                                                                    "value":  "COMPLETED",
+                                                                                    "description":  "Optional ATTEMPTED or COMPLETED filter.",
+                                                                                    "disabled":  true
+                                                                                },
+                                                                                {
+                                                                                    "key":  "outcome",
+                                                                                    "value":  "REPLAYED",
+                                                                                    "description":  "Optional allowlisted command outcome filter.",
+                                                                                    "disabled":  true
+                                                                                }
+                                                                            ]
+                                                              },
+                                                      "description":  "Lists safe command-audit entries in occurredAt DESC, id DESC order. Optional filters are disabled by default and must be enabled deliberately."
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "const operatorAccessToken = String(pm.environment.get(\u0027operatorAccessToken\u0027) || \u0027\u0027).trim();",
+                                                                                    "if (!operatorAccessToken) {",
+                                                                                    "    throw new Error(\u0027Set operatorAccessToken to a valid ADMIN JWT before running Operations requests.\u0027);",
+                                                                                    "}",
+                                                                                    "const auditPage = Number(pm.environment.get(\u0027auditPage\u0027));",
+                                                                                    "const auditSize = Number(pm.environment.get(\u0027auditSize\u0027));",
+                                                                                    "if (!Number.isInteger(auditPage) || auditPage \u003c 0) {",
+                                                                                    "    throw new Error(\u0027Set auditPage to a zero-based non-negative integer.\u0027);",
+                                                                                    "}",
+                                                                                    "if (!Number.isInteger(auditSize) || auditSize \u003c 1 || auditSize \u003e 100) {",
+                                                                                    "    throw new Error(\u0027Set auditSize to an integer between 1 and 100.\u0027);",
+                                                                                    "}"
+                                                                                ]
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "const response = pm.response.json();",
+                                                                                    "pm.expect(response.items).to.be.an(\u0027array\u0027);",
+                                                                                    "pm.expect(response.page).to.be.a(\u0027number\u0027);",
+                                                                                    "pm.expect(response.size).to.be.a(\u0027number\u0027);",
+                                                                                    "pm.expect(response.totalElements).to.be.a(\u0027number\u0027);",
+                                                                                    "function assertSafeAuditEntry(entry) {",
+                                                                                    "    pm.expect(entry).to.not.have.property(\u0027payload\u0027);",
+                                                                                    "    pm.expect(entry).to.not.have.property(\u0027recordKey\u0027);",
+                                                                                    "    pm.expect(entry).to.not.have.property(\u0027operatorEmail\u0027);",
+                                                                                    "    pm.expect(entry).to.not.have.property(\u0027exceptionMessage\u0027);",
+                                                                                    "    pm.expect(entry).to.not.have.property(\u0027stackTrace\u0027);",
+                                                                                    "    pm.expect(entry).to.not.have.property(\u0027replayLeaseOwner\u0027);",
+                                                                                    "}",
+                                                                                    "response.items.forEach(assertSafeAuditEntry);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  },
+                                  {
+                                      "name":  "Get Kafka Dead-Letter Command Audit Timeline",
+                                      "request":  {
+                                                      "method":  "GET",
+                                                      "header":  [
+
+                                                                 ],
+                                                      "auth":  {
+                                                                   "type":  "bearer",
+                                                                   "bearer":  [
+                                                                                  {
+                                                                                      "key":  "token",
+                                                                                      "value":  "{{operatorAccessToken}}",
+                                                                                      "type":  "string"
+                                                                                  }
+                                                                              ]
+                                                               },
+                                                      "url":  {
+                                                                  "raw":  "{{baseUrl}}/api/v1/operations/kafka/dead-letter-command-audits/{{auditCommandId}}",
+                                                                  "host":  [
+                                                                               "{{baseUrl}}"
+                                                                           ],
+                                                                  "path":  [
+                                                                               "api",
+                                                                               "v1",
+                                                                               "operations",
+                                                                               "kafka",
+                                                                               "dead-letter-command-audits",
+                                                                               "{{auditCommandId}}"
+                                                                           ]
+                                                              },
+                                                      "description":  "Returns the chronological ATTEMPTED and optional COMPLETED entries for the deliberately selected command UUID."
+                                                  },
+                                      "event":  [
+                                                    {
+                                                        "listen":  "prerequest",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "const operatorAccessToken = String(pm.environment.get(\u0027operatorAccessToken\u0027) || \u0027\u0027).trim();",
+                                                                                    "if (!operatorAccessToken) {",
+                                                                                    "    throw new Error(\u0027Set operatorAccessToken to a valid ADMIN JWT before running Operations requests.\u0027);",
+                                                                                    "}",
+                                                                                    "const auditCommandId = String(pm.environment.get(\u0027auditCommandId\u0027) || \u0027\u0027).trim();",
+                                                                                    "const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;",
+                                                                                    "if (!uuidPattern.test(auditCommandId)) {",
+                                                                                    "    throw new Error(\u0027Set auditCommandId to a valid operator command UUID before running this request.\u0027);",
+                                                                                    "}"
+                                                                                ]
+                                                                   }
+                                                    },
+                                                    {
+                                                        "listen":  "test",
+                                                        "script":  {
+                                                                       "type":  "text/javascript",
+                                                                       "exec":  [
+                                                                                    "pm.test(\u0027Status code is 200\u0027, function () { pm.response.to.have.status(200); });",
+                                                                                    "pm.test(\u0027Response is JSON\u0027, function () {",
+                                                                                    "    pm.expect(pm.response.headers.get(\u0027Content-Type\u0027)).to.include(\u0027application/json\u0027);",
+                                                                                    "});",
+                                                                                    "const response = pm.response.json();",
+                                                                                    "const expectedCommandId = String(pm.environment.get(\u0027auditCommandId\u0027)).toLowerCase();",
+                                                                                    "pm.expect(String(response.commandId).toLowerCase()).to.eql(expectedCommandId);",
+                                                                                    "pm.expect(response.complete).to.be.a(\u0027boolean\u0027);",
+                                                                                    "pm.expect(response.entries).to.be.an(\u0027array\u0027).that.is.not.empty;",
+                                                                                    "function assertSafeAuditEntry(entry) {",
+                                                                                    "    pm.expect(entry).to.not.have.property(\u0027payload\u0027);",
+                                                                                    "    pm.expect(entry).to.not.have.property(\u0027recordKey\u0027);",
+                                                                                    "    pm.expect(entry).to.not.have.property(\u0027operatorEmail\u0027);",
+                                                                                    "    pm.expect(entry).to.not.have.property(\u0027exceptionMessage\u0027);",
+                                                                                    "    pm.expect(entry).to.not.have.property(\u0027stackTrace\u0027);",
+                                                                                    "    pm.expect(entry).to.not.have.property(\u0027replayLeaseOwner\u0027);",
+                                                                                    "}",
+                                                                                    "response.entries.forEach(assertSafeAuditEntry);"
+                                                                                ]
+                                                                   }
+                                                    }
+                                                ]
+                                  }
+                              ]
+                 }
+             ]
 }

--- a/src/main/java/com/nursena/payflow/common/api/ApiError.java
+++ b/src/main/java/com/nursena/payflow/common/api/ApiError.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
     description = "Stable error response returned by PayFlow."
 )
 public record ApiError(
-
     @Schema(
         description = "Time at which the error was generated.",
         example = "2026-07-17T12:00:00Z",
@@ -45,6 +44,14 @@ public record ApiError(
 
     @Schema(
         description =
+            "Effective request correlation identifier. "
+                + "Matches the X-Correlation-ID response header.",
+        example = "550e8400-e29b-41d4-a716-446655440000"
+    )
+    String correlationId,
+
+    @Schema(
+        description =
             "Field-level violations. Empty for "
                 + "non-validation errors."
     )
@@ -56,7 +63,6 @@ public record ApiError(
         description = "A request-field validation failure."
     )
     public record FieldViolation(
-
         @Schema(
             description = "Invalid request field.",
             example = "email"

--- a/src/main/java/com/nursena/payflow/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/common/exception/GlobalExceptionHandler.java
@@ -4,7 +4,10 @@ import java.time.Instant;
 import java.util.List;
 
 import com.nursena.payflow.common.api.ApiError;
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationContext;
+
 import jakarta.servlet.http.HttpServletRequest;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -16,53 +19,65 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessRuleException.class)
     ResponseEntity<ApiError> handleBusinessRule(
-            BusinessRuleException exception,
-            HttpServletRequest request
+        BusinessRuleException exception,
+        HttpServletRequest request
     ) {
         return buildResponse(
-                HttpStatus.UNPROCESSABLE_ENTITY,
-                exception.getCode(),
-                exception.getMessage(),
-                request.getRequestURI(),
-                List.of()
+            HttpStatus.UNPROCESSABLE_ENTITY,
+            exception.getCode(),
+            exception.getMessage(),
+            request,
+            List.of()
         );
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     ResponseEntity<ApiError> handleValidation(
-            MethodArgumentNotValidException exception,
-            HttpServletRequest request
+        MethodArgumentNotValidException exception,
+        HttpServletRequest request
     ) {
-        List<ApiError.FieldViolation> violations = exception.getBindingResult()
+        List<ApiError.FieldViolation> violations =
+            exception.getBindingResult()
                 .getFieldErrors()
                 .stream()
-                .map(error -> new ApiError.FieldViolation(error.getField(), error.getDefaultMessage()))
+                .map(
+                    error ->
+                        new ApiError.FieldViolation(
+                            error.getField(),
+                            error.getDefaultMessage()
+                        )
+                )
                 .toList();
 
         return buildResponse(
-                HttpStatus.BAD_REQUEST,
-                "VALIDATION_FAILED",
-                "Request validation failed.",
-                request.getRequestURI(),
-                violations
+            HttpStatus.BAD_REQUEST,
+            "VALIDATION_FAILED",
+            "Request validation failed.",
+            request,
+            violations
         );
     }
 
     private ResponseEntity<ApiError> buildResponse(
-            HttpStatus status,
-            String code,
-            String message,
-            String path,
-            List<ApiError.FieldViolation> violations
+        HttpStatus status,
+        String code,
+        String message,
+        HttpServletRequest request,
+        List<ApiError.FieldViolation> violations
     ) {
-        ApiError body = new ApiError(
+        ApiError body =
+            new ApiError(
                 Instant.now(),
                 status.value(),
                 code,
                 message,
-                path,
+                request.getRequestURI(),
+                RequestCorrelationContext.require(request),
                 violations
-        );
-        return ResponseEntity.status(status).body(body);
+            );
+
+        return ResponseEntity
+            .status(status)
+            .body(body);
     }
 }

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandAuditExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandAuditExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.nursena.payflow.eventprocessing.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationContext;
+
 import java.time.Instant;
 import java.util.List;
 
@@ -71,6 +73,7 @@ public class KafkaDeadLetterCommandAuditExceptionHandler {
                 code,
                 message,
                 request.getRequestURI(),
+                RequestCorrelationContext.require(request),
                 List.of()
             );
 

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.nursena.payflow.eventprocessing.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationContext;
+
 import java.time.Instant;
 import java.util.List;
 
@@ -175,6 +177,7 @@ KafkaDeadLetterCommandExceptionHandler {
                 code,
                 message,
                 request.getRequestURI(),
+                RequestCorrelationContext.require(request),
                 List.of()
             );
 

--- a/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterQueryExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterQueryExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.nursena.payflow.eventprocessing.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationContext;
+
 import java.time.Instant;
 import java.util.List;
 
@@ -66,6 +68,7 @@ public class KafkaDeadLetterQueryExceptionHandler {
                 code,
                 message,
                 request.getRequestURI(),
+                RequestCorrelationContext.require(request),
                 List.of()
             );
 

--- a/src/main/java/com/nursena/payflow/observability/adapter/in/web/CorrelationIdOpenApiConfiguration.java
+++ b/src/main/java/com/nursena/payflow/observability/adapter/in/web/CorrelationIdOpenApiConfiguration.java
@@ -1,0 +1,14 @@
+package com.nursena.payflow.observability.adapter.in.web;
+
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class CorrelationIdOpenApiConfiguration {
+
+    @Bean
+    OpenApiCustomizer correlationIdOpenApiCustomizer() {
+        return new CorrelationIdOpenApiCustomizer();
+    }
+}

--- a/src/main/java/com/nursena/payflow/observability/adapter/in/web/CorrelationIdOpenApiCustomizer.java
+++ b/src/main/java/com/nursena/payflow/observability/adapter/in/web/CorrelationIdOpenApiCustomizer.java
@@ -1,0 +1,134 @@
+package com.nursena.payflow.observability.adapter.in.web;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+
+public final class CorrelationIdOpenApiCustomizer
+    implements OpenApiCustomizer {
+
+    public static final int MAXIMUM_LENGTH =
+        64;
+
+    public static final String VALUE_PATTERN =
+        "^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$";
+
+    public static final String DESCRIPTION =
+        "Effective server-owned request correlation identifier. "
+            + "A valid inbound value is echoed; otherwise PayFlow "
+            + "generates a replacement identifier.";
+
+    @Override
+    public void customise(
+        OpenAPI openApi
+    ) {
+        Objects.requireNonNull(
+            openApi,
+            "OpenAPI model must not be null"
+        );
+
+        Paths paths =
+            openApi.getPaths();
+
+        if (paths == null) {
+            return;
+        }
+
+        for (PathItem pathItem : paths.values()) {
+            addToPathItem(
+                pathItem
+            );
+        }
+    }
+
+    private static void addToPathItem(
+        PathItem pathItem
+    ) {
+        if (pathItem == null) {
+            return;
+        }
+
+        List<Operation> operations =
+            pathItem.readOperations();
+
+        if (operations == null) {
+            return;
+        }
+
+        for (Operation operation : operations) {
+            addToOperation(
+                operation
+            );
+        }
+    }
+
+    private static void addToOperation(
+        Operation operation
+    ) {
+        if (operation == null) {
+            return;
+        }
+
+        ApiResponses responses =
+            operation.getResponses();
+
+        if (responses == null) {
+            return;
+        }
+
+        for (
+            Map.Entry<String, ApiResponse> entry
+                : responses.entrySet()
+        ) {
+            ApiResponse response =
+                entry.getValue();
+
+            if (response != null) {
+                response.addHeaderObject(
+                    RequestCorrelationFilter.HEADER_NAME,
+                    newCorrelationHeader()
+                );
+            }
+        }
+    }
+
+    private static Header newCorrelationHeader() {
+        StringSchema schema =
+            new StringSchema();
+
+        schema.setMaxLength(
+            MAXIMUM_LENGTH
+        );
+
+        schema.setPattern(
+            VALUE_PATTERN
+        );
+
+        Header header =
+            new Header();
+
+        header.setDescription(
+            DESCRIPTION
+        );
+
+        header.setRequired(
+            true
+        );
+
+        header.setSchema(
+            schema
+        );
+
+        return header;
+    }
+}

--- a/src/main/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationConfiguration.java
+++ b/src/main/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationConfiguration.java
@@ -5,9 +5,10 @@ import java.util.EnumSet;
 import com.nursena.payflow.observability.adapter.out.uuid.UuidCorrelationIdGenerator;
 import com.nursena.payflow.observability.domain.CorrelationIdGenerator;
 import com.nursena.payflow.observability.domain.CorrelationIdPolicy;
+import com.nursena.payflow.observability.logging.RequestCompletionLogger;
+import com.nursena.payflow.observability.logging.Slf4jRequestCompletionLogger;
 
 import jakarta.servlet.DispatcherType;
-
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,15 +28,23 @@ public class RequestCorrelationConfiguration {
     }
 
     @Bean
+    RequestCompletionLogger requestCompletionLogger() {
+        return new Slf4jRequestCompletionLogger();
+    }
+
+    @Bean
     FilterRegistrationBean<RequestCorrelationFilter>
         requestCorrelationFilter(
             CorrelationIdPolicy policy,
-            CorrelationIdGenerator generator
+            CorrelationIdGenerator generator,
+            RequestCompletionLogger completionLogger
         ) {
         RequestCorrelationFilter filter =
             new RequestCorrelationFilter(
                 policy,
-                generator
+                generator,
+                System::nanoTime,
+                completionLogger
             );
 
         FilterRegistrationBean<RequestCorrelationFilter>

--- a/src/main/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationConfiguration.java
+++ b/src/main/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 
 @Configuration(proxyBeanMethods = false)
-class RequestCorrelationConfiguration {
+public class RequestCorrelationConfiguration {
 
     @Bean
     CorrelationIdPolicy correlationIdPolicy() {

--- a/src/main/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationConfiguration.java
+++ b/src/main/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationConfiguration.java
@@ -1,0 +1,71 @@
+package com.nursena.payflow.observability.adapter.in.web;
+
+import java.util.EnumSet;
+
+import com.nursena.payflow.observability.adapter.out.uuid.UuidCorrelationIdGenerator;
+import com.nursena.payflow.observability.domain.CorrelationIdGenerator;
+import com.nursena.payflow.observability.domain.CorrelationIdPolicy;
+
+import jakarta.servlet.DispatcherType;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration(proxyBeanMethods = false)
+class RequestCorrelationConfiguration {
+
+    @Bean
+    CorrelationIdPolicy correlationIdPolicy() {
+        return new CorrelationIdPolicy();
+    }
+
+    @Bean
+    CorrelationIdGenerator correlationIdGenerator() {
+        return new UuidCorrelationIdGenerator();
+    }
+
+    @Bean
+    FilterRegistrationBean<RequestCorrelationFilter>
+        requestCorrelationFilter(
+            CorrelationIdPolicy policy,
+            CorrelationIdGenerator generator
+        ) {
+        RequestCorrelationFilter filter =
+            new RequestCorrelationFilter(
+                policy,
+                generator
+            );
+
+        FilterRegistrationBean<RequestCorrelationFilter>
+            registration =
+                new FilterRegistrationBean<>(
+                    filter
+                );
+
+        registration.setName(
+            "requestCorrelationFilter"
+        );
+
+        registration.setOrder(
+            Ordered.HIGHEST_PRECEDENCE
+        );
+
+        registration.setDispatcherTypes(
+            EnumSet.of(
+                DispatcherType.REQUEST
+            )
+        );
+
+        registration.addUrlPatterns(
+            "/*"
+        );
+
+        registration.setMatchAfter(
+            false
+        );
+
+        return registration;
+    }
+}

--- a/src/main/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationContext.java
+++ b/src/main/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationContext.java
@@ -1,0 +1,38 @@
+package com.nursena.payflow.observability.adapter.in.web;
+
+import java.util.Objects;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public final class RequestCorrelationContext {
+
+    private RequestCorrelationContext() {
+    }
+
+    public static String require(
+        HttpServletRequest request
+    ) {
+        Objects.requireNonNull(
+            request,
+            "HTTP request must not be null"
+        );
+
+        Object value =
+            request.getAttribute(
+                RequestCorrelationFilter
+                    .REQUEST_ATTRIBUTE
+            );
+
+        boolean validValue =
+            value instanceof String identifier
+                && !identifier.isBlank();
+
+        if (!validValue) {
+            throw new IllegalStateException(
+                "effective correlation ID is unavailable"
+            );
+        }
+
+        return (String) value;
+    }
+}

--- a/src/main/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationFilter.java
+++ b/src/main/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationFilter.java
@@ -1,0 +1,116 @@
+package com.nursena.payflow.observability.adapter.in.web;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Objects;
+
+import com.nursena.payflow.observability.domain.CorrelationIdGenerator;
+import com.nursena.payflow.observability.domain.CorrelationIdPolicy;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public final class RequestCorrelationFilter
+    extends OncePerRequestFilter {
+
+    public static final String HEADER_NAME =
+        "X-Correlation-ID";
+
+    public static final String MDC_KEY =
+        "correlationId";
+
+    public static final String REQUEST_ATTRIBUTE =
+        RequestCorrelationFilter.class.getName()
+            + ".effectiveCorrelationId";
+
+    private final CorrelationIdPolicy policy;
+    private final CorrelationIdGenerator generator;
+
+    public RequestCorrelationFilter(
+        CorrelationIdPolicy policy,
+        CorrelationIdGenerator generator
+    ) {
+        this.policy =
+            Objects.requireNonNull(
+                policy,
+                "correlation ID policy must not be null"
+            );
+
+        this.generator =
+            Objects.requireNonNull(
+                generator,
+                "correlation ID generator must not be null"
+            );
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        String effectiveCorrelationId =
+            policy.effective(
+                singleInboundValue(request),
+                generator
+            );
+
+        request.setAttribute(
+            REQUEST_ATTRIBUTE,
+            effectiveCorrelationId
+        );
+
+        response.setHeader(
+            HEADER_NAME,
+            effectiveCorrelationId
+        );
+
+        MDC.put(
+            MDC_KEY,
+            effectiveCorrelationId
+        );
+
+        try {
+            filterChain.doFilter(
+                request,
+                response
+            );
+        }
+        finally {
+            MDC.remove(
+                MDC_KEY
+            );
+        }
+    }
+
+    private static String singleInboundValue(
+        HttpServletRequest request
+    ) {
+        Enumeration<String> values =
+            request.getHeaders(
+                HEADER_NAME
+            );
+
+        boolean headerMissing =
+            values == null
+                || !values.hasMoreElements();
+
+        if (headerMissing) {
+            return null;
+        }
+
+        String value =
+            values.nextElement();
+
+        if (values.hasMoreElements()) {
+            return null;
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationFilter.java
+++ b/src/main/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationFilter.java
@@ -2,18 +2,27 @@ package com.nursena.payflow.observability.adapter.in.web;
 
 import java.io.IOException;
 import java.util.Enumeration;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import java.util.regex.Pattern;
 
 import com.nursena.payflow.observability.domain.CorrelationIdGenerator;
 import com.nursena.payflow.observability.domain.CorrelationIdPolicy;
+import com.nursena.payflow.observability.logging.HttpRequestCompletion;
+import com.nursena.payflow.observability.logging.HttpRequestOutcome;
+import com.nursena.payflow.observability.logging.RequestCompletionLogger;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerMapping;
 
 public final class RequestCorrelationFilter
     extends OncePerRequestFilter {
@@ -28,12 +37,35 @@ public final class RequestCorrelationFilter
         RequestCorrelationFilter.class.getName()
             + ".effectiveCorrelationId";
 
+    public static final String UNMATCHED_ROUTE =
+        "UNMATCHED";
+
+    public static final String UNKNOWN_METHOD =
+        "UNKNOWN";
+
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(
+            RequestCorrelationFilter.class
+        );
+
+    private static final Pattern SAFE_METHOD =
+        Pattern.compile(
+            "[A-Z]{1,16}"
+        );
+
+    private static final int MAXIMUM_ROUTE_LENGTH =
+        256;
+
     private final CorrelationIdPolicy policy;
     private final CorrelationIdGenerator generator;
+    private final LongSupplier nanoTime;
+    private final RequestCompletionLogger completionLogger;
 
     public RequestCorrelationFilter(
         CorrelationIdPolicy policy,
-        CorrelationIdGenerator generator
+        CorrelationIdGenerator generator,
+        LongSupplier nanoTime,
+        RequestCompletionLogger completionLogger
     ) {
         this.policy =
             Objects.requireNonNull(
@@ -45,6 +77,18 @@ public final class RequestCorrelationFilter
             Objects.requireNonNull(
                 generator,
                 "correlation ID generator must not be null"
+            );
+
+        this.nanoTime =
+            Objects.requireNonNull(
+                nanoTime,
+                "nano-time source must not be null"
+            );
+
+        this.completionLogger =
+            Objects.requireNonNull(
+                completionLogger,
+                "request completion logger must not be null"
             );
     }
 
@@ -75,17 +119,171 @@ public final class RequestCorrelationFilter
             effectiveCorrelationId
         );
 
+        long startedAtNanos =
+            nanoTime.getAsLong();
+
+        boolean failed =
+            false;
+
         try {
             filterChain.doFilter(
                 request,
                 response
             );
         }
+        catch (
+            ServletException
+                | IOException
+                | RuntimeException
+                | Error exception
+        ) {
+            failed =
+                true;
+
+            throw exception;
+        }
         finally {
+            long completedAtNanos =
+                nanoTime.getAsLong();
+
+            writeCompletionSafely(
+                request,
+                response,
+                startedAtNanos,
+                completedAtNanos,
+                failed
+            );
+
             MDC.remove(
                 MDC_KEY
             );
         }
+    }
+
+    private void writeCompletionSafely(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        long startedAtNanos,
+        long completedAtNanos,
+        boolean failed
+    ) {
+        try {
+            int statusCode =
+                effectiveStatusCode(
+                    response.getStatus(),
+                    failed
+                );
+
+            completionLogger.completed(
+                new HttpRequestCompletion(
+                    safeMethod(
+                        request.getMethod()
+                    ),
+                    safeRoute(request),
+                    statusCode,
+                    elapsedMilliseconds(
+                        startedAtNanos,
+                        completedAtNanos
+                    ),
+                    HttpRequestOutcome.from(
+                        statusCode,
+                        failed
+                    )
+                )
+            );
+        }
+        catch (RuntimeException loggingFailure) {
+            LOGGER.warn(
+                "HTTP request completion logging failed.",
+                loggingFailure
+            );
+        }
+    }
+
+    private static int effectiveStatusCode(
+        int responseStatus,
+        boolean failed
+    ) {
+        boolean invalidStatus =
+            responseStatus < 100
+                || responseStatus > 599;
+
+        if (invalidStatus) {
+            return 500;
+        }
+
+        if (failed && responseStatus < 500) {
+            return 500;
+        }
+
+        return responseStatus;
+    }
+
+    private static long elapsedMilliseconds(
+        long startedAtNanos,
+        long completedAtNanos
+    ) {
+        long elapsedNanos =
+            completedAtNanos - startedAtNanos;
+
+        if (elapsedNanos < 0) {
+            return 0;
+        }
+
+        return TimeUnit.NANOSECONDS
+            .toMillis(
+                elapsedNanos
+            );
+    }
+
+    private static String safeMethod(
+        String method
+    ) {
+        if (method == null) {
+            return UNKNOWN_METHOD;
+        }
+
+        String normalized =
+            method.toUpperCase(
+                Locale.ROOT
+            );
+
+        if (!SAFE_METHOD
+            .matcher(normalized)
+            .matches()) {
+            return UNKNOWN_METHOD;
+        }
+
+        return normalized;
+    }
+
+    private static String safeRoute(
+        HttpServletRequest request
+    ) {
+        Object routeAttribute =
+            request.getAttribute(
+                HandlerMapping
+                    .BEST_MATCHING_PATTERN_ATTRIBUTE
+            );
+
+        if (routeAttribute == null) {
+            return UNMATCHED_ROUTE;
+        }
+
+        String route =
+            routeAttribute.toString();
+
+        boolean unsafe =
+            route.isBlank()
+                || route.length() > MAXIMUM_ROUTE_LENGTH
+                || route.indexOf('\r') >= 0
+                || route.indexOf('\n') >= 0;
+
+        if (unsafe) {
+            return UNMATCHED_ROUTE;
+        }
+
+        return route;
     }
 
     private static String singleInboundValue(

--- a/src/main/java/com/nursena/payflow/observability/adapter/out/uuid/UuidCorrelationIdGenerator.java
+++ b/src/main/java/com/nursena/payflow/observability/adapter/out/uuid/UuidCorrelationIdGenerator.java
@@ -1,0 +1,15 @@
+package com.nursena.payflow.observability.adapter.out.uuid;
+
+import java.util.UUID;
+
+import com.nursena.payflow.observability.domain.CorrelationIdGenerator;
+
+public final class UuidCorrelationIdGenerator
+    implements CorrelationIdGenerator {
+
+    @Override
+    public String generate() {
+        return UUID.randomUUID()
+            .toString();
+    }
+}

--- a/src/main/java/com/nursena/payflow/observability/domain/CorrelationIdGenerator.java
+++ b/src/main/java/com/nursena/payflow/observability/domain/CorrelationIdGenerator.java
@@ -1,0 +1,7 @@
+package com.nursena.payflow.observability.domain;
+
+@FunctionalInterface
+public interface CorrelationIdGenerator {
+
+    String generate();
+}

--- a/src/main/java/com/nursena/payflow/observability/domain/CorrelationIdPolicy.java
+++ b/src/main/java/com/nursena/payflow/observability/domain/CorrelationIdPolicy.java
@@ -1,0 +1,52 @@
+package com.nursena.payflow.observability.domain;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public final class CorrelationIdPolicy {
+
+    public static final int MAXIMUM_LENGTH =
+        64;
+
+    private static final Pattern ACCEPTED_VALUE =
+        Pattern.compile(
+            "[A-Za-z0-9][A-Za-z0-9._:-]{0,63}"
+        );
+
+    public boolean isAccepted(
+        String candidate
+    ) {
+        return candidate != null
+            && ACCEPTED_VALUE
+                .matcher(candidate)
+                .matches();
+    }
+
+    public String effective(
+        String inboundCandidate,
+        CorrelationIdGenerator generator
+    ) {
+        Objects.requireNonNull(
+            generator,
+            "correlation ID generator must not be null"
+        );
+
+        if (isAccepted(inboundCandidate)) {
+            return inboundCandidate;
+        }
+
+        String generated =
+            Objects.requireNonNull(
+                generator.generate(),
+                "generated correlation ID must not be null"
+            );
+
+        if (!isAccepted(generated)) {
+            throw new IllegalStateException(
+                "generated correlation ID violates the policy"
+            );
+        }
+
+        return generated;
+    }
+}

--- a/src/main/java/com/nursena/payflow/observability/logging/HttpRequestCompletion.java
+++ b/src/main/java/com/nursena/payflow/observability/logging/HttpRequestCompletion.java
@@ -1,0 +1,62 @@
+package com.nursena.payflow.observability.logging;
+
+import java.util.Objects;
+
+public record HttpRequestCompletion(
+    String method,
+    String route,
+    int statusCode,
+    long durationMilliseconds,
+    HttpRequestOutcome outcome
+) {
+
+    public HttpRequestCompletion {
+        method =
+            requireText(
+                method,
+                "HTTP method"
+            );
+
+        route =
+            requireText(
+                route,
+                "HTTP route"
+            );
+
+        if (statusCode < 100 || statusCode > 599) {
+            throw new IllegalArgumentException(
+                "HTTP status code must be between 100 and 599"
+            );
+        }
+
+        if (durationMilliseconds < 0) {
+            throw new IllegalArgumentException(
+                "HTTP duration must not be negative"
+            );
+        }
+
+        outcome =
+            Objects.requireNonNull(
+                outcome,
+                "HTTP request outcome must not be null"
+            );
+    }
+
+    private static String requireText(
+        String value,
+        String field
+    ) {
+        Objects.requireNonNull(
+            value,
+            field + " must not be null"
+        );
+
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(
+                field + " must not be blank"
+            );
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/com/nursena/payflow/observability/logging/HttpRequestOutcome.java
+++ b/src/main/java/com/nursena/payflow/observability/logging/HttpRequestOutcome.java
@@ -1,0 +1,22 @@
+package com.nursena.payflow.observability.logging;
+
+public enum HttpRequestOutcome {
+    SUCCESS,
+    CLIENT_ERROR,
+    SERVER_ERROR;
+
+    public static HttpRequestOutcome from(
+        int statusCode,
+        boolean failed
+    ) {
+        if (failed || statusCode >= 500) {
+            return SERVER_ERROR;
+        }
+
+        if (statusCode >= 400) {
+            return CLIENT_ERROR;
+        }
+
+        return SUCCESS;
+    }
+}

--- a/src/main/java/com/nursena/payflow/observability/logging/RequestCompletionLogger.java
+++ b/src/main/java/com/nursena/payflow/observability/logging/RequestCompletionLogger.java
@@ -1,0 +1,9 @@
+package com.nursena.payflow.observability.logging;
+
+@FunctionalInterface
+public interface RequestCompletionLogger {
+
+    void completed(
+        HttpRequestCompletion completion
+    );
+}

--- a/src/main/java/com/nursena/payflow/observability/logging/SensitiveLogValueMasker.java
+++ b/src/main/java/com/nursena/payflow/observability/logging/SensitiveLogValueMasker.java
@@ -1,0 +1,99 @@
+package com.nursena.payflow.observability.logging;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.core.JsonStreamContext;
+
+import net.logstash.logback.mask.ValueMasker;
+
+public final class SensitiveLogValueMasker
+    implements ValueMasker {
+
+    public static final String MASK =
+        "[REDACTED]";
+
+    private static final String SENSITIVE_KEY =
+        "authorization"
+            + "|password"
+            + "|passphrase"
+            + "|refresh[_-]?token"
+            + "|access[_-]?token"
+            + "|client[_-]?secret"
+            + "|api[_-]?key"
+            + "|private[_-]?key"
+            + "|secret"
+            + "|token";
+
+    private static final Pattern SECRET_ASSIGNMENT =
+        Pattern.compile(
+            "(?i)([\"']?(?:"
+                + SENSITIVE_KEY
+                + ")[\"']?\\s*[:=]\\s*)"
+                + "(?:Bearer\\s+[^\\s,;]+"
+                + "|\"[^\"]*\""
+                + "|'[^']*'"
+                + "|[^\\s,;]+)"
+        );
+
+    private static final Pattern BEARER_CREDENTIAL =
+        Pattern.compile(
+            "(?i)\\bBearer\\s+[A-Za-z0-9._~+/=-]+"
+        );
+
+    private static final Pattern JWT =
+        Pattern.compile(
+            "\\beyJ[A-Za-z0-9_-]{5,}"
+                + "\\.[A-Za-z0-9_-]{5,}"
+                + "\\.[A-Za-z0-9_-]{5,}\\b"
+        );
+
+    @Override
+    public Object mask(
+        JsonStreamContext context,
+        Object value
+    ) {
+        if (!(value instanceof CharSequence characters)) {
+            return null;
+        }
+
+        String original =
+            characters.toString();
+
+        String redacted =
+            redact(original);
+
+        if (original.equals(redacted)) {
+            return null;
+        }
+
+        return redacted;
+    }
+
+    public static String redact(
+        String value
+    ) {
+        Objects.requireNonNull(
+            value,
+            "log value must not be null"
+        );
+
+        String redacted =
+            SECRET_ASSIGNMENT
+                .matcher(value)
+                .replaceAll(
+                    "$1" + MASK
+                );
+
+        redacted =
+            BEARER_CREDENTIAL
+                .matcher(redacted)
+                .replaceAll(
+                    "Bearer " + MASK
+                );
+
+        return JWT
+            .matcher(redacted)
+            .replaceAll(MASK);
+    }
+}

--- a/src/main/java/com/nursena/payflow/observability/logging/Slf4jRequestCompletionLogger.java
+++ b/src/main/java/com/nursena/payflow/observability/logging/Slf4jRequestCompletionLogger.java
@@ -1,0 +1,157 @@
+package com.nursena.payflow.observability.logging;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+public final class Slf4jRequestCompletionLogger
+    implements RequestCompletionLogger {
+
+    public static final String EVENT_KEY =
+        "event";
+
+    public static final String METHOD_KEY =
+        "http.method";
+
+    public static final String ROUTE_KEY =
+        "http.route";
+
+    public static final String STATUS_CODE_KEY =
+        "http.status_code";
+
+    public static final String DURATION_KEY =
+        "duration_ms";
+
+    public static final String OUTCOME_KEY =
+        "outcome";
+
+    public static final String COMPLETION_EVENT =
+        "http.request.completed";
+
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(
+            Slf4jRequestCompletionLogger.class
+        );
+
+    private static final List<String> TEMPORARY_KEYS =
+        List.of(
+            EVENT_KEY,
+            METHOD_KEY,
+            ROUTE_KEY,
+            STATUS_CODE_KEY,
+            DURATION_KEY,
+            OUTCOME_KEY
+        );
+
+    @Override
+    public void completed(
+        HttpRequestCompletion completion
+    ) {
+        Objects.requireNonNull(
+            completion,
+            "HTTP request completion must not be null"
+        );
+
+        Map<String, String> previousValues =
+            capturePreviousValues();
+
+        try {
+            putCompletionFields(
+                completion
+            );
+
+            LOGGER.info(
+                "HTTP request completed: method={}, route={}, "
+                    + "status={}, durationMs={}, outcome={}.",
+                completion.method(),
+                completion.route(),
+                completion.statusCode(),
+                completion.durationMilliseconds(),
+                completion.outcome()
+            );
+        }
+        finally {
+            restorePreviousValues(
+                previousValues
+            );
+        }
+    }
+
+    private static Map<String, String>
+        capturePreviousValues() {
+        Map<String, String> previousValues =
+            new HashMap<>();
+
+        for (String key : TEMPORARY_KEYS) {
+            previousValues.put(
+                key,
+                MDC.get(key)
+            );
+        }
+
+        return previousValues;
+    }
+
+    private static void putCompletionFields(
+        HttpRequestCompletion completion
+    ) {
+        MDC.put(
+            EVENT_KEY,
+            COMPLETION_EVENT
+        );
+
+        MDC.put(
+            METHOD_KEY,
+            completion.method()
+        );
+
+        MDC.put(
+            ROUTE_KEY,
+            completion.route()
+        );
+
+        MDC.put(
+            STATUS_CODE_KEY,
+            Integer.toString(
+                completion.statusCode()
+            )
+        );
+
+        MDC.put(
+            DURATION_KEY,
+            Long.toString(
+                completion.durationMilliseconds()
+            )
+        );
+
+        MDC.put(
+            OUTCOME_KEY,
+            completion.outcome()
+                .name()
+        );
+    }
+
+    private static void restorePreviousValues(
+        Map<String, String> previousValues
+    ) {
+        for (String key : TEMPORARY_KEYS) {
+            String previousValue =
+                previousValues.get(key);
+
+            if (previousValue == null) {
+                MDC.remove(key);
+            }
+            else {
+                MDC.put(
+                    key,
+                    previousValue
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransactionHistoryExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.nursena.payflow.transaction.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationContext;
+
 import java.time.Instant;
 import java.util.List;
 
@@ -65,6 +67,7 @@ public class TransactionHistoryExceptionHandler {
             code,
             message,
             request.getRequestURI(),
+            RequestCorrelationContext.require(request),
             List.of()
         );
 

--- a/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.nursena.payflow.transaction.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationContext;
+
 import java.time.Instant;
 import java.util.List;
 
@@ -100,6 +102,7 @@ public class TransferMoneyExceptionHandler {
             code,
             message,
             request.getRequestURI(),
+            RequestCorrelationContext.require(request),
             List.of()
         );
 

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationContext;
+
 import java.time.Instant;
 import java.util.List;
 
@@ -31,6 +33,7 @@ public class CurrentUserProfileExceptionHandler {
             exception.getCode(),
             exception.getMessage(),
             request.getRequestURI(),
+            RequestCorrelationContext.require(request),
             List.of()
         );
 

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/UserAuthenticationExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/UserAuthenticationExceptionHandler.java
@@ -1,6 +1,7 @@
 
 package com.nursena.payflow.user.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationContext;
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
@@ -181,6 +182,7 @@ public class UserAuthenticationExceptionHandler {
             code,
             message,
             request.getRequestURI(),
+            RequestCorrelationContext.require(request),
             List.of()
         );
     }

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/UserRegistrationExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/UserRegistrationExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationContext;
 import java.time.Instant;
 import java.util.List;
 
@@ -28,6 +29,7 @@ public class UserRegistrationExceptionHandler {
             exception.getCode(),
             exception.getMessage(),
             request.getRequestURI(),
+            RequestCorrelationContext.require(request),
             List.of()
         );
 

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/GetCurrentWalletExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/GetCurrentWalletExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.wallet.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationContext;
 import java.time.Instant;
 import java.util.List;
 
@@ -30,6 +31,7 @@ public class GetCurrentWalletExceptionHandler {
             exception.getCode(),
             exception.getMessage(),
             request.getRequestURI(),
+            RequestCorrelationContext.require(request),
             List.of()
         );
 

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.wallet.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationContext;
 import java.time.Instant;
 import java.util.List;
 
@@ -30,6 +31,7 @@ public class OpenWalletExceptionHandler {
             exception.getCode(),
             exception.getMessage(),
             request.getRequestURI(),
+            RequestCorrelationContext.require(request),
             List.of()
         );
 

--- a/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.wallet.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationContext;
 import java.time.Instant;
 import java.util.List;
 
@@ -31,6 +32,7 @@ public class TopUpWalletExceptionHandler {
             exception.getCode(),
             exception.getMessage(),
             request.getRequestURI(),
+            RequestCorrelationContext.require(request),
             List.of()
         );
 
@@ -50,6 +52,7 @@ public class TopUpWalletExceptionHandler {
             exception.getCode(),
             exception.getMessage(),
             request.getRequestURI(),
+            RequestCorrelationContext.require(request),
             List.of()
         );
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty
+        scope="context"
+        name="applicationName"
+        source="spring.application.name"
+        defaultValue="payflow"/>
+
+    <springProperty
+        scope="context"
+        name="rootLogLevel"
+        source="logging.level.root"
+        defaultValue="INFO"/>
+
+    <property
+        name="PLAIN_LOG_PATTERN"
+        value="%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] %logger{40} correlationId=%X{correlationId:-none} - %msg%n%ex"/>
+
+    <appender
+        name="PLAIN_CONSOLE"
+        class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${PLAIN_LOG_PATTERN}</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <appender
+        name="JSON_CONSOLE"
+        class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <findAndRegisterJacksonModules>false</findAndRegisterJacksonModules>
+            <customFields>
+                {"service":"${applicationName}","schemaVersion":1}
+            </customFields>
+
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+                <message>message</message>
+                <logger>logger</logger>
+                <thread>thread</thread>
+                <level>level</level>
+                <levelValue>[ignore]</levelValue>
+                <stackTrace>exception</stackTrace>
+                <tags>[ignore]</tags>
+            </fieldNames>
+
+            <includeMdc>true</includeMdc>
+            <includeMdcKeyName>correlationId</includeMdcKeyName>
+            <includeContext>false</includeContext>
+            <includeKeyValuePairs>false</includeKeyValuePairs>
+            <includeStructuredArguments>false</includeStructuredArguments>
+            <includeNonStructuredArguments>false</includeNonStructuredArguments>
+            <lineSeparator>UNIX</lineSeparator>
+
+            <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                <maxLength>8192</maxLength>
+                <shortenedClassNameLength>40</shortenedClassNameLength>
+                <rootCauseFirst>true</rootCauseFirst>
+            </throwableConverter>
+
+            <decorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
+                <defaultMask>[REDACTED]</defaultMask>
+                <paths>
+                    password,
+                    passphrase,
+                    authorization,
+                    refreshToken,
+                    refresh_token,
+                    accessToken,
+                    access_token,
+                    clientSecret,
+                    client_secret,
+                    apiKey,
+                    api_key,
+                    privateKey,
+                    private_key,
+                    secret,
+                    token
+                </paths>
+                <valueMasker class="com.nursena.payflow.observability.logging.SensitiveLogValueMasker"/>
+            </decorator>
+        </encoder>
+    </appender>
+
+    <springProfile name="structured-logging | production">
+        <root level="${rootLogLevel}">
+            <appender-ref ref="JSON_CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!structured-logging &amp; !production">
+        <root level="${rootLogLevel}">
+            <appender-ref ref="PLAIN_CONSOLE"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -50,6 +50,12 @@
 
             <includeMdc>true</includeMdc>
             <includeMdcKeyName>correlationId</includeMdcKeyName>
+            <includeMdcKeyName>event</includeMdcKeyName>
+            <includeMdcKeyName>http.method</includeMdcKeyName>
+            <includeMdcKeyName>http.route</includeMdcKeyName>
+            <includeMdcKeyName>http.status_code</includeMdcKeyName>
+            <includeMdcKeyName>duration_ms</includeMdcKeyName>
+            <includeMdcKeyName>outcome</includeMdcKeyName>
             <includeContext>false</includeContext>
             <includeKeyValuePairs>false</includeKeyValuePairs>
             <includeStructuredArguments>false</includeStructuredArguments>

--- a/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandAuditControllerTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandAuditControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.eventprocessing.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -55,6 +56,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(KafkaDeadLetterCommandAuditController.class)
 @Import({
+    RequestCorrelationConfiguration.class,
     SecurityConfiguration.class,
     KafkaDeadLetterCommandAuditExceptionHandler.class
 })

--- a/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandControllerTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterCommandControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.eventprocessing.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -52,6 +53,7 @@ import org.springframework.test.web.servlet.request
     KafkaDeadLetterCommandController.class
 )
 @Import({
+    RequestCorrelationConfiguration.class,
     SecurityConfiguration.class,
     KafkaDeadLetterCommandExceptionHandler.class
 })

--- a/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterQueryControllerTest.java
+++ b/src/test/java/com/nursena/payflow/eventprocessing/adapter/in/web/KafkaDeadLetterQueryControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.eventprocessing.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -52,6 +53,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(KafkaDeadLetterQueryController.class)
 @Import({
+    RequestCorrelationConfiguration.class,
     SecurityConfiguration.class,
     KafkaDeadLetterQueryExceptionHandler.class
 })

--- a/src/test/java/com/nursena/payflow/observability/adapter/in/web/CorrelationIdOpenApiCustomizerTest.java
+++ b/src/test/java/com/nursena/payflow/observability/adapter/in/web/CorrelationIdOpenApiCustomizerTest.java
@@ -1,0 +1,255 @@
+package com.nursena.payflow.observability.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.junit.jupiter.api.Test;
+
+class CorrelationIdOpenApiCustomizerTest {
+
+    private final CorrelationIdOpenApiCustomizer
+        customizer =
+            new CorrelationIdOpenApiCustomizer();
+
+    @Test
+    void shouldAddCorrelationHeaderToEveryResponse() {
+        ApiResponse getResponse =
+            new ApiResponse();
+
+        getResponse.setDescription(
+            "GET response"
+        );
+
+        ApiResponse postResponse =
+            new ApiResponse();
+
+        postResponse.setDescription(
+            "POST response"
+        );
+
+        OpenAPI openApi =
+            openApiWithResponses(
+                getResponse,
+                postResponse
+            );
+
+        customizer.customise(
+            openApi
+        );
+
+        assertThat(
+            getResponse.getHeaders()
+        )
+            .containsKey(
+                RequestCorrelationFilter.HEADER_NAME
+            );
+
+        assertThat(
+            postResponse.getHeaders()
+        )
+            .containsKey(
+                RequestCorrelationFilter.HEADER_NAME
+            );
+    }
+
+    @Test
+    void shouldExposeBoundedRequiredHeaderSchema() {
+        ApiResponse response =
+            new ApiResponse();
+
+        response.setDescription(
+            "Successful response"
+        );
+
+        OpenAPI openApi =
+            openApiWithResponses(
+                response,
+                null
+            );
+
+        customizer.customise(
+            openApi
+        );
+
+        Header header =
+            response.getHeaders()
+                .get(
+                    RequestCorrelationFilter.HEADER_NAME
+                );
+
+        assertThat(header)
+            .isNotNull();
+
+        assertThat(
+            header.getRequired()
+        )
+            .isTrue();
+
+        assertThat(
+            header.getDescription()
+        )
+            .isEqualTo(
+                CorrelationIdOpenApiCustomizer.DESCRIPTION
+            );
+
+        assertThat(
+            header.getSchema()
+                .getMaxLength()
+        )
+            .isEqualTo(
+                CorrelationIdOpenApiCustomizer.MAXIMUM_LENGTH
+            );
+
+        assertThat(
+            header.getSchema()
+                .getPattern()
+        )
+            .isEqualTo(
+                CorrelationIdOpenApiCustomizer.VALUE_PATTERN
+            );
+    }
+
+    @Test
+    void shouldPreserveResponseDescription() {
+        ApiResponse response =
+            new ApiResponse();
+
+        response.setDescription(
+            "Existing contract"
+        );
+
+        OpenAPI openApi =
+            openApiWithResponses(
+                response,
+                null
+            );
+
+        customizer.customise(
+            openApi
+        );
+
+        assertThat(
+            response.getDescription()
+        )
+            .isEqualTo(
+                "Existing contract"
+            );
+    }
+
+    @Test
+    void shouldIgnoreIncompleteOpenApiModels() {
+        OpenAPI emptyOpenApi =
+            new OpenAPI();
+
+        OpenAPI operationWithoutResponses =
+            new OpenAPI();
+
+        Operation operation =
+            new Operation();
+
+        PathItem pathItem =
+            new PathItem();
+
+        pathItem.setGet(
+            operation
+        );
+
+        Paths paths =
+            new Paths();
+
+        paths.addPathItem(
+            "/test",
+            pathItem
+        );
+
+        operationWithoutResponses.setPaths(
+            paths
+        );
+
+        assertThatCode(
+            () -> customizer.customise(
+                emptyOpenApi
+            )
+        )
+            .doesNotThrowAnyException();
+
+        assertThatCode(
+            () -> customizer.customise(
+                operationWithoutResponses
+            )
+        )
+            .doesNotThrowAnyException();
+    }
+
+    private static OpenAPI openApiWithResponses(
+        ApiResponse getResponse,
+        ApiResponse postResponse
+    ) {
+        ApiResponses getResponses =
+            new ApiResponses();
+
+        getResponses.addApiResponse(
+            "200",
+            getResponse
+        );
+
+        Operation getOperation =
+            new Operation();
+
+        getOperation.setResponses(
+            getResponses
+        );
+
+        PathItem pathItem =
+            new PathItem();
+
+        pathItem.setGet(
+            getOperation
+        );
+
+        if (postResponse != null) {
+            ApiResponses postResponses =
+                new ApiResponses();
+
+            postResponses.addApiResponse(
+                "201",
+                postResponse
+            );
+
+            Operation postOperation =
+                new Operation();
+
+            postOperation.setResponses(
+                postResponses
+            );
+
+            pathItem.setPost(
+                postOperation
+            );
+        }
+
+        Paths paths =
+            new Paths();
+
+        paths.addPathItem(
+            "/test",
+            pathItem
+        );
+
+        OpenAPI openApi =
+            new OpenAPI();
+
+        openApi.setPaths(
+            paths
+        );
+
+        return openApi;
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/adapter/in/web/RequestCompletionHttpIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/observability/adapter/in/web/RequestCompletionHttpIntegrationTest.java
@@ -1,0 +1,418 @@
+package com.nursena.payflow.observability.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+import com.nursena.payflow.common.exception.GlobalExceptionHandler;
+import com.nursena.payflow.observability.domain.CorrelationIdPolicy;
+import com.nursena.payflow.observability.logging.HttpRequestCompletion;
+import com.nursena.payflow.observability.logging.HttpRequestOutcome;
+import com.nursena.payflow.observability.logging.RequestCompletionLogger;
+import com.nursena.payflow.observability.logging.Slf4jRequestCompletionLogger;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+class RequestCompletionHttpIntegrationTest {
+
+    private static final String GENERATED_ID =
+        "generated-completion-123";
+
+    private final List<HttpRequestCompletion>
+        completionEvents =
+            new ArrayList<>();
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        AtomicLong nanoTime =
+            new AtomicLong(
+                1_000_000L
+            );
+
+        Slf4jRequestCompletionLogger
+            structuredLogger =
+                new Slf4jRequestCompletionLogger();
+
+        RequestCompletionLogger completionLogger =
+            completion -> {
+                completionEvents.add(
+                    completion
+                );
+
+                structuredLogger.completed(
+                    completion
+                );
+            };
+
+        RequestCorrelationFilter filter =
+            new RequestCorrelationFilter(
+                new CorrelationIdPolicy(),
+                () -> GENERATED_ID,
+                () -> nanoTime.getAndAdd(
+                    5_000_000L
+                ),
+                completionLogger
+            );
+
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(
+                    new TestController()
+                )
+                .setControllerAdvice(
+                    new GlobalExceptionHandler()
+                )
+                .addFilters(filter)
+                .build();
+    }
+
+    @AfterEach
+    void clearMdc() {
+        MDC.clear();
+    }
+
+    @Test
+    void shouldLogSuccessfulRequestOnceWithRouteTemplate()
+        throws Exception {
+        mockMvc.perform(
+            get(
+                "/test/completion/items/{itemId}",
+                "wallet-123"
+            )
+                .queryParam(
+                    "token",
+                    "query-secret"
+                )
+                .header(
+                    "Authorization",
+                    "Bearer header-secret"
+                )
+                .header(
+                    RequestCorrelationFilter.HEADER_NAME,
+                    "request-123"
+                )
+        )
+            .andExpect(
+                status().isOk()
+            );
+
+        HttpRequestCompletion completion =
+            singleCompletion();
+
+        assertThat(
+            completion.method()
+        )
+            .isEqualTo("GET");
+
+        assertThat(
+            completion.route()
+        )
+            .isEqualTo(
+                "/test/completion/items/{itemId}"
+            );
+
+        assertThat(
+            completion.statusCode()
+        )
+            .isEqualTo(200);
+
+        assertThat(
+            completion.durationMilliseconds()
+        )
+            .isEqualTo(5);
+
+        assertThat(
+            completion.outcome()
+        )
+            .isEqualTo(
+                HttpRequestOutcome.SUCCESS
+            );
+
+        assertThat(
+            completion.toString()
+        )
+            .doesNotContain(
+                "wallet-123",
+                "query-secret",
+                "header-secret",
+                "Authorization",
+                "token"
+            );
+    }
+
+    @Test
+    void shouldLogValidationErrorOnce()
+        throws Exception {
+        mockMvc.perform(
+            post("/test/completion/validation")
+                .contentType(APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "value": ""
+                    }
+                    """
+                )
+        )
+            .andExpect(
+                status().isBadRequest()
+            );
+
+        HttpRequestCompletion completion =
+            singleCompletion();
+
+        assertThat(
+            completion.route()
+        )
+            .isEqualTo(
+                "/test/completion/validation"
+            );
+
+        assertThat(
+            completion.statusCode()
+        )
+            .isEqualTo(400);
+
+        assertThat(
+            completion.outcome()
+        )
+            .isEqualTo(
+                HttpRequestOutcome.CLIENT_ERROR
+            );
+    }
+
+    @Test
+    void shouldLogBusinessErrorOnce()
+        throws Exception {
+        mockMvc.perform(
+            get("/test/completion/business")
+        )
+            .andExpect(
+                status().isUnprocessableEntity()
+            );
+
+        HttpRequestCompletion completion =
+            singleCompletion();
+
+        assertThat(
+            completion.route()
+        )
+            .isEqualTo(
+                "/test/completion/business"
+            );
+
+        assertThat(
+            completion.statusCode()
+        )
+            .isEqualTo(422);
+
+        assertThat(
+            completion.outcome()
+        )
+            .isEqualTo(
+                HttpRequestOutcome.CLIENT_ERROR
+            );
+    }
+
+    @Test
+    void shouldLogUnmatchedRequestWithoutRawPath()
+        throws Exception {
+        mockMvc.perform(
+            get("/private/customer-123")
+                .queryParam(
+                    "password",
+                    "query-secret"
+                )
+        )
+            .andExpect(
+                status().isNotFound()
+            );
+
+        HttpRequestCompletion completion =
+            singleCompletion();
+
+        assertThat(
+            completion.route()
+        )
+            .isEqualTo(
+                RequestCorrelationFilter
+                    .UNMATCHED_ROUTE
+            );
+
+        assertThat(
+            completion.statusCode()
+        )
+            .isEqualTo(404);
+
+        assertThat(
+            completion.toString()
+        )
+            .doesNotContain(
+                "private",
+                "customer-123",
+                "password",
+                "query-secret"
+            );
+    }
+
+    @Test
+    void shouldLogUnhandledFailureAsServerError() {
+        try {
+            mockMvc.perform(
+                get("/test/completion/failure")
+            )
+                .andReturn();
+        }
+        catch (Exception expected) {
+        }
+
+        HttpRequestCompletion completion =
+            singleCompletion();
+
+        assertThat(
+            completion.route()
+        )
+            .isEqualTo(
+                "/test/completion/failure"
+            );
+
+        assertThat(
+            completion.statusCode()
+        )
+            .isEqualTo(500);
+
+        assertThat(
+            completion.outcome()
+        )
+            .isEqualTo(
+                HttpRequestOutcome.SERVER_ERROR
+            );
+    }
+
+    @Test
+    void shouldClearRequestAndCompletionMdcAfterRequest()
+        throws Exception {
+        mockMvc.perform(
+            get(
+                "/test/completion/items/{itemId}",
+                "wallet-123"
+            )
+        )
+            .andExpect(
+                status().isOk()
+            );
+
+        assertThat(
+            MDC.get(
+                RequestCorrelationFilter.MDC_KEY
+            )
+        )
+            .isNull();
+
+        assertThat(
+            MDC.get(
+                Slf4jRequestCompletionLogger.EVENT_KEY
+            )
+        )
+            .isNull();
+
+        assertThat(
+            MDC.get(
+                Slf4jRequestCompletionLogger.ROUTE_KEY
+            )
+        )
+            .isNull();
+
+        assertThat(
+            completionEvents
+        )
+            .hasSize(1);
+    }
+
+    private HttpRequestCompletion singleCompletion() {
+        assertThat(
+            completionEvents
+        )
+            .hasSize(1);
+
+        return completionEvents.get(0);
+    }
+
+    @RestController
+    @RequestMapping("/test/completion")
+    static class TestController {
+
+        @GetMapping("/items/{itemId}")
+        Map<String, String> item(
+            @PathVariable
+            String itemId
+        ) {
+            return Map.of(
+                "itemId",
+                itemId
+            );
+        }
+
+        @PostMapping("/validation")
+        void validation(
+            @Valid
+            @RequestBody
+            TestRequest request
+        ) {
+        }
+
+        @GetMapping("/business")
+        void business() {
+            throw new TestBusinessRuleException();
+        }
+
+        @GetMapping("/failure")
+        void failure() {
+            throw new IllegalStateException(
+                "simulated unhandled failure"
+            );
+        }
+    }
+
+    record TestRequest(
+        @NotBlank(
+            message = "Value is required."
+        )
+        String value
+    ) {
+    }
+
+    static final class TestBusinessRuleException
+        extends BusinessRuleException {
+
+        TestBusinessRuleException() {
+            super(
+                "TEST_BUSINESS_RULE",
+                "Simulated business-rule failure."
+            );
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationContextTest.java
+++ b/src/test/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationContextTest.java
@@ -1,0 +1,96 @@
+package com.nursena.payflow.observability.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class RequestCorrelationContextTest {
+
+    @Test
+    void shouldReadEffectiveCorrelationId() {
+        MockHttpServletRequest request =
+            new MockHttpServletRequest();
+
+        request.setAttribute(
+            RequestCorrelationFilter
+                .REQUEST_ATTRIBUTE,
+            "request-123"
+        );
+
+        assertThat(
+            RequestCorrelationContext
+                .require(request)
+        )
+            .isEqualTo(
+                "request-123"
+            );
+    }
+
+    @Test
+    void shouldRejectMissingAttribute() {
+        MockHttpServletRequest request =
+            new MockHttpServletRequest();
+
+        assertThatThrownBy(
+            () ->
+                RequestCorrelationContext
+                    .require(request)
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "effective correlation ID is unavailable"
+            );
+    }
+
+    @Test
+    void shouldRejectNonStringAttribute() {
+        MockHttpServletRequest request =
+            new MockHttpServletRequest();
+
+        request.setAttribute(
+            RequestCorrelationFilter
+                .REQUEST_ATTRIBUTE,
+            123
+        );
+
+        assertThatThrownBy(
+            () ->
+                RequestCorrelationContext
+                    .require(request)
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "effective correlation ID is unavailable"
+            );
+    }
+
+    @Test
+    void shouldRejectBlankAttribute() {
+        MockHttpServletRequest request =
+            new MockHttpServletRequest();
+
+        request.setAttribute(
+            RequestCorrelationFilter
+                .REQUEST_ATTRIBUTE,
+            " "
+        );
+
+        assertThatThrownBy(
+            () ->
+                RequestCorrelationContext
+                    .require(request)
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "effective correlation ID is unavailable"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationFilterTest.java
+++ b/src/test/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationFilterTest.java
@@ -1,0 +1,365 @@
+package com.nursena.payflow.observability.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+
+import com.nursena.payflow.observability.domain.CorrelationIdPolicy;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class RequestCorrelationFilterTest {
+
+    @AfterEach
+    void clearMdc() {
+        MDC.clear();
+    }
+
+    @Test
+    void shouldPreserveAcceptedInboundValueDuringRequest()
+        throws Exception {
+        RequestCorrelationFilter filter =
+            filter(
+                "generated-123"
+            );
+
+        MockHttpServletRequest request =
+            new MockHttpServletRequest();
+
+        request.addHeader(
+            RequestCorrelationFilter.HEADER_NAME,
+            "request-123"
+        );
+
+        MockHttpServletResponse response =
+            new MockHttpServletResponse();
+
+        filter.doFilter(
+            request,
+            response,
+            (servletRequest, servletResponse) -> {
+                assertThat(
+                    MDC.get(
+                        RequestCorrelationFilter.MDC_KEY
+                    )
+                )
+                    .isEqualTo(
+                        "request-123"
+                    );
+
+                assertThat(
+                    ((HttpServletRequest) servletRequest)
+                        .getAttribute(
+                            RequestCorrelationFilter
+                                .REQUEST_ATTRIBUTE
+                        )
+                )
+                    .isEqualTo(
+                        "request-123"
+                    );
+            }
+        );
+
+        assertThat(
+            response.getHeader(
+                RequestCorrelationFilter.HEADER_NAME
+            )
+        )
+            .isEqualTo(
+                "request-123"
+            );
+
+        assertThat(
+            MDC.get(
+                RequestCorrelationFilter.MDC_KEY
+            )
+        )
+            .isNull();
+    }
+
+    @Test
+    void shouldGenerateWhenHeaderIsMissing()
+        throws Exception {
+        RequestCorrelationFilter filter =
+            filter(
+                "generated-123"
+            );
+
+        MockHttpServletRequest request =
+            new MockHttpServletRequest();
+
+        MockHttpServletResponse response =
+            new MockHttpServletResponse();
+
+        filter.doFilter(
+            request,
+            response,
+            (servletRequest, servletResponse) -> {
+                assertThat(
+                    MDC.get(
+                        RequestCorrelationFilter.MDC_KEY
+                    )
+                )
+                    .isEqualTo(
+                        "generated-123"
+                    );
+            }
+        );
+
+        assertThat(
+            response.getHeader(
+                RequestCorrelationFilter.HEADER_NAME
+            )
+        )
+            .isEqualTo(
+                "generated-123"
+            );
+    }
+
+    @Test
+    void shouldReplaceLineBreakingHeader()
+        throws Exception {
+        RequestCorrelationFilter filter =
+            filter(
+                "generated-123"
+            );
+
+        MockHttpServletRequest request =
+            new MockHttpServletRequest();
+
+        request.addHeader(
+            RequestCorrelationFilter.HEADER_NAME,
+            "request-123\r\nforged"
+        );
+
+        MockHttpServletResponse response =
+            new MockHttpServletResponse();
+
+        filter.doFilter(
+            request,
+            response,
+            (servletRequest, servletResponse) -> {
+                assertThat(
+                    MDC.get(
+                        RequestCorrelationFilter.MDC_KEY
+                    )
+                )
+                    .isEqualTo(
+                        "generated-123"
+                    );
+            }
+        );
+
+        assertThat(
+            response.getHeader(
+                RequestCorrelationFilter.HEADER_NAME
+            )
+        )
+            .isEqualTo(
+                "generated-123"
+            );
+    }
+
+    @Test
+    void shouldReplaceOversizedHeader()
+        throws Exception {
+        RequestCorrelationFilter filter =
+            filter(
+                "generated-123"
+            );
+
+        MockHttpServletRequest request =
+            new MockHttpServletRequest();
+
+        request.addHeader(
+            RequestCorrelationFilter.HEADER_NAME,
+            "a".repeat(
+                CorrelationIdPolicy
+                    .MAXIMUM_LENGTH
+                    + 1
+            )
+        );
+
+        MockHttpServletResponse response =
+            new MockHttpServletResponse();
+
+        filter.doFilter(
+            request,
+            response,
+            (servletRequest, servletResponse) -> {
+                assertThat(
+                    MDC.get(
+                        RequestCorrelationFilter.MDC_KEY
+                    )
+                )
+                    .isEqualTo(
+                        "generated-123"
+                    );
+            }
+        );
+
+        assertThat(
+            response.getHeader(
+                RequestCorrelationFilter.HEADER_NAME
+            )
+        )
+            .isEqualTo(
+                "generated-123"
+            );
+    }
+
+    @Test
+    void shouldReplaceDuplicateHeaderValues()
+        throws Exception {
+        RequestCorrelationFilter filter =
+            filter(
+                "generated-123"
+            );
+
+        MockHttpServletRequest request =
+            new MockHttpServletRequest();
+
+        request.addHeader(
+            RequestCorrelationFilter.HEADER_NAME,
+            "request-123"
+        );
+
+        request.addHeader(
+            RequestCorrelationFilter.HEADER_NAME,
+            "request-456"
+        );
+
+        MockHttpServletResponse response =
+            new MockHttpServletResponse();
+
+        filter.doFilter(
+            request,
+            response,
+            (servletRequest, servletResponse) -> {
+                assertThat(
+                    MDC.get(
+                        RequestCorrelationFilter.MDC_KEY
+                    )
+                )
+                    .isEqualTo(
+                        "generated-123"
+                    );
+            }
+        );
+
+        assertThat(
+            response.getHeader(
+                RequestCorrelationFilter.HEADER_NAME
+            )
+        )
+            .isEqualTo(
+                "generated-123"
+            );
+    }
+
+    @Test
+    void shouldRemoveCorrelationContextWhenChainFails() {
+        RequestCorrelationFilter filter =
+            filter(
+                "generated-123"
+            );
+
+        MockHttpServletRequest request =
+            new MockHttpServletRequest();
+
+        MockHttpServletResponse response =
+            new MockHttpServletResponse();
+
+        assertThatThrownBy(
+            () -> filter.doFilter(
+                request,
+                response,
+                (servletRequest, servletResponse) -> {
+                    throw new ServletException(
+                        "simulated failure"
+                    );
+                }
+            )
+        )
+            .isInstanceOf(
+                ServletException.class
+            )
+            .hasMessage(
+                "simulated failure"
+            );
+
+        assertThat(
+            MDC.get(
+                RequestCorrelationFilter.MDC_KEY
+            )
+        )
+            .isNull();
+
+        assertThat(
+            response.getHeader(
+                RequestCorrelationFilter.HEADER_NAME
+            )
+        )
+            .isEqualTo(
+                "generated-123"
+            );
+    }
+
+    @Test
+    void shouldPreserveUnrelatedMdcFields()
+        throws ServletException, IOException {
+        MDC.put(
+            "unrelated",
+            "retained"
+        );
+
+        RequestCorrelationFilter filter =
+            filter(
+                "generated-123"
+            );
+
+        filter.doFilter(
+            new MockHttpServletRequest(),
+            new MockHttpServletResponse(),
+            (servletRequest, servletResponse) -> {
+                assertThat(
+                    MDC.get("unrelated")
+                )
+                    .isEqualTo(
+                        "retained"
+                    );
+            }
+        );
+
+        assertThat(
+            MDC.get("unrelated")
+        )
+            .isEqualTo(
+                "retained"
+            );
+
+        assertThat(
+            MDC.get(
+                RequestCorrelationFilter.MDC_KEY
+            )
+        )
+            .isNull();
+    }
+
+    private static RequestCorrelationFilter filter(
+        String generatedValue
+    ) {
+        return new RequestCorrelationFilter(
+            new CorrelationIdPolicy(),
+            () -> generatedValue
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationFilterTest.java
+++ b/src/test/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationFilterTest.java
@@ -359,7 +359,10 @@ class RequestCorrelationFilterTest {
     ) {
         return new RequestCorrelationFilter(
             new CorrelationIdPolicy(),
-            () -> generatedValue
+            () -> generatedValue,
+            System::nanoTime,
+            completion -> {
+            }
         );
     }
 }

--- a/src/test/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationHttpIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationHttpIntegrationTest.java
@@ -42,7 +42,10 @@ class RequestCorrelationHttpIntegrationTest {
         RequestCorrelationFilter filter =
             new RequestCorrelationFilter(
                 new CorrelationIdPolicy(),
-                () -> GENERATED_ID
+                () -> GENERATED_ID,
+                System::nanoTime,
+                completion -> {
+                }
             );
 
         mockMvc =

--- a/src/test/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationHttpIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/observability/adapter/in/web/RequestCorrelationHttpIntegrationTest.java
@@ -1,0 +1,328 @@
+package com.nursena.payflow.observability.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
+
+import com.nursena.payflow.common.exception.BusinessRuleException;
+import com.nursena.payflow.common.exception.GlobalExceptionHandler;
+import com.nursena.payflow.observability.domain.CorrelationIdPolicy;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+class RequestCorrelationHttpIntegrationTest {
+
+    private static final String GENERATED_ID =
+        "generated-123";
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        RequestCorrelationFilter filter =
+            new RequestCorrelationFilter(
+                new CorrelationIdPolicy(),
+                () -> GENERATED_ID
+            );
+
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(
+                    new TestController()
+                )
+                .setControllerAdvice(
+                    new GlobalExceptionHandler()
+                )
+                .addFilters(filter)
+                .build();
+    }
+
+    @AfterEach
+    void clearMdc() {
+        MDC.clear();
+    }
+
+    @Test
+    void shouldExposeAcceptedCorrelationIdOnSuccessfulResponse()
+        throws Exception {
+        mockMvc.perform(
+            get("/test/correlation/success")
+                .header(
+                    RequestCorrelationFilter
+                        .HEADER_NAME,
+                    "request-123"
+                )
+        )
+            .andExpect(
+                status().isOk()
+            )
+            .andExpect(
+                header().string(
+                    RequestCorrelationFilter
+                        .HEADER_NAME,
+                    "request-123"
+                )
+            )
+            .andExpect(
+                jsonPath("$.correlationId")
+                    .value("request-123")
+            );
+    }
+
+    @Test
+    void shouldGenerateCorrelationIdWhenMissing()
+        throws Exception {
+        mockMvc.perform(
+            get("/test/correlation/success")
+        )
+            .andExpect(
+                status().isOk()
+            )
+            .andExpect(
+                header().string(
+                    RequestCorrelationFilter
+                        .HEADER_NAME,
+                    GENERATED_ID
+                )
+            )
+            .andExpect(
+                jsonPath("$.correlationId")
+                    .value(GENERATED_ID)
+            );
+    }
+
+    @Test
+    void shouldIncludeCorrelationIdInBusinessErrorBody()
+        throws Exception {
+        mockMvc.perform(
+            get("/test/correlation/business")
+                .header(
+                    RequestCorrelationFilter
+                        .HEADER_NAME,
+                    "business-123"
+                )
+        )
+            .andExpect(
+                status().isUnprocessableEntity()
+            )
+            .andExpect(
+                header().string(
+                    RequestCorrelationFilter
+                        .HEADER_NAME,
+                    "business-123"
+                )
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("TEST_BUSINESS_RULE")
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/test/correlation/business"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.correlationId")
+                    .value("business-123")
+            )
+            .andExpect(
+                jsonPath("$.violations")
+                    .isEmpty()
+            );
+    }
+
+    @Test
+    void shouldIncludeCorrelationIdInValidationErrorBody()
+        throws Exception {
+        mockMvc.perform(
+            post("/test/correlation/validation")
+                .contentType(APPLICATION_JSON)
+                .header(
+                    RequestCorrelationFilter
+                        .HEADER_NAME,
+                    "validation-123"
+                )
+                .content(
+                    """
+                    {
+                      "value": ""
+                    }
+                    """
+                )
+        )
+            .andExpect(
+                status().isBadRequest()
+            )
+            .andExpect(
+                header().string(
+                    RequestCorrelationFilter
+                        .HEADER_NAME,
+                    "validation-123"
+                )
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value("VALIDATION_FAILED")
+            )
+            .andExpect(
+                jsonPath("$.correlationId")
+                    .value("validation-123")
+            )
+            .andExpect(
+                jsonPath("$.violations[0].field")
+                    .value("value")
+            )
+            .andExpect(
+                jsonPath("$.violations[0].message")
+                    .value("Value is required.")
+            );
+    }
+
+    @Test
+    void shouldReplaceMalformedInboundValue()
+        throws Exception {
+        mockMvc.perform(
+            get("/test/correlation/business")
+                .header(
+                    RequestCorrelationFilter
+                        .HEADER_NAME,
+                    "bad value"
+                )
+        )
+            .andExpect(
+                status().isUnprocessableEntity()
+            )
+            .andExpect(
+                header().string(
+                    RequestCorrelationFilter
+                        .HEADER_NAME,
+                    GENERATED_ID
+                )
+            )
+            .andExpect(
+                jsonPath("$.correlationId")
+                    .value(GENERATED_ID)
+            );
+    }
+
+    @Test
+    void shouldReplaceDuplicateInboundValues()
+        throws Exception {
+        mockMvc.perform(
+            get("/test/correlation/business")
+                .header(
+                    RequestCorrelationFilter
+                        .HEADER_NAME,
+                    "request-123",
+                    "request-456"
+                )
+        )
+            .andExpect(
+                status().isUnprocessableEntity()
+            )
+            .andExpect(
+                header().string(
+                    RequestCorrelationFilter
+                        .HEADER_NAME,
+                    GENERATED_ID
+                )
+            )
+            .andExpect(
+                jsonPath("$.correlationId")
+                    .value(GENERATED_ID)
+            );
+    }
+
+    @Test
+    void shouldClearMdcAfterCompletedRequest()
+        throws Exception {
+        mockMvc.perform(
+            get("/test/correlation/success")
+                .header(
+                    RequestCorrelationFilter
+                        .HEADER_NAME,
+                    "request-123"
+                )
+        )
+            .andExpect(
+                status().isOk()
+            );
+
+        assertThat(
+            MDC.get(
+                RequestCorrelationFilter
+                    .MDC_KEY
+            )
+        )
+            .isNull();
+    }
+
+    @RestController
+    @RequestMapping("/test/correlation")
+    static class TestController {
+
+        @GetMapping("/success")
+        Map<String, String> success(
+            HttpServletRequest request
+        ) {
+            return Map.of(
+                "correlationId",
+                RequestCorrelationContext
+                    .require(request)
+            );
+        }
+
+        @GetMapping("/business")
+        Map<String, String> business() {
+            throw new TestBusinessRuleException();
+        }
+
+        @PostMapping("/validation")
+        void validation(
+            @Valid
+            @RequestBody
+            TestRequest request
+        ) {
+        }
+    }
+
+    record TestRequest(
+        @NotBlank(
+            message = "Value is required."
+        )
+        String value
+    ) {
+    }
+
+    static final class TestBusinessRuleException
+        extends BusinessRuleException {
+
+        TestBusinessRuleException() {
+            super(
+                "TEST_BUSINESS_RULE",
+                "Simulated business-rule failure."
+            );
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/adapter/out/uuid/UuidCorrelationIdGeneratorTest.java
+++ b/src/test/java/com/nursena/payflow/observability/adapter/out/uuid/UuidCorrelationIdGeneratorTest.java
@@ -1,0 +1,35 @@
+package com.nursena.payflow.observability.adapter.out.uuid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class UuidCorrelationIdGeneratorTest {
+
+    private final UuidCorrelationIdGenerator generator =
+        new UuidCorrelationIdGenerator();
+
+    @Test
+    void shouldGenerateCanonicalUuid() {
+        String generated =
+            generator.generate();
+
+        assertThat(
+            UUID.fromString(generated)
+                .toString()
+        )
+            .isEqualTo(generated);
+    }
+
+    @Test
+    void shouldGenerateDistinctValues() {
+        assertThat(
+            generator.generate()
+        )
+            .isNotEqualTo(
+                generator.generate()
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/domain/CorrelationIdPolicyTest.java
+++ b/src/test/java/com/nursena/payflow/observability/domain/CorrelationIdPolicyTest.java
@@ -1,0 +1,157 @@
+package com.nursena.payflow.observability.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class CorrelationIdPolicyTest {
+
+    private final CorrelationIdPolicy policy =
+        new CorrelationIdPolicy();
+
+    @Test
+    void shouldAcceptBoundedAsciiIdentifiers() {
+        assertThat(
+            policy.isAccepted(
+                "request-123_ABC.trace:7"
+            )
+        )
+            .isTrue();
+
+        assertThat(
+            policy.isAccepted(
+                "550e8400-e29b-41d4-a716-446655440000"
+            )
+        )
+            .isTrue();
+    }
+
+    @Test
+    void shouldRejectMissingBlankOrWhitespaceBearingValues() {
+        assertThat(
+            policy.isAccepted(null)
+        )
+            .isFalse();
+
+        assertThat(
+            policy.isAccepted("")
+        )
+            .isFalse();
+
+        assertThat(
+            policy.isAccepted(
+                " request-123"
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            policy.isAccepted(
+                "request 123"
+            )
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldRejectLineBreaksAndUnsupportedCharacters() {
+        assertThat(
+            policy.isAccepted(
+                "request-123\r\nforged-entry"
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            policy.isAccepted(
+                "request/123"
+            )
+        )
+            .isFalse();
+
+        assertThat(
+            policy.isAccepted(
+                "istek-ç"
+            )
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldRejectOversizedValues() {
+        assertThat(
+            policy.isAccepted(
+                "a".repeat(
+                    CorrelationIdPolicy
+                        .MAXIMUM_LENGTH
+                )
+            )
+        )
+            .isTrue();
+
+        assertThat(
+            policy.isAccepted(
+                "a".repeat(
+                    CorrelationIdPolicy
+                        .MAXIMUM_LENGTH
+                        + 1
+                )
+            )
+        )
+            .isFalse();
+    }
+
+    @Test
+    void shouldPreserveAcceptedInboundValue() {
+        String effective =
+            policy.effective(
+                "request-123",
+                () -> "generated-456"
+            );
+
+        assertThat(effective)
+            .isEqualTo(
+                "request-123"
+            );
+    }
+
+    @Test
+    void shouldGenerateForMissingOrRejectedInboundValue() {
+        assertThat(
+            policy.effective(
+                null,
+                () -> "generated-123"
+            )
+        )
+            .isEqualTo(
+                "generated-123"
+            );
+
+        assertThat(
+            policy.effective(
+                "bad value",
+                () -> "generated-456"
+            )
+        )
+            .isEqualTo(
+                "generated-456"
+            );
+    }
+
+    @Test
+    void shouldRejectInvalidGeneratedValue() {
+        assertThatThrownBy(
+            () -> policy.effective(
+                null,
+                () -> "invalid generated value"
+            )
+        )
+            .isInstanceOf(
+                IllegalStateException.class
+            )
+            .hasMessage(
+                "generated correlation ID violates the policy"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/logging/HttpRequestOutcomeTest.java
+++ b/src/test/java/com/nursena/payflow/observability/logging/HttpRequestOutcomeTest.java
@@ -1,0 +1,73 @@
+package com.nursena.payflow.observability.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class HttpRequestOutcomeTest {
+
+    @Test
+    void shouldClassifySuccessfulResponse() {
+        assertThat(
+            HttpRequestOutcome.from(
+                200,
+                false
+            )
+        )
+            .isEqualTo(
+                HttpRequestOutcome.SUCCESS
+            );
+    }
+
+    @Test
+    void shouldClassifyRedirectionAsSuccess() {
+        assertThat(
+            HttpRequestOutcome.from(
+                302,
+                false
+            )
+        )
+            .isEqualTo(
+                HttpRequestOutcome.SUCCESS
+            );
+    }
+
+    @Test
+    void shouldClassifyClientError() {
+        assertThat(
+            HttpRequestOutcome.from(
+                422,
+                false
+            )
+        )
+            .isEqualTo(
+                HttpRequestOutcome.CLIENT_ERROR
+            );
+    }
+
+    @Test
+    void shouldClassifyServerError() {
+        assertThat(
+            HttpRequestOutcome.from(
+                503,
+                false
+            )
+        )
+            .isEqualTo(
+                HttpRequestOutcome.SERVER_ERROR
+            );
+    }
+
+    @Test
+    void shouldPrioritizeUnhandledFailure() {
+        assertThat(
+            HttpRequestOutcome.from(
+                200,
+                true
+            )
+        )
+            .isEqualTo(
+                HttpRequestOutcome.SERVER_ERROR
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/logging/ObservabilityAcceptanceDocumentationTest.java
+++ b/src/test/java/com/nursena/payflow/observability/logging/ObservabilityAcceptanceDocumentationTest.java
@@ -1,0 +1,201 @@
+package com.nursena.payflow.observability.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class ObservabilityAcceptanceDocumentationTest {
+
+    private static final Path README =
+        Path.of("README.md");
+
+    private static final Path OPERATIONS_GUIDE =
+        Path.of(
+            "docs",
+            "operations",
+            "structured-logging.md"
+        );
+
+    private static final Path RELEASE_NOTES =
+        Path.of(
+            "docs",
+            "releases",
+            "v0.11.0.md"
+        );
+
+    private static final Path POSTMAN_COLLECTION =
+        Path.of(
+            "postman",
+            "PayFlow.postman_collection.json"
+        );
+
+    private static final Path DOCKER_SMOKE =
+        Path.of(
+            ".github",
+            "workflows",
+            "docker-smoke.yml"
+        );
+
+    private final ObjectMapper objectMapper =
+        new ObjectMapper();
+
+    @Test
+    void shouldDocumentSynchronousAndAsynchronousBoundaries()
+        throws IOException {
+        String guide =
+            Files.readString(
+                OPERATIONS_GUIDE
+            );
+
+        assertThat(guide)
+            .contains(
+                "## Synchronous and asynchronous boundaries"
+            )
+            .contains(
+                "does not treat a request correlation ID as a business identifier"
+            )
+            .contains(
+                "transactional outbox publication"
+            )
+            .contains(
+                "Kafka consumers"
+            )
+            .contains(
+                "must be an explicit event-schema decision"
+            );
+    }
+
+    @Test
+    void shouldDocumentBoundedExceptionPolicy()
+        throws IOException {
+        String guide =
+            Files.readString(
+                OPERATIONS_GUIDE
+            );
+
+        assertThat(guide)
+            .contains(
+                "## Exception and stack-trace policy"
+            )
+            .contains(
+                "maximum depth per throwable: 30"
+            )
+            .contains(
+                "maximum encoded exception length: 8192 characters"
+            )
+            .contains(
+                "The request-completion event never includes a throwable"
+            )
+            .contains(
+                "No profile enables request bodies"
+            );
+    }
+
+    @Test
+    void shouldPublishReleaseCandidateNotesAndReadmeLink()
+        throws IOException {
+        String releaseNotes =
+            Files.readString(
+                RELEASE_NOTES
+            );
+
+        String readme =
+            Files.readString(
+                README
+            );
+
+        assertThat(releaseNotes)
+            .contains(
+                "# PayFlow v0.11.0 release candidate notes"
+            )
+            .contains(
+                "v0.10.0 remains the latest published release"
+            )
+            .contains(
+                "No database migration is included."
+            )
+            .contains(
+                "Asynchronous request-correlation propagation is deliberately out of scope"
+            );
+
+        assertThat(readme)
+            .contains(
+                "docs/releases/v0.11.0.md"
+            )
+            .contains(
+                "submitted for protected pull-request review"
+            );
+    }
+
+    @Test
+    void shouldVerifyCorrelationHeaderInPostman()
+        throws IOException {
+        JsonNode collection =
+            objectMapper.readTree(
+                Files.readString(
+                    POSTMAN_COLLECTION
+                )
+            );
+
+        String serialized =
+            collection.toString();
+
+        assertThat(serialized)
+            .contains(
+                "Response contains a bounded X-Correlation-ID"
+            )
+            .contains(
+                "pm.response.headers.get('X-Correlation-ID')"
+            )
+            .contains(
+                "to.be.at.most(64)"
+            )
+            .contains(
+                "pm.environment.set('correlationId'"
+            );
+    }
+
+    @Test
+    void shouldDefineProtectedDockerSmokeContract()
+        throws IOException {
+        String workflow =
+            Files.readString(
+                DOCKER_SMOKE
+            );
+
+        assertThat(workflow)
+            .contains(
+                "name: Docker Smoke"
+            )
+            .contains(
+                "pull_request:"
+            )
+            .contains(
+                "SPRING_PROFILES_ACTIVE: production"
+            )
+            .contains(
+                "docker compose config --quiet"
+            )
+            .contains(
+                "GRAFANA_ADMIN_PASSWORD: payflow-smoke-local-only"
+            )
+            .contains(
+                "http://localhost:8080/api/v1/system/health"
+            )
+            .contains(
+                "X-Correlation-ID"
+            )
+            .contains(
+                "\"event\":\"http.request.completed\""
+            )
+            .contains(
+                "down -v --remove-orphans"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/logging/SensitiveLogValueMaskerTest.java
+++ b/src/test/java/com/nursena/payflow/observability/logging/SensitiveLogValueMaskerTest.java
@@ -1,0 +1,140 @@
+package com.nursena.payflow.observability.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SensitiveLogValueMaskerTest {
+
+    private final SensitiveLogValueMasker masker =
+        new SensitiveLogValueMasker();
+
+    @Test
+    void shouldMaskBearerAuthorizationAssignment() {
+        String value =
+            "Authorization: Bearer abc.def-123";
+
+        assertThat(
+            SensitiveLogValueMasker.redact(value)
+        )
+            .isEqualTo(
+                "Authorization: [REDACTED]"
+            );
+    }
+
+    @Test
+    void shouldMaskJsonPassword() {
+        String value =
+            """
+            {"email":"person@example.com","password":"secret-value"}
+            """.trim();
+
+        String redacted =
+            SensitiveLogValueMasker.redact(value);
+
+        assertThat(redacted)
+            .contains(
+                "\"password\":[REDACTED]"
+            )
+            .doesNotContain(
+                "secret-value"
+            );
+    }
+
+    @Test
+    void shouldMaskOpaqueRefreshTokenAssignment() {
+        String value =
+            "refresh_token=opaque-refresh-token-123";
+
+        assertThat(
+            SensitiveLogValueMasker.redact(value)
+        )
+            .isEqualTo(
+                "refresh_token=[REDACTED]"
+            );
+    }
+
+    @Test
+    void shouldMaskJwtAnywhere() {
+        String jwt =
+            "eyJhbGciOiJSUzI1NiJ9"
+                + ".eyJzdWIiOiIxMjM0NTY3ODkwIn0"
+                + ".signature-value";
+
+        String redacted =
+            SensitiveLogValueMasker.redact(
+                "token received " + jwt
+            );
+
+        assertThat(redacted)
+            .isEqualTo(
+                "token received [REDACTED]"
+            );
+    }
+
+    @Test
+    void shouldMaskMultipleSecrets() {
+        String value =
+            "password=first apiKey=second client_secret=third";
+
+        String redacted =
+            SensitiveLogValueMasker.redact(value);
+
+        assertThat(redacted)
+            .contains(
+                "password=[REDACTED]"
+            )
+            .contains(
+                "apiKey=[REDACTED]"
+            )
+            .contains(
+                "client_secret=[REDACTED]"
+            )
+            .doesNotContain(
+                "first",
+                "second",
+                "third"
+            );
+    }
+
+    @Test
+    void shouldLeaveOrdinaryMessageUnchanged() {
+        String value =
+            "Wallet transfer completed successfully.";
+
+        assertThat(
+            masker.mask(
+                null,
+                value
+            )
+        )
+            .isNull();
+
+        assertThat(
+            SensitiveLogValueMasker.redact(value)
+        )
+            .isEqualTo(value);
+    }
+
+    @Test
+    void shouldLeaveCorrelationIdentifierUnchanged() {
+        String value =
+            "correlationId=request-123";
+
+        assertThat(
+            SensitiveLogValueMasker.redact(value)
+        )
+            .isEqualTo(value);
+    }
+
+    @Test
+    void shouldIgnoreNonStringValues() {
+        assertThat(
+            masker.mask(
+                null,
+                42
+            )
+        )
+            .isNull();
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/logging/Slf4jRequestCompletionLoggerTest.java
+++ b/src/test/java/com/nursena/payflow/observability/logging/Slf4jRequestCompletionLoggerTest.java
@@ -1,0 +1,290 @@
+package com.nursena.payflow.observability.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+class Slf4jRequestCompletionLoggerTest {
+
+    private Logger logger;
+    private Level originalLevel;
+    private boolean originalAdditive;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void setUp() {
+        logger =
+            (Logger) LoggerFactory.getLogger(
+                Slf4jRequestCompletionLogger.class
+            );
+
+        originalLevel =
+            logger.getLevel();
+
+        originalAdditive =
+            logger.isAdditive();
+
+        logger.setLevel(
+            Level.INFO
+        );
+
+        logger.setAdditive(
+            false
+        );
+
+        appender =
+            new SnapshottingListAppender();
+
+        appender.setContext(
+            logger.getLoggerContext()
+        );
+
+        appender.start();
+
+        logger.addAppender(
+            appender
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(
+            appender
+        );
+
+        appender.stop();
+
+        logger.setLevel(
+            originalLevel
+        );
+
+        logger.setAdditive(
+            originalAdditive
+        );
+
+        MDC.clear();
+    }
+
+    @Test
+    void shouldWriteSafeStructuredFieldsAndPreserveCorrelation() {
+        MDC.put(
+            "correlationId",
+            "request-123"
+        );
+
+        new Slf4jRequestCompletionLogger()
+            .completed(
+                completion()
+            );
+
+        assertThat(
+            appender.list
+        )
+            .hasSize(1);
+
+        ILoggingEvent event =
+            appender.list.get(0);
+
+        assertThat(
+            event.getMDCPropertyMap()
+        )
+            .containsEntry(
+                "correlationId",
+                "request-123"
+            )
+            .containsEntry(
+                Slf4jRequestCompletionLogger.EVENT_KEY,
+                Slf4jRequestCompletionLogger
+                    .COMPLETION_EVENT
+            )
+            .containsEntry(
+                Slf4jRequestCompletionLogger.METHOD_KEY,
+                "GET"
+            )
+            .containsEntry(
+                Slf4jRequestCompletionLogger.ROUTE_KEY,
+                "/api/v1/wallets/{walletId}"
+            )
+            .containsEntry(
+                Slf4jRequestCompletionLogger.STATUS_CODE_KEY,
+                "200"
+            )
+            .containsEntry(
+                Slf4jRequestCompletionLogger.DURATION_KEY,
+                "12"
+            )
+            .containsEntry(
+                Slf4jRequestCompletionLogger.OUTCOME_KEY,
+                "SUCCESS"
+            );
+
+        assertThat(
+            MDC.get("correlationId")
+        )
+            .isEqualTo(
+                "request-123"
+            );
+
+        assertTemporaryFieldsCleared();
+    }
+
+    @Test
+    void shouldRestorePreexistingTemporaryFields() {
+        MDC.put(
+            Slf4jRequestCompletionLogger.EVENT_KEY,
+            "previous-event"
+        );
+
+        MDC.put(
+            Slf4jRequestCompletionLogger.METHOD_KEY,
+            "PREVIOUS"
+        );
+
+        new Slf4jRequestCompletionLogger()
+            .completed(
+                completion()
+            );
+
+        assertThat(
+            MDC.get(
+                Slf4jRequestCompletionLogger.EVENT_KEY
+            )
+        )
+            .isEqualTo(
+                "previous-event"
+            );
+
+        assertThat(
+            MDC.get(
+                Slf4jRequestCompletionLogger.METHOD_KEY
+            )
+        )
+            .isEqualTo(
+                "PREVIOUS"
+            );
+
+        assertThat(
+            MDC.get(
+                Slf4jRequestCompletionLogger.ROUTE_KEY
+            )
+        )
+            .isNull();
+    }
+
+    @Test
+    void shouldExposeOnlyBoundedCompletionFields() {
+        new Slf4jRequestCompletionLogger()
+            .completed(
+                completion()
+            );
+
+        Map<String, String> fields =
+            appender.list
+                .get(0)
+                .getMDCPropertyMap();
+
+        assertThat(fields)
+            .containsOnlyKeys(
+                Slf4jRequestCompletionLogger.EVENT_KEY,
+                Slf4jRequestCompletionLogger.METHOD_KEY,
+                Slf4jRequestCompletionLogger.ROUTE_KEY,
+                Slf4jRequestCompletionLogger.STATUS_CODE_KEY,
+                Slf4jRequestCompletionLogger.DURATION_KEY,
+                Slf4jRequestCompletionLogger.OUTCOME_KEY
+            );
+
+        assertThat(
+            appender.list
+                .get(0)
+                .getFormattedMessage()
+        )
+            .doesNotContain(
+                "password",
+                "authorization",
+                "token",
+                "secret"
+            );
+
+        assertTemporaryFieldsCleared();
+    }
+
+    private static HttpRequestCompletion completion() {
+        return new HttpRequestCompletion(
+            "GET",
+            "/api/v1/wallets/{walletId}",
+            200,
+            12,
+            HttpRequestOutcome.SUCCESS
+        );
+    }
+
+    private static void assertTemporaryFieldsCleared() {
+        assertThat(
+            MDC.get(
+                Slf4jRequestCompletionLogger.EVENT_KEY
+            )
+        )
+            .isNull();
+
+        assertThat(
+            MDC.get(
+                Slf4jRequestCompletionLogger.METHOD_KEY
+            )
+        )
+            .isNull();
+
+        assertThat(
+            MDC.get(
+                Slf4jRequestCompletionLogger.ROUTE_KEY
+            )
+        )
+            .isNull();
+
+        assertThat(
+            MDC.get(
+                Slf4jRequestCompletionLogger.STATUS_CODE_KEY
+            )
+        )
+            .isNull();
+
+        assertThat(
+            MDC.get(
+                Slf4jRequestCompletionLogger.DURATION_KEY
+            )
+        )
+            .isNull();
+
+        assertThat(
+            MDC.get(
+                Slf4jRequestCompletionLogger.OUTCOME_KEY
+            )
+        )
+            .isNull();
+    }
+
+    private static final class SnapshottingListAppender
+        extends ListAppender<ILoggingEvent> {
+
+        @Override
+        protected void append(
+            ILoggingEvent event
+        ) {
+            event.prepareForDeferredProcessing();
+
+            super.append(
+                event
+            );
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/logging/StructuredJsonEncodingTest.java
+++ b/src/test/java/com/nursena/payflow/observability/logging/StructuredJsonEncodingTest.java
@@ -1,0 +1,345 @@
+package com.nursena.payflow.observability.logging;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggingEvent;
+
+import net.logstash.logback.encoder.LogstashEncoder;
+import net.logstash.logback.fieldnames.LogstashFieldNames;
+import net.logstash.logback.mask.MaskingJsonGeneratorDecorator;
+
+import org.junit.jupiter.api.Test;
+
+class StructuredJsonEncodingTest {
+
+    private final ObjectMapper objectMapper =
+        new ObjectMapper();
+
+    @Test
+    void shouldEncodeOneValidJsonLineWithStableFields()
+        throws Exception {
+        LogstashEncoder encoder =
+            encoder(true);
+
+        try {
+            LoggingEvent event =
+                event(
+                    "Transfer completed.",
+                    Map.of(
+                        "correlationId",
+                        "request-123",
+                        "unrelated",
+                        "must-not-appear"
+                    )
+                );
+
+            String encoded =
+                new String(
+                    encoder.encode(event),
+                    UTF_8
+                );
+
+            JsonNode json =
+                objectMapper.readTree(encoded);
+
+            assertThat(
+                json.path("service").asText()
+            )
+                .isEqualTo(
+                    "payflow"
+                );
+
+            assertThat(
+                json.path("schemaVersion").asInt()
+            )
+                .isEqualTo(1);
+
+            assertThat(
+                json.path("message").asText()
+            )
+                .isEqualTo(
+                    "Transfer completed."
+                );
+
+            assertThat(
+                json.path("correlationId").asText()
+            )
+                .isEqualTo(
+                    "request-123"
+                );
+
+            assertThat(
+                json.has("unrelated")
+            )
+                .isFalse();
+
+            assertThat(
+                encoded.indexOf('\n')
+            )
+                .isEqualTo(
+                    encoded.length() - 1
+                );
+
+            assertThat(encoded)
+                .doesNotContain("\r");
+        }
+        finally {
+            encoder.stop();
+        }
+    }
+
+    @Test
+    void shouldRedactSensitiveMessageValues()
+        throws Exception {
+        LogstashEncoder encoder =
+            encoder(true);
+
+        try {
+            String jwt =
+                "eyJhbGciOiJSUzI1NiJ9"
+                    + ".eyJzdWIiOiIxMjM0NTY3ODkwIn0"
+                    + ".signature-value";
+
+            LoggingEvent event =
+                event(
+                    "Authorization: Bearer "
+                        + jwt
+                        + "\r\npassword=secret-value",
+                    Map.of(
+                        "correlationId",
+                        "request-456"
+                    )
+                );
+
+            String encoded =
+                new String(
+                    encoder.encode(event),
+                    UTF_8
+                );
+
+            JsonNode json =
+                objectMapper.readTree(encoded);
+
+            assertThat(
+                json.path("message").asText()
+            )
+                .contains(
+                    "[REDACTED]"
+                )
+                .doesNotContain(
+                    jwt,
+                    "secret-value"
+                );
+
+            assertThat(encoded)
+                .doesNotContain(
+                    jwt,
+                    "secret-value"
+                );
+
+            assertThat(
+                encoded.indexOf('\n')
+            )
+                .isEqualTo(
+                    encoded.length() - 1
+                );
+        }
+        finally {
+            encoder.stop();
+        }
+    }
+
+    @Test
+    void shouldMaskSensitiveStructuredFieldsByPath()
+        throws Exception {
+        LogstashEncoder encoder =
+            encoder(false);
+
+        try {
+            Map<String, String> mdc =
+                new HashMap<>();
+
+            mdc.put(
+                "correlationId",
+                "request-789"
+            );
+
+            mdc.put(
+                "password",
+                "structured-secret"
+            );
+
+            LoggingEvent event =
+                event(
+                    "Structured field test.",
+                    mdc
+                );
+
+            JsonNode json =
+                objectMapper.readTree(
+                    encoder.encode(event)
+                );
+
+            assertThat(
+                json.path("password").asText()
+            )
+                .isEqualTo(
+                    SensitiveLogValueMasker.MASK
+                );
+
+            assertThat(
+                json.toString()
+            )
+                .doesNotContain(
+                    "structured-secret"
+                );
+        }
+        finally {
+            encoder.stop();
+        }
+    }
+
+    private static LogstashEncoder encoder(
+        boolean correlationOnly
+    ) {
+        LoggerContext context =
+            new LoggerContext();
+
+        context.start();
+
+        LogstashEncoder encoder =
+            new LogstashEncoder();
+
+        encoder.setContext(context);
+        encoder.setCustomFields(
+            """
+            {
+              "service": "payflow",
+              "schemaVersion": 1
+            }
+            """
+        );
+
+        encoder.setIncludeMdc(true);
+        encoder.setIncludeContext(false);
+        encoder.setIncludeKeyValuePairs(false);
+        encoder.setIncludeStructuredArguments(false);
+        encoder.setIncludeNonStructuredArguments(false);
+        encoder.setLineSeparator("UNIX");
+
+        if (correlationOnly) {
+            encoder.addIncludeMdcKeyName(
+                "correlationId"
+            );
+        }
+
+        LogstashFieldNames fieldNames =
+            new LogstashFieldNames();
+
+        fieldNames.setTimestamp(
+            "timestamp"
+        );
+
+        fieldNames.setVersion(null);
+        fieldNames.setMessage(
+            "message"
+        );
+
+        fieldNames.setLogger(
+            "logger"
+        );
+
+        fieldNames.setThread(
+            "thread"
+        );
+
+        fieldNames.setLevel(
+            "level"
+        );
+
+        fieldNames.setLevelValue(null);
+        fieldNames.setStackTrace(
+            "exception"
+        );
+
+        fieldNames.setTags(null);
+
+        encoder.setFieldNames(
+            fieldNames
+        );
+
+        MaskingJsonGeneratorDecorator decorator =
+            new MaskingJsonGeneratorDecorator();
+
+        decorator.setDefaultMask(
+            SensitiveLogValueMasker.MASK
+        );
+
+        decorator.addPaths(
+            "password,passphrase,authorization,"
+                + "refreshToken,refresh_token,"
+                + "accessToken,access_token,"
+                + "clientSecret,client_secret,"
+                + "apiKey,api_key,"
+                + "privateKey,private_key,"
+                + "secret,token"
+        );
+
+        decorator.addValueMasker(
+            new SensitiveLogValueMasker()
+        );
+
+        encoder.setJsonGeneratorDecorator(
+            decorator
+        );
+
+        decorator.start();
+        encoder.start();
+
+        return encoder;
+    }
+
+    private static LoggingEvent event(
+        String message,
+        Map<String, String> mdc
+    ) {
+        LoggingEvent event =
+            new LoggingEvent();
+
+        event.setLoggerName(
+            "com.nursena.payflow.TestLogger"
+        );
+
+        event.setLevel(
+            Level.INFO
+        );
+
+        event.setThreadName(
+            "test-thread"
+        );
+
+        event.setInstant(
+            Instant.parse(
+                "2026-01-01T00:00:00Z"
+            )
+        );
+
+        event.setMessage(message);
+        event.setMDCPropertyMap(
+            new HashMap<>(mdc)
+        );
+
+        return event;
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/logging/StructuredLoggingConfigurationContractTest.java
+++ b/src/test/java/com/nursena/payflow/observability/logging/StructuredLoggingConfigurationContractTest.java
@@ -1,0 +1,145 @@
+package com.nursena.payflow.observability.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class StructuredLoggingConfigurationContractTest {
+
+    private static final Path POM =
+        Path.of("pom.xml");
+
+    private static final Path LOGBACK =
+        Path.of(
+            "src",
+            "main",
+            "resources",
+            "logback-spring.xml"
+        );
+
+    @Test
+    void shouldPinJackson2CompatibleEncoderRelease()
+        throws IOException {
+        String pom =
+            Files.readString(POM);
+
+        assertThat(pom)
+            .contains(
+                "<logstash-logback-encoder.version>"
+                    + "8.1"
+                    + "</logstash-logback-encoder.version>"
+            )
+            .contains(
+                "<artifactId>"
+                    + "logstash-logback-encoder"
+                    + "</artifactId>"
+            )
+            .doesNotContain(
+                "<logstash-logback-encoder.version>"
+                    + "9.0"
+            );
+    }
+
+    @Test
+    void shouldDefineProductionJsonProfile()
+        throws IOException {
+        String configuration =
+            Files.readString(LOGBACK);
+
+        assertThat(configuration)
+            .contains(
+                "structured-logging | production"
+            )
+            .contains(
+                "net.logstash.logback.encoder.LogstashEncoder"
+            )
+            .contains(
+                "\"schemaVersion\":1"
+            )
+            .contains(
+                "<lineSeparator>UNIX</lineSeparator>"
+            );
+    }
+
+    @Test
+    void shouldWhitelistCorrelationContextAndDisableArguments()
+        throws IOException {
+        String configuration =
+            Files.readString(LOGBACK);
+
+        assertThat(configuration)
+            .contains(
+                "<includeMdcKeyName>"
+                    + "correlationId"
+                    + "</includeMdcKeyName>"
+            )
+            .contains(
+                "<includeKeyValuePairs>"
+                    + "false"
+                    + "</includeKeyValuePairs>"
+            )
+            .contains(
+                "<includeStructuredArguments>"
+                    + "false"
+                    + "</includeStructuredArguments>"
+            )
+            .contains(
+                "<includeNonStructuredArguments>"
+                    + "false"
+                    + "</includeNonStructuredArguments>"
+            );
+    }
+
+    @Test
+    void shouldConfigureFieldAndValueRedaction()
+        throws IOException {
+        String configuration =
+            Files.readString(LOGBACK);
+
+        assertThat(configuration)
+            .contains(
+                "MaskingJsonGeneratorDecorator"
+            )
+            .contains(
+                "<defaultMask>[REDACTED]</defaultMask>"
+            )
+            .contains(
+                "password,"
+            )
+            .contains(
+                "authorization,"
+            )
+            .contains(
+                "refreshToken,"
+            )
+            .contains(
+                "accessToken,"
+            )
+            .contains(
+                SensitiveLogValueMasker.class
+                    .getName()
+            );
+    }
+
+    @Test
+    void shouldKeepReadableLocalPatternWithCorrelationId()
+        throws IOException {
+        String configuration =
+            Files.readString(LOGBACK);
+
+        assertThat(configuration)
+            .contains(
+                "!structured-logging &amp; !production"
+            )
+            .contains(
+                "correlationId=%X{correlationId:-none}"
+            )
+            .contains(
+                "PLAIN_CONSOLE"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/logging/StructuredLoggingConfigurationContractTest.java
+++ b/src/test/java/com/nursena/payflow/observability/logging/StructuredLoggingConfigurationContractTest.java
@@ -21,6 +21,16 @@ class StructuredLoggingConfigurationContractTest {
             "logback-spring.xml"
         );
 
+    private static final Path README =
+        Path.of("README.md");
+
+    private static final Path OPERATIONS_GUIDE =
+        Path.of(
+            "docs",
+            "operations",
+            "structured-logging.md"
+        );
+
     @Test
     void shouldPinJackson2CompatibleEncoderRelease()
         throws IOException {
@@ -141,5 +151,96 @@ class StructuredLoggingConfigurationContractTest {
             .contains(
                 "PLAIN_CONSOLE"
             );
+    }
+
+    @Test
+    void shouldWhitelistOnlyBoundedRequestCompletionFields()
+        throws IOException {
+        String configuration =
+            Files.readString(LOGBACK);
+
+        assertThat(configuration)
+            .contains(
+                mdcAllowlistEntry(
+                    Slf4jRequestCompletionLogger.EVENT_KEY
+                )
+            )
+            .contains(
+                mdcAllowlistEntry(
+                    Slf4jRequestCompletionLogger.METHOD_KEY
+                )
+            )
+            .contains(
+                mdcAllowlistEntry(
+                    Slf4jRequestCompletionLogger.ROUTE_KEY
+                )
+            )
+            .contains(
+                mdcAllowlistEntry(
+                    Slf4jRequestCompletionLogger.STATUS_CODE_KEY
+                )
+            )
+            .contains(
+                mdcAllowlistEntry(
+                    Slf4jRequestCompletionLogger.DURATION_KEY
+                )
+            )
+            .contains(
+                mdcAllowlistEntry(
+                    Slf4jRequestCompletionLogger.OUTCOME_KEY
+                )
+            )
+            .doesNotContain(
+                "<includeMdcKeyName>authorization</includeMdcKeyName>",
+                "<includeMdcKeyName>cookie</includeMdcKeyName>",
+                "<includeMdcKeyName>query</includeMdcKeyName>",
+                "<includeMdcKeyName>request.body</includeMdcKeyName>",
+                "<includeMdcKeyName>response.body</includeMdcKeyName>"
+            );
+    }
+
+    @Test
+    void shouldDocumentActivationFieldsAndSecurityBoundaries()
+        throws IOException {
+        String readme =
+            Files.readString(README);
+
+        String operationsGuide =
+            Files.readString(
+                OPERATIONS_GUIDE
+            );
+
+        assertThat(readme)
+            .contains(
+                "docs/operations/structured-logging.md"
+            );
+
+        assertThat(operationsGuide)
+            .contains(
+                "SPRING_PROFILES_ACTIVE"
+            )
+            .contains(
+                "`http.route`"
+            )
+            .contains(
+                "`UNMATCHED`"
+            )
+            .contains(
+                "Query strings are never logged."
+            )
+            .contains(
+                "Request and response bodies are never logged."
+            )
+            .contains(
+                "Authorization and cookie headers are never logged."
+            );
+    }
+
+    private static String mdcAllowlistEntry(
+        String key
+    ) {
+        return "<includeMdcKeyName>"
+            + key
+            + "</includeMdcKeyName>";
     }
 }

--- a/src/test/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryControllerTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/adapter/in/web/GetTransactionHistoryControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.transaction.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -36,6 +37,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(GetTransactionHistoryController.class)
 @Import({
+    RequestCorrelationConfiguration.class,
     SecurityConfiguration.class,
     TransactionHistoryExceptionHandler.class
 })

--- a/src/test/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyControllerTest.java
+++ b/src/test/java/com/nursena/payflow/transaction/adapter/in/web/TransferMoneyControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.transaction.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -35,6 +36,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(TransferMoneyController.class)
 @Import({
+    RequestCorrelationConfiguration.class,
     SecurityConfiguration.class,
     TransferMoneyExceptionHandler.class
 })

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/AuthenticateUserControllerTest.java
@@ -1,6 +1,7 @@
 
 package com.nursena.payflow.user.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
@@ -62,6 +63,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(AuthenticateUserController.class)
 @Import({
+    RequestCorrelationConfiguration.class,
     SecurityConfiguration.class,
     UserAuthenticationExceptionHandler.class
 })

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/CurrentUserProfileControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -27,6 +28,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(CurrentUserProfileController.class)
 @Import({
+    RequestCorrelationConfiguration.class,
     SecurityConfiguration.class,
     CurrentUserProfileExceptionHandler.class
 })

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/RegisterUserControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/RegisterUserControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
@@ -24,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 @WebMvcTest(RegisterUserController.class)
 @Import({
+    RequestCorrelationConfiguration.class,
     SecurityConfiguration.class,
     UserRegistrationExceptionHandler.class
 })

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/RevokeCurrentRefreshSessionControllerTest.java
@@ -6,10 +6,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationFilter;
 import com.nursena.payflow.user.application.port.in.RevokeCurrentRefreshSessionUseCase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +26,10 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(
     RevokeCurrentRefreshSessionController.class
 )
-@Import(SecurityConfiguration.class)
+@Import({
+    RequestCorrelationConfiguration.class,
+    SecurityConfiguration.class
+})
 class RevokeCurrentRefreshSessionControllerTest {
 
     private static final String CURRENT_TOKEN =
@@ -118,6 +124,17 @@ class RevokeCurrentRefreshSessionControllerTest {
             )
             .andExpect(
                 status().isBadRequest()
+            )
+            .andExpect(
+                header().exists(
+                    RequestCorrelationFilter
+                        .HEADER_NAME
+                )
+            )
+            .andExpect(
+                jsonPath(
+                    "$.correlationId"
+                ).isNotEmpty()
             )
             .andExpect(
                 jsonPath(

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/RotateRefreshCredentialsControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.user.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -30,6 +31,7 @@ import org.springframework.test.web.servlet.MockMvc;
     RotateRefreshCredentialsController.class
 )
 @Import({
+    RequestCorrelationConfiguration.class,
     SecurityConfiguration.class,
     UserAuthenticationExceptionHandler.class
 })

--- a/src/test/java/com/nursena/payflow/wallet/adapter/in/web/GetCurrentWalletControllerTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/adapter/in/web/GetCurrentWalletControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.wallet.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -28,6 +29,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(GetCurrentWalletController.class)
 @Import({
+    RequestCorrelationConfiguration.class,
     SecurityConfiguration.class,
     GetCurrentWalletExceptionHandler.class
 })

--- a/src/test/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletControllerTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/adapter/in/web/OpenWalletControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.wallet.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,6 +31,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(OpenWalletController.class)
 @Import({
+    RequestCorrelationConfiguration.class,
     SecurityConfiguration.class,
     OpenWalletExceptionHandler.class
 })class OpenWalletControllerTest {

--- a/src/test/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletControllerTest.java
+++ b/src/test/java/com/nursena/payflow/wallet/adapter/in/web/TopUpWalletControllerTest.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.wallet.adapter.in.web;
 
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -32,6 +33,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(TopUpWalletController.class)
 @Import({
+    RequestCorrelationConfiguration.class,
     SecurityConfiguration.class,
     TopUpWalletExceptionHandler.class
 })


### PR DESCRIPTION
## Summary  Introduces the PayFlow v0.11.0 observability foundation:  - strict, server-owned `X-Correlation-ID` validation and generation - response-header and centralized-error correlation - request-lifetime MDC with guaranteed cleanup - structured JSON logging for production-oriented profiles - centralized credential and secret redaction - exactly one bounded HTTP completion event per request - route-template logging without raw URI, query, body, header, user, or financial data - OpenAPI and Postman response-correlation contracts - operations guidance for synchronous and asynchronous boundaries - protected Docker smoke verification for production JSON logs  The feature remains a modular-monolith infrastructure concern and does not change authentication, authorization, database, wallet, transfer, outbox, Kafka, or audit business rules.  ## Type of change  - [x] Feature - [ ] Bug fix - [ ] Refactor - [x] Test - [x] Documentation - [x] Infrastructure  ## Verification  - [x] Unit tests added or updated - [x] Integration tests added or updated when applicable - [x] `mvn clean verify` passes locally - [x] API or database changes are documented - [x] No secrets or sensitive data were committed - [x] Focused observability acceptance: 47 tests - [x] Full verification: 1017 tests across 215 Surefire reports - [x] Docker Compose configuration validation - [x] Protected CI build-and-test - [x] Protected Docker smoke  ## Security boundaries  - inbound correlation IDs are bounded to 64 allowlisted characters - duplicate, malformed, oversized, and newline-bearing values are replaced - tokens, passwords, authorization values, secrets, API keys, client secrets, private keys, bearer credentials, and JWT-like values are redacted - request completion logs exclude raw paths, query strings, bodies, cookies, authorization headers, user identifiers, wallet/transfer identifiers, amounts, balances, and idempotency keys - correlation IDs remain log context and are not metric labels or authorization credentials - servlet MDC is not implicitly propagated across asynchronous boundaries  ## Architecture and operations  - Feature commits: 5 - Files changed against `main`: 59 - Maven version: `0.11.0-SNAPSHOT` - Release candidate notes: `docs/releases/v0.11.0.md` - Operations guide: `docs/operations/structured-logging.md` - Docker smoke workflow: `.github/workflows/docker-smoke.yml`  ## Related issue  Closes #107