### PR TITLE
chore(project): start v0.14.0 development

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Completed capabilities include:
 - operator-only, paginated command-audit queries and chronological command timelines
 - Prometheus metrics, Grafana dashboards, and alert rules for Kafka consumer failures
 
-OpenAPI documentation covers the implemented API, while executable Postman workflows remain aligned with released end-to-end flows. PayFlow v0.13.0 is the latest published release and the Maven version remains `0.13.0` until the next development increment begins. The release combines verified-email ownership, password recovery, and protected account-action mail delivery without changing the simulated-money boundary.
+OpenAPI documentation covers the implemented API, while executable Postman workflows remain aligned with released end-to-end flows. PayFlow v0.13.0 is the latest published release, and the active development line uses `0.14.0-SNAPSHOT`. The v0.14.0 milestone adds TOTP multi-factor authentication, digest-only single-use recovery codes, and bounded step-up authentication without changing the simulated-money boundary.
 
 The immutable v0.13.0 publication record is anchored to annotated tag `v0.13.0`, merge commit `726f631a0de800870813ccb0c00b2676eb5d172b`, and successful release workflow run [31115952987](https://github.com/nursena-pc/payflow/actions/runs/31115952987). The published `payflow-0.13.0.jar` is 100015861 bytes and its independently verified SHA-256 is `78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA`.
 
@@ -142,19 +142,31 @@ The protected release-preparation PR #114 produced the verified `v0.12.0` tag ta
 
 See the [v0.12.0 release notes](docs/releases/v0.12.0.md) and the [JWT key-rotation operations guide](docs/operations/jwt-key-rotation.md). The provider decision is recorded in [ADR 0012](docs/adr/0012-jwt-signing-key-rotation.md).
 
-## v0.13.0 release preparation
+## v0.13.0 release
 
-The protected v0.13.0 release candidate freezes email-ownership verification, password recovery, and secure account-action mail delivery. Account-action credentials use 256 bits of cryptographically secure randomness, canonical unpadded Base64 URL encoding, purpose-specific lifetimes, digest-only persistence, serialized supersession, and pessimistically locked single-use consumption.
+PayFlow v0.13.0 was published from merge commit `726f631a0de800870813ccb0c00b2676eb5d172b`. The release freezes email-ownership verification, password recovery, and secure account-action mail delivery. Account-action credentials use 256 bits of cryptographically secure randomness, canonical unpadded Base64 URL encoding, purpose-specific lifetimes, digest-only persistence, serialized supersession, and pessimistically locked single-use consumption.
 
 Registration issues the initial verification credential in the user transaction. Generic verification and recovery request endpoints do not disclose account existence or eligibility. Verification marks ownership exactly once. Password recovery reuses the registration password policy, replaces the BCrypt hash, consumes the recovery credential, and revokes every active refresh-token family atomically with the `PASSWORD_RECOVERY` reason.
 
 Provider-ready verification and recovery links are protected with AES-256-GCM before persistence in the dedicated V17 mail outbox. SMTP delivery runs only after commit through a leased PostgreSQL dispatcher using `FOR UPDATE SKIP LOCKED`, bounded retry, credential-expiry cutoffs, and stable `Message-ID` values. Terminal delivery outcomes erase protected content, while logs and metrics exclude recipients, links, credentials, digests, and encrypted bytes. Production requires configured RSA signing material and a configured 32-byte mail-content protection key.
 
-Feature PRs [#121](https://github.com/nursena-pc/payflow/pull/121), [#123](https://github.com/nursena-pc/payflow/pull/123), and [#125](https://github.com/nursena-pc/payflow/pull/125) passed protected `build-and-test` and `docker-smoke` checks. The latest feature-line verification executed 1,174 tests with zero failures and zero errors. The tag-triggered release workflow will rebuild the exact tagged commit, verify that it is reachable from `main`, publish `payflow-0.13.0.jar`, and publish its SHA-256 checksum.
+Feature PRs [#121](https://github.com/nursena-pc/payflow/pull/121), [#123](https://github.com/nursena-pc/payflow/pull/123), and [#125](https://github.com/nursena-pc/payflow/pull/125), plus release-preparation PR [#127](https://github.com/nursena-pc/payflow/pull/127), passed protected `build-and-test` and `docker-smoke` checks. Release workflow run [31115952987](https://github.com/nursena-pc/payflow/actions/runs/31115952987) rebuilt the tagged commit and published `payflow-0.13.0.jar` with its independently verified SHA-256 checksum.
 
-Per-identity and per-client Redis quotas for account-action requests are explicitly deferred to the later generalized abuse-protection milestone. v0.13.0 retains generic accepted responses and credential-safe observable output, but does not claim that deferred limiter capability.
+Per-identity and per-client Redis quotas for account-action requests remain explicitly deferred to the later generalized abuse-protection milestone. v0.13.0 retains generic accepted responses and credential-safe observable output, but does not claim that deferred limiter capability.
 
 See the [v0.13.0 release notes](docs/releases/v0.13.0.md), [ADR 0013](docs/adr/0013-secure-mail-outbox-and-smtp-delivery.md), and the [mail-delivery operations guide](docs/operations/account-action-mail-delivery.md).
+
+## v0.14.0 active development
+
+The active `0.14.0-SNAPSHOT` line introduces TOTP-based multi-factor authentication and step-up authentication as a separate identity-security increment. The design begins with an explicit threat model and a package-bounded MFA lifecycle instead of coupling authenticator state directly to controllers, JWT parsing, or persistence adapters.
+
+Enrollment will create a pending authenticator secret, protect it before PostgreSQL persistence through a dedicated application port, and activate it only after a valid TOTP proof. The plaintext secret and `otpauth://` provisioning value may cross the enrollment response boundary once, but they must never enter logs, metrics, traces, errors, audit payloads, or durable plaintext storage.
+
+Users with enabled MFA will complete password verification before receiving a short-lived, digest-only login challenge. A valid TOTP or one unused recovery code will consume that challenge exactly once before access and refresh credentials are issued. Challenge attempts, expiration, replay, concurrent verification, and refresh-session side effects will be covered with real PostgreSQL tests.
+
+Recovery codes will be generated from cryptographically secure randomness, returned once at activation or explicit rotation, stored only as fixed-length digests, and consumed atomically. Disabling or rotating MFA will require a recent step-up proof and will revoke active refresh-token families with a dedicated account-security reason.
+
+The first delivery increment freezes the threat model, persistence boundaries, public error semantics, clock-skew policy, and explicit non-goals in the [roadmap](docs/roadmap.md). Generalized API-wide abuse protection, SMS or email OTP, WebAuthn/passkeys, external identity providers, device trust, and behavioral risk scoring remain outside v0.14.0.
 
 ## Implemented API
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,14 +2,15 @@
 
 ## Current delivery focus
 
-PayFlow v0.13.0 is the latest tagged release and uses the Maven version
-`0.13.0`. The next planned milestone is v0.14.0 multi-factor authentication;
-its development version has not been opened yet.
+PayFlow v0.13.0 is the latest tagged release. The active development line uses
+the Maven version `0.14.0-SNAPSHOT`.
 
 The v0.13.0 account-recovery and secure-mail-delivery release was published
 from verified merge commit `726f631a0de800870813ccb0c00b2676eb5d172b`
-through successful release workflow run `31115952987`. It preserves the
-existing anti-enumeration, refresh-session, and logging boundaries.
+through successful release workflow run `31115952987`. The v0.14.0 milestone
+adds TOTP multi-factor authentication, digest-only recovery codes, and bounded
+step-up authentication while preserving the existing anti-enumeration,
+refresh-session, and logging boundaries.
 
 PayFlow remains a modular monolith. PostgreSQL is the system of record; Redis is
 used only for bounded, explicitly expiring abuse-control state.
@@ -518,8 +519,116 @@ The release is ready only when:
 - release checksum verification: passed
 - publication-evidence JSON SHA-256: `4FDD37BC1BF5D058A391A23784CCF87DED3FADCC3F9DB564806A8A52DC1F7B51`
 
+## v0.14.0 — Active Development: MFA and Step-Up Authentication
+
+### Product outcome
+
+PayFlow users can protect an email-verified account with a standards-compatible
+TOTP authenticator, complete MFA during login, recover with one-time codes, and
+prove recent possession of a second factor before selected account-security or
+operator actions. Password verification remains the first login factor. No
+access or refresh credential is issued until an enabled MFA challenge succeeds.
+
+### Increment 1 — Threat model and lifecycle boundaries
+
+- [x] Open the dedicated v0.14.0 implementation issue
+- [ ] Record MFA enrollment, login, recovery, disable, bypass, replay, and concurrency threats
+- [ ] Keep MFA state separate from `UserStatus` and email-verification state
+- [ ] Define `DISABLED`, `PENDING`, and `ENABLED` lifecycle transitions explicitly
+- [ ] Define stable public errors that do not reveal secrets, recovery-code state, or internal challenge state
+- [ ] Define account-security refresh-family revocation reasons before implementation
+- [ ] Keep controllers, JWT adapters, and JPA entities outside the MFA domain model
+
+### Increment 2 — TOTP enrollment and secret protection
+
+- [ ] Require an authenticated, active, email-verified user to begin enrollment
+- [ ] Generate a high-entropy TOTP secret with a standards-compatible `otpauth://` provisioning value
+- [ ] Protect every pending or active TOTP secret before PostgreSQL persistence
+- [ ] Use a dedicated MFA secret-protection port and separate production key material
+- [ ] Return the plaintext provisioning secret only in the enrollment response that created it
+- [ ] Activate enrollment only after a valid TOTP proof within the documented clock-skew window
+- [ ] Serialize replacement so one user has at most one effective pending or active authenticator
+- [ ] Exclude secrets, provisioning URIs, TOTP values, protected bytes, and key material from observable output
+
+### Increment 3 — MFA login challenge
+
+- [ ] Preserve existing Redis-backed password-attempt protection before user lookup and password verification
+- [ ] Issue a short-lived opaque MFA login challenge only after the password and account eligibility checks succeed
+- [ ] Persist only a fixed-length challenge digest, expiration, bounded attempt state, and terminal state
+- [ ] Issue no access or refresh credential while an enabled user's challenge remains unresolved
+- [ ] Consume a successful challenge exactly once before issuing access and refresh credentials
+- [ ] Permit one documented TOTP clock step on either side of the current step
+- [ ] Reject expired, exhausted, replayed, malformed, and superseded challenges through one stable public contract
+- [ ] Lock verification so concurrent submissions have at most one successful winner
+
+### Increment 4 — Recovery codes and MFA disable
+
+- [ ] Generate recovery codes from cryptographically secure randomness
+- [ ] Return plaintext recovery codes once at activation or explicit rotation
+- [ ] Persist only fixed-length recovery-code digests
+- [ ] Consume every recovery code atomically and at most once
+- [ ] Make recovery-code and TOTP challenge failures indistinguishable at the public boundary
+- [ ] Require recent step-up proof before recovery-code rotation or MFA disable
+- [ ] Revoke active refresh-token families after MFA disable or secret replacement
+- [ ] Preserve append-only, credential-free account-security audit evidence
+
+### Increment 5 — Step-up authentication
+
+- [ ] Introduce an application-facing step-up policy independent from controller annotations
+- [ ] Bind every step-up grant to one authenticated subject, purpose, issue time, and short expiration
+- [ ] Require a recent second-factor proof for MFA disable and recovery-code rotation
+- [ ] Evaluate dead-letter replay and discard as explicit operator step-up candidates
+- [ ] Reject cross-purpose, expired, replayed, or wrong-subject grants
+- [ ] Keep step-up grants out of logs, metric labels, audit payloads, and persistence plaintext
+- [ ] Document which operations remain bearer-only and which require step-up
+
+### Increment 6 — Verification and public contracts
+
+- [ ] Unit-test TOTP vectors, clock skew, lifecycle transitions, protection, digesting, and redaction
+- [ ] Verify clean Flyway installation and upgrades from the v0.13.0 schema with PostgreSQL
+- [ ] Verify enrollment replacement, challenge consumption, recovery-code use, and disable races
+- [ ] Add real endpoint-to-database, MockMvc, OpenAPI, and Postman contracts
+- [ ] Add an MFA threat model, ADR, and operations guide
+- [ ] Verify production startup fails safely without configured MFA secret-protection material
+- [ ] Run the complete Maven verification suite and production Docker smoke
+- [ ] Pass protected `build-and-test` and `docker-smoke` checks for every increment
+
+## Explicit v0.14.0 non-goals
+
+- SMS, voice-call, or email-delivered one-time passwords
+- WebAuthn, passkeys, FIDO2 security keys, or biometric authentication
+- external OAuth, OpenID Connect, SAML, or social-login providers
+- trusted-device cookies, remember-this-device behavior, or device fingerprinting
+- behavioral analytics, geolocation risk, impossible-travel detection, or adaptive authentication
+- generalized registration, refresh, recovery, or operations rate-limit policy; that remains a v0.15.0 concern
+- frontend QR rendering, mobile deep-link UX, or authenticator-app branding
+- remote KMS, HSM, Vault, Kubernetes, or microservice extraction
+- access-token denylisting or immediate revocation of already-issued JWTs
+
+These concerns require separate threat models and versioned contracts. v0.14.0
+is limited to TOTP enrollment, MFA login completion, single-use recovery codes,
+selected step-up policies, and the evidence needed to trust those boundaries.
+
+## v0.14.0 release exit criteria
+
+The release is ready only when:
+
+- [ ] TOTP secrets are never stored or emitted as durable plaintext
+- [ ] enabled MFA prevents access and refresh issuance until the second factor succeeds
+- [ ] login challenges are short-lived, digest-only, attempt-bounded, and single-use
+- [ ] recovery codes are returned once, stored only as digests, and consumed once
+- [ ] concurrent enrollment, challenge, recovery, rotation, and disable operations preserve one valid outcome
+- [ ] account-security changes revoke active refresh-token families as documented
+- [ ] selected step-up operations reject wrong-subject, wrong-purpose, expired, and replayed grants
+- [ ] errors, logs, metrics, traces, and audits expose no MFA credentials or protected secret material
+- [ ] focused unit, PostgreSQL, HTTP, OpenAPI, and Postman tests pass
+- [ ] the complete Maven suite and production Docker smoke pass
+- [ ] threat model, ADR, operations guide, configuration, and implementation agree
+- [ ] protected feature and release-preparation pull requests are merged
+- [ ] the v0.14.0 tag, JAR, checksum, and GitHub Release are published
+
 ## Later v1.0 candidates
 
-Later v1.0 candidates include multi-factor authentication, generalized abuse
-protection, load/performance evidence, backup/restore rehearsal, API freeze,
-SBOM generation, and release stabilization.
+Later v1.0 candidates include generalized abuse protection, load/performance
+evidence, backup/restore rehearsal, API freeze, SBOM generation, and release
+stabilization.

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.13.0</version>
+    <version>0.14.0-SNAPSHOT</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 

--- a/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
@@ -22,37 +22,44 @@ class RoadmapContractTest {
         Path.of("docs", "roadmap.md");
 
     @Test
-    void shouldAlignRoadmapWithPublishedReleaseVersion()
+    void shouldAlignRoadmapWithActiveDevelopmentVersion()
         throws Exception {
 
         String projectVersion = readProjectVersion();
         String roadmap = Files.readString(ROADMAP);
+        String normalizedRoadmap = normalizeWhitespace(roadmap);
 
         assertThat(projectVersion)
-            .isEqualTo("0.13.0");
+            .isEqualTo("0.14.0-SNAPSHOT");
 
         assertThat(roadmap)
             .contains(
                 "PayFlow v0.13.0 is the latest tagged release",
-                "the Maven version",
-                "`" + projectVersion + "`",
-                "The next planned milestone is v0.14.0",
+                "the Maven version `" + projectVersion + "`",
                 "## v0.10.0 — Released: Trusted Client Context",
                 "## v0.11.0 — Released: Structured Logging and Request Correlation",
                 "## v0.12.0 — Released: JWT Signing-Key Rotation",
                 "## v0.13.0 — Released: Account Recovery and Secure Mail Delivery",
+                "## v0.14.0 — Active Development: MFA and Step-Up Authentication",
                 "726f631a0de800870813ccb0c00b2676eb5d172b",
                 "31115952987"
             )
             .doesNotContain(
                 "0.13.0-SNAPSHOT",
-                "## v0.13.0 — Active Development",
-                "## v0.13.0 — Release Candidate"
+                "## v0.14.0 — Release Candidate",
+                "## v0.14.0 — Released"
+            );
+
+        assertThat(normalizedRoadmap)
+            .contains(
+                "TOTP multi-factor authentication",
+                "digest-only recovery codes",
+                "bounded step-up authentication"
             );
     }
 
     @Test
-    void shouldFreezeDeliveredScopeAndExplicitDeferrals()
+    void shouldFreezeV013PublicationAndOpenV014Boundaries()
         throws IOException {
 
         assertThat(Files.readString(ROADMAP))
@@ -72,8 +79,22 @@ class RoadmapContractTest {
                 "- [x] the v0.13.0 tag, JAR, checksum, and GitHub Release are published",
                 "9879780a418d8490b835c36b7a01cd0019621a7e",
                 "78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA",
-                "4FDD37BC1BF5D058A391A23784CCF87DED3FADCC3F9DB564806A8A52DC1F7B51"
+                "4FDD37BC1BF5D058A391A23784CCF87DED3FADCC3F9DB564806A8A52DC1F7B51",
+                "- [x] Open the dedicated v0.14.0 implementation issue",
+                "Keep MFA state separate from `UserStatus` and email-verification state",
+                "Protect every pending or active TOTP secret before PostgreSQL persistence",
+                "Persist only fixed-length recovery-code digests",
+                "Introduce an application-facing step-up policy independent from controller annotations",
+                "generalized registration, refresh, recovery, or operations rate-limit policy; that remains a v0.15.0 concern"
             );
+    }
+
+    private static String normalizeWhitespace(
+        String value
+    ) {
+        return value
+            .replaceAll("\\s+", " ")
+            .trim();
     }
 
     private static String readProjectVersion()

--- a/src/test/java/com/nursena/payflow/configuration/V013ReleasePublicationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V013ReleasePublicationContractTest.java
@@ -40,7 +40,7 @@ class V013ReleasePublicationContractTest {
         assertThat(Files.readString(README))
             .contains(
                 "PayFlow v0.13.0 is the latest published release",
-                "Maven version remains `0.13.0`",
+                "## v0.13.0 release",
                 "annotated tag `v0.13.0`",
                 "726f631a0de800870813ccb0c00b2676eb5d172b",
                 "31115952987",
@@ -48,8 +48,8 @@ class V013ReleasePublicationContractTest {
                 "78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA"
             )
             .doesNotContain(
-                "0.13.0-SNAPSHOT",
-                "v0.13.0 is in protected release preparation"
+                "v0.13.0 is in protected release preparation",
+                "## v0.13.0 release preparation"
             );
     }
 

--- a/src/test/java/com/nursena/payflow/configuration/V014DevelopmentContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V014DevelopmentContractTest.java
@@ -1,0 +1,113 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class V014DevelopmentContractTest {
+
+    private static final Path README =
+        Path.of("README.md");
+
+    private static final Path CHANGELOG =
+        Path.of("CHANGELOG.md");
+
+    private static final Path ROADMAP =
+        Path.of("docs", "roadmap.md");
+
+    @Test
+    void shouldExposeV014DevelopmentStatus()
+        throws IOException {
+
+        assertThat(Files.readString(README))
+            .contains(
+                "PayFlow v0.13.0 is the latest published release",
+                "active development line uses `0.14.0-SNAPSHOT`",
+                "## v0.14.0 active development",
+                "TOTP-based multi-factor authentication",
+                "digest-only login challenge",
+                "single-use recovery codes",
+                "recent step-up proof"
+            )
+            .doesNotContain(
+                "Maven version remains `0.13.0`",
+                "## v0.14.0 release preparation"
+            );
+    }
+
+    @Test
+    void shouldDefineMfaLifecycleAndSecretBoundaries()
+        throws IOException {
+
+        assertThat(Files.readString(ROADMAP))
+            .contains(
+                "`DISABLED`, `PENDING`, and `ENABLED` lifecycle transitions",
+                "Keep MFA state separate from `UserStatus` and email-verification state",
+                "Protect every pending or active TOTP secret before PostgreSQL persistence",
+                "dedicated MFA secret-protection port",
+                "Return the plaintext provisioning secret only in the enrollment response that created it",
+                "Activate enrollment only after a valid TOTP proof",
+                "one user has at most one effective pending or active authenticator",
+                "Exclude secrets, provisioning URIs, TOTP values, protected bytes, and key material from observable output"
+            );
+    }
+
+    @Test
+    void shouldDefineChallengeAndRecoveryCodeBoundaries()
+        throws IOException {
+
+        assertThat(Files.readString(ROADMAP))
+            .contains(
+                "Issue a short-lived opaque MFA login challenge only after the password and account eligibility checks succeed",
+                "Persist only a fixed-length challenge digest, expiration, bounded attempt state, and terminal state",
+                "Issue no access or refresh credential while an enabled user's challenge remains unresolved",
+                "Consume a successful challenge exactly once",
+                "concurrent submissions have at most one successful winner",
+                "Persist only fixed-length recovery-code digests",
+                "Consume every recovery code atomically and at most once",
+                "Revoke active refresh-token families after MFA disable or secret replacement"
+            );
+    }
+
+    @Test
+    void shouldDefineStepUpPolicyAndExplicitDeferrals()
+        throws IOException {
+
+        assertThat(Files.readString(ROADMAP))
+            .contains(
+                "application-facing step-up policy independent from controller annotations",
+                "Bind every step-up grant to one authenticated subject, purpose, issue time, and short expiration",
+                "Evaluate dead-letter replay and discard as explicit operator step-up candidates",
+                "Reject cross-purpose, expired, replayed, or wrong-subject grants",
+                "SMS, voice-call, or email-delivered one-time passwords",
+                "WebAuthn, passkeys, FIDO2 security keys, or biometric authentication",
+                "generalized registration, refresh, recovery, or operations rate-limit policy; that remains a v0.15.0 concern",
+                "access-token denylisting or immediate revocation of already-issued JWTs"
+            );
+    }
+
+    @Test
+    void shouldRetainV013PublicationAndUnreleasedChangelog()
+        throws IOException {
+
+        assertThat(Files.readString(ROADMAP))
+            .contains(
+                "## v0.13.0 — Released: Account Recovery and Secure Mail Delivery",
+                "published merge and tag commit: `726f631a0de800870813ccb0c00b2676eb5d172b`",
+                "release workflow run: [`31115952987`]",
+                "published JAR SHA-256: `78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA`"
+            );
+
+        assertThat(Files.readString(CHANGELOG))
+            .contains(
+                "## [Unreleased]",
+                "## [0.13.0] - 2026-08-06",
+                "[0.13.0]: https://github.com/nursena-pc/payflow/compare/v0.12.0...v0.13.0",
+                "[Unreleased]: https://github.com/nursena-pc/payflow/compare/v0.13.0...HEAD"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- open the Maven `0.14.0-SNAPSHOT` development line from exact main baseline `beae8b5cd0f50da6a6f6abd7e7a31e24cb526d6c`
- freeze the TOTP MFA, recovery-code, login-challenge, and step-up architecture boundaries
- preserve the immutable v0.13.0 tag, release workflow, artifact, and publication record
- add executable v0.14.0 development contracts before implementation begins

## Scope

- `pom.xml` version transition only
- README and roadmap development-state contracts
- historical v0.13.0 publication contract made independent from the active Maven version
- no MFA endpoint, database migration, dependency, or runtime behavior is implemented in this pull request

## Verification

- focused contracts: 19 tests / 4 reports
- complete Maven verification: 1179 tests / 262 reports
- failures: 0
- errors: 0
- skipped: 0
- Docker Compose configuration: PASS
- artifact: `payflow-0.14.0-SNAPSHOT.jar`
- artifact SHA-256: `85633CC08383D654495037729773868D01917AB102D574216FED27BA2A1D3F3B`

Closes #130