### PR TITLE
chore(release): prepare v0.11.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+* text=auto
+
+*.java       text eol=lf
+*.xml        text eol=lf
+*.yml        text eol=lf
+*.yaml       text eol=lf
+*.md         text eol=lf
+*.json       text eol=lf
+*.properties text eol=lf
+*.sql        text eol=lf
+*.sh         text eol=lf
+mvnw         text eol=lf
+
+*.cmd        text eol=crlf
+*.ps1        text eol=crlf
+
+*.jar        binary
+*.png        binary
+*.jpg        binary
+*.jpeg       binary
+*.gif        binary
+*.ico        binary
+*.pdf        binary

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ Completed capabilities include:
 - operator-only, paginated command-audit queries and chronological command timelines
 - Prometheus metrics, Grafana dashboards, and alert rules for Kafka consumer failures
 
-OpenAPI documentation and executable Postman workflows cover the implemented API. PayFlow v0.10.0 is the latest published release, including spoofing-resistant effective client-address resolution behind explicitly trusted reverse proxies, safe fallback behavior, bounded observability, and executable operational contracts. The v0.11.0 development line is open for the next explicitly scoped increment. See the [v0.10.0 release notes](docs/releases/v0.10.0.md), the [trusted client-context ADR](docs/adr/0011-trusted-client-context.md), and the [roadmap](docs/roadmap.md).
+OpenAPI documentation and executable Postman workflows cover the implemented API. PayFlow v0.10.0 remains the latest published release while v0.11.0 is in protected release preparation. The v0.11.0 release commit freezes the observability contract and is eligible for tagging only after the release-preparation pull request passes protected review and CI.
+
+See the [v0.11.0 release notes](docs/releases/v0.11.0.md), the [structured logging operations guide](docs/operations/structured-logging.md), the [v0.10.0 release notes](docs/releases/v0.10.0.md), and the [roadmap](docs/roadmap.md).
 
 ## Structured logging
 
