### PR TITLE
chore(project): start v0.13.0 development

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Completed capabilities include:
 - operator-only, paginated command-audit queries and chronological command timelines
 - Prometheus metrics, Grafana dashboards, and alert rules for Kafka consumer failures
 
-OpenAPI documentation and executable Postman workflows cover the implemented API. PayFlow v0.11.0 is the latest published release; v0.12.0 is in protected release preparation. The v0.12.0 release commit freezes a bounded JWT signing-key provider, stable key identifiers, and active/previous verification overlap without changing public API payloads.
+OpenAPI documentation and executable Postman workflows cover the implemented API. PayFlow v0.12.0 is the latest published release; the active `0.13.0-SNAPSHOT` line is reserved for verified-email and password-recovery workflows. The v0.12.0 release freezes a bounded JWT signing-key provider, stable key identifiers, and active/previous verification overlap without changing public API payloads.
 
 See the [v0.12.0 release notes](docs/releases/v0.12.0.md), the [JWT key-rotation operations guide](docs/operations/jwt-key-rotation.md), the [v0.11.0 release notes](docs/releases/v0.11.0.md), and the [roadmap](docs/roadmap.md).
 
@@ -125,15 +125,21 @@ The tag-triggered release workflow rebuilt and verified the project before publi
 
 See the [v0.11.0 release notes](docs/releases/v0.11.0.md) and the [structured logging operations guide](docs/operations/structured-logging.md).
 
-## v0.12.0 release preparation
+## v0.12.0 release
 
-PayFlow v0.12.0 is prepared for protected release review. The release separates JWT key retrieval from token issuance and verification. New tokens carry the configured active `kid`. The resource server accepts only RS256 tokens whose key identifier selects the active or immediately previous public key.
+PayFlow v0.12.0 was published from merge commit `fb0f97d076864cf3e45aabe0e3c25c81520ee101`. The release separates JWT key retrieval from token issuance and verification. New tokens carry the configured active `kid`. The resource server accepts only RS256 tokens whose key identifier selects the active or immediately previous public key.
 
 Local development uses one process-local ephemeral RSA key by default. The `production` profile requires configured PKCS#8 private and X.509 public key resources and fails startup when locations, identifiers, key strength, or the active key pair are invalid. Private keys and runtime key directories must never be committed.
 
-The `v0.12.0` tag must be created only from the verified merge commit of the release-preparation pull request. Tag publication triggers the independent release workflow that rebuilds and verifies the project before publishing the executable JAR, SHA-256 checksum, and GitHub Release.
+The protected release-preparation PR #114 produced the verified `v0.12.0` tag target. Release workflow run `30921514114` rebuilt and verified the project before publishing the executable JAR, SHA-256 checksum, and GitHub Release.
 
 See the [v0.12.0 release notes](docs/releases/v0.12.0.md) and the [JWT key-rotation operations guide](docs/operations/jwt-key-rotation.md). The provider decision is recorded in [ADR 0012](docs/adr/0012-jwt-signing-key-rotation.md).
+
+## v0.13.0 active development
+
+The active `0.13.0-SNAPSHOT` line introduces email-ownership verification and secure password recovery without weakening the existing session, token, or anti-enumeration boundaries. Account-action credentials will be opaque, single-use, time-limited, and persisted only as digests. Password recovery will revoke every active refresh-token family after a successful password change.
+
+The development plan keeps email-verification state separate from account status, preserves existing users through an explicit migration policy, applies bounded Redis-backed request limits, and keeps plaintext tokens out of persistence and observable output. Public endpoint contracts, delivery behavior, concurrency guarantees, and test evidence are defined in the [roadmap](docs/roadmap.md) before implementation begins.
 
 ## Implemented API
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,14 +2,14 @@
 
 ## Current delivery focus
 
