### PR TITLE
feat(auth): establish MFA lifecycle foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Domain-only MFA lifecycle foundation with explicit `DISABLED`, `PENDING`, and `ENABLED` transitions.
+- Typed step-up purpose vocabulary for user account-security changes and explicit Kafka dead-letter operator candidates.
+- ADR 0014 and a versioned MFA threat model covering enrollment, login challenge, recovery, disable, replay, concurrency, and observable-output boundaries.
+
+### Security
+
+- Dedicated `MFA_DISABLED` and `MFA_AUTHENTICATOR_REPLACED` refresh-family revocation reasons reserved before mutation workflows are implemented.
+- Stable coarse public failure semantics prevent future MFA endpoints from exposing internal challenge, TOTP, recovery-code, or step-up state.
+- MFA lifecycle policy remains independent from `UserStatus`, email-verification state, Spring Security, JWT adapters, and JPA entities.
+
 ## [0.13.0] - 2026-08-06
 
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Users with enabled MFA will complete password verification before receiving a sh
 
 Recovery codes will be generated from cryptographically secure randomness, returned once at activation or explicit rotation, stored only as fixed-length digests, and consumed atomically. Disabling or rotating MFA will require a recent step-up proof and will revoke active refresh-token families with a dedicated account-security reason.
 
-The first delivery increment freezes the threat model, persistence boundaries, public error semantics, clock-skew policy, and explicit non-goals in the [roadmap](docs/roadmap.md). Generalized API-wide abuse protection, SMS or email OTP, WebAuthn/passkeys, external identity providers, device trust, and behavioral risk scoring remain outside v0.14.0.
+The first delivery increment now freezes the domain lifecycle, typed step-up purpose vocabulary, account-security refresh-family revocation reasons, stable public failure semantics, and concurrency/observable-output boundaries. The accepted design is recorded in [ADR 0014](docs/adr/0014-mfa-and-step-up-authentication.md) and the [MFA threat model](docs/security/mfa-threat-model.md). No MFA endpoint, authenticator persistence, TOTP verification, recovery-code implementation, or runtime step-up enforcement is introduced by this foundation increment. Generalized API-wide abuse protection, SMS or email OTP, WebAuthn/passkeys, external identity providers, device trust, and behavioral risk scoring remain outside v0.14.0.
 
 ## Implemented API
 

