### PR TITLE
docs(release): record v0.13.0 publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,11 @@ Completed capabilities include:
 - operator-only, paginated command-audit queries and chronological command timelines
 - Prometheus metrics, Grafana dashboards, and alert rules for Kafka consumer failures
 
-OpenAPI documentation covers the implemented API, while executable Postman workflows remain aligned with released end-to-end flows. PayFlow v0.12.0 is the latest published release; v0.13.0 is in protected release preparation with the Maven version frozen at `0.13.0`. The candidate combines verified-email ownership, password recovery, and protected account-action mail delivery without changing the simulated-money boundary.
+OpenAPI documentation covers the implemented API, while executable Postman workflows remain aligned with released end-to-end flows. PayFlow v0.13.0 is the latest published release and the Maven version remains `0.13.0` until the next development increment begins. The release combines verified-email ownership, password recovery, and protected account-action mail delivery without changing the simulated-money boundary.
 
-See the [v0.13.0 release notes](docs/releases/v0.13.0.md), the [account-action mail-delivery operations guide](docs/operations/account-action-mail-delivery.md), [ADR 0013](docs/adr/0013-secure-mail-outbox-and-smtp-delivery.md), the [v0.12.0 release notes](docs/releases/v0.12.0.md), and the [roadmap](docs/roadmap.md).
+The immutable v0.13.0 publication record is anchored to annotated tag `v0.13.0`, merge commit `726f631a0de800870813ccb0c00b2676eb5d172b`, and successful release workflow run [31115952987](https://github.com/nursena-pc/payflow/actions/runs/31115952987). The published `payflow-0.13.0.jar` is 100015861 bytes and its independently verified SHA-256 is `78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA`.
+
+See the [v0.13.0 release notes](docs/releases/v0.13.0.md), the [published GitHub Release](https://github.com/nursena-pc/payflow/releases/tag/v0.13.0), the [account-action mail-delivery operations guide](docs/operations/account-action-mail-delivery.md), [ADR 0013](docs/adr/0013-secure-mail-outbox-and-smtp-delivery.md), the [v0.12.0 release notes](docs/releases/v0.12.0.md), and the [roadmap](docs/roadmap.md).
 
 ## Structured logging
 

--- a/docs/releases/v0.13.0.md
+++ b/docs/releases/v0.13.0.md
@@ -63,6 +63,20 @@ process real money and is not certified for production financial use.
 - Flyway V17 adds the protected mail outbox, lease state, retry metadata, and terminal-content retention rules
 - migration tests cover upgrades from the V13, V14, V15, and V16 baselines to the latest schema
 
+## Publication record
+
+- release-preparation issue and PR: [#126](https://github.com/nursena-pc/payflow/issues/126), [#127](https://github.com/nursena-pc/payflow/pull/127)
+- release-candidate commit: `2d4c8b9b30b2291108da93b0df1edab97f032328`
+- published merge and tag commit: `726f631a0de800870813ccb0c00b2676eb5d172b`
+- annotated tag object: `9879780a418d8490b835c36b7a01cd0019621a7e`
+- release workflow: [run 31115952987](https://github.com/nursena-pc/payflow/actions/runs/31115952987), successful
+- GitHub Release: [`v0.13.0`](https://github.com/nursena-pc/payflow/releases/tag/v0.13.0)
+- published at: `2026-08-06T15:35:55Z`
+- JAR asset: `payflow-0.13.0.jar`, `100015861` bytes
+- independently verified JAR SHA-256: `78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA`
+- checksum asset verification: passed
+- immutable publication-evidence JSON SHA-256: `4FDD37BC1BF5D058A391A23784CCF87DED3FADCC3F9DB564806A8A52DC1F7B51`
+
 ## Verification
 
 - focused credential generation, digesting, lifetime, supersession, and consumption tests passed
@@ -71,8 +85,8 @@ process real money and is not certified for production financial use.
 - mail-content context binding, leased dispatch, retry, terminal failure, and SMTP construction tests passed
 - OpenAPI and Postman contracts cover the public verification and recovery endpoints
 - the complete suite executed 1,174 tests with zero failures and zero errors
-- protected `build-and-test` and `docker-smoke` checks passed for feature PRs #121, #123, and #125
-- the release workflow rebuilds and verifies the exact tagged commit before publishing assets
+- protected `build-and-test` and `docker-smoke` checks passed for feature PRs #121, #123, #125, and release-preparation PR #127
+- release workflow run 31115952987 rebuilt and verified the exact tagged commit before publishing assets
 
 ## Operations
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,14 +2,14 @@
 
 ## Current delivery focus
 
-PayFlow v0.12.0 is the latest tagged release. v0.13.0 is in protected release
-preparation and uses the Maven version `0.13.0`.
+PayFlow v0.13.0 is the latest tagged release and uses the Maven version
+`0.13.0`. The next planned milestone is v0.14.0 multi-factor authentication;
+its development version has not been opened yet.
 
-The v0.12.0 JWT signing-key rotation release was published from verified merge
-commit `fb0f97d076864cf3e45aabe0e3c25c81520ee101`. The v0.13.0 release
-candidate freezes email-ownership verification, password recovery, and secure
-account-action mail delivery while preserving the existing anti-enumeration,
-refresh-session, and logging boundaries.
+The v0.13.0 account-recovery and secure-mail-delivery release was published
+from verified merge commit `726f631a0de800870813ccb0c00b2676eb5d172b`
+through successful release workflow run `31115952987`. It preserves the
+existing anti-enumeration, refresh-session, and logging boundaries.
 
 PayFlow remains a modular monolith. PostgreSQL is the system of record; Redis is
 used only for bounded, explicitly expiring abuse-control state.
@@ -378,7 +378,7 @@ The release is ready only when:
 - executable JAR size: `99,140,599` bytes
 - verified SHA-256: `BA0BF76D07B3426E9C8DDE5E128A0C7B957807F71AA982EDC5927077980AB391`
 
-## v0.13.0 — Release Candidate: Account Recovery and Secure Mail Delivery
+## v0.13.0 — Released: Account Recovery and Secure Mail Delivery
 
 ### Product outcome
 
@@ -450,7 +450,7 @@ The generic request responses and anti-enumeration behavior are part of
 v0.13.0. Purpose-specific Redis quotas of 3 requests per normalized identity
 per hour and 20 requests per effective client per hour, hashed limiter
 dimensions, fail-closed limiter outages, and low-cardinality limiter outcomes
-are intentionally deferred. They are not claimed by this release candidate.
+are intentionally deferred. They are not claimed by this release.
 
 ### Increment 6 — Verification and public contracts
 
@@ -477,9 +477,8 @@ are intentionally deferred. They are not claimed by this release candidate.
 - remote KMS, HSM, Vault, Kubernetes, or microservice extraction
 
 These concerns require separate threat models and versioned contracts. The
-v0.13.0 release candidate is limited to ownership verification, password
-recovery, bounded email delivery, and the security evidence needed to trust
-them.
+v0.13.0 is limited to ownership verification, password recovery, bounded
+email delivery, and the security evidence needed to trust them.
 
 ## v0.13.0 release exit criteria
 
@@ -497,8 +496,8 @@ The release is ready only when:
 - [x] the complete 1,174-test Maven suite and production Docker smoke pass
 - [x] ADR, operations guide, configuration, and implementation agree
 - [x] protected feature pull requests #121, #123, and #125 are merged
-- [ ] the protected v0.13.0 release-preparation pull request is merged
-- [ ] the v0.13.0 tag, JAR, checksum, and GitHub Release are published
+- [x] the protected v0.13.0 release-preparation pull request is merged
+- [x] the v0.13.0 tag, JAR, checksum, and GitHub Release are published
 
 ### Release-candidate evidence
 
@@ -508,6 +507,16 @@ The release is ready only when:
 - integrated feature merge commit: `01a1437b13d48ce08e477f5fa5962aa9fb113be6`
 - complete verification: 1,174 tests, zero failures, zero errors
 - feature-line artifact SHA-256: `214412C8FA5E6279FD9874EC935AA95B5FA90C0CD20166CCF027C7A0EC2C5191`
+- release-preparation PR: `#127`
+- release-candidate commit: `2d4c8b9b30b2291108da93b0df1edab97f032328`
+- published merge and tag commit: `726f631a0de800870813ccb0c00b2676eb5d172b`
+- annotated tag object: `9879780a418d8490b835c36b7a01cd0019621a7e`
+- release workflow run: [`31115952987`](https://github.com/nursena-pc/payflow/actions/runs/31115952987)
+- published at: `2026-08-06T15:35:55Z`
+- published JAR size: `100015861` bytes
+- published JAR SHA-256: `78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA`
+- release checksum verification: passed
+- publication-evidence JSON SHA-256: `4FDD37BC1BF5D058A391A23784CCF87DED3FADCC3F9DB564806A8A52DC1F7B51`
 
 ## Later v1.0 candidates
 

--- a/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
@@ -22,7 +22,7 @@ class RoadmapContractTest {
         Path.of("docs", "roadmap.md");
 
     @Test
-    void shouldAlignRoadmapWithReleaseCandidateVersion()
+    void shouldAlignRoadmapWithPublishedReleaseVersion()
         throws Exception {
 
         String projectVersion = readProjectVersion();
@@ -33,18 +33,21 @@ class RoadmapContractTest {
 
         assertThat(roadmap)
             .contains(
-                "PayFlow v0.12.0 is the latest tagged release",
-                "v0.13.0 is in protected release",
-                "the Maven version `" + projectVersion + "`",
+                "PayFlow v0.13.0 is the latest tagged release",
+                "the Maven version",
+                "`" + projectVersion + "`",
+                "The next planned milestone is v0.14.0",
                 "## v0.10.0 — Released: Trusted Client Context",
                 "## v0.11.0 — Released: Structured Logging and Request Correlation",
                 "## v0.12.0 — Released: JWT Signing-Key Rotation",
-                "## v0.13.0 — Release Candidate: Account Recovery and Secure Mail Delivery",
-                "01a1437b13d48ce08e477f5fa5962aa9fb113be6"
+                "## v0.13.0 — Released: Account Recovery and Secure Mail Delivery",
+                "726f631a0de800870813ccb0c00b2676eb5d172b",
+                "31115952987"
             )
             .doesNotContain(
                 "0.13.0-SNAPSHOT",
-                "## v0.13.0 — Active Development"
+                "## v0.13.0 — Active Development",
+                "## v0.13.0 — Release Candidate"
             );
     }
 
@@ -64,9 +67,12 @@ class RoadmapContractTest {
                 "- [x] Run the complete Maven verification suite and production Docker smoke",
                 "1,174 tests, zero failures, zero errors",
                 "Deferred to the generalized abuse-protection milestone",
-                "They are not claimed by this release candidate",
-                "- [ ] the protected v0.13.0 release-preparation pull request is merged",
-                "- [ ] the v0.13.0 tag, JAR, checksum, and GitHub Release are published"
+                "They are not claimed by this release",
+                "- [x] the protected v0.13.0 release-preparation pull request is merged",
+                "- [x] the v0.13.0 tag, JAR, checksum, and GitHub Release are published",
+                "9879780a418d8490b835c36b7a01cd0019621a7e",
+                "78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA",
+                "4FDD37BC1BF5D058A391A23784CCF87DED3FADCC3F9DB564806A8A52DC1F7B51"
             );
     }
 

--- a/src/test/java/com/nursena/payflow/configuration/V012ReleasePublicationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V012ReleasePublicationContractTest.java
@@ -68,14 +68,14 @@ class V012ReleasePublicationContractTest {
 
         assertThat(Files.readString(README))
             .contains(
-                "PayFlow v0.12.0 is the latest published release",
                 "docs/releases/v0.12.0.md",
                 "## v0.12.0 release",
-                "fb0f97d076864cf3e45aabe0e3c25c81520ee101",
+                "PayFlow v0.12.0 was published from merge commit `fb0f97d076864cf3e45aabe0e3c25c81520ee101`",
                 "protected release-preparation PR #114",
                 "Release workflow run `30921514114`"
             )
             .doesNotContain(
+                "PayFlow v0.12.0 is the latest published release",
                 "The active `0.12.0-SNAPSHOT` line",
                 "v0.12.0 is in protected release preparation",
                 "## v0.12.0 release preparation"
@@ -83,13 +83,13 @@ class V012ReleasePublicationContractTest {
 
         assertThat(Files.readString(ROADMAP))
             .contains(
-                "PayFlow v0.12.0 is the latest tagged release",
                 "## v0.12.0 — Released: JWT Signing-Key Rotation",
                 "release workflow run: `30921514114`",
                 "executable JAR size: `99,140,599` bytes",
                 "BA0BF76D07B3426E9C8DDE5E128A0C7B957807F71AA982EDC5927077980AB391"
             )
             .doesNotContain(
+                "PayFlow v0.12.0 is the latest tagged release",
                 "## v0.12.0 — Release Candidate: JWT Signing-Key Rotation"
             );
     }

--- a/src/test/java/com/nursena/payflow/configuration/V013ReleasePublicationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V013ReleasePublicationContractTest.java
@@ -8,7 +8,7 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 
-class V013ReleasePreparationContractTest {
+class V013ReleasePublicationContractTest {
 
     private static final Path README =
         Path.of("README.md");
@@ -34,22 +34,22 @@ class V013ReleasePreparationContractTest {
         );
 
     @Test
-    void shouldExposeProtectedReleasePreparationStatus()
+    void shouldExposePublishedReleaseStatus()
         throws IOException {
 
         assertThat(Files.readString(README))
             .contains(
-                "PayFlow v0.12.0 is the latest published release",
-                "v0.13.0 is in protected release preparation",
-                "Maven version frozen at `0.13.0`",
-                "## v0.13.0 release preparation",
-                "1,174 tests with zero failures and zero errors",
-                "Per-identity and per-client Redis quotas",
-                "explicitly deferred"
+                "PayFlow v0.13.0 is the latest published release",
+                "Maven version remains `0.13.0`",
+                "annotated tag `v0.13.0`",
+                "726f631a0de800870813ccb0c00b2676eb5d172b",
+                "31115952987",
+                "100015861 bytes",
+                "78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA"
             )
             .doesNotContain(
                 "0.13.0-SNAPSHOT",
-                "## v0.13.0 active development"
+                "v0.13.0 is in protected release preparation"
             );
     }
 
@@ -74,13 +74,16 @@ class V013ReleasePreparationContractTest {
         assertThat(Files.readString(RELEASE_NOTES))
             .contains(
                 "# PayFlow v0.13.0",
-                "Email ownership verification",
-                "Password recovery",
-                "Secure transactional mail outbox",
-                "1,174 tests",
-                "payflow-0.13.0.jar",
-                "payflow-0.13.0.jar.sha256",
-                "`v0.12.0...v0.13.0`"
+                "## Publication record",
+                "[#126]",
+                "[#127]",
+                "9879780a418d8490b835c36b7a01cd0019621a7e",
+                "726f631a0de800870813ccb0c00b2676eb5d172b",
+                "run 31115952987",
+                "2026-08-06T15:35:55Z",
+                "100015861",
+                "78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA",
+                "4FDD37BC1BF5D058A391A23784CCF87DED3FADCC3F9DB564806A8A52DC1F7B51"
             )
             .doesNotContain(
                 "0.13.0-SNAPSHOT",
@@ -89,32 +92,26 @@ class V013ReleasePreparationContractTest {
     }
 
     @Test
-    void shouldRecordSecurityAndUpgradeBoundaries()
+    void shouldRecordPublishedRoadmapEvidence()
         throws IOException {
-
-        assertThat(Files.readString(RELEASE_NOTES))
-            .contains(
-                "digest-only persistence",
-                "single-use consumption",
-                "PASSWORD_RECOVERY",
-                "AES-256-GCM",
-                "FOR UPDATE SKIP LOCKED",
-                "bounded duplicate risk",
-                "Flyway V15",
-                "Flyway V16",
-                "Flyway V17",
-                "purpose-specific Redis request quotas are deferred"
-            );
 
         assertThat(Files.readString(ROADMAP))
             .contains(
-                "They are not claimed by this release candidate",
-                "purpose-specific Redis request quotas"
+                "## v0.13.0 — Released: Account Recovery and Secure Mail Delivery",
+                "- [x] the protected v0.13.0 release-preparation pull request is merged",
+                "- [x] the v0.13.0 tag, JAR, checksum, and GitHub Release are published",
+                "release-preparation PR: `#127`",
+                "release-candidate commit: `2d4c8b9b30b2291108da93b0df1edab97f032328`",
+                "published merge and tag commit: `726f631a0de800870813ccb0c00b2676eb5d172b`",
+                "annotated tag object: `9879780a418d8490b835c36b7a01cd0019621a7e`",
+                "published JAR size: `100015861` bytes",
+                "published JAR SHA-256: `78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA`",
+                "publication-evidence JSON SHA-256: `4FDD37BC1BF5D058A391A23784CCF87DED3FADCC3F9DB564806A8A52DC1F7B51`"
             );
     }
 
     @Test
-    void shouldRequireFinalTagFromMainAndNonSnapshotMetadata()
+    void shouldRetainProtectedTagPublicationWorkflow()
         throws IOException {
 
         assertThat(Files.readString(RELEASE_WORKFLOW))


### PR DESCRIPTION
## Summary

- mark v0.13.0 as the latest published release
- record the exact merge commit, annotated tag object, and release workflow run
- record the publication timestamp, release asset size, and independently verified SHA-256
- mark the two remaining v0.13.0 roadmap release gates complete
- replace release-preparation contracts with immutable publication contracts
- keep v0.14.0 explicitly planned but not started

## Immutable publication evidence

- tag: v0.13.0
- tag object: 9879780a418d8490b835c36b7a01cd0019621a7e
- tag and merge commit: 726f631a0de800870813ccb0c00b2676eb5d172b
- release-candidate commit: 2d4c8b9b30b2291108da93b0df1edab97f032328
- workflow run: 31115952987
- published at: 2026-08-06T15:35:55Z
- JAR size: 100015861 bytes
- JAR SHA-256: 78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA
- publication-evidence JSON SHA-256: 4FDD37BC1BF5D058A391A23784CCF87DED3FADCC3F9DB564806A8A52DC1F7B51
- source revalidation: annotated tag, workflow run, GitHub Release, downloaded JAR, and checksum asset

## Verification

- focused publication contracts: 14 tests, 0 failures, 0 errors
- complete Maven suite: 1174 tests
- failures: 0
- errors: 0
- skipped: 0
- Surefire XML reports: 261
- Docker Compose configuration: pass
- repository secret-hygiene gate: pass
- local verification JAR SHA-256: 54F8FA86E468501B87394C73BCFEAD182A2DC3FA23BDD99301C3D54D2ED740EE
- protected build-and-test and docker-smoke checks: pass

## Publication boundary

This PR records an already immutable publication. It does not move the tag, mutate the GitHub Release, or publish replacement assets.

Closes #128