-PayFlow v0.11.0 is the latest tagged release. The v0.12.0 release candidate uses
-the Maven version `0.12.0`.
+PayFlow v0.12.0 is the latest tagged release. The active development line uses
+the Maven version `0.13.0-SNAPSHOT`.
 
-The v0.11.0 observability release was published from verified merge commit
-`00401d55546fb819fe7d96a8fad8e8c43e37649c`. The v0.12.0 JWT signing-key
-rotation increment was merged through protected PR #113. The current focus is
-protected release review, then replacement of the invalid pre-release tag only
-after the verified release-preparation merge commit is known.
+The v0.12.0 JWT signing-key rotation release was published from verified merge
+commit `fb0f97d076864cf3e45aabe0e3c25c81520ee101`. The v0.13.0 increment
+focuses on email-ownership verification and secure password recovery while
+preserving the existing anti-enumeration, refresh-session, and logging
+boundaries.
 
 PayFlow remains a modular monolith. PostgreSQL is the system of record; Redis is
 used only for bounded, explicitly expiring abuse-control state.
@@ -287,7 +287,7 @@ The release is ready only when:
 - [x] the executable JAR and SHA-256 checksum are published and independently verified
 - [x] the GitHub Release is published
 
-## v0.12.0 — Release Candidate: JWT Signing-Key Rotation
+## v0.12.0 — Released: JWT Signing-Key Rotation
 
 ### Product outcome
 
@@ -336,9 +336,11 @@ keys and only RS256 signatures.
 - [x] Add an ADR for the signing-key provider and overlap model
 - [x] Update README, configuration examples, and architecture documentation
 - [x] Prepare v0.12.0 release notes after the implementation PR is merged
-- [ ] Merge v0.12.0 release preparation through a protected pull request
-- [ ] Tag the verified release merge commit as `v0.12.0`
-- [ ] Publish the executable JAR, SHA-256 checksum, and GitHub Release
+- [x] Merge v0.12.0 release preparation through protected PR #114
+- [x] Tag merge commit `fb0f97d076864cf3e45aabe0e3c25c81520ee101` as `v0.12.0`
+- [x] Publish `payflow-0.12.0.jar`
+- [x] Publish and independently verify `payflow-0.12.0.jar.sha256`
+- [x] Publish the GitHub Release
 
 ## Explicit v0.12.0 non-goals
 
@@ -368,11 +370,127 @@ The release is ready only when:
 - [x] focused and complete Maven verification pass through protected CI
 - [x] production-profile Docker smoke and protected CI pass
 - [x] OpenAPI, operations documentation, ADRs, and implementation agree