--- a/docs/adr/0014-mfa-and-step-up-authentication.md
+++ b/docs/adr/0014-mfa-and-step-up-authentication.md
@@ -1,0 +1,184 @@
+# ADR 0014: Keep MFA lifecycle and step-up policy inside the identity domain
+
+- Status: Accepted
+- Date: 2026-08-07
+- Decision owners: PayFlow maintainers
+
+## Context
+
+PayFlow v0.14.0 adds TOTP multi-factor authentication, single-use recovery
+codes, and purpose-bound step-up authentication. The existing identity module
+already separates password hashing, JWT issuance, refresh sessions, login
+protection, email verification, and password recovery through domain and
+application boundaries.
+
+MFA adds new security state that could easily become coupled to Spring Security,
+controller branches, JPA entities, or raw cryptographic representations. That
+would make lifecycle rules difficult to test, allow transport details to define
+security policy, and make future authenticator replacement or alternate factor
+support unnecessarily invasive.
+
+The implementation also needs to distinguish account-security session
+revocation from password recovery and ordinary logout. Step-up authorization
+must not become a collection of ad hoc controller annotations because the same
+proof semantics will protect user operations and selected operator commands.
+
+## Decision
+
+### Domain lifecycle
+
+PayFlow freezes an MFA lifecycle with exactly three states:
+
+- `DISABLED`
+- `PENDING`
+- `ENABLED`
+
+The initial domain transition model permits only:
+
+- `DISABLED -> PENDING` to begin enrollment
+- `PENDING -> ENABLED` after successful enrollment proof
+- `PENDING -> DISABLED` to cancel incomplete enrollment
+- `ENABLED -> DISABLED` after the required authenticated security proof
+
+The lifecycle object contains no Spring, servlet, JWT, JPA, database, or
+cryptography type. JPA entities do not enter the MFA domain model. A dedicated
+domain exception exposes only the stable message `MFA state transition is
+invalid.` for invalid internal transitions.
+
+Persistence and secret material are deliberately absent from this first
+aggregate. Later increments will compose the lifecycle with a protected
+TOTP-secret record and PostgreSQL locking without changing the allowed state
+machine.
+
+### MFA remains independent from account eligibility
+
+`UserStatus`, email-verification state, and MFA lifecycle remain separate
+concepts.
+
+Account eligibility answers whether the account may authenticate. MFA answers
+whether a second factor is required after password verification. A database or
+application shortcut that encodes MFA state into `UserStatus` is rejected.
+
+### Secret-protection boundary
+
+The TOTP secret is sensitive reversible material, unlike password hashes,
+refresh-token digests, or recovery-code digests. The implementation will use an
+application-facing MFA secret-protection port. The adapter owns reversible
+protection and production key loading.
+
+The plaintext secret may exist transiently while generating a provisioning
+response or verifying a TOTP value, but it is protected before durable
+persistence and excluded from observable output.
+
+The MFA protection key is distinct from JWT signing keys and mail-content
+protection keys. Sharing those keys would couple unrelated compromise and
+rotation domains.
+
+### Step-up purposes are typed security policy
+
+Step-up authorization uses a closed purpose vocabulary rather than free-form
+controller strings. The initial purposes are:
+
+- `mfa-disable`
+- `recovery-code-rotation`
+- `mfa-authenticator-replacement`
+- `kafka-dead-letter-replay`
+- `kafka-dead-letter-discard`
+
+Each purpose is associated with either an authenticated user or a PayFlow
+operator. The Kafka dead-letter purposes are frozen as operator step-up
+candidates, but existing replay and discard behavior is not changed by this
+foundation increment.
+
+Future grants must be bound to one authenticated subject and one exact purpose;
+a grant created for one purpose cannot satisfy another.
+
+### Account-security refresh revocation
+
+Two additional durable refresh-family reasons are reserved before the mutation
+use cases are implemented:
+
+- `MFA_DISABLED`
+- `MFA_AUTHENTICATOR_REPLACED`
+
+These reasons make later session invalidation auditable without overloading
+`ALL_SESSIONS_LOGOUT`, `PASSWORD_RECOVERY`, or `ADMINISTRATIVE_REVOCATION`.
+They are contract names in this foundation increment only. The domain enum and
+PostgreSQL revocation-reason constraint must be extended together in the first
+increment that actually persists either reason; this pull request does not
+create an unusable persistence value ahead of that migration.
+
+The change does not modify access-token residual validity and does not add a JWT
+denylist.
+
+### Public failure semantics
+
+The detailed threat model freezes coarse public error names before endpoints
+are added:
+
+- `MFA_STATE_CONFLICT`
+- `MFA_VERIFICATION_FAILED`
+- `STEP_UP_REQUIRED`
+- `STEP_UP_INVALID`
+- `MFA_SECURITY_UNAVAILABLE`
+
+Internal states such as expired, exhausted, replayed, consumed, superseded,
+wrong recovery-code state, or invalid TOTP are not exposed as separate public
+login-verification errors.
+
+## Consequences
+
+### Positive
+
+- MFA state transitions are executable domain rules rather than controller
+  branches.
+- The user aggregate does not gain unrelated authenticator-secret fields.
+- JPA, Spring Security, and cryptographic adapters remain replaceable.
+- Future recovery-code and step-up work starts from stable typed purposes.
+- Session revocation caused by MFA changes has explicit durable reasons.
+- The threat model can be tested as a versioned repository contract before
+  security-sensitive endpoints exist.
+
+### Trade-offs
+
+- More small domain types are introduced before persistence exists.
+- The first increment deliberately provides no endpoint or user-visible MFA
+  capability.
+- Operator step-up purposes exist before dead-letter command enforcement is
+  wired, so documentation must distinguish frozen policy from implemented
+  runtime enforcement.
+
+## Rejected alternatives
+
+### Store MFA state on `UserStatus`
+
+Rejected because account availability and second-factor enrollment are
+independent lifecycle dimensions. Combining them would create invalid states
+and migration risk.
+
+### Let controllers own `PENDING` and `ENABLED` branches
+
+Rejected because transport code would become the security policy and concurrent
+persistence operations could bypass the intended state machine.
+
+### Put JPA entities in the domain model
+
+Rejected because database representation, row locking, and protected-secret
+columns belong to the persistence adapter.
+
+### Reuse the mail-content protection key
+
+Rejected because MFA authenticator secrets and provider-ready mail payloads
+have different compromise, retention, and rotation boundaries.
+
+### Use one generic `SECURITY_CHANGE` refresh revocation reason
+
+Rejected because disable and authenticator replacement are materially distinct
+security events and should remain distinguishable without inspecting sensitive
+audit payloads.
+
+### Protect operator actions with ad hoc controller annotations
+
+Rejected because step-up proof must be subject-bound, purpose-bound, time-bound,
+and reusable across inbound adapters without making controllers authoritative
+for security policy.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -532,12 +532,18 @@ access or refresh credential is issued until an enabled MFA challenge succeeds.
 ### Increment 1 — Threat model and lifecycle boundaries
 
 - [x] Open the dedicated v0.14.0 implementation issue
-- [ ] Record MFA enrollment, login, recovery, disable, bypass, replay, and concurrency threats
-- [ ] Keep MFA state separate from `UserStatus` and email-verification state
-- [ ] Define `DISABLED`, `PENDING`, and `ENABLED` lifecycle transitions explicitly
-- [ ] Define stable public errors that do not reveal secrets, recovery-code state, or internal challenge state
-- [ ] Define account-security refresh-family revocation reasons before implementation
-- [ ] Keep controllers, JWT adapters, and JPA entities outside the MFA domain model
+- [x] Record MFA enrollment, login, recovery, disable, bypass, replay, and concurrency threats
+- [x] Keep MFA state separate from `UserStatus` and email-verification state
+- [x] Define `DISABLED`, `PENDING`, and `ENABLED` lifecycle transitions explicitly
+- [x] Define stable public errors that do not reveal secrets, recovery-code state, or internal challenge state
+- [x] Define account-security refresh-family revocation reasons before implementation
+- [x] Keep controllers, JWT adapters, and JPA entities outside the MFA domain model
+
+The accepted foundation is documented in [ADR 0014](adr/0014-mfa-and-step-up-authentication.md)
+and the [MFA threat model](security/mfa-threat-model.md). The domain now freezes the
+lifecycle state machine, typed step-up purposes, and dedicated `MFA_DISABLED` and
+`MFA_AUTHENTICATOR_REPLACED` refresh-family revocation reasons without adding
+MFA persistence, endpoints, TOTP verification, or runtime step-up enforcement.
 
 ### Increment 2 — TOTP enrollment and secret protection
 

