### PR TITLE
feat(auth): add MFA recovery codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Standards-compatible 160-bit Base32 TOTP provisioning with HMAC-SHA1, six digits, 30-second steps, and a bounded ±1 verification window.
 - Password-first MFA login challenges with `202 MFA_REQUIRED` for enabled authenticators and a dedicated confirmation endpoint.
 - PostgreSQL V19 digest-only challenge persistence with expiration, attempt budget, terminal state, supersession, and pessimistic consumption locking.
+- Ten 128-bit Base64URL MFA recovery codes returned once when enrollment is activated.
+- PostgreSQL V20 digest-only recovery-code persistence with pessimistic single-use consumption.
+- MFA login challenge completion with either the existing TOTP proof or one unused recovery code.
 
 ### Security
 
@@ -29,6 +32,8 @@ and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - MFA-enabled password login creates no access token, refresh-token family, or refresh-token record until a TOTP challenge is consumed successfully.
 - Unknown, malformed, expired, exhausted, superseded, replayed, and invalid-proof challenge outcomes share the stable `MFA_CHALLENGE_INVALID` contract.
 - Challenge plaintext, digests, TOTP values, and revealed authenticator secrets stay outside observable output; concurrent confirmation permits one credential-issuing winner.
+- Recovery-code plaintext and digests remain outside logs, metrics, traces, audit payloads, and exception messages; invalid, unknown, malformed, and consumed recovery proofs reuse `MFA_CHALLENGE_INVALID`.
+- Recovery-code consumption, challenge consumption, and credential issuance share one transaction so downstream credential failure cannot permanently consume a recovery code.
 
 ## [0.13.0] - 2026-08-06
 

--- a/README.md
+++ b/README.md
@@ -164,13 +164,13 @@ Enrollment will create a pending authenticator secret, protect it before Postgre
 
 Users with enabled MFA will complete password verification before receiving a short-lived, digest-only login challenge. A valid TOTP or one unused recovery code will consume that challenge exactly once before access and refresh credentials are issued. Challenge attempts, expiration, replay, concurrent verification, and refresh-session side effects will be covered with real PostgreSQL tests.
 
-Recovery codes will be generated from cryptographically secure randomness, returned once at activation or explicit rotation, stored only as fixed-length digests, and consumed atomically. Disabling or rotating MFA will require a recent step-up proof and will revoke active refresh-token families with a dedicated account-security reason.
+The fourth increment implements recovery codes without weakening the step-up boundary reserved for later account-security mutations. Successful TOTP enrollment confirmation generates ten independent 128-bit canonical Base64URL recovery codes, returns that plaintext set once, and stores only SHA-256 digests in PostgreSQL V20. Login-challenge confirmation accepts either the existing six-digit TOTP proof or one unused recovery code; recovery-code consumption, challenge consumption, and credential issuance share one transaction. Explicit recovery-code rotation, MFA disable, and authenticator replacement remain deferred until purpose-bound step-up grants exist.
 
 The first delivery increment now freezes the domain lifecycle, typed step-up purpose vocabulary, account-security refresh-family revocation reasons, stable public failure semantics, and concurrency/observable-output boundaries. The accepted design is recorded in [ADR 0014](docs/adr/0014-mfa-and-step-up-authentication.md) and the [MFA threat model](docs/security/mfa-threat-model.md). No MFA endpoint, authenticator persistence, TOTP verification, recovery-code implementation, or runtime step-up enforcement is introduced by this foundation increment. Generalized API-wide abuse protection, SMS or email OTP, WebAuthn/passkeys, external identity providers, device trust, and behavioral risk scoring remain outside v0.14.0.
 
 The second increment implemented authenticated TOTP enrollment before the login flow was gated by MFA. `POST /api/v1/users/me/mfa/enrollment` requires the current password, generates a 160-bit secret, returns the canonical Base32 secret and `otpauth://` URI once, and persists only AES-256-GCM-protected secret material. `POST /api/v1/users/me/mfa/enrollment/confirm` activates the pending authenticator only after a six-digit TOTP proof within the current ±1 30-second step. `DELETE /api/v1/users/me/mfa/enrollment` cancels only pending enrollment, while `GET /api/v1/users/me/mfa` exposes lifecycle metadata without secret material. PostgreSQL V18 enforces one effective authenticator row per user and production requires a dedicated MFA encryption key independent from JWT and mail keys. See the [TOTP enrollment security contract](docs/security/mfa-enrollment.md).
 
-The third increment gates credential issuance for `ENABLED` MFA users. A correct password creates no access token, refresh-token family, or refresh-token record; it returns `202` with one short-lived opaque challenge instead. PostgreSQL V19 stores only the SHA-256 challenge digest, expiration, bounded attempt budget, and terminal state. `POST /api/v1/auth/mfa/challenges/confirm` locks and consumes the challenge after a valid TOTP proof, then enters the same credential-issuance boundary used by non-MFA login. Unknown, expired, exhausted, superseded, malformed, replayed, and invalid-proof outcomes share `401 MFA_CHALLENGE_INVALID`. Concurrent confirmation has at most one successful credential-issuing winner. See the [MFA login challenge security contract](docs/security/mfa-login-challenge.md).
+The third increment gates credential issuance for `ENABLED` MFA users. A correct password creates no access token, refresh-token family, or refresh-token record; it returns `202` with one short-lived opaque challenge instead. PostgreSQL V19 stores only the SHA-256 challenge digest, expiration, bounded attempt budget, and terminal state. `POST /api/v1/auth/mfa/challenges/confirm` locks and consumes the challenge after a valid second-factor proof, then enters the same credential-issuance boundary used by non-MFA login. The fourth increment extends that proof boundary to one unused recovery code while preserving the same generic failure and single-winner semantics. Unknown, expired, exhausted, superseded, malformed, replayed, consumed-recovery-code, and invalid-proof outcomes share `401 MFA_CHALLENGE_INVALID`. Concurrent confirmation has at most one successful credential-issuing winner. See the [MFA login challenge security contract](docs/security/mfa-login-challenge.md) and [recovery-code security contract](docs/security/mfa-recovery-codes.md).
 
 ## Implemented API
 
@@ -178,14 +178,14 @@ The third increment gates credential issuance for `ENABLED` MFA users. A correct
 |---|---|---|---|
 | `POST` | `/api/v1/auth/register` | Public | Registers a new user and stores a BCrypt password hash. |
 | `POST` | `/api/v1/auth/login` | Public | Applies Redis-backed password protection; returns credentials when MFA is disabled or `202 MFA_REQUIRED` with an opaque challenge when MFA is enabled. |
-| `POST` | `/api/v1/auth/mfa/challenges/confirm` | Public | Consumes one pending MFA login challenge after a valid TOTP proof and then issues access and refresh credentials. |
+| `POST` | `/api/v1/auth/mfa/challenges/confirm` | Public | Consumes one pending MFA login challenge after a valid TOTP or unused recovery-code proof and then issues access and refresh credentials. |
 | `POST` | `/api/v1/auth/email-verification/requests` | Public | Accepts a generic verification request without disclosing account existence or eligibility. |
 | `POST` | `/api/v1/auth/email-verification/confirm` | Public | Consumes one opaque credential and marks email ownership exactly once. |
 | `POST` | `/api/v1/auth/password-recovery/requests` | Public | Accepts a generic recovery request without disclosing account existence or eligibility. |
 | `POST` | `/api/v1/auth/password-recovery/confirm` | Public | Atomically replaces the BCrypt password hash and revokes active refresh sessions. |
 | `GET` | `/api/v1/users/me/mfa` | Bearer | Returns the owning user's MFA lifecycle metadata without secret material. |
 | `POST` | `/api/v1/users/me/mfa/enrollment` | Bearer + current password | Starts one pending TOTP enrollment and returns the provisioning secret once. |
-| `POST` | `/api/v1/users/me/mfa/enrollment/confirm` | Bearer | Activates the pending authenticator after a valid six-digit TOTP proof. |
+| `POST` | `/api/v1/users/me/mfa/enrollment/confirm` | Bearer | Activates the pending authenticator after a valid six-digit TOTP proof and returns ten plaintext recovery codes once. |
 | `DELETE` | `/api/v1/users/me/mfa/enrollment` | Bearer | Cancels only a pending enrollment and deletes its protected secret row. |
 | `POST` | `/api/v1/auth/refresh` | Public | Atomically rotates an active opaque refresh credential. |
 | `POST` | `/api/v1/auth/logout` | Public | Idempotently revokes the refresh-token family represented by the submitted credential. |
@@ -486,13 +486,14 @@ docker compose --profile app up --build
 
 ## Database model
 
-Flyway migrations define users, MFA authenticators and digest-only login challenges, refresh-token families and records, wallets, payment transactions, immutable ledger entries, transactional outbox records, processed Kafka events, Kafka dead-letter records, and append-only operator command audits.
+Flyway migrations define users, MFA authenticators, digest-only login challenges and recovery codes, refresh-token families and records, wallets, payment transactions, immutable ledger entries, transactional outbox records, processed Kafka events, Kafka dead-letter records, and append-only operator command audits.
 
 Important database guarantees include:
 
 - unique normalized user email addresses
 - one effective MFA authenticator per user
 - fixed-length and unique MFA login-challenge digests with one pending challenge per user
+- fixed-length recovery-code digests with single-use consumption and no durable plaintext recovery credential
 - fixed-length and globally unique refresh-token digests
 - plaintext refresh tokens excluded from the persistence schema
 - same-family refresh-token successor lineage

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -586,16 +586,26 @@ credential-issuance boundary. Unknown, malformed, expired, exhausted,
 superseded, replayed, and invalid-proof outcomes share the stable
 `MFA_CHALLENGE_INVALID` response.
 
-### Increment 4 — Recovery codes and MFA disable
+### Increment 4 — Recovery codes
 
-- [ ] Generate recovery codes from cryptographically secure randomness
-- [ ] Return plaintext recovery codes once at activation or explicit rotation
-- [ ] Persist only fixed-length recovery-code digests
-- [ ] Consume every recovery code atomically and at most once
-- [ ] Make recovery-code and TOTP challenge failures indistinguishable at the public boundary
-- [ ] Require recent step-up proof before recovery-code rotation or MFA disable
-- [ ] Revoke active refresh-token families after MFA disable or secret replacement
-- [ ] Preserve append-only, credential-free account-security audit evidence
+- [x] Generate recovery codes from cryptographically secure randomness
+- [x] Return plaintext recovery codes once when TOTP enrollment is activated
+- [x] Persist only fixed-length recovery-code digests
+- [x] Consume every recovery code atomically and at most once
+- [x] Make recovery-code and TOTP challenge failures indistinguishable at the public boundary
+- [x] Keep recovery-code plaintext and digests out of observable output
+- [ ] Rotate recovery codes only after a recent purpose-bound step-up proof exists
+
+The recovery-code implementation generates ten independent 128-bit opaque
+Base64URL values when pending TOTP enrollment becomes `ENABLED`. The activation
+response returns that plaintext set once while PostgreSQL V20 persists only
+32-byte SHA-256 digests. Login-challenge confirmation accepts either the
+existing six-digit TOTP proof or one unused recovery code. The matching recovery
+row is pessimistically locked and consumed in the same transaction as challenge
+consumption and credential issuance. Invalid, unknown, malformed, and already
+consumed recovery proofs share `401 MFA_CHALLENGE_INVALID` with invalid TOTP.
+Explicit recovery-code rotation is intentionally deferred until purpose-bound
+step-up grants exist.
 
 ### Increment 5 — Step-up authentication
 
@@ -607,7 +617,16 @@ superseded, replayed, and invalid-proof outcomes share the stable
 - [ ] Keep step-up grants out of logs, metric labels, audit payloads, and persistence plaintext
 - [ ] Document which operations remain bearer-only and which require step-up
 
-### Increment 6 — Verification and public contracts
+### Increment 6 — MFA disable, recovery-code rotation, and replacement
+
+- [ ] Require the exact recent step-up purpose before MFA disable or recovery-code rotation
+- [ ] Rotate the complete recovery-code set atomically and return replacement plaintext once
+- [ ] Disable the enabled authenticator only after `mfa-disable` step-up succeeds
+- [ ] Require `mfa-authenticator-replacement` step-up before replacing an enabled authenticator
+- [ ] Revoke active refresh-token families after MFA disable or authenticator replacement
+- [ ] Preserve append-only, credential-free account-security audit evidence
+
+### Increment 7 — Verification and public contracts
 
 - [ ] Unit-test TOTP vectors, clock skew, lifecycle transitions, protection, digesting, and redaction
 - [ ] Verify clean Flyway installation and upgrades from the v0.13.0 schema with PostgreSQL

--- a/docs/security/mfa-login-challenge.md
+++ b/docs/security/mfa-login-challenge.md
@@ -2,18 +2,19 @@
 
 ## Scope
 
-This increment changes the password-login outcome only for users whose TOTP
-MFA authenticator is already `ENABLED`. Password verification remains the first
-factor and the existing Redis-backed password-attempt protection still executes
-before user lookup and password verification.
+Password verification remains the first factor and the existing Redis-backed
+password-attempt protection still executes before user lookup and password
+verification. A successful password check does not create an access token,
+refresh-token family, or refresh-token record for an MFA-enabled user. Instead
+the application returns one short-lived opaque challenge.
 
-A successful password check does not create an access token, refresh-token
-family, or refresh-token record for an MFA-enabled user. Instead the application
-returns one short-lived opaque challenge. Only successful challenge confirmation
-may enter the existing credential-issuance boundary.
+Challenge confirmation accepts either the enabled authenticator's six-digit
+TOTP proof or one unused MFA recovery code. Only successful second-factor
+confirmation may enter the existing credential-issuance boundary.
 
-Recovery codes, MFA disable, authenticator replacement, and reusable step-up
-grants are intentionally outside this increment.
+MFA disable, recovery-code rotation, authenticator replacement, and reusable
+step-up grants remain outside this increment sequence until purpose-bound
+step-up authorization exists.
 
 ## Challenge credential
 
@@ -32,14 +33,20 @@ the owning user row is locked. PostgreSQL additionally enforces at most one
 
 ## Verification and terminal states
 
-`POST /api/v1/auth/mfa/challenges/confirm` accepts the opaque challenge and a
-TOTP proof. Verification resolves the digest to a candidate user, locks the user,
-locks the challenge, and locks the enabled authenticator before revealing the
-protected TOTP secret.
+`POST /api/v1/auth/mfa/challenges/confirm` accepts the opaque challenge and one
+second-factor proof. Verification resolves the challenge digest to a candidate
+user, locks the user, locks the challenge, and locks the enabled authenticator
+before selecting the proof path.
 
-A valid TOTP proof uses the same RFC 4226/6238 profile as enrollment: HMAC-SHA1,
-six digits, 30-second steps, and one adjacent counter on either side. The
-plaintext secret is zeroed after verification.
+A six-digit proof uses the existing RFC 4226/6238 profile: HMAC-SHA1, six digits,
+30-second steps, and one adjacent counter on either side. The revealed plaintext
+TOTP secret is zeroed after verification.
+
+A canonical 22-character Base64URL proof is treated as a recovery-code
+candidate. PayFlow hashes it with SHA-256, pessimistically locks a matching code
+for the challenge user, and accepts only an unconsumed row. The recovery code is
+consumed in the same transaction as challenge consumption and credential
+issuance.
 
 Challenge states are:
 
