### PR TITLE
feat(user): add account-action persistence foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Nullable email-verification state independent from account status, with existing users safely backfilled during the V15 migration.
+- Package-bounded user-domain behavior for one-time email verification and password replacement through the future recovery workflow.
+- Constrained digest-only account-action credential storage for email verification and password recovery.
+
+### Security
+
+- New registrations remain unverified while every pre-v0.13.0 account keeps its existing authentication eligibility.
+- PostgreSQL enforces credential purpose, SHA-256 digest length, lifetime, terminal-state consistency, and at most one unresolved credential per user and purpose.
+
 ## [0.12.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ The active `0.13.0-SNAPSHOT` line introduces email-ownership verification and se
 
 The development plan keeps email-verification state separate from account status, preserves existing users through an explicit migration policy, applies bounded Redis-backed request limits, and keeps plaintext tokens out of persistence and observable output. Public endpoint contracts, delivery behavior, concurrency guarantees, and test evidence are defined in the [roadmap](docs/roadmap.md) before implementation begins.
 
+The first implementation increment adds the nullable verification timestamp, backfills existing users as verified, keeps new registrations unverified, and introduces the constrained V15 digest-only credential schema. Credential generation, workflow endpoints, abuse control, and email delivery remain isolated in later increments.
+
 ## Implemented API
 
 | Method | Endpoint | Authentication | Description |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -391,12 +391,12 @@ revokes every active refresh-token family atomically.
 ### Increment 1 — Domain model and migration policy
 
 - [x] Open the dedicated v0.13.0 implementation issue under release train #106