-- [ ] v0.12.0 release preparation and publication gates complete
+- [x] v0.12.0 release preparation and publication gates complete
+
+### Publication record
+
+- release workflow run: `30921514114`
+- executable JAR size: `99,140,599` bytes
+- verified SHA-256: `BA0BF76D07B3426E9C8DDE5E128A0C7B957807F71AA982EDC5927077980AB391`
+
+## v0.13.0 — Active Development: Email Verification & Password Recovery
+
+### Product outcome
+
+PayFlow users can prove ownership of their normalized email address and recover
+access after forgetting a password without exposing whether an account exists.
+Every account-action credential is opaque, single-use, time-limited, and stored
+only as a digest. A successful password recovery changes the BCrypt hash and
+revokes every active refresh-token family atomically.
+
+### Increment 1 — Domain model and migration policy
+
+- [x] Open the dedicated v0.13.0 implementation issue under release train #106
+- [ ] Add nullable `email_verified_at` as an invariant separate from `UserStatus`
+- [ ] Backfill every pre-v0.13.0 user as verified to prevent migration lockout
+- [ ] Register new users without a verified-email timestamp
+- [ ] Add explicit `verifyEmail` and `changePassword` domain behavior
+- [ ] Keep password mutation unavailable outside the recovery use case
+- [ ] Add Flyway V15 with constrained account-action token persistence
+
+### Increment 2 — Opaque account-action credentials
+
+- [ ] Generate at least 256 bits of cryptographically secure randomness
+- [ ] Use strict canonical unpadded Base64 URL encoding
+- [ ] Persist only fixed-length SHA-256 digests, never plaintext credentials
+- [ ] Separate `EMAIL_VERIFICATION` and `PASSWORD_RECOVERY` purposes
+- [ ] Enforce purpose-specific expiration and one successful consumption
+- [ ] Invalidate prior active credentials for the same user and purpose
+- [ ] Lock credential consumption so concurrent confirmation has one winner
+- [ ] Exclude credentials and digests from logs, metrics, traces, errors, and APIs
+
+### Increment 3 — Email-verification workflow
+
+- [ ] Issue a verification credential after successful registration
+- [ ] Add generic `POST /api/v1/auth/email-verification/requests`
+- [ ] Add token-confirmation `POST /api/v1/auth/email-verification/confirm`
+- [ ] Build links only from validated configuration, never request host headers
+- [ ] Mark email ownership exactly once in the confirmation transaction
+- [ ] Reject login for unverified new users only after credentials match
+- [ ] Preserve generic behavior for unknown, closed, or already-verified accounts
+
+### Increment 4 — Password-recovery workflow
+
+- [ ] Add generic `POST /api/v1/auth/password-recovery/requests`
+- [ ] Add token-confirmation `POST /api/v1/auth/password-recovery/confirm`
+- [ ] Reuse the registration password-strength and BCrypt policy
+- [ ] Consume the recovery credential and replace the password hash atomically
+- [ ] Revoke all active refresh-token families with `PASSWORD_RECOVERY`
+- [ ] Preserve the existing short access-token residual-validity boundary
+- [ ] Keep invalid, expired, consumed, and superseded token errors indistinguishable
+
+### Increment 5 — Delivery and abuse protection
+
+- [ ] Introduce an application-facing email-delivery port and SMTP adapter
+- [ ] Keep SMTP, templates, and link construction outside domain code
+- [ ] Return the same accepted response for eligible and ineligible identities
+- [ ] Apply identical limiter work before account eligibility is evaluated
+- [ ] Limit each normalized identity and purpose to 3 requests per hour
+- [ ] Limit each effective client and purpose to 20 requests per hour
+- [ ] Store only hashed limiter dimensions with explicit Redis expiration
+- [ ] Fail closed when Redis cannot make a safe abuse-control decision
+- [ ] Record only bounded, low-cardinality delivery and security outcomes
+
+### Increment 6 — Verification and public contracts
+
+- [ ] Unit-test domain state, credential shape, digesting, and lifetime policy
+- [ ] Verify Flyway V14-to-V15 upgrade and clean installation with PostgreSQL
+- [ ] Verify concurrent confirmation and transactional rollback with PostgreSQL
+- [ ] Verify identity/client thresholds, expiration, and outage behavior with Redis
+- [ ] Verify mail delivery without exposing credentials in captured diagnostics
+- [ ] Add MockMvc, real endpoint-to-database, OpenAPI, and Postman contracts
+- [ ] Add an ADR and operations guide for account-action credentials and delivery
+- [ ] Run the complete Maven verification suite and production Docker smoke
+- [ ] Pass protected `build-and-test` and `docker-smoke` checks before merge
+
+## Explicit v0.13.0 non-goals
+
+- email-address change or multiple email addresses per user
+- multi-factor authentication, recovery codes, or step-up authentication
+- external OAuth, OpenID Connect, or social-login providers
+- access-token denylisting or immediate revocation of already-issued JWTs
+- browser cookies, CSRF policy, frontend pages, mobile deep links, or UI branding
+- durable storage of plaintext credentials or provider-ready reset URLs
+- encrypted email outbox or guaranteed asynchronous email delivery
+- email marketing, localization, attachments, or provider migration tooling
+- generalized API-wide rate limiting or device fingerprinting
+- remote KMS, HSM, Vault, Kubernetes, or microservice extraction
+
+These concerns require separate threat models and versioned contracts. The
+v0.13.0 increment is limited to ownership verification, password recovery,
+bounded email delivery, and the security evidence needed to trust them.
+
+## v0.13.0 release exit criteria
+
+The release is ready only when:
+
+- [ ] pre-v0.13.0 users remain able to authenticate after migration
+- [ ] newly registered users cannot authenticate before email verification
+- [ ] account-action plaintext and digests never enter observable output
+- [ ] request responses do not disclose account existence or eligibility
+- [ ] expired, consumed, superseded, and malformed credentials fail safely
+- [ ] concurrent confirmation permits at most one successful state transition
+- [ ] password recovery changes the hash and revokes all refresh families atomically
+- [ ] abuse limits use normalized hashed dimensions and bounded expiration
+- [ ] SMTP failures do not weaken token or account-state correctness
+- [ ] focused unit, PostgreSQL, Redis, HTTP, OpenAPI, and Postman tests pass
+- [ ] the complete Maven suite and production Docker smoke pass
+- [ ] ADR, operations guide, configuration, and implementation agree
+- [ ] protected feature and release-preparation pull requests are merged
+- [ ] the v0.13.0 tag, JAR, checksum, and GitHub Release are published
 
 ## Later v1.0 candidates
 