@@ -112,13 +114,17 @@ PayFlow supports single-line JSON logs through the `structured-logging` and `pro
 
 See the [structured logging operations guide](docs/operations/structured-logging.md) for activation, field contracts, redaction boundaries, and verification commands.
 
-## v0.11.0 release candidate
+## v0.11.0 release preparation
 
-PayFlow v0.10.0 remains the latest published release. The v0.11.0 observability increment is submitted for protected pull-request review with trustworthy request correlation, structured JSON logs, bounded completion events, centralized redaction, OpenAPI/Postman contracts, and Docker smoke verification.
+PayFlow v0.11.0 is prepared for protected release review. The release freezes trustworthy request correlation, structured JSON logging, bounded request-completion events, centralized redaction, OpenAPI/Postman contracts, operations guidance, and Docker smoke verification.
 
-See the [v0.11.0 release candidate notes](docs/releases/v0.11.0.md), the [structured logging operations guide](docs/operations/structured-logging.md), the [v0.10.0 release notes](docs/releases/v0.10.0.md), and the [roadmap](docs/roadmap.md).
+The `v0.11.0` tag must be created only from the verified merge commit of the release-preparation pull request. Tag publication triggers the independent release workflow that rebuilds and verifies the project before publishing the executable JAR, SHA-256 checksum, and GitHub Release.
 
-## Implemented API| Method | Endpoint | Authentication | Description |
+See the [v0.11.0 release notes](docs/releases/v0.11.0.md) and the [structured logging operations guide](docs/operations/structured-logging.md).
+
+## Implemented API
+
+| Method | Endpoint | Authentication | Description |
 |---|---|---|---|
 | `POST` | `/api/v1/auth/register` | Public | Registers a new user and stores a BCrypt password hash. |
 | `POST` | `/api/v1/auth/login` | Public | Applies Redis-backed login protection and returns access and refresh credentials. |

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -1,37 +1,31 @@
-# PayFlow v0.11.0 release candidate notes
+# PayFlow v0.11.0
 
-PayFlow v0.11.0 introduces a bounded observability foundation for request diagnosis. These notes describe the feature branch submitted for protected pull-request review; v0.10.0 remains the latest published release until the separate release gate completes.
+PayFlow v0.11.0 adds a bounded, testable observability foundation for synchronous HTTP request diagnosis.
 
-## Added
+PayFlow remains an educational simulated digital-wallet backend. It does not process real money and is not certified for production financial use.
 
-- Strict `X-Correlation-ID` validation with a maximum length of 64 characters and a constrained character allowlist.
-- Server-generated UUID identifiers when the inbound value is absent, duplicated, malformed, oversized, or newline-bearing.
-- Correlation IDs in response headers and centralized API error bodies.
-- Request-lifetime MDC setup and guaranteed cleanup.
-- Single-line JSON logging for the `structured-logging` and `production` profiles.
-- Stable structured fields for service, schema version, severity, logger, thread, message, correlation ID, and bounded exception output.
-- Exactly one `http.request.completed` event for each synchronous HTTP request.
-- Bounded request fields for method, Spring MVC route template, effective status, duration, and outcome.
-- Global OpenAPI response-header documentation for `X-Correlation-ID`.
-- Executable Postman verification of the effective response correlation header.
-- Docker smoke verification for production-profile JSON logs and response correlation.
-- Operations guidance for activation, field contracts, redaction, synchronous boundaries, asynchronous boundaries, and exception policy.
+## Highlights
 
-## Security
+### Trustworthy request correlation
 
-- Correlation identifiers cannot contain line breaks or uncontrolled characters.
-- Duplicate inbound correlation headers are rejected and replaced.
-- Access tokens, refresh tokens, passwords, authorization values, API keys, client secrets, private keys, bearer credentials, and JWT-like values are masked with `[REDACTED]`.
-- Structured and non-structured argument expansion is disabled.
-- Query strings, raw URI paths, path-variable values, request bodies, response bodies, cookies, user identifiers, wallet identifiers, transfer identifiers, balances, amounts, and idempotency keys are excluded from request-completion fields.
-- Unresolved routes use the fixed `UNMATCHED` value.
-- Unrecognized methods use the fixed `UNKNOWN` value.
-- Correlation IDs remain log context and are not introduced as high-cardinality metric labels.
-- Servlet MDC is not implicitly propagated into scheduled, outbox, Kafka, retry, or dead-letter execution.
+- strict `X-Correlation-ID` validation with a maximum length of 64 characters and a constrained character allowlist
+- server-generated UUID identifiers when the inbound value is absent, duplicated, malformed, oversized, or newline-bearing
+- one effective identifier returned in every HTTP response
+- the same identifier included in centralized API error responses
+- request-lifetime MDC setup with guaranteed cleanup
+- OpenAPI response-header documentation and executable Postman verification
 
-## Operational contract
+### Structured JSON logging
 
-Production-oriented profiles write one JSON object per UNIX-delimited line. Request completion events contain:
+- single-line JSON logs for the `structured-logging` and `production` profiles
+- stable common fields for timestamp, service, schema version, severity, logger, thread, message, correlation ID, and bounded exception output
+- centralized masking for credentials, tokens, secrets, authorization values, API keys, client secrets, private keys, bearer values, and JWT-like values
+- structured, non-structured, and arbitrary key-value argument expansion disabled
+- readable local logs retain the effective correlation identifier
+
+### Bounded request-completion events
+
+Every synchronous HTTP request emits exactly one `http.request.completed` event with:
 
 - `event`
 - `correlationId`
@@ -41,32 +35,89 @@ Production-oriented profiles write one JSON object per UNIX-delimited line. Requ
 - `duration_ms`
 - `outcome`
 
-Exception output is emitted only for explicit throwable logging and is bounded to a maximum encoded length of 8192 characters with a maximum depth of 30 frames per throwable.
+The route field uses the Spring MVC route template rather than the raw URI. Unresolved routes use `UNMATCHED`, and unrecognized methods use `UNKNOWN`.
 
-## Verification baseline
+### Security boundaries
 
-The protected pull request requires:
+Request-completion logs exclude:
 
-- focused observability acceptance tests
-- `mvn -B -ntp clean verify`
-- valid Docker Compose configuration
-- Docker image construction
-- application startup with PostgreSQL, Redis, and Kafka
-- public health-response verification
-- response `X-Correlation-ID` verification
-- production-profile JSON completion-event verification
-- clean repository and sensitive-data checks
+- query strings
+- raw URI paths and path-variable values
+- request and response bodies
+- authorization and cookie headers
+- email addresses and user identifiers
+- wallet and transfer identifiers
+- balances, amounts, and idempotency keys
+- handled application exception objects
 
-## Compatibility and boundaries
+Correlation IDs remain log context. They are not authentication credentials, authorization inputs, business identifiers, transaction identifiers, Kafka partition keys, or high-cardinality metric labels.
+
+Servlet MDC is not implicitly propagated into scheduled jobs, transactional outbox publication, Kafka consumers, retries, or dead-letter execution. Any future asynchronous propagation requires an explicit versioned event contract.
+
+## Verification
+
+- 47 focused observability acceptance tests passed before feature merge
+- 1,017 complete Maven tests passed with zero failures and zero errors
+- 215 Surefire reports were produced
+- protected `build-and-test` CI passed
+- production-profile Docker smoke passed
+- response correlation and JSON completion logs were verified in containers
+- post-merge `main` verification passed
+- post-merge `main` CI passed
+- PR #108 was merged through the protected workflow
+- issue #107 was closed after merge
+
+The focused checkpoint suites overlap and must not be added together as a separate project-wide test total.
+
+## Operations
+
+Activate JSON logging with either Spring profile:
+
+```text
+structured-logging
+production
+```
+
+See [`docs/operations/structured-logging.md`](../operations/structured-logging.md) for field definitions, activation, redaction guarantees, exception policy, synchronous boundaries, and verification commands.
+
+## Upgrade notes
 
 - No database migration is included.
-- No public request or response payload is changed except the previously introduced `correlationId` field in centralized API errors.
-- The response correlation header is additive.
-- Existing authentication, wallet, transfer, outbox, Kafka, and operations authorization contracts remain unchanged.
-- Asynchronous request-correlation propagation is deliberately out of scope and must be introduced through a future versioned event contract.
+- No existing authentication, authorization, wallet, transfer, ledger, outbox, Kafka, dead-letter, or audit business rule changes.
+- The `X-Correlation-ID` response header is additive.
+- Centralized API error payloads include the effective `correlationId`.
+- Production-oriented logging output changes from plain text to single-line JSON.
+- Log collectors should parse one JSON object per line and index only the documented bounded fields.
+- Applications relying on raw URI logging must use the bounded route-template field instead.
+- Asynchronous request-correlation propagation remains deliberately out of scope.
+
+## Compatibility
+
+- Java 21
+- Spring Boot 3.5.16
+- PostgreSQL, Redis, and Kafka contracts remain compatible with v0.10.0
+- no Flyway schema change
+
+## Release assets
+
+- `payflow-0.11.0.jar`
+- `payflow-0.11.0.jar.sha256`
+
+Verify the downloaded artifact on PowerShell:
+
+```powershell
+(Get-FileHash .\payflow-0.11.0.jar -Algorithm SHA256).Hash
+Get-Content .\payflow-0.11.0.jar.sha256
+```
 
 ## Related work
 
-- Issue: [#107](https://github.com/nursena-pc/payflow/issues/107)
+- Feature issue: [#107](https://github.com/nursena-pc/payflow/issues/107)
+- Feature pull request: [#108](https://github.com/nursena-pc/payflow/pull/108)
+- Release train: [#106](https://github.com/nursena-pc/payflow/issues/106)
 - Operations guide: [`docs/operations/structured-logging.md`](../operations/structured-logging.md)
 - Previous release: [`v0.10.0`](v0.10.0.md)
+
+## Full changelog
+
+`v0.10.0...v0.11.0`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,13 +2,13 @@
 
 ## Current delivery focus
 
-PayFlow v0.10.0 is the latest tagged release. The active development line uses
-`0.11.0-SNAPSHOT`.
+PayFlow v0.10.0 is the latest tagged release. The v0.11.0 release candidate uses
+the Maven version `0.11.0`.
 
-The v0.10.0 trusted client-context increment is released and independently
-verified. The current focus is post-release stabilization and selection of the
-next v0.11.0 increment through a dedicated issue with explicit scope, threat
-model, acceptance criteria, and rollback boundaries.
+The v0.11.0 observability increment was merged through protected PR #108. The
+current focus is release train #106: protected release review, full verification,
+tagging the verified merge commit, and independently validating the published
+JAR and SHA-256 checksum.
 
 PayFlow remains a modular monolith. PostgreSQL is the system of record; Redis is
 used only for bounded, explicitly expiring abuse-control state.
@@ -66,6 +66,9 @@ used only for bounded, explicitly expiring abuse-control state.
 - [x] Idempotent event consumption
 - [x] Durable dead-letter intake, replay, and discard lifecycle
 - [x] Append-only operator command auditing
+- [x] Trustworthy request correlation with strict inbound identifier validation
+- [x] Structured JSON logging with centralized sensitive-value masking
+- [x] One bounded request-completion event per synchronous HTTP request
 
 ## v0.9.0 — Released
 
@@ -181,14 +184,109 @@ The release is ready only when:
 - [x] the executable JAR and SHA-256 checksum are published
 - [x] the GitHub Release is published
 
+## v0.11.0 — Release Candidate: Structured Logging and Request Correlation
+
+### Product outcome
+
+Operators can follow a synchronous HTTP request through bounded application
+logs using one trustworthy correlation identifier without exposing credentials,
+personal data, financial data, raw request paths, or attacker-controlled log
+structure.
+
+### Increment 1 — Request correlation
+
+- [x] Define a bounded correlation-ID policy
+- [x] Replace absent, duplicated, malformed, oversized, and newline-bearing input
+- [x] Generate a server-controlled UUID when inbound input is unusable
+- [x] Return the effective identifier in every HTTP response
+- [x] Include the effective identifier in centralized API error responses
+- [x] Establish and clear request-lifetime MDC safely
+
+### Increment 2 — Structured logging and redaction
+
+- [x] Add single-line JSON logs for `structured-logging` and `production`
+- [x] Define stable service, schema, severity, logger, thread, message, and correlation fields
+- [x] Mask credentials, tokens, secrets, authorization values, API keys, private keys, and JWT-like values
+- [x] Disable uncontrolled structured and non-structured argument expansion
+- [x] Bound encoded exception length and throwable depth
+
+### Increment 3 — Bounded HTTP completion events
+
+- [x] Emit exactly one `http.request.completed` event per synchronous request
+- [x] Use the Spring MVC route template instead of the raw request URI
+- [x] Bound method, status, duration, and outcome fields
+- [x] Use stable `UNMATCHED` and `UNKNOWN` fallback values
+- [x] Exclude bodies, query strings, headers, identifiers, balances, and amounts
+- [x] Keep correlation IDs out of metric labels
+
+### Increment 4 — Public and operational contracts
+
+- [x] Document the global `X-Correlation-ID` response header in OpenAPI
+- [x] Add executable Postman response-correlation verification
+- [x] Document activation, field schema, redaction, and exception policy
+- [x] Document synchronous and asynchronous propagation boundaries
+- [x] Verify production-profile response correlation and JSON logs in Docker
+
+### Increment 5 — Verification and release preparation
+
+- [x] Merge the observability increment through protected PR #108
+- [x] Close implementation issue #107 after merge
+- [x] Pass 47 focused observability acceptance tests
+- [x] Pass 1,017 complete Maven tests with zero failures and zero errors
+- [x] Produce 215 Surefire XML reports
+- [x] Pass protected `build-and-test` CI
+- [x] Pass production-profile Docker smoke verification
+- [x] Prepare v0.11.0 release notes
+- [ ] Merge v0.11.0 release preparation through a protected pull request
+- [ ] Tag the verified release merge commit as `v0.11.0`
+- [ ] Publish `payflow-0.11.0.jar`
+- [ ] Publish and independently verify `payflow-0.11.0.jar.sha256`
+- [ ] Publish the GitHub Release
+
+## Explicit v0.11.0 non-goals
+
+- distributed tracing implementation
+- implicit servlet-MDC propagation to scheduled jobs, outbox publishers, Kafka consumers, retries, or dead-letter execution
+- request or response body logging
+- raw URI, query-string, cookie, authorization-header, or forwarding-header logging
+- user, wallet, transfer, balance, amount, or idempotency-key logging
+- correlation IDs as authentication, authorization, business, transaction, partition, or metric-label inputs
+- signing-key rotation or external key-management integration
+- password recovery, verified-email workflows, or multi-factor authentication
+- generalized API-wide abuse protection
+
+These concerns require separate issues, threat models, and versioned contracts
+rather than being silently added to the observability increment.
+
+## v0.11.0 release exit criteria
+
+The release is ready only when:
+
+- [x] invalid or attacker-controlled correlation input is replaced safely
+- [x] every synchronous response returns one effective correlation identifier
+- [x] centralized API errors expose the same effective identifier
+- [x] production-oriented logs are valid single-line JSON
+- [x] sensitive values are redacted and request-completion fields remain bounded
+- [x] focused unit, integration, acceptance, OpenAPI, Postman, and Docker checks pass
+- [x] the complete Maven suite passes
+- [x] protected CI passes for the feature merge
+- [x] v0.11.0 release notes are prepared
+- [ ] the release-preparation pull request is merged
+- [ ] the v0.11.0 tag is published
+- [ ] the executable JAR and SHA-256 checksum are published and independently verified
+- [ ] the GitHub Release is published
+
 ## Future candidates
 
-Potential v0.11.0 increments include:
+Potential v0.12.0 increments include:
 
-- structured JSON logging and request correlation
-- signing-key rotation and external key-management integration
-- load and performance verification
-- password recovery and verified-email workflows
-- multi-factor authentication
-- broader operational-security dashboards
-- generalized API abuse protection
+- signing-key rotation and external key-management boundary
+- JWT `kid` issuance and multi-key verification
+- active and previous key overlap with controlled rollback
+- local key-provider adapter and startup validation
+- key-material redaction and failure-mode acceptance tests
+
+Later v1.0 candidates include verified-email and password-recovery workflows,
+multi-factor authentication, generalized abuse protection, load/performance
+evidence, backup/restore rehearsal, API freeze, SBOM generation, and release
+stabilization.

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.11.0</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 

--- a/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
@@ -22,7 +22,7 @@ class RoadmapContractTest {
         Path.of("docs", "roadmap.md");
 
     @Test
-    void shouldAlignRoadmapWithPublishedReleaseAndNextDevelopmentVersion()
+    void shouldAlignRoadmapWithReleaseCandidateVersion()
         throws Exception {
 
         String projectVersion =
@@ -32,7 +32,7 @@ class RoadmapContractTest {
             Files.readString(ROADMAP_PATH);
 
         assertThat(projectVersion)
-            .isEqualTo("0.11.0-SNAPSHOT");
+            .isEqualTo("0.11.0");
 
         assertThat(roadmap)
             .contains(
@@ -40,6 +40,7 @@ class RoadmapContractTest {
                 "`" + projectVersion + "`",
                 "## v0.9.0 — Released",
                 "## v0.10.0 — Released: Trusted Client Context",
+                "## v0.11.0 — Release Candidate: Structured Logging and Request Correlation",
                 "- [x] Open the v0.10.0 implementation issue",
                 "- [x] Define trusted-proxy CIDR configuration",
                 "- [x] Validate IPv4 and IPv6 network ranges at startup",
@@ -94,11 +95,20 @@ class RoadmapContractTest {
                 "- [x] the executable JAR and SHA-256 checksum are published",
                 "- [x] the GitHub Release is published",
                 "release workflow run: `30675532483`",
-                "verified SHA-256: `174D7F51D27F19B0A45B281869FF86BD9DC52F59B41B20B479827B92102D957B`"
+                "verified SHA-256: `174D7F51D27F19B0A45B281869FF86BD9DC52F59B41B20B479827B92102D957B`",
+                "- [x] Merge the observability increment through protected PR #108",
+                "- [x] Pass 1,017 complete Maven tests with zero failures and zero errors",
+                "- [x] Prepare v0.11.0 release notes",
+                "- [ ] Merge v0.11.0 release preparation through a protected pull request",
+                "- [ ] Tag the verified release merge commit as `v0.11.0`",
+                "- [ ] Publish `payflow-0.11.0.jar`",
+                "- [ ] Publish and independently verify `payflow-0.11.0.jar.sha256`",
+                "Potential v0.12.0 increments include:"
             )
             .doesNotContain(
                 "0.9.0-SNAPSHOT",
                 "0.10.0-SNAPSHOT",
+                "0.11.0-SNAPSHOT",
                 "The v0.9.0 release candidate",
                 "The v0.10.0 release candidate",
                 "## v0.7.0 — Identity and Session Security"

--- a/src/test/java/com/nursena/payflow/configuration/V010ReleasePreparationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V010ReleasePreparationContractTest.java
@@ -3,23 +3,15 @@ package com.nursena.payflow.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.junit.jupiter.api.Test;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 class V010ReleasePreparationContractTest {
-
-    private static final Path POM_PATH =
-        Path.of("pom.xml");
 
     private static final Path README_PATH =
         Path.of("README.md");
@@ -44,18 +36,14 @@ class V010ReleasePreparationContractTest {
         );
 
     @Test
-    void shouldUseNextDevelopmentVersionAfterPublishedRelease()
-        throws Exception {
-
-        assertThat(readProjectVersion())
-            .isEqualTo("0.11.0-SNAPSHOT");
+    void shouldRetainPublishedReleaseRecord()
+        throws IOException {
 
         assertThat(
             Files.readString(README_PATH)
         )
             .contains(
-                "v0.10.0 is the latest published release",
-                "v0.11.0 development line",
+                "v0.10.0 remains the latest published release",
                 "docs/releases/v0.10.0.md"
             );
 
@@ -64,7 +52,6 @@ class V010ReleasePreparationContractTest {
         )
             .contains(
                 "PayFlow v0.10.0 is the latest tagged release",
-                "`0.11.0-SNAPSHOT`",
                 "## v0.10.0 — Released: Trusted Client Context"
             )
             .doesNotContain(
@@ -175,52 +162,4 @@ class V010ReleasePreparationContractTest {
         }
     }
 
-    private static String readProjectVersion()
-        throws Exception {
-
-        DocumentBuilderFactory factory =
-            DocumentBuilderFactory.newInstance();
-
-        factory.setFeature(
-            "http://apache.org/xml/features/disallow-doctype-decl",
-            true
-        );
-
-        try (InputStream input =
-            Files.newInputStream(POM_PATH)) {
-
-            Element project =
-                factory
-                    .newDocumentBuilder()
-                    .parse(input)
-                    .getDocumentElement();
-
-            NodeList children =
-                project.getChildNodes();
-
-            for (int index = 0;
-                index < children.getLength();
-                index++) {
-
-                Node child =
-                    children.item(index);
-
-                if (
-                    child.getNodeType()
-                        == Node.ELEMENT_NODE
-                        && "version".equals(
-                            child.getNodeName()
-                        )
-                ) {
-                    return child
-                        .getTextContent()
-                        .trim();
-                }
-            }
-        }
-
-        throw new IOException(
-            "Project version was not found in pom.xml"
-        );
-    }
 }

--- a/src/test/java/com/nursena/payflow/configuration/V011ReleasePreparationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V011ReleasePreparationContractTest.java
@@ -1,0 +1,203 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+class V011ReleasePreparationContractTest {
+
+    private static final Path POM_PATH =
+        Path.of("pom.xml");
+
+    private static final Path README_PATH =
+        Path.of("README.md");
+
+    private static final Path ROADMAP_PATH =
+        Path.of("docs", "roadmap.md");
+
+    private static final Path RELEASE_NOTES_PATH =
+        Path.of(
+            "docs",
+            "releases",
+            "v0.11.0.md"
+        );
+
+    private static final Path RELEASE_WORKFLOW_PATH =
+        Path.of(
+            ".github",
+            "workflows",
+            "release.yml"
+        );
+
+    private static final Path GIT_ATTRIBUTES_PATH =
+        Path.of(".gitattributes");
+
+    @Test
+    void shouldUseReleaseCandidateVersion()
+        throws Exception {
+
+        assertThat(readProjectVersion())
+            .isEqualTo("0.11.0");
+
+        assertThat(
+            Files.readString(README_PATH)
+        )
+            .contains(
+                "v0.11.0 is in protected release preparation",
+                "docs/releases/v0.11.0.md",
+                "v0.11.0 release preparation",
+                "verified merge commit of the release-preparation pull request"
+            );
+
+        assertThat(
+            Files.readString(ROADMAP_PATH)
+        )
+            .contains(
+                "The v0.11.0 release candidate uses",
+                "the Maven version `0.11.0`",
+                "release train #106",
+                "## v0.11.0 — Release Candidate: Structured Logging and Request Correlation"
+            )
+            .doesNotContain(
+                "0.11.0-SNAPSHOT"
+            );
+    }
+
+    @Test
+    void shouldDocumentReleaseScopeVerificationAndAssets()
+        throws IOException {
+
+        assertThat(
+            Files.readString(RELEASE_NOTES_PATH)
+        )
+            .contains(
+                "# PayFlow v0.11.0",
+                "### Trustworthy request correlation",
+                "### Structured JSON logging",
+                "### Bounded request-completion events",
+                "### Security boundaries",
+                "## Verification",
+                "1,017 complete Maven tests passed",
+                "215 Surefire reports were produced",
+                "## Upgrade notes",
+                "No database migration is included.",
+                "## Release assets",
+                "`payflow-0.11.0.jar`",
+                "`payflow-0.11.0.jar.sha256`",
+                "`v0.10.0...v0.11.0`"
+            );
+    }
+
+    @Test
+    void shouldKeepPublicationCriteriaOpenUntilProtectedReleaseCompletes()
+        throws IOException {
+
+        assertThat(
+            Files.readString(ROADMAP_PATH)
+        )
+            .contains(
+                "- [x] Merge the observability increment through protected PR #108",
+                "- [x] Prepare v0.11.0 release notes",
+                "- [ ] Merge v0.11.0 release preparation through a protected pull request",
+                "- [ ] Tag the verified release merge commit as `v0.11.0`",
+                "- [ ] Publish `payflow-0.11.0.jar`",
+                "- [ ] Publish and independently verify `payflow-0.11.0.jar.sha256`",
+                "- [ ] Publish the GitHub Release"
+            );
+    }
+
+    @Test
+    void shouldRetainTagTriggeredVerifiedReleaseWorkflow()
+        throws IOException {
+
+        assertThat(
+            Files.readString(RELEASE_WORKFLOW_PATH)
+        )
+            .contains(
+                "name: Release",
+                "tags:",
+                "v[0-9]+.[0-9]+.[0-9]+",
+                "contents: write",
+                "mvn -B -ntp clean verify",
+                "sha256sum",
+                "actions/upload-artifact@v7",
+                "gh release create",
+                "--verify-tag"
+            );
+    }
+
+    @Test
+    void shouldEnforceRepositoryLineEndingPolicy()
+        throws IOException {
+
+        assertThat(
+            Files.readString(GIT_ATTRIBUTES_PATH)
+        )
+            .contains(
+                "* text=auto",
+                "*.java       text eol=lf",
+                "*.xml        text eol=lf",
+                "*.md         text eol=lf",
+                "*.cmd        text eol=crlf",
+                "*.ps1        text eol=crlf"
+            );
+    }
+
+    private static String readProjectVersion()
+        throws Exception {
+
+        DocumentBuilderFactory factory =
+            DocumentBuilderFactory.newInstance();
+
+        factory.setFeature(
+            "http://apache.org/xml/features/disallow-doctype-decl",
+            true
+        );
+
+        try (InputStream input =
+            Files.newInputStream(POM_PATH)) {
+
+            Element project =
+                factory
+                    .newDocumentBuilder()
+                    .parse(input)
+                    .getDocumentElement();
+
+            NodeList children =
+                project.getChildNodes();
+
+            for (int index = 0;
+                index < children.getLength();
+                index++) {
+
+                Node child =
+                    children.item(index);
+
+                if (
+                    child.getNodeType()
+                        == Node.ELEMENT_NODE
+                        && "version".equals(
+                            child.getNodeName()
+                        )
+                ) {
+                    return child
+                        .getTextContent()
+                        .trim();
+                }
+            }
+        }
+
+        throw new IOException(
+            "Project version was not found in pom.xml"
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/logging/ObservabilityAcceptanceDocumentationTest.java
+++ b/src/test/java/com/nursena/payflow/observability/logging/ObservabilityAcceptanceDocumentationTest.java
@@ -98,7 +98,7 @@ class ObservabilityAcceptanceDocumentationTest {
     }
 
     @Test
-    void shouldPublishReleaseCandidateNotesAndReadmeLink()
+    void shouldPublishReleasePreparationNotesAndReadmeLink()
         throws IOException {
         String releaseNotes =
             Files.readString(
@@ -112,16 +112,16 @@ class ObservabilityAcceptanceDocumentationTest {
 
         assertThat(releaseNotes)
             .contains(
-                "# PayFlow v0.11.0 release candidate notes"
+                "# PayFlow v0.11.0"
             )
             .contains(
-                "v0.10.0 remains the latest published release"
+                "## Release assets"
             )
             .contains(
                 "No database migration is included."
             )
             .contains(
-                "Asynchronous request-correlation propagation is deliberately out of scope"
+                "Asynchronous request-correlation propagation remains deliberately out of scope"
             );
 
         assertThat(readme)
@@ -129,7 +129,7 @@ class ObservabilityAcceptanceDocumentationTest {
                 "docs/releases/v0.11.0.md"
             )
             .contains(
-                "submitted for protected pull-request review"
+                "v0.11.0 is in protected release preparation"
             );
     }
 


### PR DESCRIPTION
## Summary

- freeze Maven version `0.11.0`
- finalize v0.11.0 observability release notes and roadmap gates
- align executable documentation contracts with release preparation
- enforce deterministic repository line endings

## Verification

- 1,022 tests passed
- `mvnw.cmd -B -ntp clean verify`
- `docker compose config --quiet`
- `git diff --cached --check`
- exact nine-path release budget

## Release boundary

Publication gates remain open until this PR is merged. The `v0.11.0` annotated tag must be created from the verified merge commit.

Closes #106