@@ -49,20 +56,25 @@ Challenge states are:
 - `EXPIRED` — the lifetime elapsed before successful confirmation.
 - `SUPERSEDED` — a newer successful password stage replaced it.
 
-Invalid TOTP proofs decrement the persisted attempt budget. The transition to
-`EXHAUSTED` and the transition to `EXPIRED` are committed even though the public
-request returns an authentication failure. A consumed, exhausted, expired,
-superseded, unknown, oversized, blank, or replayed challenge uses the same
-`401 MFA_CHALLENGE_INVALID` contract as an invalid TOTP proof.
+Invalid TOTP, unknown recovery-code, malformed recovery-code, and consumed
+recovery-code proofs decrement the same persisted challenge attempt budget.
+`EXHAUSTED` and `EXPIRED` transitions are committed even though the public
+request returns an authentication failure. Consumed, exhausted, expired,
+superseded, unknown, oversized, blank, replayed, and invalid-proof outcomes use
+the same `401 MFA_CHALLENGE_INVALID` contract.
 
-## Concurrency
+## Concurrency and transaction boundary
 
 Challenge confirmation uses pessimistic locking. Two concurrent confirmations
-for the same challenge cannot both cross the credential-issuance boundary. The
-winner persists `CONSUMED` before access and refresh credentials are created;
-the loser observes a terminal challenge and receives the generic unauthorized
-contract. Integration verification requires exactly one refresh-token family
-and one initial refresh-token record after concurrent replay.
+for the same challenge cannot both cross the credential-issuance boundary. A
+recovery-code row is also pessimistically locked before it is consumed. The
+winner persists both recovery-code consumption when applicable and challenge
+`CONSUMED` before access and refresh credentials are created; all of those writes
+share the same transaction. If downstream credential issuance fails, the
+recovery-code and challenge writes roll back together.
+
+Integration verification requires exactly one refresh-token family and one
+initial refresh-token record after concurrent replay.
 
 ## Observable-output boundary
 
@@ -73,10 +85,12 @@ exception messages, or persistent plaintext columns:
 - challenge digest;
 - TOTP code;
 - revealed TOTP secret;
+- recovery-code plaintext;
+- recovery-code digest;
 - access token;
 - refresh token.
 
-Request, response, command, generated-challenge, and digest value objects use
+Request, response, command, generated-credential, and digest value objects use
 redacted `toString()` behavior where credentials could otherwise be exposed.
 
 ## Operational configuration