-- [ ] Add nullable `email_verified_at` as an invariant separate from `UserStatus`
-- [ ] Backfill every pre-v0.13.0 user as verified to prevent migration lockout
-- [ ] Register new users without a verified-email timestamp
-- [ ] Add explicit `verifyEmail` and `changePassword` domain behavior
-- [ ] Keep password mutation unavailable outside the recovery use case
-- [ ] Add Flyway V15 with constrained account-action token persistence
+- [x] Add nullable `email_verified_at` as an invariant separate from `UserStatus`
+- [x] Backfill every pre-v0.13.0 user as verified to prevent migration lockout
+- [x] Register new users without a verified-email timestamp
+- [x] Add explicit `verifyEmail` and `changePassword` domain behavior
+- [x] Keep password mutation unavailable outside the recovery use case
+- [x] Add Flyway V15 with constrained account-action token persistence
 
 ### Increment 2 — Opaque account-action credentials
 

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/UserJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/UserJpaEntity.java
@@ -33,6 +33,9 @@ class UserJpaEntity {
     @Column(nullable = false, length = 20)
     private UserStatus status;
 
+    @Column(name = "email_verified_at")
+    private Instant emailVerifiedAt;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 
@@ -48,6 +51,7 @@ class UserJpaEntity {
         String passwordHash,
         UserRole role,
         UserStatus status,
+        Instant emailVerifiedAt,
         Instant createdAt,
         Instant updatedAt
     ) {
@@ -56,6 +60,7 @@ class UserJpaEntity {
         this.passwordHash = passwordHash;
         this.role = role;
         this.status = status;
+        this.emailVerifiedAt = emailVerifiedAt;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -78,6 +83,10 @@ class UserJpaEntity {
 
     UserStatus getStatus() {
         return status;
+    }
+
+    Instant getEmailVerifiedAt() {
+        return emailVerifiedAt;
     }
 
     Instant getCreatedAt() {

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -63,6 +63,7 @@ class UserPersistenceAdapter implements UserRepositoryPort {
             user.passwordHash(),
             user.role(),
             user.status(),
+            user.emailVerifiedAt(),
             user.createdAt(),
             user.updatedAt()
         );
@@ -75,6 +76,7 @@ class UserPersistenceAdapter implements UserRepositoryPort {
             entity.getPasswordHash(),
             entity.getRole(),
             entity.getStatus(),
+            entity.getEmailVerifiedAt(),
             entity.getCreatedAt(),
             entity.getUpdatedAt()
         );

--- a/src/main/java/com/nursena/payflow/user/domain/model/User.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/User.java
@@ -8,9 +8,10 @@ public final class User {
 
     private final UUID id;
     private final EmailAddress email;
-    private final String passwordHash;
+    private String passwordHash;
     private final UserRole role;
     private UserStatus status;
+    private Instant emailVerifiedAt;
     private final Instant createdAt;
     private Instant updatedAt;
 
@@ -20,6 +21,7 @@ public final class User {
         String passwordHash,
         UserRole role,
         UserStatus status,
+        Instant emailVerifiedAt,
         Instant createdAt,
         Instant updatedAt
     ) {
@@ -30,6 +32,9 @@ public final class User {
         this.status = Objects.requireNonNull(status, "status must not be null");
         this.createdAt = Objects.requireNonNull(createdAt, "createdAt must not be null");
         this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt must not be null");
+        this.emailVerifiedAt = emailVerifiedAt;
+
+        validateEmailVerificationTime();
     }
 
     public static User register(
@@ -43,6 +48,7 @@ public final class User {
             passwordHash,
             UserRole.USER,
             UserStatus.ACTIVE,
+            null,
             now,
             now
         );
@@ -54,6 +60,7 @@ public final class User {
         String passwordHash,
         UserRole role,
         UserStatus status,
+        Instant emailVerifiedAt,
         Instant createdAt,
         Instant updatedAt
     ) {
@@ -63,9 +70,30 @@ public final class User {
             passwordHash,
             role,
             status,
+            emailVerifiedAt,
             createdAt,
             updatedAt
         );
+    }
+
+    public boolean verifyEmail(Instant now) {
+        Instant verifiedAt = requireMutationTime(now);
+
+        if (emailVerifiedAt != null) {
+            return false;
+        }
+
+        emailVerifiedAt = verifiedAt;
+        updatedAt = verifiedAt;
+
+        return true;
+    }
+
+    void changePassword(String replacementPasswordHash, Instant now) {
+        Instant changedAt = requireMutationTime(now);
+
+        passwordHash = requirePasswordHash(replacementPasswordHash);
+        updatedAt = changedAt;
     }
 
     public void suspend(Instant now) {
@@ -79,6 +107,36 @@ public final class User {
         }
 
         return passwordHash;
+    }
+
+    private Instant requireMutationTime(Instant now) {
+        Instant mutationTime =
+            Objects.requireNonNull(now, "now must not be null");
+
+        if (mutationTime.isBefore(createdAt)) {
+            throw new IllegalArgumentException(
+                "now must not be before createdAt"
+            );
+        }
+
+        if (mutationTime.isBefore(updatedAt)) {
+            throw new IllegalArgumentException(
+                "now must not be before updatedAt"
+            );
+        }
+
+        return mutationTime;
+    }
+
+    private void validateEmailVerificationTime() {
+        if (
+            emailVerifiedAt != null
+                && emailVerifiedAt.isBefore(createdAt)
+        ) {
+            throw new IllegalArgumentException(
+                "emailVerifiedAt must not be before createdAt"
+            );
+        }
     }
 
     public UUID id() {
@@ -99,6 +157,14 @@ public final class User {
 
     public UserStatus status() {
         return status;
+    }
+
+    public boolean isEmailVerified() {
+        return emailVerifiedAt != null;
+    }
+
+    public Instant emailVerifiedAt() {
+        return emailVerifiedAt;
     }
 
     public Instant createdAt() {

--- a/src/main/resources/db/migration/V15__add_account_action_credentials.sql
+++ b/src/main/resources/db/migration/V15__add_account_action_credentials.sql
@@ -1,0 +1,93 @@
+ALTER TABLE users
+    ADD COLUMN email_verified_at TIMESTAMPTZ;
+
+-- Accounts created before V15 keep their existing authentication eligibility.
+UPDATE users
+SET email_verified_at = CURRENT_TIMESTAMP;
+
+ALTER TABLE users
+    ADD CONSTRAINT chk_users_email_verification_time
+    CHECK (
+        email_verified_at IS NULL
+        OR email_verified_at >= created_at
+    );
+
+CREATE TABLE account_action_credentials (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    purpose VARCHAR(32) NOT NULL,
+    credential_digest BYTEA NOT NULL,
+    issued_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    consumed_at TIMESTAMPTZ,
+    superseded_at TIMESTAMPTZ,
+
+    CONSTRAINT fk_account_action_credentials_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT uq_account_action_credentials_digest
+        UNIQUE (credential_digest),
+
+    CONSTRAINT chk_account_action_credentials_purpose
+        CHECK (
+            purpose IN (
+                'EMAIL_VERIFICATION',
+                'PASSWORD_RECOVERY'
+            )
+        ),
+
+    CONSTRAINT chk_account_action_credentials_digest_length
+        CHECK (
+            octet_length(credential_digest) = 32
+        ),
+
+    CONSTRAINT chk_account_action_credentials_lifetime
+        CHECK (
+            expires_at > issued_at
+        ),
+
+    CONSTRAINT chk_account_action_credentials_terminal_state
+        CHECK (
+            consumed_at IS NULL
+            OR superseded_at IS NULL
+        ),
+
+    CONSTRAINT chk_account_action_credentials_consumption_time
+        CHECK (
+            consumed_at IS NULL
+            OR (
+                consumed_at >= issued_at
+                AND consumed_at < expires_at
+            )
+        ),
+
+    CONSTRAINT chk_account_action_credentials_supersession_time
+        CHECK (
+            superseded_at IS NULL
+            OR superseded_at >= issued_at
+        )
+);
+
+-- Issuance supersedes any prior unresolved credential before inserting the
+-- replacement. The index makes concurrent issuance fail safely.
+CREATE UNIQUE INDEX uq_account_action_credentials_unresolved
+    ON account_action_credentials (
+        user_id,
+        purpose
+    )
+    WHERE consumed_at IS NULL
+      AND superseded_at IS NULL;
+
+CREATE INDEX idx_account_action_credentials_user_purpose_issued
+    ON account_action_credentials (
+        user_id,
+        purpose,
+        issued_at DESC
+    );
+
+CREATE INDEX idx_account_action_credentials_expires_at
+    ON account_action_credentials (
+        expires_at
+    );

--- a/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
@@ -64,7 +64,10 @@ class RoadmapContractTest {
                 "- [x] v0.12.0 release preparation and publication gates complete",
                 "- [x] focused and complete Maven verification pass through protected CI",
                 "- [x] Open the dedicated v0.13.0 implementation issue under release train #106",
-                "- [ ] Add nullable `email_verified_at` as an invariant separate from `UserStatus`",
+                "- [x] Add nullable `email_verified_at` as an invariant separate from `UserStatus`",
+                "- [x] Backfill every pre-v0.13.0 user as verified to prevent migration lockout",
+                "- [x] Register new users without a verified-email timestamp",
+                "- [x] Add Flyway V15 with constrained account-action token persistence",
                 "- [ ] Persist only fixed-length SHA-256 digests, never plaintext credentials",
                 "- [ ] Revoke all active refresh-token families with `PASSWORD_RECOVERY`",
                 "- [ ] request responses do not disclose account existence or eligibility"

--- a/src/test/java/com/nursena/payflow/user/adapter/out/persistence/UserPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/persistence/UserPersistenceAdapterTest.java
@@ -57,6 +57,9 @@ class UserPersistenceAdapterTest {
             NOW
         );
 
+        Instant verifiedAt = NOW.plusSeconds(60);
+        user.verifyEmail(verifiedAt);
+
         when(repository.saveAndFlush(any(UserJpaEntity.class)))
             .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -68,8 +71,10 @@ class UserPersistenceAdapterTest {
             .isEqualTo(user.passwordHash());
         assertThat(savedUser.role()).isEqualTo(user.role());
         assertThat(savedUser.status()).isEqualTo(user.status());
+        assertThat(savedUser.emailVerifiedAt())
+            .isEqualTo(verifiedAt);
         assertThat(savedUser.createdAt()).isEqualTo(NOW);
-        assertThat(savedUser.updatedAt()).isEqualTo(NOW);
+        assertThat(savedUser.updatedAt()).isEqualTo(verifiedAt);
     }
 
     @Test
@@ -80,12 +85,16 @@ class UserPersistenceAdapterTest {
             NOW
         );
 
+        Instant verifiedAt = NOW.plusSeconds(60);
+        user.verifyEmail(verifiedAt);
+
         UserJpaEntity entity = new UserJpaEntity(
             user.id(),
             user.email().value(),
             user.passwordHash(),
             user.role(),
             user.status(),
+            user.emailVerifiedAt(),
             user.createdAt(),
             user.updatedAt()
         );
@@ -107,6 +116,8 @@ class UserPersistenceAdapterTest {
             .isEqualTo(user.passwordHash());
         assertThat(foundUser.role()).isEqualTo(user.role());
         assertThat(foundUser.status()).isEqualTo(user.status());
+        assertThat(foundUser.emailVerifiedAt())
+            .isEqualTo(verifiedAt);
         assertThat(foundUser.createdAt())
             .isEqualTo(user.createdAt());
         assertThat(foundUser.updatedAt())
@@ -158,6 +169,7 @@ class UserPersistenceAdapterTest {
             user.passwordHash(),
             user.role(),
             user.status(),
+            user.emailVerifiedAt(),
             user.createdAt(),
             user.updatedAt()
         );

--- a/src/test/java/com/nursena/payflow/user/application/service/AuthenticateUserServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/AuthenticateUserServiceTest.java
@@ -941,6 +941,7 @@ class AuthenticateUserServiceTest {
             UserRole.USER,
             UserStatus.ACTIVE,
             NOW,
+            NOW,
             NOW
         );
     }
@@ -954,6 +955,7 @@ class AuthenticateUserServiceTest {
             PASSWORD_HASH,
             UserRole.USER,
             UserStatus.SUSPENDED,
+            NOW,
             NOW,
             NOW
         );

--- a/src/test/java/com/nursena/payflow/user/application/service/GetCurrentUserProfileServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/GetCurrentUserProfileServiceTest.java
@@ -89,6 +89,7 @@ class GetCurrentUserProfileServiceTest {
             UserRole.USER,
             UserStatus.ACTIVE,
             CREATED_AT,
+            CREATED_AT,
             CREATED_AT
         );
     }

--- a/src/test/java/com/nursena/payflow/user/application/service/RegisterUserServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RegisterUserServiceTest.java
@@ -94,6 +94,8 @@ class RegisterUserServiceTest {
             .isEqualTo(UserRole.USER);
         assertThat(savedUser.status())
             .isEqualTo(UserStatus.ACTIVE);
+        assertThat(savedUser.isEmailVerified()).isFalse();
+        assertThat(savedUser.emailVerifiedAt()).isNull();
         assertThat(savedUser.createdAt())
             .isEqualTo(NOW);
     }

--- a/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsTransactionTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RotateRefreshCredentialsTransactionTest.java
@@ -911,6 +911,7 @@ class RotateRefreshCredentialsTransactionTest {
             UserRole.USER,
             status,
             FAMILY_CREATED_AT,
+            FAMILY_CREATED_AT,
             FAMILY_CREATED_AT
         );
     }

--- a/src/test/java/com/nursena/payflow/user/domain/model/UserTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/UserTest.java
@@ -3,7 +3,9 @@ package com.nursena.payflow.user.domain.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.lang.reflect.Modifier;
 import java.time.Instant;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +26,8 @@ class UserTest {
         assertThat(user.email().value()).isEqualTo("nursena@example.com");
         assertThat(user.role()).isEqualTo(UserRole.USER);
         assertThat(user.status()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(user.isEmailVerified()).isFalse();
+        assertThat(user.emailVerifiedAt()).isNull();
         assertThat(user.createdAt()).isEqualTo(NOW);
         assertThat(user.updatedAt()).isEqualTo(NOW);
     }
@@ -54,5 +58,130 @@ class UserTest {
 
         assertThat(user.status()).isEqualTo(UserStatus.SUSPENDED);
         assertThat(user.updatedAt()).isEqualTo(suspensionTime);
+    }
+
+    @Test
+    void shouldVerifyEmailExactlyOnce() {
+        User user = User.register(
+            EmailAddress.of("nursena@example.com"),
+            "$2a$12$hashed-password",
+            NOW
+        );
+
+        Instant verificationTime =
+            Instant.parse("2026-07-12T13:00:00Z");
+
+        assertThat(user.verifyEmail(verificationTime)).isTrue();
+        assertThat(user.verifyEmail(
+            verificationTime.plusSeconds(60)
+        )).isFalse();
+
+        assertThat(user.isEmailVerified()).isTrue();
+        assertThat(user.emailVerifiedAt())
+            .isEqualTo(verificationTime);
+        assertThat(user.updatedAt())
+            .isEqualTo(verificationTime);
+    }
+
+    @Test
+    void shouldRestoreVerifiedEmailState() {
+        Instant verificationTime =
+            Instant.parse("2026-07-12T13:00:00Z");
+
+        User user = User.rehydrate(
+            UUID.randomUUID(),
+            EmailAddress.of("nursena@example.com"),
+            "$2a$12$hashed-password",
+            UserRole.USER,
+            UserStatus.ACTIVE,
+            verificationTime,
+            NOW,
+            verificationTime
+        );
+
+        assertThat(user.isEmailVerified()).isTrue();
+        assertThat(user.emailVerifiedAt())
+            .isEqualTo(verificationTime);
+    }
+
+    @Test
+    void shouldRejectVerificationStateBeforeRegistration() {
+        assertThatThrownBy(() -> User.rehydrate(
+            UUID.randomUUID(),
+            EmailAddress.of("nursena@example.com"),
+            "$2a$12$hashed-password",
+            UserRole.USER,
+            UserStatus.ACTIVE,
+            NOW.minusSeconds(1),
+            NOW,
+            NOW
+        ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(
+                "emailVerifiedAt must not be before createdAt"
+            );
+    }
+
+    @Test
+    void shouldRejectVerificationBeforeRegistration() {
+        User user = User.register(
+            EmailAddress.of("nursena@example.com"),
+            "$2a$12$hashed-password",
+            NOW
+        );
+
+        assertThatThrownBy(() -> user.verifyEmail(
+            NOW.minusSeconds(1)
+        ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("now must not be before createdAt");
+    }
+
+    @Test
+    void shouldChangePasswordOnlyThroughPackageBoundary()
+        throws NoSuchMethodException {
+
+        User user = User.register(
+            EmailAddress.of("nursena@example.com"),
+            "$2a$12$old-hashed-password",
+            NOW
+        );
+
+        Instant recoveryTime =
+            Instant.parse("2026-07-12T14:00:00Z");
+
+        user.changePassword(
+            "$2a$12$replacement-hashed-password",
+            recoveryTime
+        );
+
+        assertThat(user.passwordHash())
+            .isEqualTo("$2a$12$replacement-hashed-password");
+        assertThat(user.updatedAt()).isEqualTo(recoveryTime);
+        assertThat(Modifier.isPublic(
+            User.class
+                .getDeclaredMethod(
+                    "changePassword",
+                    String.class,
+                    Instant.class
+                )
+                .getModifiers()
+        )).isFalse();
+    }
+
+    @Test
+    void shouldRejectBlankReplacementPasswordHash() {
+        User user = User.register(
+            EmailAddress.of("nursena@example.com"),
+            "$2a$12$old-hashed-password",
+            NOW
+        );
+
+        assertThatThrownBy(() -> user.changePassword(
+            " ",
+            NOW.plusSeconds(60)
+        ))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("passwordHash must not be blank");
     }
 }

--- a/src/test/java/com/nursena/payflow/user/integration/AccountActionCredentialMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/AccountActionCredentialMigrationIntegrationTest.java
@@ -1,0 +1,415 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class AccountActionCredentialMigrationIntegrationTest {
+
+    private static final Instant CREATED_AT =
+        Instant.parse("2026-08-04T12:00:00Z");
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    private static JdbcTemplate jdbcTemplate;
+
+    @BeforeAll
+    static void configureJdbcTemplate() {
+        DriverManagerDataSource dataSource =
+            new DriverManagerDataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            );
+
+        jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    @BeforeEach
+    void resetDatabase() {
+        flyway().clean();
+    }
+
+    @Test
+    void shouldUpgradeV14ToV15AndVerifyExistingUsers() {
+        migrateToVersion("14");
+
+        UUID existingUserId = UUID.randomUUID();
+
+        insertUser(existingUserId);
+
+        assertThat(columnExists(
+            "users",
+            "email_verified_at"
+        )).isFalse();
+        assertThat(tableExists(
+            "account_action_credentials"
+        )).isFalse();
+
+        migrateToLatestVersion();
+
+        assertThat(currentSchemaVersion()).isEqualTo("15");
+        assertThat(migrationApplied("15")).isTrue();
+        assertThat(tableExists(
+            "account_action_credentials"
+        )).isTrue();
+
+        Timestamp emailVerifiedAt =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT email_verified_at
+                FROM users
+                WHERE id = ?
+                """,
+                Timestamp.class,
+                existingUserId
+            );
+
+        assertThat(emailVerifiedAt)
+            .isNotNull();
+        assertThat(emailVerifiedAt.toInstant())
+            .isAfterOrEqualTo(CREATED_AT);
+        assertThat(failedMigrationCount()).isZero();
+    }
+
+    @Test
+    void shouldInstallConstrainedCredentialStorageOnCleanDatabase() {
+        migrateToLatestVersion();
+
+        UUID userId = UUID.randomUUID();
+
+        insertUser(userId);
+
+        assertThat(jdbcTemplate.queryForObject(
+            """
+            SELECT email_verified_at IS NULL
+            FROM users
+            WHERE id = ?
+            """,
+            Boolean.class,
+            userId
+        )).isTrue();
+
+        assertThatThrownBy(() -> jdbcTemplate.update(
+            """
+            UPDATE users
+            SET email_verified_at = ?
+            WHERE id = ?
+            """,
+            Timestamp.from(CREATED_AT.minusSeconds(1)),
+            userId
+        )).isInstanceOf(DataIntegrityViolationException.class);
+
+        insertCredential(
+            UUID.randomUUID(),
+            userId,
+            "EMAIL_VERIFICATION",
+            digest((byte) 1),
+            CREATED_AT,
+            CREATED_AT.plusSeconds(3_600),
+            null,
+            null
+        );
+
+        assertThatThrownBy(() -> insertCredential(
+            UUID.randomUUID(),
+            userId,
+            "EMAIL_VERIFICATION",
+            digest((byte) 2),
+            CREATED_AT.plusSeconds(60),
+            CREATED_AT.plusSeconds(3_660),
+            null,
+            null
+        )).isInstanceOf(DataIntegrityViolationException.class);
+
+        assertThatThrownBy(() -> insertCredential(
+            UUID.randomUUID(),
+            userId,
+            "PASSWORD_RECOVERY",
+            new byte[31],
+            CREATED_AT,
+            CREATED_AT.plusSeconds(3_600),
+            null,
+            null
+        )).isInstanceOf(DataIntegrityViolationException.class);
+
+        assertThatThrownBy(() -> insertCredential(
+            UUID.randomUUID(),
+            userId,
+            "UNSUPPORTED",
+            digest((byte) 3),
+            CREATED_AT,
+            CREATED_AT.plusSeconds(3_600),
+            null,
+            null
+        )).isInstanceOf(DataIntegrityViolationException.class);
+
+        assertThatThrownBy(() -> insertCredential(
+            UUID.randomUUID(),
+            userId,
+            "PASSWORD_RECOVERY",
+            digest((byte) 4),
+            CREATED_AT,
+            CREATED_AT,
+            null,
+            null
+        )).isInstanceOf(DataIntegrityViolationException.class);
+
+        assertThatThrownBy(() -> insertCredential(
+            UUID.randomUUID(),
+            userId,
+            "PASSWORD_RECOVERY",
+            digest((byte) 5),
+            CREATED_AT,
+            CREATED_AT.plusSeconds(3_600),
+            CREATED_AT.plusSeconds(60),
+            CREATED_AT.plusSeconds(120)
+        )).isInstanceOf(DataIntegrityViolationException.class);
+
+        assertThatThrownBy(() -> insertCredential(
+            UUID.randomUUID(),
+            userId,
+            "PASSWORD_RECOVERY",
+            digest((byte) 1),
+            CREATED_AT,
+            CREATED_AT.plusSeconds(3_600),
+            null,
+            null
+        )).isInstanceOf(DataIntegrityViolationException.class);
+
+        insertCredential(
+            UUID.randomUUID(),
+            userId,
+            "PASSWORD_RECOVERY",
+            digest((byte) 6),
+            CREATED_AT,
+            CREATED_AT.plusSeconds(3_600),
+            null,
+            null
+        );
+
+        assertThat(jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM account_action_credentials",
+            Integer.class
+        )).isEqualTo(2);
+
+        assertThat(indexExists(
+            "uq_account_action_credentials_unresolved"
+        )).isTrue();
+        assertThat(failedMigrationCount()).isZero();
+    }
+
+    private static Flyway flyway() {
+        return Flyway.configure()
+            .cleanDisabled(false)
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .load();
+    }
+
+    private static void migrateToVersion(String targetVersion) {
+        Flyway.configure()
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .target(targetVersion)
+            .load()
+            .migrate();
+    }
+
+    private static void migrateToLatestVersion() {
+        flyway().migrate();
+    }
+
+    private static void insertUser(UUID userId) {
+        Timestamp createdAt = Timestamp.from(CREATED_AT);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, 'USER', 'ACTIVE', ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            "test-password-hash",
+            createdAt,
+            createdAt
+        );
+    }
+
+    private static void insertCredential(
+        UUID id,
+        UUID userId,
+        String purpose,
+        byte[] digest,
+        Instant issuedAt,
+        Instant expiresAt,
+        Instant consumedAt,
+        Instant supersededAt
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO account_action_credentials (
+                id,
+                user_id,
+                purpose,
+                credential_digest,
+                issued_at,
+                expires_at,
+                consumed_at,
+                superseded_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            id,
+            userId,
+            purpose,
+            digest,
+            Timestamp.from(issuedAt),
+            Timestamp.from(expiresAt),
+            consumedAt == null
+                ? null
+                : Timestamp.from(consumedAt),
+            supersededAt == null
+                ? null
+                : Timestamp.from(supersededAt)
+        );
+    }
+
+    private static byte[] digest(byte value) {
+        byte[] digest = new byte[32];
+        Arrays.fill(digest, value);
+        return digest;
+    }
+
+    private static String currentSchemaVersion() {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT version
+            FROM flyway_schema_history
+            WHERE success = TRUE
+              AND version IS NOT NULL
+            ORDER BY installed_rank DESC
+            LIMIT 1
+            """,
+            String.class
+        );
+    }
+
+    private static boolean migrationApplied(String version) {
+        Boolean applied = jdbcTemplate.queryForObject(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM flyway_schema_history
+                WHERE version = ?
+                  AND success = TRUE
+            )
+            """,
+            Boolean.class,
+            version
+        );
+
+        return Boolean.TRUE.equals(applied);
+    }
+
+    private static boolean tableExists(String tableName) {
+        Boolean exists = jdbcTemplate.queryForObject(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = 'public'
+                  AND table_name = ?
+            )
+            """,
+            Boolean.class,
+            tableName
+        );
+
+        return Boolean.TRUE.equals(exists);
+    }
+
+    private static boolean columnExists(
+        String tableName,
+        String columnName
+    ) {
+        Boolean exists = jdbcTemplate.queryForObject(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = ?
+                  AND column_name = ?
+            )
+            """,
+            Boolean.class,
+            tableName,
+            columnName
+        );
+
+        return Boolean.TRUE.equals(exists);
+    }
+
+    private static boolean indexExists(String indexName) {
+        Boolean exists = jdbcTemplate.queryForObject(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_indexes
+                WHERE schemaname = 'public'
+                  AND indexname = ?
+            )
+            """,
+            Boolean.class,
+            indexName
+        );
+
+        return Boolean.TRUE.equals(exists);
+    }
+
+    private static int failedMigrationCount() {
+        Integer count = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM flyway_schema_history
+            WHERE success = FALSE
+            """,
+            Integer.class
+        );
+
+        return count == null ? 0 : count;
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/RefreshSessionMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RefreshSessionMigrationIntegrationTest.java
@@ -40,7 +40,7 @@ class RefreshSessionMigrationIntegrationTest {
     }
 
     @Test
-    void shouldUpgradeV13ToV14AndPreserveExistingUserData() {
+    void shouldUpgradeV13ToLatestAndPreserveExistingUserData() {
         migrateToVersion("13");
 
         assertThat(currentSchemaVersion())
@@ -74,7 +74,7 @@ class RefreshSessionMigrationIntegrationTest {
         migrateToLatestVersion();
 
         assertThat(currentSchemaVersion())
-            .isEqualTo("14");
+            .isEqualTo("15");
 
         assertThat(migrationApplied("13"))
             .isTrue();

--- a/src/test/java/com/nursena/payflow/user/integration/RegisterUserIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RegisterUserIntegrationTest.java
@@ -5,6 +5,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.sql.Timestamp;
+
 import com.nursena.payflow.user.domain.model.UserRole;
 import com.nursena.payflow.user.domain.model.UserStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,7 +65,12 @@ class RegisterUserIntegrationTest {
 
         UserDatabaseRow user = jdbcTemplate.queryForObject(
             """
-            SELECT email, password_hash, role, status
+            SELECT
+                email,
+                password_hash,
+                role,
+                status,
+                email_verified_at
             FROM users
             WHERE email = ?
             """,
@@ -71,7 +78,8 @@ class RegisterUserIntegrationTest {
                 resultSet.getString("email"),
                 resultSet.getString("password_hash"),
                 resultSet.getString("role"),
-                resultSet.getString("status")
+                resultSet.getString("status"),
+                resultSet.getTimestamp("email_verified_at")
             ),
             "integration.user@example.com"
         );
@@ -89,6 +97,7 @@ class RegisterUserIntegrationTest {
             .isEqualTo(UserRole.USER.name());
         assertThat(user.status())
             .isEqualTo(UserStatus.ACTIVE.name());
+        assertThat(user.emailVerifiedAt()).isNull();
     }
 
     @Test
@@ -135,7 +144,8 @@ class RegisterUserIntegrationTest {
         String email,
         String passwordHash,
         String role,
-        String status
+        String status,
+        Timestamp emailVerifiedAt
     ) {
     }
 }


### PR DESCRIPTION
## Summary

- add nullable email-verification state independently from account status
- backfill pre-v0.13.0 users as verified while new registrations remain unverified
- add idempotent email verification and package-bounded password replacement behavior
- add Flyway V15 digest-only account-action credential storage
- enforce credential purpose, digest length, lifetime, terminal state, and unresolved-credential uniqueness in PostgreSQL

## Security boundaries

- plaintext account-action credentials are not persisted
- credential digests are fixed at the SHA-256 length
- email verification remains independent from `UserStatus`
- password mutation is not exposed as a public `User` operation
- concurrent issuance cannot leave more than one unresolved credential per user and purpose

## Verification

- `mvnw.cmd -B -ntp clean verify`
- V14-to-V15 migration and clean-install PostgreSQL coverage
- V13-to-latest migration regression coverage with existing-user preservation
- registration, domain, persistence, and roadmap contract coverage

Refs #115

This pull request intentionally does not close #115. Credential generation, confirmation workflows, abuse control, SMTP delivery, and public endpoints remain in later increments.