-Later v1.0 candidates include verified-email and password-recovery workflows,
-multi-factor authentication, generalized abuse protection, load/performance
-evidence, backup/restore rehearsal, API freeze, SBOM generation, and release
-stabilization.
+Later v1.0 candidates include multi-factor authentication, generalized abuse
+protection, load/performance evidence, backup/restore rehearsal, API freeze,
+SBOM generation, and release stabilization.

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.12.0</version>
+    <version>0.13.0-SNAPSHOT</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 

--- a/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
@@ -22,33 +22,34 @@ class RoadmapContractTest {
         Path.of("docs", "roadmap.md");
 
     @Test
-    void shouldAlignRoadmapWithReleaseCandidate()
+    void shouldAlignRoadmapWithActiveDevelopmentVersion()
         throws Exception {
 
         String projectVersion = readProjectVersion();
         String roadmap = Files.readString(ROADMAP);
 
         assertThat(projectVersion)
-            .isEqualTo("0.12.0");
+            .isEqualTo("0.13.0-SNAPSHOT");
 
         assertThat(roadmap)
             .contains(
-                "PayFlow v0.11.0 is the latest tagged release",
+                "PayFlow v0.12.0 is the latest tagged release",
                 "the Maven version `" + projectVersion + "`",
                 "## v0.10.0 — Released: Trusted Client Context",
                 "## v0.11.0 — Released: Structured Logging and Request Correlation",
-                "## v0.12.0 — Release Candidate: JWT Signing-Key Rotation",
-                "merged through protected PR #113",
-                "protected release review"
+                "## v0.12.0 — Released: JWT Signing-Key Rotation",
+                "## v0.13.0 — Active Development: Email Verification & Password Recovery",
+                "fb0f97d076864cf3e45aabe0e3c25c81520ee101",
+                "email-ownership verification and secure password recovery"
             )
             .doesNotContain(
-                "The v0.11.0 release candidate uses",
-                "v0.11.0 is in protected release preparation"
+                "The v0.12.0 release candidate uses",
+                "## v0.12.0 — Release Candidate: JWT Signing-Key Rotation"
             );
     }
 
     @Test
-    void shouldKeepOnlyV012PublicationGatesOpen()
+    void shouldCloseV012PublicationAndOpenV013DeliveryGates()
         throws IOException {
 
         assertThat(Files.readString(ROADMAP))
@@ -59,10 +60,14 @@ class RoadmapContractTest {
                 "- [x] Merge the JWT signing-key rotation increment through protected PR #113",
                 "- [x] Close implementation issue #112 after merge",
                 "- [x] Prepare v0.12.0 release notes after the implementation PR is merged",
-                "- [ ] Merge v0.12.0 release preparation through a protected pull request",
-                "- [ ] Tag the verified release merge commit as `v0.12.0`",
+                "- [x] Merge v0.12.0 release preparation through protected PR #114",
+                "- [x] v0.12.0 release preparation and publication gates complete",
                 "- [x] focused and complete Maven verification pass through protected CI",
-                "- [ ] v0.12.0 release preparation and publication gates complete"
+                "- [x] Open the dedicated v0.13.0 implementation issue under release train #106",
+                "- [ ] Add nullable `email_verified_at` as an invariant separate from `UserStatus`",
+                "- [ ] Persist only fixed-length SHA-256 digests, never plaintext credentials",
+                "- [ ] Revoke all active refresh-token families with `PASSWORD_RECOVERY`",
+                "- [ ] request responses do not disclose account existence or eligibility"
             );
     }
 

--- a/src/test/java/com/nursena/payflow/configuration/V011ReleasePublicationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V011ReleasePublicationContractTest.java
@@ -36,7 +36,7 @@ class V011ReleasePublicationContractTest {
 
         assertThat(Files.readString(README))
             .contains(
-                "PayFlow v0.11.0 is the latest published release",
+                "## v0.11.0 release",
                 "docs/releases/v0.11.0.md",
                 "00401d55546fb819fe7d96a8fad8e8c43e37649c"
             )
@@ -46,8 +46,8 @@ class V011ReleasePublicationContractTest {
 
         assertThat(Files.readString(ROADMAP))
             .contains(
-                "PayFlow v0.11.0 is the latest tagged release",
                 "## v0.11.0 — Released: Structured Logging and Request Correlation",
+                "00401d55546fb819fe7d96a8fad8e8c43e37649c",
                 "protected PR #111",
                 "release workflow run: `30816366250`",
                 "executable JAR size: `99,121,200` bytes",

--- a/src/test/java/com/nursena/payflow/configuration/V012ReleasePublicationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V012ReleasePublicationContractTest.java
@@ -3,20 +3,12 @@ package com.nursena.payflow.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.junit.jupiter.api.Test;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
-class V012ReleasePreparationContractTest {
-
-    private static final Path POM =
-        Path.of("pom.xml");
+class V012ReleasePublicationContractTest {
 
     private static final Path README =
         Path.of("README.md");
@@ -71,33 +63,34 @@ class V012ReleasePreparationContractTest {
         );
 
     @Test
-    void shouldUseFinalReleaseCandidateVersion()
-        throws Exception {
-
-        assertThat(readProjectVersion())
-            .isEqualTo("0.12.0");
+    void shouldRetainPublishedReleaseRecord()
+        throws IOException {
 
         assertThat(Files.readString(README))
             .contains(
-                "v0.12.0 is in protected release preparation",
+                "PayFlow v0.12.0 is the latest published release",
                 "docs/releases/v0.12.0.md",
-                "v0.12.0 release preparation",
-                "verified merge commit of the release-preparation pull request"
+                "## v0.12.0 release",
+                "fb0f97d076864cf3e45aabe0e3c25c81520ee101",
+                "protected release-preparation PR #114",
+                "Release workflow run `30921514114`"
             )
             .doesNotContain(
                 "The active `0.12.0-SNAPSHOT` line",
-                "The active v0.12.0 development line"
+                "v0.12.0 is in protected release preparation",
+                "## v0.12.0 release preparation"
             );
 
         assertThat(Files.readString(ROADMAP))
             .contains(
-                "The v0.12.0 release candidate uses",
-                "the Maven version `0.12.0`",
-                "## v0.12.0 — Release Candidate: JWT Signing-Key Rotation"
+                "PayFlow v0.12.0 is the latest tagged release",
+                "## v0.12.0 — Released: JWT Signing-Key Rotation",
+                "release workflow run: `30921514114`",
+                "executable JAR size: `99,140,599` bytes",
+                "BA0BF76D07B3426E9C8DDE5E128A0C7B957807F71AA982EDC5927077980AB391"
             )
             .doesNotContain(
-                "0.12.0-SNAPSHOT",
-                "## v0.12.0 — Active Development: JWT Signing-Key Rotation"
+                "## v0.12.0 — Release Candidate: JWT Signing-Key Rotation"
             );
     }
 
@@ -229,17 +222,19 @@ class V012ReleasePreparationContractTest {
     }
 
     @Test
-    void shouldKeepPublicationCriteriaOpenUntilProtectedReleaseCompletes()
+    void shouldRecordCompletedPublicationCriteria()
         throws IOException {
 
         assertThat(Files.readString(ROADMAP))
             .contains(
                 "- [x] Pass protected `build-and-test` and Docker smoke CI for PR #113",
                 "- [x] Prepare v0.12.0 release notes after the implementation PR is merged",
-                "- [ ] Merge v0.12.0 release preparation through a protected pull request",
-                "- [ ] Tag the verified release merge commit as `v0.12.0`",
-                "- [ ] Publish the executable JAR, SHA-256 checksum, and GitHub Release",
-                "- [ ] v0.12.0 release preparation and publication gates complete"
+                "- [x] Merge v0.12.0 release preparation through protected PR #114",
+                "- [x] Tag merge commit `fb0f97d076864cf3e45aabe0e3c25c81520ee101` as `v0.12.0`",
+                "- [x] Publish `payflow-0.12.0.jar`",
+                "- [x] Publish and independently verify `payflow-0.12.0.jar.sha256`",
+                "- [x] Publish the GitHub Release",
+                "- [x] v0.12.0 release preparation and publication gates complete"
             );
     }
 
@@ -259,48 +254,4 @@ class V012ReleasePreparationContractTest {
             );
     }
 
-    private static String readProjectVersion()
-        throws Exception {
-
-        DocumentBuilderFactory factory =
-            DocumentBuilderFactory.newInstance();
-
-        factory.setFeature(
-            "http://apache.org/xml/features/disallow-doctype-decl",
-            true
-        );
-
-        try (InputStream input = Files.newInputStream(POM)) {
-            Element project = factory
-                .newDocumentBuilder()
-                .parse(input)
-                .getDocumentElement();
-
-            NodeList children = project.getChildNodes();
-
-            for (
-                int index = 0;
-                index < children.getLength();
-                index++
-            ) {
-                Node child = children.item(index);
-
-                if (
-                    child.getNodeType()
-                        == Node.ELEMENT_NODE
-                        && "version".equals(
-                            child.getNodeName()
-                        )
-                ) {
-                    return child
-                        .getTextContent()
-                        .trim();
-                }
-            }
-        }
-
-        throw new IOException(
-            "Project version was not found in pom.xml"
-        );
-    }
 }

--- a/src/test/java/com/nursena/payflow/configuration/V013DevelopmentContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V013DevelopmentContractTest.java
@@ -1,0 +1,81 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class V013DevelopmentContractTest {
+
+    private static final Path README =
+        Path.of("README.md");
+
+    private static final Path CHANGELOG =
+        Path.of("CHANGELOG.md");
+
+    private static final Path ROADMAP =
+        Path.of("docs", "roadmap.md");
+
+    @Test
+    void shouldExposeV013DevelopmentStatus()
+        throws IOException {
+
+        assertThat(Files.readString(README))
+            .contains(
+                "PayFlow v0.12.0 is the latest published release",
+                "the active `0.13.0-SNAPSHOT` line",
+                "## v0.13.0 active development",
+                "email-ownership verification and secure password recovery",
+                "persisted only as digests",
+                "revoke every active refresh-token family"
+            )
+            .doesNotContain(
+                "v0.12.0 is in protected release preparation",
+                "## v0.12.0 release preparation"
+            );
+    }
+
+    @Test
+    void shouldDefineCredentialAndEnumerationBoundaries()
+        throws IOException {
+
+        assertThat(Files.readString(ROADMAP))
+            .contains(
+                "at least 256 bits of cryptographically secure randomness",
+                "Persist only fixed-length SHA-256 digests, never plaintext credentials",
+                "one successful consumption",
+                "Return the same accepted response for eligible and ineligible identities",
+                "Apply identical limiter work before account eligibility is evaluated",
+                "3 requests per hour",
+                "20 requests per hour",
+                "Fail closed when Redis cannot make a safe abuse-control decision"
+            );
+    }
+
+    @Test
+    void shouldDefinePublicFlowsAndSessionRevocation()
+        throws IOException {
+
+        assertThat(Files.readString(ROADMAP))
+            .contains(
+                "POST /api/v1/auth/email-verification/requests",
+                "POST /api/v1/auth/email-verification/confirm",
+                "POST /api/v1/auth/password-recovery/requests",
+                "POST /api/v1/auth/password-recovery/confirm",
+                "Backfill every pre-v0.13.0 user as verified",
+                "Revoke all active refresh-token families with `PASSWORD_RECOVERY`",
+                "concurrent confirmation has one winner",
+                "Preserve the existing short access-token residual-validity boundary"
+            );
+
+        assertThat(Files.readString(CHANGELOG))
+            .contains(
+                "## [Unreleased]",
+                "## [0.12.0] - 2026-08-04",
+                "[Unreleased]: https://github.com/nursena-pc/payflow/compare/v0.12.0...HEAD"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/observability/logging/ObservabilityAcceptanceDocumentationTest.java
+++ b/src/test/java/com/nursena/payflow/observability/logging/ObservabilityAcceptanceDocumentationTest.java
@@ -98,7 +98,7 @@ class ObservabilityAcceptanceDocumentationTest {
     }
 
     @Test
-    void shouldPublishReleasePreparationNotesAndReadmeLink()
+    void shouldRetainPublishedReleaseNotesAndReadmeLink()
         throws IOException {
         String releaseNotes =
             Files.readString(
@@ -126,10 +126,8 @@ class ObservabilityAcceptanceDocumentationTest {
 
         assertThat(readme)
             .contains(
-                "docs/releases/v0.11.0.md"
-            )
-            .contains(
-                "PayFlow v0.11.0 is the latest published release"
+                "docs/releases/v0.11.0.md",
+                "## v0.11.0 release"
             );
     }
 


### PR DESCRIPTION
## Summary

- record the verified v0.12.0 publication and close its roadmap gates
- start the Maven `0.13.0-SNAPSHOT` development line
- define the email-verification and password-recovery threat model, endpoint
  contracts, abuse limits, migration policy, and release exit criteria
- convert the v0.12.0 release-preparation contract into a publication contract
- add executable v0.13.0 development and roadmap contracts

## Security boundaries

- account-action credentials are opaque, single-use, time-limited, and stored
  only as SHA-256 digests
- request endpoints do not reveal account existence or eligibility
- email ownership remains separate from account status
- pre-v0.13.0 users are explicitly protected from migration lockout
- password recovery revokes every active refresh family atomically
- plaintext credentials remain outside persistence and observable output

## Verification

- `git diff --cached --check`
- exact staged-path budget
- `mvnw.cmd -B -ntp clean verify`
- protected `build-and-test`
- protected `docker-smoke`

This kickoff PR contains no feature endpoint or persistence implementation.
Implementation remains tracked by the linked v0.13.0 issue under release train
#106 and will be delivered in small, reviewable commits.

Related implementation: #115