@@ -86,5 +100,6 @@ MFA_LOGIN_CHALLENGE_TTL=5m
 MFA_LOGIN_CHALLENGE_MAX_ATTEMPTS=5
 ```
 
-These settings bound only the post-password MFA challenge. Generalized API-wide
-abuse protection remains a v0.15.0 concern.
+These settings bound the post-password MFA challenge regardless of which
+second-factor proof is supplied. Generalized API-wide abuse protection remains
+a v0.15.0 concern.

--- a/docs/security/mfa-recovery-codes.md
+++ b/docs/security/mfa-recovery-codes.md
@@ -1,0 +1,87 @@
+# MFA Recovery Codes Security Contract
+
+## Scope
+
+Recovery codes provide a one-time fallback proof for users whose TOTP
+authenticator is already enabled. This increment covers code generation at MFA
+activation, digest-only PostgreSQL persistence, login-challenge consumption,
+replay resistance, concurrency, and observable-output boundaries.
+
+Explicit recovery-code rotation is not implemented here. Rotation, MFA disable,
+and authenticator replacement require the purpose-bound step-up capability from
+the following increment before public mutation endpoints are added.
+
+## Generation and one-time disclosure
+
+Successful TOTP enrollment confirmation generates exactly ten independent
+recovery codes. Each code contains 128 bits of `SecureRandom` entropy encoded as
+canonical unpadded Base64URL text, producing 22 characters from the alphabet
+`A-Z`, `a-z`, `0-9`, `_`, and `-`.
+
+The enrollment-confirmation response returns the plaintext set once. No
+plaintext recovery code is persisted. If a response is lost, the existing TOTP
+authenticator remains usable; replacement code issuance is reserved for the
+future step-up-protected rotation flow.
+
+## Digest-only persistence
+
+PostgreSQL V20 stores one row per recovery code with:
+
+- a random UUID primary key;
+- the owning user identifier;
+- a 32-byte SHA-256 digest;
+- creation time;
+- nullable consumption time.
+
+The database rejects non-32-byte digests, globally duplicated digests, and
+consumption timestamps before creation. It contains no plaintext recovery-code
+column. An index scopes unconsumed-code lookup by user without changing the
+fixed-length digest security boundary.
+
+## Login verification
+
+The existing `POST /api/v1/auth/mfa/challenges/confirm` request retains one
+`code` field. A six-digit value follows the TOTP path. A canonical 22-character
+Base64URL value follows the recovery-code path. Other shapes fail through the
+same public contract.
+
+For recovery-code verification, PayFlow:
+
+1. resolves and locks the owning user, challenge, and enabled authenticator;
+2. hashes the supplied recovery code with SHA-256;
+3. pessimistically locks the matching code for that user;
+4. rejects missing or already consumed rows without revealing their state;
+5. consumes the code and challenge in the credential-issuance transaction.
+
+The public response does not reveal whether a proof was a TOTP, recovery code,
+unknown value, malformed value, or consumed value. Failure remains
+`401 MFA_CHALLENGE_INVALID` and consumes one challenge attempt.
+
+## Concurrency and rollback
+
+A recovery code can be consumed at most once. Concurrent confirmation requests
+cannot both receive authenticated sessions because challenge and recovery-code
+rows are pessimistically locked. Recovery-code consumption, challenge
+consumption, refresh-family creation, and initial refresh-token creation share
+one transaction. A downstream credential-issuance failure rolls back the
+recovery-code consumption rather than stranding the user with a silently lost
+code.
+
+## Observable-output boundary
+
+Recovery-code plaintext and digests must not appear in logs, metric labels,
+traces, audit payloads, exception messages, or `toString()` output. The only
+intentional plaintext boundary is the successful enrollment-confirmation
+response that creates the initial code set and, in a later increment, the
+step-up-protected explicit rotation response.
+
+## Deferred work
+
+This increment does not add:
+
+- recovery-code rotation;
+- MFA disable;
+- authenticator replacement;
+- step-up grant issuance or enforcement;
+- recovery-code remaining-count disclosure;
+- generalized API-wide abuse protection.

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/ConfirmMfaLoginChallengeController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/ConfirmMfaLoginChallengeController.java
@@ -38,8 +38,9 @@ public class ConfirmMfaLoginChallengeController {
         operationId = "confirmMfaLoginChallenge",
         summary = "Complete an MFA login challenge",
         description =
-            "Consumes one pending challenge after a valid TOTP proof and only "
-                + "then issues access and refresh credentials."
+            "Consumes one pending challenge after a valid TOTP or unused "
+                + "recovery-code proof and only then issues access and refresh "
+                + "credentials."
     )
     @ApiResponses({
         @ApiResponse(

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/ConfirmMfaLoginChallengeRequest.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/ConfirmMfaLoginChallengeRequest.java
@@ -6,7 +6,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ConfirmMfaLoginChallengeRequest(
     @Schema(description = "Opaque challenge returned by password login.")
     String challengeToken,
-    @Schema(description = "Six-digit TOTP proof.", example = "123456")
+    @Schema(
+        description = "Six-digit TOTP or one unused MFA recovery code.",
+        example = "123456"
+    )
     String code
 ) {
     @Override

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/MfaEnrollmentConfirmationResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/MfaEnrollmentConfirmationResponse.java
@@ -1,20 +1,48 @@
 package com.nursena.payflow.user.adapter.in.web;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
 
 import com.nursena.payflow.user.application.port.in.ConfirmMfaEnrollmentResult;
 import com.nursena.payflow.user.domain.model.MfaLifecycleState;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(name = "MfaEnrollmentConfirmationResponse")
 public record MfaEnrollmentConfirmationResponse(
     MfaLifecycleState state,
-    Instant activatedAt
+    Instant activatedAt,
+    @Schema(
+        description = "One-time plaintext recovery codes. Store them securely; "
+            + "the API does not expose this set again."
+    )
+    List<String> recoveryCodes
 ) {
+    public MfaEnrollmentConfirmationResponse {
+        recoveryCodes = List.copyOf(Objects.requireNonNull(
+            recoveryCodes,
+            "recoveryCodes must not be null"
+        ));
+
+        if (recoveryCodes.isEmpty()) {
+            throw new IllegalArgumentException(
+                "recoveryCodes must not be empty"
+            );
+        }
+    }
+
     static MfaEnrollmentConfirmationResponse from(
         ConfirmMfaEnrollmentResult result
     ) {
         return new MfaEnrollmentConfirmationResponse(
             result.state(),
-            result.activatedAt()
+            result.activatedAt(),
+            result.recoveryCodes()
         );
+    }
+
+    @Override
+    public String toString() {
+        return "MfaEnrollmentConfirmationResponse[redacted]";
     }
 }

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/MfaRecoveryCodeJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/MfaRecoveryCodeJpaEntity.java
@@ -1,0 +1,70 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "mfa_recovery_codes")
+class MfaRecoveryCodeJpaEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private UUID userId;
+
+    @Column(name = "code_digest", nullable = false, updatable = false)
+    private byte[] codeDigest;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "consumed_at")
+    private Instant consumedAt;
+
+    protected MfaRecoveryCodeJpaEntity() {
+    }
+
+    MfaRecoveryCodeJpaEntity(
+        UUID id,
+        UUID userId,
+        byte[] codeDigest,
+        Instant createdAt,
+        Instant consumedAt
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.codeDigest = Arrays.copyOf(
+            codeDigest,
+            codeDigest.length
+        );
+        this.createdAt = createdAt;
+        this.consumedAt = consumedAt;
+    }
+
+    UUID getId() {
+        return id;
+    }
+
+    UUID getUserId() {
+        return userId;
+    }
+
+    byte[] getCodeDigest() {
+        return Arrays.copyOf(codeDigest, codeDigest.length);
+    }
+
+    Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    Instant getConsumedAt() {
+        return consumedAt;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/MfaRecoveryCodePersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/MfaRecoveryCodePersistenceAdapter.java
@@ -1,0 +1,82 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeRepositoryPort;
+import com.nursena.payflow.user.domain.model.MfaRecoveryCode;
+import com.nursena.payflow.user.domain.model.MfaRecoveryCodeDigest;
+import org.springframework.stereotype.Component;
+
+@Component
+class MfaRecoveryCodePersistenceAdapter
+    implements MfaRecoveryCodeRepositoryPort {
+
+    private final SpringDataMfaRecoveryCodeRepository repository;
+
+    MfaRecoveryCodePersistenceAdapter(
+        SpringDataMfaRecoveryCodeRepository repository
+    ) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<MfaRecoveryCode> saveAll(
+        List<MfaRecoveryCode> recoveryCodes
+    ) {
+        List<MfaRecoveryCodeJpaEntity> entities = new ArrayList<>();
+
+        for (MfaRecoveryCode recoveryCode : recoveryCodes) {
+            entities.add(toEntity(recoveryCode));
+        }
+
+        return repository.saveAllAndFlush(entities)
+            .stream()
+            .map(MfaRecoveryCodePersistenceAdapter::toDomain)
+            .toList();
+    }
+
+    @Override
+    public MfaRecoveryCode save(MfaRecoveryCode recoveryCode) {
+        return toDomain(
+            repository.saveAndFlush(toEntity(recoveryCode))
+        );
+    }
+
+    @Override
+    public Optional<MfaRecoveryCode> findByUserIdAndDigestForUpdate(
+        UUID userId,
+        MfaRecoveryCodeDigest digest
+    ) {
+        return repository.findByUserIdAndDigestForUpdate(
+            userId,
+            digest.value()
+        ).map(MfaRecoveryCodePersistenceAdapter::toDomain);
+    }
+
+    private static MfaRecoveryCodeJpaEntity toEntity(
+        MfaRecoveryCode recoveryCode
+    ) {
+        return new MfaRecoveryCodeJpaEntity(
+            recoveryCode.id(),
+            recoveryCode.userId(),
+            recoveryCode.digest().value(),
+            recoveryCode.createdAt(),
+            recoveryCode.consumedAt()
+        );
+    }
+
+    private static MfaRecoveryCode toDomain(
+        MfaRecoveryCodeJpaEntity entity
+    ) {
+        return MfaRecoveryCode.rehydrate(
+            entity.getId(),
+            entity.getUserId(),
+            MfaRecoveryCodeDigest.of(entity.getCodeDigest()),
+            entity.getCreatedAt(),
+            entity.getConsumedAt()
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataMfaRecoveryCodeRepository.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataMfaRecoveryCodeRepository.java
@@ -1,0 +1,26 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+interface SpringDataMfaRecoveryCodeRepository
+    extends JpaRepository<MfaRecoveryCodeJpaEntity, UUID> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT recoveryCode
+        FROM MfaRecoveryCodeJpaEntity recoveryCode
+        WHERE recoveryCode.userId = :userId
+          AND recoveryCode.codeDigest = :digest
+        """)
+    Optional<MfaRecoveryCodeJpaEntity> findByUserIdAndDigestForUpdate(
+        @Param("userId") UUID userId,
+        @Param("digest") byte[] digest
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/MfaSecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/MfaSecurityConfiguration.java
@@ -6,6 +6,8 @@ import java.util.Base64;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeDigestPort;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeGenerationPort;
 import com.nursena.payflow.user.application.port.out.MfaSecretProtectionPort;
 import com.nursena.payflow.user.application.port.out.TotpSecretGenerationPort;
 import com.nursena.payflow.user.application.port.out.TotpVerificationPort;
@@ -49,6 +51,18 @@ class MfaSecurityConfiguration {
     @Bean
     TotpVerificationPort totpVerificationPort() {
         return new HmacSha1TotpVerificationAdapter();
+    }
+
+    @Bean
+    MfaRecoveryCodeGenerationPort mfaRecoveryCodeGenerationPort() {
+        return new SecureRandomMfaRecoveryCodeGenerationAdapter(
+            new SecureRandom()
+        );
+    }
+
+    @Bean
+    MfaRecoveryCodeDigestPort mfaRecoveryCodeDigestPort() {
+        return new Sha256MfaRecoveryCodeDigestAdapter();
     }
 
     private static byte[] randomKey() {

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/SecureRandomMfaRecoveryCodeGenerationAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/SecureRandomMfaRecoveryCodeGenerationAdapter.java
@@ -1,0 +1,38 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+import com.nursena.payflow.user.application.port.out.GeneratedMfaRecoveryCode;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeGenerationPort;
+
+final class SecureRandomMfaRecoveryCodeGenerationAdapter
+    implements MfaRecoveryCodeGenerationPort {
+
+    private static final int RANDOM_BYTES = 16;
+    private final SecureRandom secureRandom;
+
+    SecureRandomMfaRecoveryCodeGenerationAdapter(
+        SecureRandom secureRandom
+    ) {
+        this.secureRandom = secureRandom;
+    }
+
+    @Override
+    public GeneratedMfaRecoveryCode generate() {
+        byte[] random = new byte[RANDOM_BYTES];
+        secureRandom.nextBytes(random);
+
+        try {
+            return new GeneratedMfaRecoveryCode(
+                Base64.getUrlEncoder()
+                    .withoutPadding()
+                    .encodeToString(random)
+            );
+        }
+        finally {
+            Arrays.fill(random, (byte) 0);
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/security/Sha256MfaRecoveryCodeDigestAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/security/Sha256MfaRecoveryCodeDigestAdapter.java
@@ -1,0 +1,37 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeDigestPort;
+import com.nursena.payflow.user.domain.model.MfaRecoveryCodeDigest;
+
+final class Sha256MfaRecoveryCodeDigestAdapter
+    implements MfaRecoveryCodeDigestPort {
+
+    @Override
+    public MfaRecoveryCodeDigest digest(String value) {
+        if (
+            value == null
+                || !value.matches("[A-Za-z0-9_-]{22}")
+        ) {
+            throw new IllegalArgumentException(
+                "recovery code must be canonical Base64URL text"
+            );
+        }
+
+        try {
+            return MfaRecoveryCodeDigest.of(
+                MessageDigest.getInstance("SHA-256")
+                    .digest(value.getBytes(StandardCharsets.US_ASCII))
+            );
+        }
+        catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(
+                "SHA-256 is unavailable.",
+                exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/ConfirmMfaEnrollmentResult.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/ConfirmMfaEnrollmentResult.java
@@ -1,13 +1,15 @@
 package com.nursena.payflow.user.application.port.in;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 
 import com.nursena.payflow.user.domain.model.MfaLifecycleState;
 
 public record ConfirmMfaEnrollmentResult(
     MfaLifecycleState state,
-    Instant activatedAt
+    Instant activatedAt,
+    List<String> recoveryCodes
 ) {
     public ConfirmMfaEnrollmentResult {
         Objects.requireNonNull(state, "state must not be null");
@@ -15,5 +17,20 @@ public record ConfirmMfaEnrollmentResult(
             activatedAt,
             "activatedAt must not be null"
         );
+        recoveryCodes = List.copyOf(Objects.requireNonNull(
+            recoveryCodes,
+            "recoveryCodes must not be null"
+        ));
+
+        if (recoveryCodes.isEmpty()) {
+            throw new IllegalArgumentException(
+                "recoveryCodes must not be empty"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ConfirmMfaEnrollmentResult[redacted]";
     }
 }

--- a/src/main/java/com/nursena/payflow/user/application/port/out/GeneratedMfaRecoveryCode.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/GeneratedMfaRecoveryCode.java
@@ -1,0 +1,21 @@
+package com.nursena.payflow.user.application.port.out;
+
+import java.util.Objects;
+
+public record GeneratedMfaRecoveryCode(String value) {
+
+    public GeneratedMfaRecoveryCode {
+        Objects.requireNonNull(value, "value must not be null");
+
+        if (!value.matches("[A-Za-z0-9_-]{22}")) {
+            throw new IllegalArgumentException(
+                "value must be a canonical 128-bit Base64URL recovery code"
+            );
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "GeneratedMfaRecoveryCode[redacted]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/MfaRecoveryCodeDigestPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/MfaRecoveryCodeDigestPort.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.user.application.port.out;
+
+import com.nursena.payflow.user.domain.model.MfaRecoveryCodeDigest;
+
+public interface MfaRecoveryCodeDigestPort {
+
+    MfaRecoveryCodeDigest digest(String value);
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/MfaRecoveryCodeGenerationPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/MfaRecoveryCodeGenerationPort.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.user.application.port.out;
+
+public interface MfaRecoveryCodeGenerationPort {
+
+    GeneratedMfaRecoveryCode generate();
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/MfaRecoveryCodeRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/MfaRecoveryCodeRepositoryPort.java
@@ -1,0 +1,20 @@
+package com.nursena.payflow.user.application.port.out;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.domain.model.MfaRecoveryCode;
+import com.nursena.payflow.user.domain.model.MfaRecoveryCodeDigest;
+
+public interface MfaRecoveryCodeRepositoryPort {
+
+    List<MfaRecoveryCode> saveAll(List<MfaRecoveryCode> recoveryCodes);
+
+    MfaRecoveryCode save(MfaRecoveryCode recoveryCode);
+
+    Optional<MfaRecoveryCode> findByUserIdAndDigestForUpdate(
+        UUID userId,
+        MfaRecoveryCodeDigest digest
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/ConfirmMfaEnrollmentService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/ConfirmMfaEnrollmentService.java
@@ -3,6 +3,7 @@ package com.nursena.payflow.user.application.service;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Objects;
 
 import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
@@ -34,6 +35,7 @@ public class ConfirmMfaEnrollmentService
     private final MfaAuthenticatorRepositoryPort authenticatorRepository;
     private final MfaSecretProtectionPort secretProtection;
     private final TotpVerificationPort totpVerification;
+    private final MfaRecoveryCodeIssuer recoveryCodeIssuer;
     private final Clock clock;
 
     public ConfirmMfaEnrollmentService(
@@ -41,12 +43,14 @@ public class ConfirmMfaEnrollmentService
         MfaAuthenticatorRepositoryPort authenticatorRepository,
         MfaSecretProtectionPort secretProtection,
         TotpVerificationPort totpVerification,
+        MfaRecoveryCodeIssuer recoveryCodeIssuer,
         Clock clock
     ) {
         this.userRepository = userRepository;
         this.authenticatorRepository = authenticatorRepository;
         this.secretProtection = secretProtection;
         this.totpVerification = totpVerification;
+        this.recoveryCodeIssuer = recoveryCodeIssuer;
         this.clock = clock;
     }
 
@@ -107,10 +111,15 @@ public class ConfirmMfaEnrollmentService
             authenticatorRepository.save(
                 authenticator.activate(now)
             );
+        List<String> recoveryCodes = recoveryCodeIssuer.issue(
+            user.id(),
+            now
+        );
 
         return new ConfirmMfaEnrollmentResult(
             activated.state(),
-            activated.activatedAt()
+            activated.activatedAt(),
+            recoveryCodes
         );
     }
 

--- a/src/main/java/com/nursena/payflow/user/application/service/ConfirmMfaLoginChallengeService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/ConfirmMfaLoginChallengeService.java
@@ -3,20 +3,15 @@ package com.nursena.payflow.user.application.service;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
 
-import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
 import com.nursena.payflow.user.application.port.in.AuthenticatedUserResult;
 import com.nursena.payflow.user.application.port.in.ConfirmMfaLoginChallengeCommand;
 import com.nursena.payflow.user.application.port.in.ConfirmMfaLoginChallengeUseCase;
 import com.nursena.payflow.user.application.port.out.MfaAuthenticatorRepositoryPort;
 import com.nursena.payflow.user.application.port.out.MfaLoginChallengeDigestPort;
 import com.nursena.payflow.user.application.port.out.MfaLoginChallengeRepositoryPort;
-import com.nursena.payflow.user.application.port.out.MfaSecretProtectionFailureException;
-import com.nursena.payflow.user.application.port.out.MfaSecretProtectionPort;
-import com.nursena.payflow.user.application.port.out.TotpVerificationPort;
 import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidMfaLoginChallengeException;
 import com.nursena.payflow.user.domain.model.MfaAuthenticator;
@@ -37,8 +32,7 @@ public class ConfirmMfaLoginChallengeService
     private final MfaLoginChallengeRepositoryPort challengeRepository;
     private final UserRepositoryPort userRepository;
     private final MfaAuthenticatorRepositoryPort authenticatorRepository;
-    private final MfaSecretProtectionPort secretProtection;
-    private final TotpVerificationPort totpVerification;
+    private final MfaLoginSecondFactorVerifier secondFactorVerifier;
     private final AuthenticationCredentialIssuer credentialIssuer;
     private final Clock clock;
 
@@ -47,8 +41,7 @@ public class ConfirmMfaLoginChallengeService
         MfaLoginChallengeRepositoryPort challengeRepository,
         UserRepositoryPort userRepository,
         MfaAuthenticatorRepositoryPort authenticatorRepository,
-        MfaSecretProtectionPort secretProtection,
-        TotpVerificationPort totpVerification,
+        MfaLoginSecondFactorVerifier secondFactorVerifier,
         AuthenticationCredentialIssuer credentialIssuer,
         Clock clock
     ) {
@@ -56,8 +49,7 @@ public class ConfirmMfaLoginChallengeService
         this.challengeRepository = challengeRepository;
         this.userRepository = userRepository;
         this.authenticatorRepository = authenticatorRepository;
-        this.secretProtection = secretProtection;
-        this.totpVerification = totpVerification;
+        this.secondFactorVerifier = secondFactorVerifier;
         this.credentialIssuer = credentialIssuer;
         this.clock = clock;
     }
@@ -99,28 +91,12 @@ public class ConfirmMfaLoginChallengeService
             .filter(value -> value.state() == MfaLifecycleState.ENABLED)
             .orElseThrow(InvalidMfaLoginChallengeException::new);
 
-        byte[] secret;
-        try {
-            secret = secretProtection.reveal(
-                user.id(),
-                authenticator.protectedSecret()
-            );
-        }
-        catch (MfaSecretProtectionFailureException exception) {
-            throw new MfaSecurityUnavailableException();
-        }
-
-        boolean verified;
-        try {
-            verified = totpVerification.verify(
-                secret,
-                checkedCommand.code(),
-                now
-            );
-        }
-        finally {
-            Arrays.fill(secret, (byte) 0);
-        }
+        boolean verified = secondFactorVerifier.verifyAndConsume(
+            user.id(),
+            authenticator,
+            checkedCommand.code(),
+            now
+        );
 
         if (!verified) {
             challengeRepository.save(challenge.failAttempt(now));

--- a/src/main/java/com/nursena/payflow/user/application/service/MfaLoginSecondFactorVerifier.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/MfaLoginSecondFactorVerifier.java
@@ -1,0 +1,123 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeDigestPort;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeRepositoryPort;
+import com.nursena.payflow.user.application.port.out.MfaSecretProtectionFailureException;
+import com.nursena.payflow.user.application.port.out.MfaSecretProtectionPort;
+import com.nursena.payflow.user.application.port.out.TotpVerificationPort;
+import com.nursena.payflow.user.domain.model.MfaAuthenticator;
+import com.nursena.payflow.user.domain.model.MfaRecoveryCode;
+import com.nursena.payflow.user.domain.model.MfaRecoveryCodeDigest;
+import org.springframework.stereotype.Component;
+
+@Component
+class MfaLoginSecondFactorVerifier {
+
+    private static final String TOTP_PATTERN = "[0-9]{6}";
+    private static final String RECOVERY_CODE_PATTERN =
+        "[A-Za-z0-9_-]{22}";
+
+    private final MfaSecretProtectionPort secretProtection;
+    private final TotpVerificationPort totpVerification;
+    private final MfaRecoveryCodeDigestPort recoveryCodeDigest;
+    private final MfaRecoveryCodeRepositoryPort recoveryCodeRepository;
+
+    MfaLoginSecondFactorVerifier(
+        MfaSecretProtectionPort secretProtection,
+        TotpVerificationPort totpVerification,
+        MfaRecoveryCodeDigestPort recoveryCodeDigest,
+        MfaRecoveryCodeRepositoryPort recoveryCodeRepository
+    ) {
+        this.secretProtection = secretProtection;
+        this.totpVerification = totpVerification;
+        this.recoveryCodeDigest = recoveryCodeDigest;
+        this.recoveryCodeRepository = recoveryCodeRepository;
+    }
+
+    boolean verifyAndConsume(
+        UUID userId,
+        MfaAuthenticator authenticator,
+        String proof,
+        Instant now
+    ) {
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(
+            authenticator,
+            "authenticator must not be null"
+        );
+        Objects.requireNonNull(now, "now must not be null");
+
+        if (proof == null) {
+            return false;
+        }
+
+        if (proof.matches(TOTP_PATTERN)) {
+            return verifyTotp(userId, authenticator, proof, now);
+        }
+
+        if (proof.matches(RECOVERY_CODE_PATTERN)) {
+            return verifyRecoveryCode(userId, proof, now);
+        }
+
+        return false;
+    }
+
+    private boolean verifyTotp(
+        UUID userId,
+        MfaAuthenticator authenticator,
+        String proof,
+        Instant now
+    ) {
+        byte[] secret;
+
+        try {
+            secret = secretProtection.reveal(
+                userId,
+                authenticator.protectedSecret()
+            );
+        }
+        catch (MfaSecretProtectionFailureException exception) {
+            throw new MfaSecurityUnavailableException();
+        }
+
+        try {
+            return totpVerification.verify(secret, proof, now);
+        }
+        finally {
+            Arrays.fill(secret, (byte) 0);
+        }
+    }
+
+    private boolean verifyRecoveryCode(
+        UUID userId,
+        String proof,
+        Instant now
+    ) {
+        MfaRecoveryCodeDigest digest;
+
+        try {
+            digest = recoveryCodeDigest.digest(proof);
+        }
+        catch (IllegalArgumentException exception) {
+            return false;
+        }
+
+        MfaRecoveryCode recoveryCode = recoveryCodeRepository
+            .findByUserIdAndDigestForUpdate(userId, digest)
+            .filter(value -> value.isUsableAt(now))
+            .orElse(null);
+
+        if (recoveryCode == null) {
+            return false;
+        }
+
+        recoveryCodeRepository.save(recoveryCode.consume(now));
+        return true;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/MfaRecoveryCodeIssuer.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/MfaRecoveryCodeIssuer.java
@@ -1,0 +1,95 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.out.GeneratedMfaRecoveryCode;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeDigestPort;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeGenerationPort;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeRepositoryPort;
+import com.nursena.payflow.user.domain.model.MfaRecoveryCode;
+import com.nursena.payflow.user.domain.model.MfaRecoveryCodeDigest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MfaRecoveryCodeIssuer {
+
+    static final int CODE_COUNT = 10;
+    private static final int MAX_GENERATION_ATTEMPTS = CODE_COUNT * 4;
+
+    private final MfaRecoveryCodeGenerationPort generationPort;
+    private final MfaRecoveryCodeDigestPort digestPort;
+    private final MfaRecoveryCodeRepositoryPort repository;
+
+    public MfaRecoveryCodeIssuer(
+        MfaRecoveryCodeGenerationPort generationPort,
+        MfaRecoveryCodeDigestPort digestPort,
+        MfaRecoveryCodeRepositoryPort repository
+    ) {
+        this.generationPort = generationPort;
+        this.digestPort = digestPort;
+        this.repository = repository;
+    }
+
+    public List<String> issue(UUID userId, Instant now) {
+        UUID checkedUserId = Objects.requireNonNull(
+            userId,
+            "userId must not be null"
+        );
+        Instant issuedAt = Objects.requireNonNull(
+            now,
+            "now must not be null"
+        );
+
+        List<String> plaintextCodes = new ArrayList<>(CODE_COUNT);
+        List<MfaRecoveryCode> recoveryCodes =
+            new ArrayList<>(CODE_COUNT);
+        Set<MfaRecoveryCodeDigest> digests = new HashSet<>();
+
+        int attempts = 0;
+
+        while (
+            recoveryCodes.size() < CODE_COUNT
+                && attempts < MAX_GENERATION_ATTEMPTS
+        ) {
+            attempts++;
+            GeneratedMfaRecoveryCode generated = generationPort.generate();
+            MfaRecoveryCodeDigest digest = digestPort.digest(
+                generated.value()
+            );
+
+            if (!digests.add(digest)) {
+                continue;
+            }
+
+            plaintextCodes.add(generated.value());
+            recoveryCodes.add(MfaRecoveryCode.issue(
+                UUID.randomUUID(),
+                checkedUserId,
+                digest,
+                issuedAt
+            ));
+        }
+
+        if (recoveryCodes.size() != CODE_COUNT) {
+            throw new IllegalStateException(
+                "could not generate a unique MFA recovery-code set"
+            );
+        }
+
+        List<MfaRecoveryCode> saved = repository.saveAll(recoveryCodes);
+
+        if (saved.size() != CODE_COUNT) {
+            throw new IllegalStateException(
+                "recovery-code persistence returned an incomplete set"
+            );
+        }
+
+        return List.copyOf(plaintextCodes);
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/MfaRecoveryCode.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/MfaRecoveryCode.java
@@ -1,0 +1,128 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class MfaRecoveryCode {
+
+    private final UUID id;
+    private final UUID userId;
+    private final MfaRecoveryCodeDigest digest;
+    private final Instant createdAt;
+    private final Instant consumedAt;
+
+    private MfaRecoveryCode(
+        UUID id,
+        UUID userId,
+        MfaRecoveryCodeDigest digest,
+        Instant createdAt,
+        Instant consumedAt
+    ) {
+        this.id = Objects.requireNonNull(id, "id must not be null");
+        this.userId = Objects.requireNonNull(
+            userId,
+            "userId must not be null"
+        );
+        this.digest = Objects.requireNonNull(
+            digest,
+            "digest must not be null"
+        );
+        this.createdAt = Objects.requireNonNull(
+            createdAt,
+            "createdAt must not be null"
+        );
+        this.consumedAt = consumedAt;
+
+        if (
+            consumedAt != null
+                && consumedAt.isBefore(createdAt)
+        ) {
+            throw new IllegalArgumentException(
+                "consumedAt must not be before createdAt"
+            );
+        }
+    }
+
+    public static MfaRecoveryCode issue(
+        UUID id,
+        UUID userId,
+        MfaRecoveryCodeDigest digest,
+        Instant createdAt
+    ) {
+        return new MfaRecoveryCode(
+            id,
+            userId,
+            digest,
+            createdAt,
+            null
+        );
+    }
+
+    public static MfaRecoveryCode rehydrate(
+        UUID id,
+        UUID userId,
+        MfaRecoveryCodeDigest digest,
+        Instant createdAt,
+        Instant consumedAt
+    ) {
+        return new MfaRecoveryCode(
+            id,
+            userId,
+            digest,
+            createdAt,
+            consumedAt
+        );
+    }
+
+    public MfaRecoveryCode consume(Instant now) {
+        Instant consumedOn = Objects.requireNonNull(
+            now,
+            "now must not be null"
+        );
+
+        if (!isUsableAt(consumedOn)) {
+            throw new IllegalStateException(
+                "recovery code is not usable"
+            );
+        }
+
+        return new MfaRecoveryCode(
+            id,
+            userId,
+            digest,
+            createdAt,
+            consumedOn
+        );
+    }
+
+    public boolean isUsableAt(Instant now) {
+        Instant checkedAt = Objects.requireNonNull(
+            now,
+            "now must not be null"
+        );
+
+        return consumedAt == null
+            && !checkedAt.isBefore(createdAt);
+    }
+
+    public UUID id() {
+        return id;
+    }
+
+    public UUID userId() {
+        return userId;
+    }
+
+    public MfaRecoveryCodeDigest digest() {
+        return digest;
+    }
+
+    public Instant createdAt() {
+        return createdAt;
+    }
+
+    public Instant consumedAt() {
+        return consumedAt;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/MfaRecoveryCodeDigest.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/MfaRecoveryCodeDigest.java
@@ -1,0 +1,62 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public final class MfaRecoveryCodeDigest {
+
+    public static final int SHA_256_LENGTH_BYTES = 32;
+
+    private final byte[] value;
+
+    private MfaRecoveryCodeDigest(byte[] value) {
+        Objects.requireNonNull(value, "value must not be null");
+
+        if (value.length != SHA_256_LENGTH_BYTES) {
+            throw new IllegalArgumentException(
+                "value must contain exactly "
+                    + SHA_256_LENGTH_BYTES
+                    + " bytes"
+            );
+        }
+
+        this.value = Arrays.copyOf(value, value.length);
+    }
+
+    public static MfaRecoveryCodeDigest of(byte[] value) {
+        return new MfaRecoveryCodeDigest(value);
+    }
+
+    public byte[] value() {
+        return Arrays.copyOf(value, value.length);
+    }
+
+    @Override
+    public boolean equals(Object candidate) {
+        if (this == candidate) {
+            return true;
+        }
+
+        if (
+            candidate == null
+                || getClass() != candidate.getClass()
+        ) {
+            return false;
+        }
+
+        MfaRecoveryCodeDigest other =
+            (MfaRecoveryCodeDigest) candidate;
+
+        return Arrays.equals(value, other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return "MfaRecoveryCodeDigest[redacted]";
+    }
+}

--- a/src/main/resources/db/migration/V20__create_mfa_recovery_codes.sql
+++ b/src/main/resources/db/migration/V20__create_mfa_recovery_codes.sql
@@ -1,0 +1,21 @@
+CREATE TABLE mfa_recovery_codes (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    code_digest BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    consumed_at TIMESTAMPTZ NULL,
+    CONSTRAINT fk_mfa_recovery_codes_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+    CONSTRAINT chk_mfa_recovery_codes_digest_length
+        CHECK (octet_length(code_digest) = 32),
+    CONSTRAINT chk_mfa_recovery_codes_consumed_at
+        CHECK (consumed_at IS NULL OR consumed_at >= created_at),
+    CONSTRAINT uq_mfa_recovery_codes_digest
+        UNIQUE (code_digest)
+);
+
+CREATE INDEX ix_mfa_recovery_codes_user_unconsumed
+    ON mfa_recovery_codes (user_id)
+    WHERE consumed_at IS NULL;

--- a/src/test/java/com/nursena/payflow/configuration/V014DevelopmentContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V014DevelopmentContractTest.java
@@ -18,11 +18,9 @@ class V014DevelopmentContractTest {
 
     private static final Path ROADMAP =
         Path.of("docs", "roadmap.md");
-
     @Test
     void shouldExposeV014DevelopmentStatus()
         throws IOException {
-
         assertThat(Files.readString(README))
             .contains(
                 "PayFlow v0.13.0 is the latest published release",
@@ -31,18 +29,16 @@ class V014DevelopmentContractTest {
                 "TOTP-based multi-factor authentication",
                 "digest-only login challenge",
                 "single-use recovery codes",
-                "recent step-up proof"
+                "purpose-bound step-up grants"
             )
             .doesNotContain(
                 "Maven version remains `0.13.0`",
                 "## v0.14.0 release preparation"
             );
     }
-
     @Test
     void shouldDefineMfaLifecycleAndSecretBoundaries()
         throws IOException {
-
         assertThat(Files.readString(ROADMAP))
             .contains(
                 "`DISABLED`, `PENDING`, and `ENABLED` lifecycle transitions",
@@ -55,11 +51,9 @@ class V014DevelopmentContractTest {
                 "Exclude secrets, provisioning URIs, TOTP values, protected bytes, and key material from observable output"
             );
     }
-
     @Test
     void shouldDefineChallengeAndRecoveryCodeBoundaries()
         throws IOException {
-
         assertThat(Files.readString(ROADMAP))
             .contains(
                 "Issue a short-lived opaque MFA login challenge only after the password and account eligibility checks succeed",
@@ -69,14 +63,12 @@ class V014DevelopmentContractTest {
                 "concurrent submissions have at most one successful winner",
                 "Persist only fixed-length recovery-code digests",
                 "Consume every recovery code atomically and at most once",
-                "Revoke active refresh-token families after MFA disable or secret replacement"
+                "Revoke active refresh-token families after MFA disable or authenticator replacement"
             );
     }
-
     @Test
     void shouldDefineStepUpPolicyAndExplicitDeferrals()
         throws IOException {
-
         assertThat(Files.readString(ROADMAP))
             .contains(
                 "application-facing step-up policy independent from controller annotations",
@@ -89,11 +81,9 @@ class V014DevelopmentContractTest {
                 "access-token denylisting or immediate revocation of already-issued JWTs"
             );
     }
-
     @Test
     void shouldRetainV013PublicationAndUnreleasedChangelog()
         throws IOException {
-
         assertThat(Files.readString(ROADMAP))
             .contains(
                 "## v0.13.0 — Released: Account Recovery and Secure Mail Delivery",
@@ -101,7 +91,6 @@ class V014DevelopmentContractTest {
                 "release workflow run: [`31115952987`]",
                 "published JAR SHA-256: `78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA`"
             );
-
         assertThat(Files.readString(CHANGELOG))
             .contains(
                 "## [Unreleased]",

--- a/src/test/java/com/nursena/payflow/configuration/V014MfaFoundationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V014MfaFoundationContractTest.java
@@ -187,7 +187,7 @@ class V014MfaFoundationContractTest {
             .contains(
                 "- [x] Generate a high-entropy TOTP secret with a standards-compatible `otpauth://` provisioning value",
                 "- [x] Issue a short-lived opaque MFA login challenge only after the password and account eligibility checks succeed",