--- a/docs/security/mfa-threat-model.md
+++ b/docs/security/mfa-threat-model.md
@@ -1,0 +1,356 @@
+# MFA and Step-Up Authentication Threat Model
+
+- Status: Active v0.14.0 security contract
+- Scope: TOTP enrollment, MFA login completion, recovery codes, MFA disable,
+  authenticator replacement, and selected step-up operations
+- Baseline: PayFlow `0.14.0-SNAPSHOT`
+
+## Purpose
+
+This document freezes the security boundaries that must exist before PayFlow
+persists an MFA authenticator, accepts a TOTP value, issues a recovery code, or
+creates a step-up grant. It intentionally precedes endpoint and persistence
+implementation so later increments cannot silently redefine the trust model.
+
+The first factor remains the existing password flow. MFA is an additional proof
+for eligible accounts; it is not a replacement for password verification,
+email-ownership verification, refresh-session rotation, or the existing login
+rate limiter.
+
+## Security invariants
+
+The v0.14.0 implementation must preserve all of the following invariants.
+
+1. MFA state is independent from `UserStatus` and `emailVerifiedAt`.
+2. Only `ENABLED` MFA requires a second factor during login.
+3. `PENDING` enrollment never grants MFA-protected authentication status.
+4. An enabled user receives no access or refresh credential until a valid MFA
+   login challenge is consumed successfully.
+5. TOTP secrets, provisioning URIs, TOTP values, plaintext recovery codes,
+   login-challenge credentials, step-up grants, secret-protection keys, and
+   protected secret bytes never appear in logs, metrics, traces, audit payloads,
+   exception messages, or durable plaintext storage.
+6. Recovery codes and opaque challenge credentials are persisted only through
+   fixed-length cryptographic digests suitable for equality lookup.
+7. Every security-sensitive state transition is serialized at the persistence
+   boundary so concurrent requests cannot create two winners.
+8. Security time decisions use an injected UTC `Clock`; MFA code does not call
+   `Instant.now()` directly.
+9. Disabling MFA or replacing the active authenticator revokes active refresh
+   families with an explicit account-security reason.
+10. Existing access tokens retain the documented short residual-validity
+    boundary. v0.14.0 does not introduce access-token denylisting.
+
+## Trust boundaries
+
+### Client to PayFlow
+
+The client may supply passwords, MFA challenge credentials, TOTP values,
+recovery codes, and step-up grants. Every supplied value is attacker-controlled
+until shape and state validation succeeds.
+
+TLS termination and trusted reverse-proxy resolution remain deployment
+responsibilities already defined by the existing security architecture. MFA
+must not derive security decisions from untrusted host, forwarding, or client
+metadata.
+
+### Application to PostgreSQL
+
+PostgreSQL is the system of record for durable MFA state, challenge state,
+recovery-code digests, and future step-up state when persistence is required.
+Database readers must not obtain a usable TOTP secret or plaintext recovery
+credential.
+
+The persistence adapter owns row locking, uniqueness constraints, and database
+representations. JPA entities do not enter the MFA domain model.
+
+### Application to secret protection
+
+A future application-facing MFA secret-protection port separates TOTP secret
+handling from the domain model. The adapter may use local AES-GCM key material
+in the first implementation, but provider-specific cryptography and key-loading
+types remain outside the domain and application policies.
+
+Production must fail safely when required protection material is absent or
+invalid. The production key must be separate from JWT signing keys and the
+mail-content protection key.
+
+### Authentication and authorization adapters
+
+JWT parsing, Spring Security authorities, servlet request handling, and
+controller annotations remain adapters around the MFA use cases. They may
+supply an authenticated subject, but they do not own MFA lifecycle or step-up
+policy.
+
+## MFA lifecycle
+
+The lifecycle has exactly three states:
+
+```text
+DISABLED --begin enrollment--> PENDING --valid enrollment proof--> ENABLED
+    ^                            |
+    |                            +--cancel enrollment---------------+
+    |
+    +---------------------disable with required proof---------------+
+```
+
+Allowed transitions are:
+
+- `DISABLED -> PENDING`: begin enrollment
+- `PENDING -> ENABLED`: confirm enrollment with a valid TOTP proof
+- `PENDING -> DISABLED`: cancel an incomplete enrollment
+- `ENABLED -> DISABLED`: disable MFA after the required recent step-up proof
+
+All other direct transitions are invalid. In particular:
+
+- `DISABLED -> ENABLED` is forbidden
+- `ENABLED -> PENDING` is not a replacement shortcut
+- repeated enrollment cannot create overlapping pending authenticators
+- replacement must be a dedicated serialized use case that preserves one
+  effective authenticator outcome
+
+The domain lifecycle is deliberately independent from controllers, JWT
+adapters, JPA entities, and secret-protection formats.
+
+## Enrollment threats
+
+### Enrollment hijack
+
+**Threat:** an attacker with a stolen bearer token attempts to enroll their own
+authenticator on the victim account.
+
+**Boundary:** enrollment requires an authenticated, active, email-verified
+subject. The implementation increment must define whether an additional recent
+password or step-up proof is required before activation; silently treating a
+long-lived bearer token as sufficient for every lifecycle mutation is not
+allowed.
+
+### Secret disclosure
+
+**Threat:** a TOTP secret leaks through database plaintext, logs, exceptions,
+metrics, tracing, or repeated API reads.
+
+**Boundary:** the plaintext secret and `otpauth://` provisioning value may be
+returned only by the enrollment response that created that pending secret. The
+secret is protected before durable persistence and is never returned again.
+
+### Overlapping enrollment
+
+**Threat:** concurrent enrollments create multiple pending or active secrets and
+make the effective authenticator ambiguous.
+
+**Boundary:** persistence serializes enrollment state. At most one effective
+pending or active authenticator exists for one user. Replacement is explicit
+rather than an accidental side effect of a second enrollment request.
+
+### Activation replay
+
+**Threat:** the same activation request succeeds more than once or activates a
+superseded pending secret.
+
+**Boundary:** activation verifies the currently effective pending secret under a
+lock and performs one `PENDING -> ENABLED` transition. A stale or already-used
+request receives the same safe lifecycle failure contract.
+
+## MFA login-challenge threats
+
+### Second-factor bypass
+
+**Threat:** password verification issues access or refresh credentials before
+MFA succeeds.
+
+**Boundary:** when MFA is `ENABLED`, successful password and account-eligibility
+checks create only a short-lived opaque MFA login challenge. Access and refresh
+credentials are issued only after that challenge is consumed successfully.
+
+### Challenge theft
+
+**Threat:** a database reader or operational output exposes a usable login
+challenge.
+
+**Boundary:** challenge credentials contain at least 256 bits of secure random
+entropy. Only a fixed-length SHA-256 digest is persisted. Raw credentials and
+digests are excluded from observable output.
+
+### Brute force
+
+**Threat:** an attacker submits unbounded TOTP or recovery-code guesses against
+a valid challenge.
+
+**Boundary:** each challenge has a bounded attempt count and short expiration.
+The exact threshold is an implementation configuration, not a reusable general
+API rate-limit policy. Generalized abuse protection remains a v0.15.0 concern.
+
+### Replay and concurrent verification
+
+**Threat:** two requests consume one valid challenge or one recovery code and
+both receive authenticated sessions.
+
+**Boundary:** challenge and recovery-code consumption are serialized in
+PostgreSQL. Exactly one request may perform the terminal success transition and
+create the corresponding authenticated session outcome.
+
+### Clock manipulation
+
+**Threat:** broad clock skew makes captured TOTP values valid for too long.
+
+**Boundary:** TOTP verification uses the shared UTC `Clock` and a bounded window.
+The implementation target is the current time step plus at most one adjacent
+step on either side. The exact TOTP profile is frozen with test vectors in the
+TOTP implementation increment.
+
+## Recovery-code threats
+
+### Durable plaintext recovery codes
+
+**Threat:** a database compromise provides reusable recovery credentials.
+
+**Boundary:** plaintext recovery codes are returned once at activation or
+explicit rotation. PostgreSQL stores only fixed-length digests. Recovery-code
+format and entropy are fixed by the implementation increment and verified with
+unit tests.
+
+### Recovery-code enumeration
+
+**Threat:** public responses reveal whether a supplied proof was a TOTP value,
+a recovery code, already consumed, or structurally valid.
+
+**Boundary:** login-challenge proof failures use the same public failure
+contract. Internal diagnostics may use bounded reason categories but never
+include the credential, digest, or remaining-code count.
+
+### Recovery-code replay
+
+**Threat:** one recovery code is accepted twice under concurrent requests.
+
+**Boundary:** the matching digest is locked and consumed atomically with the
+challenge outcome. A consumed code is never restored by a failed downstream
+session write; the entire authentication transaction commits or rolls back.
+
+## Disable and authenticator-replacement threats
+
+### Stolen bearer token disables MFA
+
+**Threat:** an attacker with only a valid access token weakens the account by
+disabling MFA.
+
+**Boundary:** MFA disable requires a recent step-up grant for the same subject
+and the exact `mfa-disable` purpose. Bearer authentication alone is
+insufficient.
+
+### Existing refresh sessions survive a security change
+
+**Threat:** disabling MFA or replacing the authenticator leaves previously
+issued refresh sessions usable indefinitely.
+
+**Boundary:** successful disable revokes active refresh families with
+`MFA_DISABLED`. Successful authenticator replacement revokes them with
+`MFA_AUTHENTICATOR_REPLACED`.
+
+Already-issued access tokens keep the existing short residual-validity window.
+
+## Step-up threats
+
+### Confused-deputy or cross-purpose reuse
+
+**Threat:** a grant created for one operation authorizes another operation.
+
+**Boundary:** every grant is bound to one authenticated subject, one exact
+purpose, one issue time, and one short expiration. A purpose is not a free-form
+controller string.
+
+The frozen purpose vocabulary is:
+
+| Stable value | Actor | Intended operation |
+| --- | --- | --- |
+| `mfa-disable` | authenticated user | Disable enabled MFA |
+| `recovery-code-rotation` | authenticated user | Replace recovery-code set |
+| `mfa-authenticator-replacement` | authenticated user | Replace active authenticator |
+| `kafka-dead-letter-replay` | PayFlow operator | Replay a dead-letter record |
+| `kafka-dead-letter-discard` | PayFlow operator | Discard a dead-letter record |
+
+The two Kafka purposes are explicit operator step-up candidates. Their runtime
+enforcement is introduced only when the step-up increment integrates with the
+existing operations module.
+
+### Grant theft and replay
+
+**Threat:** a captured step-up grant is reused by another subject or after its
+first accepted use.
+
+**Boundary:** wrong-subject, wrong-purpose, expired, superseded, and replayed
+grants fail through one stable step-up failure contract. Persisted grants, when
+introduced, use opaque credential and digest-only rules rather than plaintext
+bearer storage.
+
+## Stable public failure contracts
+
+The implementation must use bounded public semantics rather than exposing
+internal state. These names are frozen before endpoint implementation:
+
+| HTTP intent | Error code | Public meaning |
+| --- | --- | --- |
+| `409 Conflict` | `MFA_STATE_CONFLICT` | The authenticated lifecycle operation cannot be applied in the current public state. |
+| `401 Unauthorized` | `MFA_VERIFICATION_FAILED` | The MFA login challenge or supplied second-factor proof cannot be accepted. |
+| `403 Forbidden` | `STEP_UP_REQUIRED` | The authenticated operation requires a recent purpose-bound second-factor proof. |
+| `403 Forbidden` | `STEP_UP_INVALID` | The supplied step-up proof cannot authorize the requested operation. |
+| `503 Service Unavailable` | `MFA_SECURITY_UNAVAILABLE` | PayFlow cannot make a safe MFA security decision because required security infrastructure is unavailable. |
+
+`MFA_VERIFICATION_FAILED` intentionally covers malformed, unknown, expired,
+exhausted, consumed, replayed, and superseded challenge state plus invalid TOTP
+or recovery-code proof. The public response does not disclose which condition
+occurred or how many recovery codes remain.
+
+Authenticated lifecycle endpoints may expose coarse `DISABLED`, `PENDING`, or
+`ENABLED` state to the owning user when the endpoint contract explicitly needs
+it; they never expose secret material or internal challenge state.
+
+## Concurrency requirements
+
+The persistence implementation must prove the following single-winner
+properties with real PostgreSQL tests:
+
+- concurrent enrollment starts cannot create two effective pending secrets
+- activation and cancellation of the same pending enrollment cannot both win
+- replacement cannot leave two active authenticators
+- two valid submissions cannot both consume one login challenge
+- two requests cannot both consume one recovery code
+- disable and recovery-code rotation cannot bypass required step-up proof
+- session revocation and account-security mutation commit atomically where the
+  use case requires both
+
+In-memory synchronization, JVM-local locks, or optimistic assumptions are not
+sufficient evidence because PayFlow may run more than one application process.
+
+## Observable-output policy
+
+MFA security events may contain only bounded categories such as operation,
+outcome, factor kind, and stable reason class. They must not contain:
+
+- normalized email address
+- TOTP secret or provisioning URI
+- TOTP value
+- plaintext recovery code or recovery-code digest
+- raw challenge or challenge digest
+- raw step-up grant or grant digest
+- secret-protection key or protected secret bytes
+- remaining recovery-code values
+
+Correlation IDs may connect synchronous request logs but never become an MFA
+credential, grant identifier, persistence key, or metric label.
+
+## Explicit non-goals
+
+This threat model does not add:
+
+- SMS, voice, or email one-time passwords
+- WebAuthn, passkeys, FIDO2, or biometric authentication
+- trusted-device or remember-this-device cookies
+- external OAuth, OpenID Connect, SAML, or social login
+- device fingerprinting, geolocation, or adaptive risk scoring
+- generalized API-wide abuse protection
+- access-token denylisting or online JWT introspection
+- remote KMS, HSM, Vault, Kubernetes, or microservice extraction
+
+Those capabilities require separate versioned threat models rather than being
+silently folded into the TOTP MFA increment.