-                "- [ ] Generate recovery codes from cryptographically secure randomness",
+                "- [x] Generate recovery codes from cryptographically secure randomness",
                 "- [ ] Introduce an application-facing step-up policy independent from controller annotations"
             );
     }

--- a/src/test/java/com/nursena/payflow/configuration/V014MfaLoginChallengeContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V014MfaLoginChallengeContractTest.java
@@ -12,7 +12,7 @@ class V014MfaLoginChallengeContractTest {
     private static final Path ROOT = Path.of("");
 
     @Test
-    void shouldMarkLoginChallengeIncrementCompleteWithoutClaimingRecoveryCodes() throws IOException {
+    void shouldRetainCompletedLoginChallengeWhileRecoveryCodesAdvance() throws IOException {
         String roadmap = Files.readString(ROOT.resolve("docs/roadmap.md"));
         assertThat(roadmap).contains(
             "- [x] Preserve existing Redis-backed password-attempt protection before user lookup and password verification",
@@ -22,7 +22,7 @@ class V014MfaLoginChallengeContractTest {
             "- [x] Consume a successful challenge exactly once before issuing access and refresh credentials",
             "- [x] Reject expired, exhausted, replayed, malformed, and superseded challenges through one stable public contract",
             "- [x] Lock verification so concurrent submissions have at most one successful winner",
-            "- [ ] Generate recovery codes from cryptographically secure randomness"
+            "- [x] Generate recovery codes from cryptographically secure randomness"
         );
     }
 
@@ -77,13 +77,18 @@ class V014MfaLoginChallengeContractTest {
     }
 
     @Test
-    void shouldKeepRecoveryAndStepUpOutsideThisIncrement() throws IOException {
+    void shouldExtendChallengeProofWithoutAddingLifecycleMutation()
+        throws IOException {
         String security = normalizeWhitespace(
-            Files.readString(ROOT.resolve("docs/security/mfa-login-challenge.md"))
+            Files.readString(
+                ROOT.resolve("docs/security/mfa-login-challenge.md")
+            )
         );
         assertThat(security).contains(
-            "Recovery codes, MFA disable, authenticator replacement, and reusable step-up",
-            "outside this increment",
+            "six-digit proof uses the existing RFC 4226/6238 profile",
+            "22-character Base64URL proof is treated as a recovery-code candidate",
+            "same `401 MFA_CHALLENGE_INVALID` contract",
+            "MFA disable, recovery-code rotation, authenticator replacement",
             "Generalized API-wide abuse protection remains a v0.15.0 concern"
         );
     }

--- a/src/test/java/com/nursena/payflow/configuration/V014MfaRecoveryCodeContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V014MfaRecoveryCodeContractTest.java
@@ -1,0 +1,128 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class V014MfaRecoveryCodeContractTest {
+
+    private static final Path ROOT = Path.of("");
+    private static final Path ROADMAP = ROOT.resolve("docs/roadmap.md");
+    private static final Path README = ROOT.resolve("README.md");
+    private static final Path SECURITY = ROOT.resolve(
+        "docs/security/mfa-recovery-codes.md"
+    );
+    private static final Path MIGRATION = ROOT.resolve(
+        "src/main/resources/db/migration/V20__create_mfa_recovery_codes.sql"
+    );
+
+    @Test
+    void shouldMarkRecoveryCodeGenerationAndLoginConsumptionComplete()
+        throws IOException {
+        String roadmap = Files.readString(ROADMAP);
+
+        assertThat(roadmap).contains(
+            "### Increment 4 — Recovery codes",
+            "- [x] Generate recovery codes from cryptographically secure randomness",
+            "- [x] Return plaintext recovery codes once when TOTP enrollment is activated",
+            "- [x] Persist only fixed-length recovery-code digests",
+            "- [x] Consume every recovery code atomically and at most once",
+            "- [x] Make recovery-code and TOTP challenge failures indistinguishable at the public boundary",
+            "- [ ] Rotate recovery codes only after a recent purpose-bound step-up proof exists"
+        );
+    }
+
+    @Test
+    void shouldFreezeRecoveryCodeShapeAndOneTimeDisclosure()
+        throws IOException {
+        String security = normalizeWhitespace(
+            Files.readString(SECURITY)
+        );
+
+        assertThat(security).contains(
+            "exactly ten independent recovery codes",
+            "128 bits of `SecureRandom` entropy",
+            "canonical unpadded Base64URL text",
+            "producing 22 characters",
+            "returns the plaintext set once",
+            "No plaintext recovery code is persisted"
+        );
+    }
+
+    @Test
+    void shouldPersistOnlyFixedLengthDigests()
+        throws IOException {
+        String migration = Files.readString(MIGRATION);
+
+        assertThat(migration).contains(
+            "CREATE TABLE mfa_recovery_codes",
+            "code_digest BYTEA NOT NULL",
+            "octet_length(code_digest) = 32",
+            "UNIQUE (code_digest)",
+            "consumed_at TIMESTAMPTZ NULL",
+            "ix_mfa_recovery_codes_user_unconsumed"
+        ).doesNotContain(
+            "recovery_code VARCHAR",
+            "plaintext",
+            "code_plaintext"
+        );
+    }
+
+    @Test
+    void shouldUseOneGenericLoginFailureBoundary()
+        throws IOException {
+        String security = normalizeWhitespace(
+            Files.readString(SECURITY)
+        );
+
+        assertThat(security).contains(
+            "six-digit value follows the TOTP path",
+            "22-character Base64URL value follows the recovery-code path",
+            "same public contract",
+            "401 MFA_CHALLENGE_INVALID",
+            "already consumed rows without revealing their state"
+        );
+    }
+
+    @Test
+    void shouldKeepRotationDisableAndReplacementBehindFutureStepUp()
+        throws IOException {
+        String roadmap = Files.readString(ROADMAP);
+        String security = normalizeWhitespace(
+            Files.readString(SECURITY)
+        );
+
+        assertThat(roadmap).contains(
+            "### Increment 5 — Step-up authentication",
+            "### Increment 6 — MFA disable, recovery-code rotation, and replacement",
+            "- [ ] Require the exact recent step-up purpose before MFA disable or recovery-code rotation"
+        );
+        assertThat(security).contains(
+            "Explicit recovery-code rotation is not implemented here",
+            "purpose-bound step-up capability"
+        );
+    }
+
+    @Test
+    void shouldExposeRecoveryCodeBehaviorInReadme()
+        throws IOException {
+        String readme = normalizeWhitespace(
+            Files.readString(README)
+        );
+
+        assertThat(readme).contains(
+            "ten independent 128-bit canonical Base64URL recovery codes",
+            "stores only SHA-256 digests in PostgreSQL V20",
+            "unused recovery code",
+            "recovery-code security contract"
+        );
+    }
+
+    private static String normalizeWhitespace(String value) {
+        return value.replaceAll("\\s+", " ").trim();
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/V014TotpEnrollmentContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V014TotpEnrollmentContractTest.java
@@ -30,7 +30,7 @@ class V014TotpEnrollmentContractTest {
             "- [x] Serialize replacement so one user has at most one effective pending or active authenticator",
             "- [x] Exclude secrets, provisioning URIs, TOTP values, protected bytes, and key material from observable output",
             "- [x] Issue a short-lived opaque MFA login challenge only after the password and account eligibility checks succeed",
-            "- [ ] Generate recovery codes from cryptographically secure randomness",
+            "- [x] Generate recovery codes from cryptographically secure randomness",
             "- [ ] Introduce an application-facing step-up policy independent from controller annotations"
         );
     }

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -444,6 +444,43 @@ class OpenApiJsonContractIntegrationTest {
     }
 
     @Test
+    void shouldExposeRecoveryCodesInMfaConfirmationContracts() {
+        JsonNode confirmationSchema =
+            openApi
+                .path("components")
+                .path("schemas")
+                .path("MfaEnrollmentConfirmationResponse");
+
+        assertThat(confirmationSchema.isObject()).isTrue();
+
+        JsonNode recoveryCodes = confirmationSchema
+            .path("properties")
+            .path("recoveryCodes");
+
+        assertThat(recoveryCodes.path("type").asText())
+            .isEqualTo("array");
+        assertThat(recoveryCodes.path("items").path("type").asText())
+            .isEqualTo("string");
+        assertThat(recoveryCodes.path("description").asText())
+            .contains("One-time plaintext recovery codes");
+
+        JsonNode challengeRequestSchema =
+            openApi
+                .path("components")
+                .path("schemas")
+                .path("ConfirmMfaLoginChallengeRequest");
+
+        assertThat(challengeRequestSchema.isObject()).isTrue();
+        assertThat(
+            challengeRequestSchema
+                .path("properties")
+                .path("code")
+                .path("description")
+                .asText()
+        ).contains("unused MFA recovery code");
+    }
+
+    @Test
     void shouldExposeAuthenticatedApiOperations() {
         JsonNode profile =
             operation(

--- a/src/test/java/com/nursena/payflow/maildelivery/integration/MailOutboxMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/maildelivery/integration/MailOutboxMigrationIntegrationTest.java
@@ -48,7 +48,7 @@ class MailOutboxMigrationIntegrationTest {
         assertThat(tableExists("mail_outbox_messages")).isFalse();
 
         migrateToLatestVersion();
-        assertThat(currentSchemaVersion()).isEqualTo("19");
+        assertThat(currentSchemaVersion()).isEqualTo("20");
 
         UUID userId = UUID.randomUUID();
         UUID credentialId = UUID.randomUUID();

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/ConfirmMfaLoginChallengeControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/ConfirmMfaLoginChallengeControllerTest.java
@@ -63,7 +63,7 @@ class ConfirmMfaLoginChallengeControllerTest {
     }
 
     @Test
-    void shouldReturnGenericUnauthorizedForInvalidChallengeOrTotp() throws Exception {
+    void shouldReturnGenericUnauthorizedForInvalidChallengeOrProof() throws Exception {
         when(useCase.confirm(any(ConfirmMfaLoginChallengeCommand.class)))
             .thenThrow(new InvalidMfaLoginChallengeException());
 
@@ -75,6 +75,34 @@ class ConfirmMfaLoginChallengeControllerTest {
             .andExpect(jsonPath("$.message").value(
                 "The MFA challenge or proof could not be verified."
             ));
+    }
+
+
+    @Test
+    void shouldPassRecoveryCodeThroughSameConfirmationCommand() throws Exception {
+        when(useCase.confirm(any(ConfirmMfaLoginChallengeCommand.class)))
+            .thenReturn(new AuthenticatedUserResult(
+                "access",
+                Instant.parse("2026-08-09T12:15:00Z"),
+                "refresh",
+                Instant.parse("2026-08-16T12:00:00Z")
+            ));
+
+        String recoveryCode = "AbCdEfGhIjKlMnOpQrStUv";
+
+        mockMvc.perform(post("/api/v1/auth/mfa/challenges/confirm")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"challengeToken\":\"challenge\",\"code\":\""
+                        + recoveryCode
+                        + "\"}"
+                ))
+            .andExpect(status().isOk());
+
+        verify(useCase).confirm(argThat(command ->
+            command.challengeToken().equals("challenge")
+                && command.code().equals(recoveryCode)
+        ));
     }
 
     @Test

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/MfaEnrollmentSensitiveValueRedactionTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/MfaEnrollmentSensitiveValueRedactionTest.java
@@ -3,6 +3,7 @@ package com.nursena.payflow.user.adapter.in.web;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import com.nursena.payflow.user.application.port.in.BeginMfaEnrollmentCommand;
@@ -26,6 +27,8 @@ class MfaEnrollmentSensitiveValueRedactionTest {
         var userId = UUID.randomUUID();
         var expiresAt = Instant.parse("2026-08-08T10:10:00Z");
 
+        String recoveryCode = "AbCdEfGhIjKlMnOpQrStUv";
+
         Object[] sensitiveObjects = {
             new BeginMfaEnrollmentRequest(PASSWORD),
             new BeginMfaEnrollmentCommand(userId, PASSWORD),
@@ -42,6 +45,16 @@ class MfaEnrollmentSensitiveValueRedactionTest {
                 SECRET,
                 PROVISIONING_URI,
                 expiresAt
+            ),
+            new com.nursena.payflow.user.application.port.in.ConfirmMfaEnrollmentResult(
+                MfaLifecycleState.ENABLED,
+                expiresAt,
+                List.of(recoveryCode)
+            ),
+            new MfaEnrollmentConfirmationResponse(
+                MfaLifecycleState.ENABLED,
+                expiresAt,
+                List.of(recoveryCode)
             )
         };
 
@@ -51,6 +64,7 @@ class MfaEnrollmentSensitiveValueRedactionTest {
                 .doesNotContain(CODE)
                 .doesNotContain(SECRET)
                 .doesNotContain(PROVISIONING_URI)
+                .doesNotContain(recoveryCode)
                 .containsIgnoringCase("redacted");
         }
     }

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/SecureRandomMfaRecoveryCodeGenerationAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/SecureRandomMfaRecoveryCodeGenerationAdapterTest.java
@@ -1,0 +1,44 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.SecureRandom;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class SecureRandomMfaRecoveryCodeGenerationAdapterTest {
+
+    @Test
+    void shouldGenerateCanonical128BitBase64UrlCodes() {
+        var adapter = new SecureRandomMfaRecoveryCodeGenerationAdapter(
+            new SecureRandom()
+        );
+
+        Set<String> values = new HashSet<>();
+
+        for (int index = 0; index < 64; index++) {
+            String value = adapter.generate().value();
+            assertThat(value)
+                .hasSize(22)
+                .matches("[A-Za-z0-9_-]{22}")
+                .doesNotContain("=");
+            values.add(value);
+        }
+
+        assertThat(values).hasSize(64);
+    }
+
+    @Test
+    void shouldRedactGeneratedCodeToString() {
+        var adapter = new SecureRandomMfaRecoveryCodeGenerationAdapter(
+            new SecureRandom()
+        );
+        var generated = adapter.generate();
+
+        assertThat(generated.toString())
+            .doesNotContain(generated.value())
+            .containsIgnoringCase("redacted");
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/security/Sha256MfaRecoveryCodeDigestAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/security/Sha256MfaRecoveryCodeDigestAdapterTest.java
@@ -1,0 +1,30 @@
+package com.nursena.payflow.user.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class Sha256MfaRecoveryCodeDigestAdapterTest {
+
+    private final Sha256MfaRecoveryCodeDigestAdapter adapter =
+        new Sha256MfaRecoveryCodeDigestAdapter();
+
+    @Test
+    void shouldCreateStableFixedLengthDigest() {
+        String code = "AbCdEfGhIjKlMnOpQrStUv";
+
+        assertThat(adapter.digest(code).value()).hasSize(32);
+        assertThat(adapter.digest(code))
+            .isEqualTo(adapter.digest(code));
+    }
+
+    @Test
+    void shouldRejectNonCanonicalRecoveryCodeShape() {
+        assertThatThrownBy(() -> adapter.digest("123456"))
+            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> adapter.digest(
+            "AbCdEfGhIjKlMnOpQrStUv="
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/ConfirmMfaEnrollmentServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/ConfirmMfaEnrollmentServiceTest.java
@@ -3,11 +3,14 @@ package com.nursena.payflow.user.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Optional;
 
 import com.nursena.payflow.user.application.port.in.ConfirmMfaEnrollmentCommand;
@@ -31,52 +34,102 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ConfirmMfaEnrollmentServiceTest {
 
-    private static final Instant NOW = Instant.parse("2026-08-08T10:05:00Z");
+    private static final Instant NOW =
+        Instant.parse("2026-08-08T10:05:00Z");
+
     @Mock UserRepositoryPort userRepository;
     @Mock MfaAuthenticatorRepositoryPort authenticatorRepository;
     @Mock MfaSecretProtectionPort secretProtection;
     @Mock TotpVerificationPort totpVerification;
+    @Mock MfaRecoveryCodeIssuer recoveryCodeIssuer;
+
     private User user;
     private MfaAuthenticator pending;
     private ConfirmMfaEnrollmentService service;
 
     @BeforeEach
     void setUp() {
-        user = User.register(EmailAddress.of("user@example.com"), "hash", NOW.minusSeconds(600));
+        user = User.register(
+            EmailAddress.of("user@example.com"),
+            "hash",
+            NOW.minusSeconds(600)
+        );
         user.verifyEmail(NOW.minusSeconds(500));
-        pending = MfaAuthenticator.beginEnrollment(user.id(), ProtectedMfaSecret.of(new byte[49]), NOW.minusSeconds(60), NOW.plusSeconds(540));
-        service = new ConfirmMfaEnrollmentService(userRepository, authenticatorRepository, secretProtection, totpVerification, Clock.fixed(NOW, ZoneOffset.UTC));
+        pending = MfaAuthenticator.beginEnrollment(
+            user.id(),
+            ProtectedMfaSecret.of(new byte[49]),
+            NOW.minusSeconds(60),
+            NOW.plusSeconds(540)
+        );
+        service = new ConfirmMfaEnrollmentService(
+            userRepository,
+            authenticatorRepository,
+            secretProtection,
+            totpVerification,
+            recoveryCodeIssuer,
+            Clock.fixed(NOW, ZoneOffset.UTC)
+        );
     }
 
     @Test
-    void shouldActivateAfterValidTotp() {
-        when(userRepository.findByIdForUpdate(user.id())).thenReturn(Optional.of(user));
-        when(authenticatorRepository.findByUserIdForUpdate(user.id())).thenReturn(Optional.of(pending));
+    void shouldActivateAndReturnRecoveryCodesAfterValidTotp() {
+        when(userRepository.findByIdForUpdate(user.id()))
+            .thenReturn(Optional.of(user));
+        when(authenticatorRepository.findByUserIdForUpdate(user.id()))
+            .thenReturn(Optional.of(pending));
         byte[] raw = "12345678901234567890".getBytes();
-        when(secretProtection.reveal(user.id(), pending.protectedSecret())).thenReturn(raw);
-        when(totpVerification.verify(raw, "123456", NOW)).thenReturn(true);
-        when(authenticatorRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
-        var result = service.confirm(new ConfirmMfaEnrollmentCommand(user.id(), "123456"));
+        when(secretProtection.reveal(
+            user.id(),
+            pending.protectedSecret()
+        )).thenReturn(raw);
+        when(totpVerification.verify(raw, "123456", NOW))
+            .thenReturn(true);
+        when(authenticatorRepository.save(any()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+        List<String> codes = List.of("Rc00000000000000000001");
+        when(recoveryCodeIssuer.issue(user.id(), NOW))
+            .thenReturn(codes);
+
+        var result = service.confirm(
+            new ConfirmMfaEnrollmentCommand(user.id(), "123456")
+        );
+
         assertThat(result.state()).isEqualTo(MfaLifecycleState.ENABLED);
         assertThat(result.activatedAt()).isEqualTo(NOW);
+        assertThat(result.recoveryCodes()).containsExactlyElementsOf(codes);
+        verify(recoveryCodeIssuer).issue(user.id(), NOW);
     }
 
     @Test
-    void shouldRejectInvalidTotpWithoutActivating() {
-        when(userRepository.findByIdForUpdate(user.id())).thenReturn(Optional.of(user));
-        when(authenticatorRepository.findByUserIdForUpdate(user.id())).thenReturn(Optional.of(pending));
+    void shouldRejectInvalidTotpWithoutGeneratingRecoveryCodes() {
+        when(userRepository.findByIdForUpdate(user.id()))
+            .thenReturn(Optional.of(user));
+        when(authenticatorRepository.findByUserIdForUpdate(user.id()))
+            .thenReturn(Optional.of(pending));
         byte[] raw = "12345678901234567890".getBytes();
-        when(secretProtection.reveal(user.id(), pending.protectedSecret())).thenReturn(raw);
-        when(totpVerification.verify(raw, "000000", NOW)).thenReturn(false);
-        assertThatThrownBy(() -> service.confirm(new ConfirmMfaEnrollmentCommand(user.id(), "000000")))
-            .isInstanceOf(MfaVerificationFailedException.class);
+        when(secretProtection.reveal(
+            user.id(),
+            pending.protectedSecret()
+        )).thenReturn(raw);
+        when(totpVerification.verify(raw, "000000", NOW))
+            .thenReturn(false);
+
+        assertThatThrownBy(() -> service.confirm(
+            new ConfirmMfaEnrollmentCommand(user.id(), "000000")
+        )).isInstanceOf(MfaVerificationFailedException.class);
+
+        verify(recoveryCodeIssuer, never()).issue(any(), any());
     }
 
     @Test
     void shouldRejectMissingPendingEnrollment() {
-        when(userRepository.findByIdForUpdate(user.id())).thenReturn(Optional.of(user));
-        when(authenticatorRepository.findByUserIdForUpdate(user.id())).thenReturn(Optional.empty());
-        assertThatThrownBy(() -> service.confirm(new ConfirmMfaEnrollmentCommand(user.id(), "123456")))
-            .isInstanceOf(MfaStateConflictException.class);
+        when(userRepository.findByIdForUpdate(user.id()))
+            .thenReturn(Optional.of(user));
+        when(authenticatorRepository.findByUserIdForUpdate(user.id()))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.confirm(
+            new ConfirmMfaEnrollmentCommand(user.id(), "123456")
+        )).isInstanceOf(MfaStateConflictException.class);
     }
 }

--- a/src/test/java/com/nursena/payflow/user/application/service/ConfirmMfaLoginChallengeServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/ConfirmMfaLoginChallengeServiceTest.java
@@ -2,8 +2,6 @@ package com.nursena.payflow.user.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -15,15 +13,11 @@ import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
 
-import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
 import com.nursena.payflow.user.application.port.in.AuthenticatedUserResult;
 import com.nursena.payflow.user.application.port.in.ConfirmMfaLoginChallengeCommand;
 import com.nursena.payflow.user.application.port.out.MfaAuthenticatorRepositoryPort;
 import com.nursena.payflow.user.application.port.out.MfaLoginChallengeDigestPort;
 import com.nursena.payflow.user.application.port.out.MfaLoginChallengeRepositoryPort;
-import com.nursena.payflow.user.application.port.out.MfaSecretProtectionFailureException;
-import com.nursena.payflow.user.application.port.out.MfaSecretProtectionPort;
-import com.nursena.payflow.user.application.port.out.TotpVerificationPort;
 import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.exception.InvalidMfaLoginChallengeException;
 import com.nursena.payflow.user.domain.model.EmailAddress;
@@ -46,17 +40,20 @@ import org.springframework.transaction.annotation.Transactional;
 @ExtendWith(MockitoExtension.class)
 class ConfirmMfaLoginChallengeServiceTest {
 
-    private static final UUID USER_ID = UUID.fromString("76bf88a0-8524-43ff-ac1a-c77547d89e43");
-    private static final UUID CHALLENGE_ID = UUID.fromString("8db7ea3b-b29a-4f1d-bf4a-30d250c7278b");
-    private static final Instant NOW = Instant.parse("2026-08-08T12:00:00Z");
-    private static final MfaLoginChallengeDigest DIGEST = MfaLoginChallengeDigest.of(new byte[32]);
+    private static final UUID USER_ID =
+        UUID.fromString("76bf88a0-8524-43ff-ac1a-c77547d89e43");
+    private static final UUID CHALLENGE_ID =
+        UUID.fromString("8db7ea3b-b29a-4f1d-bf4a-30d250c7278b");
+    private static final Instant NOW =
+        Instant.parse("2026-08-08T12:00:00Z");
+    private static final MfaLoginChallengeDigest DIGEST =
+        MfaLoginChallengeDigest.of(new byte[32]);
 
     @Mock MfaLoginChallengeDigestPort digestPort;
     @Mock MfaLoginChallengeRepositoryPort challengeRepository;
     @Mock UserRepositoryPort userRepository;
     @Mock MfaAuthenticatorRepositoryPort authenticatorRepository;
-    @Mock MfaSecretProtectionPort secretProtection;
-    @Mock TotpVerificationPort totpVerification;
+    @Mock MfaLoginSecondFactorVerifier secondFactorVerifier;
     @Mock AuthenticationCredentialIssuer credentialIssuer;
 
     private ConfirmMfaLoginChallengeService service;
@@ -69,8 +66,7 @@ class ConfirmMfaLoginChallengeServiceTest {
             challengeRepository,
             userRepository,
             authenticatorRepository,
-            secretProtection,
-            totpVerification,
+            secondFactorVerifier,
             credentialIssuer,
             Clock.fixed(NOW, ZoneOffset.UTC)
         );
@@ -87,37 +83,52 @@ class ConfirmMfaLoginChallengeServiceTest {
     }
 
     @Test
-    void shouldConsumeValidTotpChallengeBeforeIssuingCredentials() {
-        MfaLoginChallenge challenge = pending(5, NOW.plusSeconds(300));
-        stubCandidate(challenge);
-        byte[] secret = new byte[20];
-        when(secretProtection.reveal(any(), any()))
-            .thenReturn(secret);
-        when(totpVerification.verify(secret, "123456", NOW)).thenReturn(true);
+    void shouldConsumeValidSecondFactorChallengeBeforeIssuingCredentials() {
+        MfaLoginChallenge challenge = pending(
+            5,
+            NOW.plusSeconds(300)
+        );
+        MfaAuthenticator authenticator = stubCandidate(challenge);
+        when(secondFactorVerifier.verifyAndConsume(
+            USER_ID,
+            authenticator,
+            "123456",
+            NOW
+        )).thenReturn(true);
         AuthenticatedUserResult credentials = credentials();
         when(credentialIssuer.issue(user, NOW)).thenReturn(credentials);
 
-        assertThat(service.confirm(command("challenge", "123456"))).isSameAs(credentials);
+        assertThat(service.confirm(command("challenge", "123456")))
+            .isSameAs(credentials);
         verify(challengeRepository).save(
             org.mockito.ArgumentMatchers.argThat(saved ->
                 saved.state() == MfaLoginChallengeState.CONSUMED
             )
         );
         verify(credentialIssuer).issue(user, NOW);
-        assertThat(secret).containsOnly((byte) 0);
     }
 
     @Test
-    void shouldDecrementAttemptAndReturnGenericFailureForWrongTotp() {
-        MfaLoginChallenge challenge = pending(5, NOW.plusSeconds(300));
-        stubCandidate(challenge);
-        byte[] secret = new byte[20];
-        when(secretProtection.reveal(any(), any())).thenReturn(secret);
-        when(totpVerification.verify(secret, "000000", NOW)).thenReturn(false);
+    void shouldDecrementAttemptAndReturnGenericFailureForInvalidProof() {
+        MfaLoginChallenge challenge = pending(
+            5,
+            NOW.plusSeconds(300)
+        );
+        MfaAuthenticator authenticator = stubCandidate(challenge);
+        when(secondFactorVerifier.verifyAndConsume(
+            USER_ID,
+            authenticator,
+            "invalid-proof",
+            NOW
+        )).thenReturn(false);
 
-        assertThatThrownBy(() -> service.confirm(command("challenge", "000000")))
+        assertThatThrownBy(() -> service.confirm(
+            command("challenge", "invalid-proof")
+        ))
             .isInstanceOf(InvalidMfaLoginChallengeException.class)
-            .hasMessage("The MFA challenge or proof could not be verified.");
+            .hasMessage(
+                "The MFA challenge or proof could not be verified."
+            );
         verify(challengeRepository).save(
             org.mockito.ArgumentMatchers.argThat(saved ->
                 saved.state() == MfaLoginChallengeState.PENDING
@@ -129,14 +140,21 @@ class ConfirmMfaLoginChallengeServiceTest {
 
     @Test
     void shouldExhaustFinalAttempt() {
-        MfaLoginChallenge challenge = pending(1, NOW.plusSeconds(300));
-        stubCandidate(challenge);
-        byte[] secret = new byte[20];
-        when(secretProtection.reveal(any(), any())).thenReturn(secret);
-        when(totpVerification.verify(secret, "000000", NOW)).thenReturn(false);
+        MfaLoginChallenge challenge = pending(
+            1,
+            NOW.plusSeconds(300)
+        );
+        MfaAuthenticator authenticator = stubCandidate(challenge);
+        when(secondFactorVerifier.verifyAndConsume(
+            USER_ID,
+            authenticator,
+            "000000",
+            NOW
+        )).thenReturn(false);
 
-        assertThatThrownBy(() -> service.confirm(command("challenge", "000000")))
-            .isInstanceOf(InvalidMfaLoginChallengeException.class);
+        assertThatThrownBy(() -> service.confirm(
+            command("challenge", "000000")
+        )).isInstanceOf(InvalidMfaLoginChallengeException.class);
         verify(challengeRepository).save(
             org.mockito.ArgumentMatchers.argThat(saved ->
                 saved.state() == MfaLoginChallengeState.EXHAUSTED
@@ -149,96 +167,143 @@ class ConfirmMfaLoginChallengeServiceTest {
     void shouldPersistExpirationBeforeGenericFailure() {
         MfaLoginChallenge challenge = pending(5, NOW);
         when(digestPort.digest("challenge")).thenReturn(DIGEST);
-        when(challengeRepository.findUserIdByDigest(DIGEST)).thenReturn(Optional.of(USER_ID));
-        when(userRepository.findByIdForUpdate(USER_ID)).thenReturn(Optional.of(user));
-        when(challengeRepository.findByDigestForUpdate(DIGEST)).thenReturn(Optional.of(challenge));
+        when(challengeRepository.findUserIdByDigest(DIGEST))
+            .thenReturn(Optional.of(USER_ID));
+        when(userRepository.findByIdForUpdate(USER_ID))
+            .thenReturn(Optional.of(user));
+        when(challengeRepository.findByDigestForUpdate(DIGEST))
+            .thenReturn(Optional.of(challenge));
 
-        assertThatThrownBy(() -> service.confirm(command("challenge", "123456")))
-            .isInstanceOf(InvalidMfaLoginChallengeException.class);
+        assertThatThrownBy(() -> service.confirm(
+            command("challenge", "123456")
+        )).isInstanceOf(InvalidMfaLoginChallengeException.class);
         verify(challengeRepository).save(
-            org.mockito.ArgumentMatchers.argThat(saved -> saved.state() == MfaLoginChallengeState.EXPIRED)
+            org.mockito.ArgumentMatchers.argThat(saved ->
+                saved.state() == MfaLoginChallengeState.EXPIRED
+            )
         );
-        verifyNoInteractions(authenticatorRepository, credentialIssuer);
+        verifyNoInteractions(
+            authenticatorRepository,
+            secondFactorVerifier,
+            credentialIssuer
+        );
     }
 
     @Test
     void shouldRejectConsumedChallengeWithoutReissuingCredentials() {
-        MfaLoginChallenge consumed = pending(5, NOW.plusSeconds(300)).consume(NOW.minusSeconds(1));
+        MfaLoginChallenge consumed = pending(
+            5,
+            NOW.plusSeconds(300)
+        ).consume(NOW.minusSeconds(1));
         when(digestPort.digest("challenge")).thenReturn(DIGEST);
-        when(challengeRepository.findUserIdByDigest(DIGEST)).thenReturn(Optional.of(USER_ID));
-        when(userRepository.findByIdForUpdate(USER_ID)).thenReturn(Optional.of(user));
-        when(challengeRepository.findByDigestForUpdate(DIGEST)).thenReturn(Optional.of(consumed));
+        when(challengeRepository.findUserIdByDigest(DIGEST))
+            .thenReturn(Optional.of(USER_ID));
+        when(userRepository.findByIdForUpdate(USER_ID))
+            .thenReturn(Optional.of(user));
+        when(challengeRepository.findByDigestForUpdate(DIGEST))
+            .thenReturn(Optional.of(consumed));
 
-        assertThatThrownBy(() -> service.confirm(command("challenge", "123456")))
-            .isInstanceOf(InvalidMfaLoginChallengeException.class);
-        verifyNoInteractions(credentialIssuer);
+        assertThatThrownBy(() -> service.confirm(
+            command("challenge", "123456")
+        )).isInstanceOf(InvalidMfaLoginChallengeException.class);
+        verifyNoInteractions(secondFactorVerifier, credentialIssuer);
     }
 
     @Test
     void shouldRejectUnknownChallengeWithoutLookingUpUser() {
         when(digestPort.digest("unknown")).thenReturn(DIGEST);
-        when(challengeRepository.findUserIdByDigest(DIGEST)).thenReturn(Optional.empty());
-        assertThatThrownBy(() -> service.confirm(command("unknown", "123456")))
-            .isInstanceOf(InvalidMfaLoginChallengeException.class);
-        verifyNoInteractions(userRepository, credentialIssuer);
+        when(challengeRepository.findUserIdByDigest(DIGEST))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.confirm(
+            command("unknown", "123456")
+        )).isInstanceOf(InvalidMfaLoginChallengeException.class);
+        verifyNoInteractions(
+            userRepository,
+            secondFactorVerifier,
+            credentialIssuer
+        );
     }
 
     @Test
     void shouldRejectMalformedChallengeThroughSamePublicException() {
-        assertThatThrownBy(() -> service.confirm(command(" ", "123456")))
-            .isInstanceOf(InvalidMfaLoginChallengeException.class);
-        verifyNoInteractions(challengeRepository, userRepository, credentialIssuer);
-    }
-
-    @Test
-    void shouldFailClosedWhenSecretCannotBeRevealed() {
-        stubCandidate(pending(5, NOW.plusSeconds(300)));
-        when(secretProtection.reveal(any(), any()))
-            .thenThrow(new MfaSecretProtectionFailureException());
-        assertThatThrownBy(() -> service.confirm(command("challenge", "123456")))
-            .isInstanceOf(MfaSecurityUnavailableException.class);
-        verifyNoInteractions(credentialIssuer);
+        assertThatThrownBy(() -> service.confirm(
+            command(" ", "123456")
+        )).isInstanceOf(InvalidMfaLoginChallengeException.class);
+        verifyNoInteractions(
+            challengeRepository,
+            userRepository,
+            secondFactorVerifier,
+            credentialIssuer
+        );
     }
 
     @Test
     void shouldRequireEnabledAuthenticatorAtVerificationTime() {
-        MfaLoginChallenge challenge = pending(5, NOW.plusSeconds(300));
+        MfaLoginChallenge challenge = pending(
+            5,
+            NOW.plusSeconds(300)
+        );
         when(digestPort.digest("challenge")).thenReturn(DIGEST);
-        when(challengeRepository.findUserIdByDigest(DIGEST)).thenReturn(Optional.of(USER_ID));
-        when(userRepository.findByIdForUpdate(USER_ID)).thenReturn(Optional.of(user));
-        when(challengeRepository.findByDigestForUpdate(DIGEST)).thenReturn(Optional.of(challenge));
-        when(authenticatorRepository.findByUserIdForUpdate(USER_ID)).thenReturn(Optional.empty());
-        assertThatThrownBy(() -> service.confirm(command("challenge", "123456")))
-            .isInstanceOf(InvalidMfaLoginChallengeException.class);
-        verifyNoInteractions(secretProtection, credentialIssuer);
+        when(challengeRepository.findUserIdByDigest(DIGEST))
+            .thenReturn(Optional.of(USER_ID));
+        when(userRepository.findByIdForUpdate(USER_ID))
+            .thenReturn(Optional.of(user));
+        when(challengeRepository.findByDigestForUpdate(DIGEST))
+            .thenReturn(Optional.of(challenge));
+        when(authenticatorRepository.findByUserIdForUpdate(USER_ID))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.confirm(
+            command("challenge", "123456")
+        )).isInstanceOf(InvalidMfaLoginChallengeException.class);
+        verifyNoInteractions(secondFactorVerifier, credentialIssuer);
     }
 
     @Test
-    void shouldUseNoRollbackForGenericChallengeFailure() throws Exception {
-        Method method = ConfirmMfaLoginChallengeService.class.getDeclaredMethod(
-            "confirm",
-            ConfirmMfaLoginChallengeCommand.class
-        );
-        Transactional transactional = method.getAnnotation(Transactional.class);
+    void shouldUseNoRollbackForGenericChallengeFailure()
+        throws Exception {
+        Method method = ConfirmMfaLoginChallengeService.class
+            .getDeclaredMethod(
+                "confirm",
+                ConfirmMfaLoginChallengeCommand.class
+            );
+        Transactional transactional =
+            method.getAnnotation(Transactional.class);
         assertThat(transactional).isNotNull();
         assertThat(transactional.noRollbackFor())
-            .containsExactly(InvalidMfaLoginChallengeException.class);
+            .containsExactly(
+                InvalidMfaLoginChallengeException.class
+            );
     }
 
-    private void stubCandidate(MfaLoginChallenge challenge) {
+    private MfaAuthenticator stubCandidate(
+        MfaLoginChallenge challenge
+    ) {
+        MfaAuthenticator authenticator = enabledAuthenticator();
         when(digestPort.digest("challenge")).thenReturn(DIGEST);
-        when(challengeRepository.findUserIdByDigest(DIGEST)).thenReturn(Optional.of(USER_ID));
-        when(userRepository.findByIdForUpdate(USER_ID)).thenReturn(Optional.of(user));
-        when(challengeRepository.findByDigestForUpdate(DIGEST)).thenReturn(Optional.of(challenge));
+        when(challengeRepository.findUserIdByDigest(DIGEST))
+            .thenReturn(Optional.of(USER_ID));
+        when(userRepository.findByIdForUpdate(USER_ID))
+            .thenReturn(Optional.of(user));
+        when(challengeRepository.findByDigestForUpdate(DIGEST))
+            .thenReturn(Optional.of(challenge));
         when(authenticatorRepository.findByUserIdForUpdate(USER_ID))
-            .thenReturn(Optional.of(enabledAuthenticator()));
+            .thenReturn(Optional.of(authenticator));
+        return authenticator;
     }
 
-    private static ConfirmMfaLoginChallengeCommand command(String token, String code) {
+    private static ConfirmMfaLoginChallengeCommand command(
+        String token,
+        String code
+    ) {
         return new ConfirmMfaLoginChallengeCommand(token, code);
     }
 
-    private static MfaLoginChallenge pending(int attempts, Instant expiresAt) {
+    private static MfaLoginChallenge pending(
+        int attempts,
+        Instant expiresAt
+    ) {
         return MfaLoginChallenge.issue(
             CHALLENGE_ID,
             USER_ID,

--- a/src/test/java/com/nursena/payflow/user/application/service/MfaLoginSecondFactorVerifierTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/MfaLoginSecondFactorVerifierTest.java
@@ -1,0 +1,191 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeDigestPort;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeRepositoryPort;
+import com.nursena.payflow.user.application.port.out.MfaSecretProtectionFailureException;
+import com.nursena.payflow.user.application.port.out.MfaSecretProtectionPort;
+import com.nursena.payflow.user.application.port.out.TotpVerificationPort;
+import com.nursena.payflow.user.domain.model.MfaAuthenticator;
+import com.nursena.payflow.user.domain.model.MfaLifecycleState;
+import com.nursena.payflow.user.domain.model.MfaRecoveryCode;
+import com.nursena.payflow.user.domain.model.MfaRecoveryCodeDigest;
+import com.nursena.payflow.user.domain.model.ProtectedMfaSecret;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MfaLoginSecondFactorVerifierTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString("20e683e1-6286-4a25-95f6-0d2cab4667fd");
+    private static final Instant NOW =
+        Instant.parse("2026-08-09T13:00:00Z");
+    private static final String RECOVERY_CODE =
+        "AbCdEfGhIjKlMnOpQrStUv";
+
+    @Mock MfaSecretProtectionPort secretProtection;
+    @Mock TotpVerificationPort totpVerification;
+    @Mock MfaRecoveryCodeDigestPort recoveryCodeDigest;
+    @Mock MfaRecoveryCodeRepositoryPort recoveryCodeRepository;
+
+    private MfaLoginSecondFactorVerifier verifier;
+    private MfaAuthenticator authenticator;
+
+    @BeforeEach
+    void setUp() {
+        verifier = new MfaLoginSecondFactorVerifier(
+            secretProtection,
+            totpVerification,
+            recoveryCodeDigest,
+            recoveryCodeRepository
+        );
+        authenticator = MfaAuthenticator.rehydrate(
+            USER_ID,
+            MfaLifecycleState.ENABLED,
+            ProtectedMfaSecret.of(new byte[49]),
+            null,
+            NOW.minusSeconds(120),
+            NOW.minusSeconds(180),
+            NOW.minusSeconds(120)
+        );
+    }
+
+    @Test
+    void shouldVerifyTotpAndClearRevealedSecret() {
+        byte[] secret = new byte[20];
+        secret[0] = 9;
+        when(secretProtection.reveal(
+            USER_ID,
+            authenticator.protectedSecret()
+        )).thenReturn(secret);
+        when(totpVerification.verify(secret, "123456", NOW))
+            .thenReturn(true);
+
+        assertThat(verifier.verifyAndConsume(
+            USER_ID,
+            authenticator,
+            "123456",
+            NOW
+        )).isTrue();
+        assertThat(secret).containsOnly((byte) 0);
+        verifyNoInteractions(recoveryCodeRepository);
+    }
+
+    @Test
+    void shouldConsumeMatchingUnusedRecoveryCodeWithoutRevealingTotpSecret() {
+        MfaRecoveryCodeDigest digest =
+            MfaRecoveryCodeDigest.of(new byte[32]);
+        MfaRecoveryCode recoveryCode = MfaRecoveryCode.issue(
+            UUID.randomUUID(),
+            USER_ID,
+            digest,
+            NOW.minusSeconds(60)
+        );
+        when(recoveryCodeDigest.digest(RECOVERY_CODE))
+            .thenReturn(digest);
+        when(recoveryCodeRepository.findByUserIdAndDigestForUpdate(
+            USER_ID,
+            digest
+        )).thenReturn(Optional.of(recoveryCode));
+        when(recoveryCodeRepository.save(any()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThat(verifier.verifyAndConsume(
+            USER_ID,
+            authenticator,
+            RECOVERY_CODE,
+            NOW
+        )).isTrue();
+
+        verify(recoveryCodeRepository).save(
+            org.mockito.ArgumentMatchers.argThat(value ->
+                value.consumedAt().equals(NOW)
+            )
+        );
+        verifyNoInteractions(secretProtection, totpVerification);
+    }
+
+    @Test
+    void shouldRejectConsumedRecoveryCodeWithoutMutatingItAgain() {
+        MfaRecoveryCodeDigest digest =
+            MfaRecoveryCodeDigest.of(new byte[32]);
+        MfaRecoveryCode recoveryCode = MfaRecoveryCode.rehydrate(
+            UUID.randomUUID(),
+            USER_ID,
+            digest,
+            NOW.minusSeconds(60),
+            NOW.minusSeconds(1)
+        );
+        when(recoveryCodeDigest.digest(RECOVERY_CODE))
+            .thenReturn(digest);
+        when(recoveryCodeRepository.findByUserIdAndDigestForUpdate(
+            USER_ID,
+            digest
+        )).thenReturn(Optional.of(recoveryCode));
+
+        assertThat(verifier.verifyAndConsume(
+            USER_ID,
+            authenticator,
+            RECOVERY_CODE,
+            NOW
+        )).isFalse();
+
+        verify(recoveryCodeRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldRejectUnknownOrMalformedProofWithoutLeakingProofType() {
+        MfaRecoveryCodeDigest digest =
+            MfaRecoveryCodeDigest.of(new byte[32]);
+        when(recoveryCodeDigest.digest(RECOVERY_CODE))
+            .thenReturn(digest);
+        when(recoveryCodeRepository.findByUserIdAndDigestForUpdate(
+            USER_ID,
+            digest
+        )).thenReturn(Optional.empty());
+
+        assertThat(verifier.verifyAndConsume(
+            USER_ID,
+            authenticator,
+            RECOVERY_CODE,
+            NOW
+        )).isFalse();
+        assertThat(verifier.verifyAndConsume(
+            USER_ID,
+            authenticator,
+            "malformed",
+            NOW
+        )).isFalse();
+    }
+
+    @Test
+    void shouldFailClosedWhenTotpSecretCannotBeRevealed() {
+        when(secretProtection.reveal(
+            USER_ID,
+            authenticator.protectedSecret()
+        )).thenThrow(new MfaSecretProtectionFailureException());
+
+        assertThatThrownBy(() -> verifier.verifyAndConsume(
+            USER_ID,
+            authenticator,
+            "123456",
+            NOW
+        )).isInstanceOf(MfaSecurityUnavailableException.class);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/MfaRecoveryCodeIssuerTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/MfaRecoveryCodeIssuerTest.java
@@ -1,0 +1,141 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.nursena.payflow.user.application.port.out.GeneratedMfaRecoveryCode;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeDigestPort;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeGenerationPort;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeRepositoryPort;
+import com.nursena.payflow.user.domain.model.MfaRecoveryCode;
+import com.nursena.payflow.user.domain.model.MfaRecoveryCodeDigest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MfaRecoveryCodeIssuerTest {
+
+    private static final UUID USER_ID =
+        UUID.fromString("d48ab875-1a71-4de0-a57b-d3bb0d384677");
+    private static final Instant NOW =
+        Instant.parse("2026-08-09T12:00:00Z");
+
+    @Mock MfaRecoveryCodeGenerationPort generationPort;
+    @Mock MfaRecoveryCodeDigestPort digestPort;
+    @Mock MfaRecoveryCodeRepositoryPort repository;
+
+    private MfaRecoveryCodeIssuer issuer;
+
+    @BeforeEach
+    void setUp() {
+        issuer = new MfaRecoveryCodeIssuer(
+            generationPort,
+            digestPort,
+            repository
+        );
+    }
+
+    @Test
+    void shouldIssueTenPlaintextCodesWhilePersistingOnlyDigests()
+        throws Exception {
+        AtomicInteger sequence = new AtomicInteger();
+        when(generationPort.generate()).thenAnswer(invocation ->
+            new GeneratedMfaRecoveryCode(code(sequence.getAndIncrement()))
+        );
+        when(digestPort.digest(any())).thenAnswer(invocation -> {
+            String value = invocation.getArgument(0);
+            return MfaRecoveryCodeDigest.of(
+                MessageDigest.getInstance("SHA-256")
+                    .digest(value.getBytes(StandardCharsets.US_ASCII))
+            );
+        });
+        when(repository.saveAll(any())).thenAnswer(invocation -> {
+            List<MfaRecoveryCode> values = invocation.getArgument(0);
+            return List.copyOf(values);
+        });
+
+        List<String> plaintext = issuer.issue(USER_ID, NOW);
+
+        assertThat(plaintext)
+            .hasSize(10)
+            .doesNotHaveDuplicates();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<MfaRecoveryCode>> captor =
+            ArgumentCaptor.forClass(List.class);
+        verify(repository).saveAll(captor.capture());
+
+        assertThat(captor.getValue())
+            .hasSize(10)
+            .allSatisfy(code -> {
+                assertThat(code.userId()).isEqualTo(USER_ID);
+                assertThat(code.createdAt()).isEqualTo(NOW);
+                assertThat(code.consumedAt()).isNull();
+                assertThat(code.digest().value()).hasSize(32);
+            });
+    }
+
+    @Test
+    void shouldRetryDuplicateDigestsWithinGeneratedSet() {
+        AtomicInteger sequence = new AtomicInteger();
+        when(generationPort.generate()).thenAnswer(invocation ->
+            new GeneratedMfaRecoveryCode(code(sequence.getAndIncrement()))
+        );
+        MfaRecoveryCodeDigest duplicate =
+            MfaRecoveryCodeDigest.of(new byte[32]);
+        AtomicInteger digests = new AtomicInteger();
+        when(digestPort.digest(any())).thenAnswer(invocation -> {
+            int index = digests.getAndIncrement();
+            if (index < 2) {
+                return duplicate;
+            }
+            byte[] value = new byte[32];
+            value[0] = (byte) index;
+            return MfaRecoveryCodeDigest.of(value);
+        });
+        when(repository.saveAll(any())).thenAnswer(invocation -> {
+            List<MfaRecoveryCode> values = invocation.getArgument(0);
+            return List.copyOf(values);
+        });
+
+        assertThat(issuer.issue(USER_ID, NOW))
+            .hasSize(10)
+            .doesNotHaveDuplicates();
+    }
+
+    @Test
+    void shouldFailClosedWhenPersistenceReturnsIncompleteSet() {
+        AtomicInteger sequence = new AtomicInteger();
+        when(generationPort.generate()).thenAnswer(invocation ->
+            new GeneratedMfaRecoveryCode(code(sequence.getAndIncrement()))
+        );
+        AtomicInteger digestSequence = new AtomicInteger();
+        when(digestPort.digest(any())).thenAnswer(invocation -> {
+            byte[] value = new byte[32];
+            value[0] = (byte) digestSequence.getAndIncrement();
+            return MfaRecoveryCodeDigest.of(value);
+        });
+        when(repository.saveAll(any())).thenReturn(List.of());
+
+        assertThatThrownBy(() -> issuer.issue(USER_ID, NOW))
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    private static String code(int index) {
+        return String.format("Rc%020d", index);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/domain/model/MfaRecoveryCodeDigestTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/MfaRecoveryCodeDigestTest.java
@@ -1,0 +1,42 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class MfaRecoveryCodeDigestTest {
+
+    @Test
+    void shouldRequireExactlySha256Length() {
+        assertThatThrownBy(() -> MfaRecoveryCodeDigest.of(new byte[31]))
+            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> MfaRecoveryCodeDigest.of(new byte[33]))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldDefensivelyCopyDigestBytes() {
+        byte[] source = new byte[32];
+        source[0] = 7;
+        MfaRecoveryCodeDigest digest = MfaRecoveryCodeDigest.of(source);
+        source[0] = 9;
+
+        byte[] returned = digest.value();
+        assertThat(returned[0]).isEqualTo((byte) 7);
+        returned[0] = 11;
+        assertThat(digest.value()[0]).isEqualTo((byte) 7);
+    }
+
+    @Test
+    void shouldUseValueEqualityAndRedactedString() {
+        byte[] value = new byte[32];
+        value[4] = 3;
+
+        assertThat(MfaRecoveryCodeDigest.of(value))
+            .isEqualTo(MfaRecoveryCodeDigest.of(value))
+            .hasSameHashCodeAs(MfaRecoveryCodeDigest.of(value));
+        assertThat(MfaRecoveryCodeDigest.of(value).toString())
+            .isEqualTo("MfaRecoveryCodeDigest[redacted]");
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/domain/model/MfaRecoveryCodeTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/MfaRecoveryCodeTest.java
@@ -1,0 +1,61 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class MfaRecoveryCodeTest {
+
+    private static final Instant CREATED_AT =
+        Instant.parse("2026-08-09T12:00:00Z");
+
+    @Test
+    void shouldIssueUsableCodeAndConsumeExactlyOnce() {
+        MfaRecoveryCode code = issue();
+
+        assertThat(code.isUsableAt(CREATED_AT)).isTrue();
+
+        MfaRecoveryCode consumed = code.consume(
+            CREATED_AT.plusSeconds(1)
+        );
+
+        assertThat(consumed.consumedAt())
+            .isEqualTo(CREATED_AT.plusSeconds(1));
+        assertThat(consumed.isUsableAt(CREATED_AT.plusSeconds(2)))
+            .isFalse();
+        assertThatThrownBy(() -> consumed.consume(
+            CREATED_AT.plusSeconds(2)
+        )).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldRejectConsumptionBeforeIssuance() {
+        assertThatThrownBy(() -> issue().consume(
+            CREATED_AT.minusSeconds(1)
+        )).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldRejectInvalidRehydratedTimestamp() {
+        assertThatThrownBy(() -> MfaRecoveryCode.rehydrate(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            MfaRecoveryCodeDigest.of(new byte[32]),
+            CREATED_AT,
+            CREATED_AT.minusSeconds(1)
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static MfaRecoveryCode issue() {
+        return MfaRecoveryCode.issue(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            MfaRecoveryCodeDigest.of(new byte[32]),
+            CREATED_AT
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/AccountActionCredentialMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/AccountActionCredentialMigrationIntegrationTest.java
@@ -66,7 +66,7 @@ class AccountActionCredentialMigrationIntegrationTest {
 
         migrateToLatestVersion();
 
-        assertThat(currentSchemaVersion()).isEqualTo("19");
+        assertThat(currentSchemaVersion()).isEqualTo("20");
         assertThat(migrationApplied("15")).isTrue();
         assertThat(migrationApplied("16")).isTrue();
         assertThat(tableExists(

--- a/src/test/java/com/nursena/payflow/user/integration/MfaAuthenticatorMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/MfaAuthenticatorMigrationIntegrationTest.java
@@ -58,7 +58,7 @@ class MfaAuthenticatorMigrationIntegrationTest {
         migrateTo("17");
         assertThat(tableExists("mfa_authenticators")).isFalse();
         flyway().migrate();
-        assertThat(currentSchemaVersion()).isEqualTo("19");
+        assertThat(currentSchemaVersion()).isEqualTo("20");
         assertThat(tableExists("mfa_authenticators")).isTrue();
     }
 

--- a/src/test/java/com/nursena/payflow/user/integration/MfaLoginChallengeHttpIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/MfaLoginChallengeHttpIntegrationTest.java
@@ -9,9 +9,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -54,6 +56,8 @@ class MfaLoginChallengeHttpIntegrationTest {
     private static final String PASSWORD = "StrongPassword123!";
     private static final byte[] TOTP_SECRET = "01234567890123456789"
         .getBytes(StandardCharsets.US_ASCII);
+    private static final String RECOVERY_CODE =
+        "AbCdEfGhIjKlMnOpQrStUv";
 
     @Container
     @ServiceConnection
@@ -70,6 +74,7 @@ class MfaLoginChallengeHttpIntegrationTest {
 
     @BeforeEach
     void cleanDatabase() {
+        jdbcTemplate.update("DELETE FROM mfa_recovery_codes");
         jdbcTemplate.update("DELETE FROM mfa_login_challenges");
         jdbcTemplate.update("DELETE FROM refresh_token_records");
         jdbcTemplate.update("DELETE FROM refresh_token_families");
@@ -127,6 +132,91 @@ class MfaLoginChallengeHttpIntegrationTest {
         )).isEqualTo("CONSUMED");
     }
 
+
+    @Test
+    void shouldConsumeUnusedRecoveryCodeAndIssueCredentials() throws Exception {
+        UserFixture fixture = insertEnabledMfaUser();
+        insertRecoveryCode(fixture.userId(), RECOVERY_CODE);
+        String challenge = challengeToken(login(fixture.email()));
+
+        mockMvc.perform(post("/api/v1/auth/mfa/challenges/confirm")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new ChallengeRequest(challenge, RECOVERY_CODE)
+                )))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.accessToken").isNotEmpty())
+            .andExpect(jsonPath("$.refreshToken").isNotEmpty());
+
+        assertThat(jdbcTemplate.queryForObject(
+            "SELECT consumed_at IS NOT NULL FROM mfa_recovery_codes WHERE user_id = ?",
+            Boolean.class,
+            fixture.userId()
+        )).isTrue();
+        assertThat(count("refresh_token_families")).isEqualTo(1);
+        assertThat(count("refresh_token_records")).isEqualTo(1);
+    }
+
+    @Test
+    void shouldRejectReusedRecoveryCodeThroughGenericFailure() throws Exception {
+        UserFixture fixture = insertEnabledMfaUser();
+        insertRecoveryCode(fixture.userId(), RECOVERY_CODE);
+        String firstChallenge = challengeToken(login(fixture.email()));
+
+        mockMvc.perform(post("/api/v1/auth/mfa/challenges/confirm")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new ChallengeRequest(firstChallenge, RECOVERY_CODE)
+                )))
+            .andExpect(status().isOk());
+
+        String secondChallenge = challengeToken(login(fixture.email()));
+
+        mockMvc.perform(post("/api/v1/auth/mfa/challenges/confirm")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    new ChallengeRequest(secondChallenge, RECOVERY_CODE)
+                )))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("MFA_CHALLENGE_INVALID"));
+
+        assertThat(jdbcTemplate.queryForObject(
+            "SELECT attempts_remaining FROM mfa_login_challenges WHERE state = 'PENDING' AND user_id = ?",
+            Integer.class,
+            fixture.userId()
+        )).isEqualTo(4);
+        assertThat(count("refresh_token_families")).isEqualTo(1);
+    }
+
+    @Test
+    void shouldPermitExactlyOneConcurrentRecoveryCodeConsumption() throws Exception {
+        UserFixture fixture = insertEnabledMfaUser();
+        insertRecoveryCode(fixture.userId(), RECOVERY_CODE);
+        String challenge = challengeToken(login(fixture.email()));
+        CountDownLatch start = new CountDownLatch(1);
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<Integer> first = executor.submit(
+                () -> confirmStatus(start, challenge, RECOVERY_CODE)
+            );
+            Future<Integer> second = executor.submit(
+                () -> confirmStatus(start, challenge, RECOVERY_CODE)
+            );
+            start.countDown();
+
+            assertThat(List.of(first.get(), second.get()))
+                .containsExactlyInAnyOrder(200, 401);
+        }
+
+        assertThat(jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM mfa_recovery_codes WHERE user_id = ? AND consumed_at IS NOT NULL",
+            Integer.class,
+            fixture.userId()
+        )).isEqualTo(1);
+        assertThat(count("refresh_token_families")).isEqualTo(1);
+        assertThat(count("refresh_token_records")).isEqualTo(1);
+    }
+
     @Test
     void shouldPersistAttemptFailureWithoutIssuingCredentials() throws Exception {
         UserFixture fixture = insertEnabledMfaUser();
@@ -162,7 +252,7 @@ class MfaLoginChallengeHttpIntegrationTest {
             Future<Integer> second = executor.submit(() -> confirmStatus(start, challenge, code));
             start.countDown();
 
-            assertThat(java.util.List.of(first.get(), second.get()))
+            assertThat(List.of(first.get(), second.get()))
                 .containsExactlyInAnyOrder(200, 401);
         }
 
@@ -239,6 +329,24 @@ class MfaLoginChallengeHttpIntegrationTest {
             Timestamp.from(now)
         );
         return new UserFixture(userId, email);
+    }
+
+
+    private void insertRecoveryCode(UUID userId, String recoveryCode)
+        throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256")
+            .digest(recoveryCode.getBytes(StandardCharsets.US_ASCII));
+        jdbcTemplate.update(
+            """
+            INSERT INTO mfa_recovery_codes (
+                id, user_id, code_digest, created_at, consumed_at
+            ) VALUES (?, ?, ?, ?, NULL)
+            """,
+            UUID.randomUUID(),
+            userId,
+            digest,
+            Timestamp.from(Instant.now())
+        );
     }
 
     private int count(String table) {

--- a/src/test/java/com/nursena/payflow/user/integration/MfaLoginChallengeMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/MfaLoginChallengeMigrationIntegrationTest.java
@@ -52,7 +52,7 @@ class MfaLoginChallengeMigrationIntegrationTest {
         migrateTo("18");
         assertThat(tableExists("mfa_login_challenges")).isFalse();
         flyway().migrate();
-        assertThat(currentSchemaVersion()).isEqualTo("19");
+        assertThat(currentSchemaVersion()).isEqualTo("20");
         assertThat(tableExists("mfa_login_challenges")).isTrue();
     }
 

--- a/src/test/java/com/nursena/payflow/user/integration/MfaRecoveryCodeMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/MfaRecoveryCodeMigrationIntegrationTest.java
@@ -1,0 +1,242 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class MfaRecoveryCodeMigrationIntegrationTest {
+
+    private static final Instant NOW =
+        Instant.parse("2026-08-09T12:00:00Z");
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    private static JdbcTemplate jdbcTemplate;
+
+    @BeforeAll
+    static void configureJdbcTemplate() {
+        jdbcTemplate = new JdbcTemplate(new DriverManagerDataSource(
+            POSTGRES.getJdbcUrl(),
+            POSTGRES.getUsername(),
+            POSTGRES.getPassword()
+        ));
+    }
+
+    @BeforeEach
+    void resetDatabase() {
+        Flyway.configure()
+            .cleanDisabled(false)
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .load()
+            .clean();
+    }
+
+    @Test
+    void shouldUpgradeV19ToDigestOnlyRecoveryCodeSchema() {
+        migrateTo("19");
+        assertThat(tableExists("mfa_recovery_codes")).isFalse();
+
+        flyway().migrate();
+
+        assertThat(currentSchemaVersion()).isEqualTo("20");
+        assertThat(tableExists("mfa_recovery_codes")).isTrue();
+    }
+
+    @Test
+    void shouldStoreFixedLengthDigestWithoutPlaintextColumn() {
+        flyway().migrate();
+        UUID userId = insertUser();
+        byte[] digest = digest((byte) 1);
+        insertRecoveryCode(userId, digest, null);
+
+        assertThat(jdbcTemplate.queryForObject(
+            "SELECT code_digest FROM mfa_recovery_codes",
+            byte[].class
+        )).containsExactly(digest);
+
+        Integer plaintextColumns = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'mfa_recovery_codes'
+              AND column_name IN ('code', 'recovery_code', 'plaintext')
+            """,
+            Integer.class
+        );
+        assertThat(plaintextColumns).isZero();
+    }
+
+    @Test
+    void shouldRejectWrongDigestLengthAndDuplicateDigest() {
+        flyway().migrate();
+        UUID firstUser = insertUser();
+        UUID secondUser = insertUser();
+        byte[] digest = digest((byte) 2);
+
+        assertThatThrownBy(() -> insertRecoveryCode(
+            firstUser,
+            new byte[31],
+            null
+        )).isInstanceOf(DataIntegrityViolationException.class);
+
+        insertRecoveryCode(firstUser, digest, null);
+
+        assertThatThrownBy(() -> insertRecoveryCode(
+            secondUser,
+            digest,
+            null
+        )).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void shouldPermitTenIndependentCodesForOneUser() {
+        flyway().migrate();
+        UUID userId = insertUser();
+
+        for (int index = 0; index < 10; index++) {
+            insertRecoveryCode(
+                userId,
+                digest((byte) (index + 1)),
+                null
+            );
+        }
+
+        assertThat(jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM mfa_recovery_codes WHERE user_id = ?",
+            Integer.class,
+            userId
+        )).isEqualTo(10);
+    }
+
+    @Test
+    void shouldRejectConsumptionBeforeCreation() {
+        flyway().migrate();
+        UUID userId = insertUser();
+
+        assertThatThrownBy(() -> insertRecoveryCode(
+            userId,
+            digest((byte) 12),
+            NOW.minusSeconds(1)
+        )).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    private static void insertRecoveryCode(
+        UUID userId,
+        byte[] digest,
+        Instant consumedAt
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO mfa_recovery_codes (
+                id, user_id, code_digest, created_at, consumed_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            UUID.randomUUID(),
+            userId,
+            digest,
+            Timestamp.from(NOW),
+            consumedAt == null ? null : Timestamp.from(consumedAt)
+        );
+    }
+
+    private static UUID insertUser() {
+        UUID id = UUID.randomUUID();
+        Timestamp now = Timestamp.from(NOW);
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id, email, password_hash, role, status,
+                email_verified_at, created_at, updated_at
+            ) VALUES (?, ?, 'hash', 'USER', 'ACTIVE', ?, ?, ?)
+            """,
+            id,
+            id + "@example.com",
+            now,
+            now,
+            now
+        );
+        return id;
+    }
+
+    private static byte[] digest(byte value) {
+        byte[] digest = new byte[32];
+        Arrays.fill(digest, value);
+        return digest;
+    }
+
+    private static Flyway flyway() {
+        return Flyway.configure()
+            .cleanDisabled(false)
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .load();
+    }
+
+    private static void migrateTo(String version) {
+        Flyway.configure()
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .target(version)
+            .load()
+            .migrate();
+    }
+
+    private static boolean tableExists(String name) {
+        Boolean exists = jdbcTemplate.queryForObject(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = 'public'
+                  AND table_name = ?
+            )
+            """,
+            Boolean.class,
+            name
+        );
+        return Boolean.TRUE.equals(exists);
+    }
+
+    private static String currentSchemaVersion() {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT version
+            FROM flyway_schema_history
+            WHERE success = TRUE
+              AND version IS NOT NULL
+            ORDER BY installed_rank DESC
+            LIMIT 1
+            """,
+            String.class
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/PasswordRecoveryMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/PasswordRecoveryMigrationIntegrationTest.java
@@ -65,7 +65,7 @@ class PasswordRecoveryMigrationIntegrationTest {
 
         migrateToLatestVersion();
 
-        assertThat(currentSchemaVersion()).isEqualTo("19");
+        assertThat(currentSchemaVersion()).isEqualTo("20");
 
         assertThat(revoke(
             familyId,

--- a/src/test/java/com/nursena/payflow/user/integration/RefreshSessionMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RefreshSessionMigrationIntegrationTest.java
@@ -74,7 +74,7 @@ class RefreshSessionMigrationIntegrationTest {
         migrateToLatestVersion();
 
         assertThat(currentSchemaVersion())
-            .isEqualTo("19");
+            .isEqualTo("20");
 
         assertThat(migrationApplied("13"))
             .isTrue();


### PR DESCRIPTION
## Summary

- implement v0.14.0 MFA recovery codes from exact main baseline `214e1be219330610e5161491e0a834f09a3fed3b`
- generate ten independent 128-bit opaque recovery codes at successful TOTP activation
- disclose the initial plaintext set once and persist only SHA-256 digests in PostgreSQL V20
- accept either TOTP or one unused recovery code through the existing MFA login-challenge confirmation boundary
- pessimistically lock and consume recovery codes at most once with rollback-safe transactional credential issuance
- preserve `401 MFA_CHALLENGE_INVALID` for malformed, unknown, consumed, and invalid second-factor proofs
- update OpenAPI, README, roadmap, changelog, migration contracts, and security documentation
- keep recovery-code rotation, MFA disable, authenticator replacement, and step-up grants deferred

## Verification

- focused MFA recovery-code verification: 195 tests / 34 reports
- complete Maven verification: 1376 tests / 305 reports, zero failures/errors/skips
- executable artifact SHA-256: `5B99F4DCD937E71E392A3948CCD16AF5BA734C6AB33E0E756C652A2DC9241B4C`
- Docker Compose interpolation passed with non-persistent process-scoped validation values
- protected `build-and-test` and `docker-smoke` checks required before merge

Closes #139