--- a/src/main/java/com/nursena/payflow/user/domain/exception/InvalidMfaLifecycleTransitionException.java
+++ b/src/main/java/com/nursena/payflow/user/domain/exception/InvalidMfaLifecycleTransitionException.java
@@ -1,0 +1,12 @@
+package com.nursena.payflow.user.domain.exception;
+
+public final class InvalidMfaLifecycleTransitionException
+    extends RuntimeException {
+
+    private static final String MESSAGE =
+        "MFA state transition is invalid.";
+
+    public InvalidMfaLifecycleTransitionException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/MfaLifecycle.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/MfaLifecycle.java
@@ -1,0 +1,77 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.util.Objects;
+
+import com.nursena.payflow.user.domain.exception
+    .InvalidMfaLifecycleTransitionException;
+
+public final class MfaLifecycle {
+
+    private final MfaLifecycleState state;
+
+    private MfaLifecycle(
+        MfaLifecycleState state
+    ) {
+        this.state = Objects.requireNonNull(
+            state,
+            "state must not be null"
+        );
+    }
+
+    public static MfaLifecycle disabled() {
+        return new MfaLifecycle(
+            MfaLifecycleState.DISABLED
+        );
+    }
+
+    public static MfaLifecycle rehydrate(
+        MfaLifecycleState state
+    ) {
+        return new MfaLifecycle(state);
+    }
+
+    public MfaLifecycle beginEnrollment() {
+        requireState(MfaLifecycleState.DISABLED);
+
+        return new MfaLifecycle(
+            MfaLifecycleState.PENDING
+        );
+    }
+
+    public MfaLifecycle activate() {
+        requireState(MfaLifecycleState.PENDING);
+
+        return new MfaLifecycle(
+            MfaLifecycleState.ENABLED
+        );
+    }
+
+    public MfaLifecycle cancelEnrollment() {
+        requireState(MfaLifecycleState.PENDING);
+
+        return disabled();
+    }
+
+    public MfaLifecycle disable() {
+        requireState(MfaLifecycleState.ENABLED);
+
+        return disabled();
+    }
+
+    public boolean requiresSecondFactor() {
+        return state.requiresSecondFactor();
+    }
+
+    private void requireState(
+        MfaLifecycleState expected
+    ) {
+        if (state != expected) {
+            throw new
+                InvalidMfaLifecycleTransitionException();
+        }
+    }
+
+    public MfaLifecycleState state() {
+        return state;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/MfaLifecycleState.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/MfaLifecycleState.java
@@ -1,0 +1,11 @@
+package com.nursena.payflow.user.domain.model;
+
+public enum MfaLifecycleState {
+    DISABLED,
+    PENDING,
+    ENABLED;
+
+    public boolean requiresSecondFactor() {
+        return this == ENABLED;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/StepUpActorKind.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/StepUpActorKind.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.user.domain.model;
+
+public enum StepUpActorKind {
+    AUTHENTICATED_USER,
+    PAYFLOW_OPERATOR
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/StepUpPurpose.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/StepUpPurpose.java
@@ -1,0 +1,78 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public enum StepUpPurpose {
+    MFA_DISABLE(
+        "mfa-disable",
+        StepUpActorKind.AUTHENTICATED_USER
+    ),
+    RECOVERY_CODE_ROTATION(
+        "recovery-code-rotation",
+        StepUpActorKind.AUTHENTICATED_USER
+    ),
+    MFA_AUTHENTICATOR_REPLACEMENT(
+        "mfa-authenticator-replacement",
+        StepUpActorKind.AUTHENTICATED_USER
+    ),
+    KAFKA_DEAD_LETTER_REPLAY(
+        "kafka-dead-letter-replay",
+        StepUpActorKind.PAYFLOW_OPERATOR
+    ),
+    KAFKA_DEAD_LETTER_DISCARD(
+        "kafka-dead-letter-discard",
+        StepUpActorKind.PAYFLOW_OPERATOR
+    );
+
+    private final String value;
+    private final StepUpActorKind actorKind;
+
+    StepUpPurpose(
+        String value,
+        StepUpActorKind actorKind
+    ) {
+        this.value = Objects.requireNonNull(
+            value,
+            "value must not be null"
+        );
+        this.actorKind = Objects.requireNonNull(
+            actorKind,
+            "actorKind must not be null"
+        );
+    }
+
+    public static StepUpPurpose fromValue(
+        String value
+    ) {
+        if (value == null) {
+            throw new IllegalArgumentException(
+                "step-up purpose is invalid"
+            );
+        }
+
+        return Arrays.stream(values())
+            .filter(candidate ->
+                candidate.value.equals(value)
+            )
+            .findFirst()
+            .orElseThrow(() ->
+                new IllegalArgumentException(
+                    "step-up purpose is invalid"
+                )
+            );
+    }
+
+    public boolean isOperatorPurpose() {
+        return actorKind
+            == StepUpActorKind.PAYFLOW_OPERATOR;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public StepUpActorKind actorKind() {
+        return actorKind;
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/V014MfaFoundationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V014MfaFoundationContractTest.java
@@ -1,0 +1,227 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions
+    .assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class V014MfaFoundationContractTest {
+
+    private static final Path README =
+        Path.of("README.md");
+
+    private static final Path CHANGELOG =
+        Path.of("CHANGELOG.md");
+
+    private static final Path ROADMAP =
+        Path.of("docs", "roadmap.md");
+
+    private static final Path ADR =
+        Path.of(
+            "docs",
+            "adr",
+            "0014-mfa-and-step-up-authentication.md"
+        );
+
+    private static final Path THREAT_MODEL =
+        Path.of(
+            "docs",
+            "security",
+            "mfa-threat-model.md"
+        );
+
+    private static final Path MFA_DOMAIN =
+        Path.of(
+            "src",
+            "main",
+            "java",
+            "com",
+            "nursena",
+            "payflow",
+            "user",
+            "domain"
+        );
+
+    @Test
+    void shouldRecordCompleteMfaThreatModel()
+        throws IOException {
+
+        String threatModel =
+            normalizeWhitespace(
+                Files.readString(THREAT_MODEL)
+            );
+
+        assertThat(threatModel)
+            .contains(
+                "Enrollment hijack",
+                "Second-factor bypass",
+                "Challenge theft",
+                "Brute force",
+                "Replay and concurrent verification",
+                "Durable plaintext recovery codes",
+                "Stolen bearer token disables MFA",
+                "Confused-deputy or cross-purpose reuse",
+                "In-memory synchronization, JVM-local locks, or optimistic assumptions are not sufficient evidence"
+            );
+    }
+
+    @Test
+    void shouldFreezeLifecycleAndArchitectureDecision()
+        throws IOException {
+
+        String adr =
+            normalizeWhitespace(
+                Files.readString(ADR)
+            );
+
+        assertThat(adr)
+            .contains(
+                "DISABLED -> PENDING",
+                "PENDING -> ENABLED",
+                "PENDING -> DISABLED",
+                "ENABLED -> DISABLED",
+                "`UserStatus`, email-verification state, and MFA lifecycle remain separate concepts",
+                "application-facing MFA secret-protection port",
+                "JPA entities do not enter the MFA domain model"
+            );
+    }
+
+    @Test
+    void shouldFreezeGenericPublicFailureContracts()
+        throws IOException {
+
+        String threatModel =
+            normalizeWhitespace(
+                Files.readString(THREAT_MODEL)
+            );
+
+        assertThat(threatModel)
+            .contains(
+                "MFA_STATE_CONFLICT",
+                "MFA_VERIFICATION_FAILED",
+                "STEP_UP_REQUIRED",
+                "STEP_UP_INVALID",
+                "MFA_SECURITY_UNAVAILABLE"
+            )
+            .contains(
+                "malformed, unknown, expired, exhausted, consumed, replayed, and superseded challenge state"
+            );
+    }
+
+    @Test
+    void shouldFreezeRevocationReasonsAndStepUpPurposes()
+        throws IOException {
+
+        String threatModel =
+            Files.readString(THREAT_MODEL);
+        String adr =
+            Files.readString(ADR);
+
+        assertThat(adr)
+            .contains(
+                "`MFA_DISABLED`",
+                "`MFA_AUTHENTICATOR_REPLACED`"
+            );
+
+        assertThat(threatModel)
+            .contains(
+                "`mfa-disable`",
+                "`recovery-code-rotation`",
+                "`mfa-authenticator-replacement`",
+                "`kafka-dead-letter-replay`",
+                "`kafka-dead-letter-discard`"
+            );
+    }
+
+    @Test
+    void shouldKeepMfaDomainFreeFromFrameworkAndAdapterTypes()
+        throws IOException {
+
+        Path lifecycle = MFA_DOMAIN.resolve(
+            Path.of("model", "MfaLifecycle.java")
+        );
+        Path state = MFA_DOMAIN.resolve(
+            Path.of("model", "MfaLifecycleState.java")
+        );
+        Path purpose = MFA_DOMAIN.resolve(
+            Path.of("model", "StepUpPurpose.java")
+        );
+
+        String source = String.join(
+            "\n",
+            Files.readString(lifecycle),
+            Files.readString(state),
+            Files.readString(purpose)
+        );
+
+        assertThat(source)
+            .doesNotContain(
+                "org.springframework",
+                "jakarta.persistence",
+                "HttpServletRequest",
+                "Jwt",
+                "JpaEntity"
+            );
+    }
+
+    @Test
+    void shouldMarkOnlyFoundationIncrementComplete()
+        throws IOException {
+
+        String roadmap =
+            Files.readString(ROADMAP);
+
+        assertThat(roadmap)
+            .contains(
+                "- [x] Record MFA enrollment, login, recovery, disable, bypass, replay, and concurrency threats",
+                "- [x] Keep MFA state separate from `UserStatus` and email-verification state",
+                "- [x] Define `DISABLED`, `PENDING`, and `ENABLED` lifecycle transitions explicitly",
+                "- [x] Define stable public errors that do not reveal secrets, recovery-code state, or internal challenge state",
+                "- [x] Define account-security refresh-family revocation reasons before implementation",
+                "- [x] Keep controllers, JWT adapters, and JPA entities outside the MFA domain model"
+            )
+            .contains(
+                "- [ ] Generate a high-entropy TOTP secret with a standards-compatible `otpauth://` provisioning value",
+                "- [ ] Issue a short-lived opaque MFA login challenge only after the password and account eligibility checks succeed",
+                "- [ ] Generate recovery codes from cryptographically secure randomness",
+                "- [ ] Introduce an application-facing step-up policy independent from controller annotations"
+            );
+    }
+
+    @Test
+    void shouldExposeFoundationWithoutClaimingRuntimeMfa()
+        throws IOException {
+
+        String readme =
+            normalizeWhitespace(
+                Files.readString(README)
+            );
+        String changelog =
+            normalizeWhitespace(
+                Files.readString(CHANGELOG)
+            );
+
+        assertThat(readme)
+            .contains(
+                "The first delivery increment now freezes the domain lifecycle, typed step-up purpose vocabulary, account-security refresh-family revocation reasons",
+                "No MFA endpoint, authenticator persistence, TOTP verification, recovery-code implementation, or runtime step-up enforcement is introduced by this foundation increment"
+            );
+
+        assertThat(changelog)
+            .contains(
+                "Domain-only MFA lifecycle foundation",
+                "Typed step-up purpose vocabulary",
+                "ADR 0014 and a versioned MFA threat model"
+            );
+    }
+
+    private static String normalizeWhitespace(
+        String value
+    ) {
+        return value.replaceAll("\\s+", " ").trim();
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/domain/model/MfaLifecycleTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/MfaLifecycleTest.java
@@ -1,0 +1,150 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.assertj.core.api.Assertions
+    .assertThat;
+import static org.assertj.core.api.Assertions
+    .assertThatThrownBy;
+
+import com.nursena.payflow.user.domain.exception
+    .InvalidMfaLifecycleTransitionException;
+import org.junit.jupiter.api.Test;
+
+class MfaLifecycleTest {
+
+    @Test
+    void shouldStartDisabled() {
+        MfaLifecycle lifecycle =
+            MfaLifecycle.disabled();
+
+        assertThat(lifecycle.state())
+            .isEqualTo(MfaLifecycleState.DISABLED);
+        assertThat(lifecycle.requiresSecondFactor())
+            .isFalse();
+    }
+
+    @Test
+    void shouldBeginEnrollmentFromDisabled() {
+        MfaLifecycle pending =
+            MfaLifecycle.disabled()
+                .beginEnrollment();
+
+        assertThat(pending.state())
+            .isEqualTo(MfaLifecycleState.PENDING);
+        assertThat(pending.requiresSecondFactor())
+            .isFalse();
+    }
+
+    @Test
+    void shouldActivatePendingEnrollment() {
+        MfaLifecycle enabled =
+            MfaLifecycle.disabled()
+                .beginEnrollment()
+                .activate();
+
+        assertThat(enabled.state())
+            .isEqualTo(MfaLifecycleState.ENABLED);
+        assertThat(enabled.requiresSecondFactor())
+            .isTrue();
+    }
+
+    @Test
+    void shouldCancelPendingEnrollment() {
+        MfaLifecycle disabled =
+            MfaLifecycle.disabled()
+                .beginEnrollment()
+                .cancelEnrollment();
+
+        assertThat(disabled.state())
+            .isEqualTo(MfaLifecycleState.DISABLED);
+    }
+
+    @Test
+    void shouldDisableEnabledLifecycle() {
+        MfaLifecycle disabled =
+            enabledLifecycle().disable();
+
+        assertThat(disabled.state())
+            .isEqualTo(MfaLifecycleState.DISABLED);
+        assertThat(disabled.requiresSecondFactor())
+            .isFalse();
+    }
+
+    @Test
+    void shouldRejectRepeatedEnrollmentStart() {
+        assertInvalidTransition(() ->
+            MfaLifecycle.disabled()
+                .beginEnrollment()
+                .beginEnrollment()
+        );
+    }
+
+    @Test
+    void shouldRejectEnrollmentStartWhenEnabled() {
+        assertInvalidTransition(() ->
+            enabledLifecycle().beginEnrollment()
+        );
+    }
+
+    @Test
+    void shouldRejectActivationWhenDisabled() {
+        assertInvalidTransition(() ->
+            MfaLifecycle.disabled().activate()
+        );
+    }
+
+    @Test
+    void shouldRejectRepeatedActivation() {
+        assertInvalidTransition(() ->
+            enabledLifecycle().activate()
+        );
+    }
+
+    @Test
+    void shouldRejectCancellationWhenDisabled() {
+        assertInvalidTransition(() ->
+            MfaLifecycle.disabled()
+                .cancelEnrollment()
+        );
+    }
+
+    @Test
+    void shouldRejectCancellationWhenEnabled() {
+        assertInvalidTransition(() ->
+            enabledLifecycle().cancelEnrollment()
+        );
+    }
+
+    @Test
+    void shouldRejectDisableWhenPending() {
+        assertInvalidTransition(() ->
+            MfaLifecycle.disabled()
+                .beginEnrollment()
+                .disable()
+        );
+    }
+
+    @Test
+    void shouldRejectDisableWhenAlreadyDisabled() {
+        assertInvalidTransition(() ->
+            MfaLifecycle.disabled().disable()
+        );
+    }
+
+    private static MfaLifecycle enabledLifecycle() {
+        return MfaLifecycle.disabled()
+            .beginEnrollment()
+            .activate();
+    }
+
+    private static void assertInvalidTransition(
+        Runnable action
+    ) {
+        assertThatThrownBy(action::run)
+            .isInstanceOf(
+                InvalidMfaLifecycleTransitionException.class
+            )
+            .hasMessage(
+                "MFA state transition is invalid."
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/domain/model/StepUpPurposeTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/StepUpPurposeTest.java
@@ -1,0 +1,88 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.assertj.core.api.Assertions
+    .assertThat;
+import static org.assertj.core.api.Assertions
+    .assertThatThrownBy;
+
+import java.util.EnumSet;
+
+import org.junit.jupiter.api.Test;
+
+class StepUpPurposeTest {
+
+    @Test
+    void shouldExposeStableUserPurposes() {
+        assertThat(
+            EnumSet.of(
+                StepUpPurpose.MFA_DISABLE,
+                StepUpPurpose.RECOVERY_CODE_ROTATION,
+                StepUpPurpose.MFA_AUTHENTICATOR_REPLACEMENT
+            )
+        )
+            .allSatisfy(purpose -> {
+                assertThat(purpose.actorKind())
+                    .isEqualTo(
+                        StepUpActorKind.AUTHENTICATED_USER
+                    );
+                assertThat(purpose.isOperatorPurpose())
+                    .isFalse();
+            });
+    }
+
+    @Test
+    void shouldExposeExplicitOperatorCandidates() {
+        assertThat(
+            EnumSet.of(
+                StepUpPurpose.KAFKA_DEAD_LETTER_REPLAY,
+                StepUpPurpose.KAFKA_DEAD_LETTER_DISCARD
+            )
+        )
+            .allSatisfy(purpose -> {
+                assertThat(purpose.actorKind())
+                    .isEqualTo(
+                        StepUpActorKind.PAYFLOW_OPERATOR
+                    );
+                assertThat(purpose.isOperatorPurpose())
+                    .isTrue();
+            });
+    }
+
+    @Test
+    void shouldResolveStablePurposeValue() {
+        assertThat(
+            StepUpPurpose.fromValue(
+                "recovery-code-rotation"
+            )
+        )
+            .isEqualTo(
+                StepUpPurpose.RECOVERY_CODE_ROTATION
+            );
+    }
+
+    @Test
+    void shouldRejectUnknownPurposeValueGenerically() {
+        assertThatThrownBy(() ->
+            StepUpPurpose.fromValue("unknown")
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "step-up purpose is invalid"
+            );
+    }
+
+    @Test
+    void shouldRejectNullPurposeValueGenerically() {
+        assertThatThrownBy(() ->
+            StepUpPurpose.fromValue(null)
+        )
+            .isInstanceOf(
+                IllegalArgumentException.class
+            )
+            .hasMessage(
+                "step-up purpose is invalid"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- establish the first v0.14.0 MFA security increment from exact main baseline `e2a55123c077c8f1a4872ea3980530537e703ee8`
- add a domain-only `DISABLED` / `PENDING` / `ENABLED` lifecycle with explicit transitions
- freeze typed purpose values for account-security and selected operator step-up flows
- record the MFA threat model, ADR, public failure semantics, concurrency rules, and observable-output exclusions
- reserve `MFA_DISABLED` and `MFA_AUTHENTICATOR_REPLACED` as future refresh-family reason names without persisting them before a matching migration

## Runtime scope

- no TOTP verification is implemented
- no authenticator, challenge, recovery-code, or step-up persistence is added
- no login, refresh, JWT, or Kafka dead-letter runtime behavior changes
- no new public endpoint is added

## Verification

- focused MFA foundation: 32 tests / 5 reports
- complete Maven verification: 1204 tests / 265 reports
- failures: 0
- errors: 0
- skipped: 0
- Docker Compose configuration: PASS
- artifact: `payflow-0.14.0-SNAPSHOT.jar`
- artifact SHA-256: `021DA81F8476B73C85628A99054FDE35DE0C19B4F10E3E287FF8F49C6A552F5D`

Closes #132