### PR TITLE
feat(user): add transactional MFA disable workflow

### DIFF
--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/AccountSecurityAuditJpaEntity.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/AccountSecurityAuditJpaEntity.java
@@ -1,0 +1,79 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.user.domain.model.AccountSecurityAuditAction;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "account_security_audits")
+class AccountSecurityAuditJpaEntity {
+
+    @Id
+    @Column(
+        name = "id",
+        nullable = false,
+        updatable = false
+    )
+    private UUID id;
+
+    @Column(
+        name = "subject_user_id",
+        nullable = false,
+        updatable = false
+    )
+    private UUID subjectUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+        name = "action",
+        nullable = false,
+        updatable = false,
+        length = 64
+    )
+    private AccountSecurityAuditAction action;
+
+    @Column(
+        name = "occurred_at",
+        nullable = false,
+        updatable = false
+    )
+    private Instant occurredAt;
+
+    protected AccountSecurityAuditJpaEntity() {
+    }
+
+    AccountSecurityAuditJpaEntity(
+        UUID id,
+        UUID subjectUserId,
+        AccountSecurityAuditAction action,
+        Instant occurredAt
+    ) {
+        this.id = id;
+        this.subjectUserId = subjectUserId;
+        this.action = action;
+        this.occurredAt = occurredAt;
+    }
+
+    UUID getId() {
+        return id;
+    }
+
+    UUID getSubjectUserId() {
+        return subjectUserId;
+    }
+
+    AccountSecurityAuditAction getAction() {
+        return action;
+    }
+
+    Instant getOccurredAt() {
+        return occurredAt;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/AccountSecurityAuditPersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/AccountSecurityAuditPersistenceAdapter.java
@@ -1,0 +1,35 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.util.Objects;
+
+import com.nursena.payflow.user.application.port.out.AccountSecurityAuditPort;
+import com.nursena.payflow.user.domain.model.AccountSecurityAuditEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+class AccountSecurityAuditPersistenceAdapter
+    implements AccountSecurityAuditPort {
+
+    private final SpringDataAccountSecurityAuditRepository
+        repository;
+
+    AccountSecurityAuditPersistenceAdapter(
+        SpringDataAccountSecurityAuditRepository repository
+    ) {
+        this.repository = Objects.requireNonNull(repository);
+    }
+
+    @Override
+    public void append(AccountSecurityAuditEvent event) {
+        Objects.requireNonNull(event, "event must not be null");
+
+        repository.saveAndFlush(
+            new AccountSecurityAuditJpaEntity(
+                event.id(),
+                event.subjectUserId(),
+                event.action(),
+                event.occurredAt()
+            )
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/MfaRecoveryCodePersistenceAdapter.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/MfaRecoveryCodePersistenceAdapter.java
@@ -56,6 +56,11 @@ class MfaRecoveryCodePersistenceAdapter
         ).map(MfaRecoveryCodePersistenceAdapter::toDomain);
     }
 
+    @Override
+    public void deleteAllByUserId(UUID userId) {
+        repository.deleteAllByUserId(userId);
+    }
+
     private static MfaRecoveryCodeJpaEntity toEntity(
         MfaRecoveryCode recoveryCode
     ) {

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataAccountSecurityAuditRepository.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataAccountSecurityAuditRepository.java
@@ -1,0 +1,9 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface SpringDataAccountSecurityAuditRepository
+    extends JpaRepository<AccountSecurityAuditJpaEntity, UUID> {
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataMfaRecoveryCodeRepository.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/out/persistence/SpringDataMfaRecoveryCodeRepository.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,4 +24,11 @@ interface SpringDataMfaRecoveryCodeRepository
         @Param("userId") UUID userId,
         @Param("digest") byte[] digest
     );
+
+    @Modifying
+    @Query("""
+        DELETE FROM MfaRecoveryCodeJpaEntity recoveryCode
+        WHERE recoveryCode.userId = :userId
+        """)
+    void deleteAllByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/nursena/payflow/user/application/port/in/DisableMfaCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/DisableMfaCommand.java
@@ -1,0 +1,28 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public final class DisableMfaCommand {
+
+    private final UUID userId;
+    private final String stepUpGrant;
+
+    public DisableMfaCommand(UUID userId, String stepUpGrant) {
+        this.userId = Objects.requireNonNull(userId, "userId must not be null");
+        this.stepUpGrant = stepUpGrant;
+    }
+
+    public UUID userId() {
+        return userId;
+    }
+
+    public String stepUpGrant() {
+        return stepUpGrant;
+    }
+
+    @Override
+    public String toString() {
+        return "DisableMfaCommand[userId=" + userId + ", stepUpGrant=[REDACTED]]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/DisableMfaUseCase.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/DisableMfaUseCase.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.user.application.port.in;
+
+public interface DisableMfaUseCase {
+
+    void disable(DisableMfaCommand command);
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/AccountSecurityAuditPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/AccountSecurityAuditPort.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.user.application.port.out;
+
+import com.nursena.payflow.user.domain.model.AccountSecurityAuditEvent;
+
+public interface AccountSecurityAuditPort {
+
+    void append(AccountSecurityAuditEvent event);
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/out/MfaRecoveryCodeRepositoryPort.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/out/MfaRecoveryCodeRepositoryPort.java
@@ -17,4 +17,6 @@ public interface MfaRecoveryCodeRepositoryPort {
         UUID userId,
         MfaRecoveryCodeDigest digest
     );
+
+    void deleteAllByUserId(UUID userId);
 }

--- a/src/main/java/com/nursena/payflow/user/application/service/DisableMfaService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/DisableMfaService.java
@@ -1,0 +1,105 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.DisableMfaCommand;
+import com.nursena.payflow.user.application.port.in.DisableMfaUseCase;
+import com.nursena.payflow.user.application.port.in.StepUpAuthorizationPolicy;
+import com.nursena.payflow.user.application.port.out.AccountSecurityAuditPort;
+import com.nursena.payflow.user.application.port.out.MfaAuthenticatorRepositoryPort;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.MfaStateConflictException;
+import com.nursena.payflow.user.domain.exception.UserNotFoundException;
+import com.nursena.payflow.user.domain.model.AccountSecurityAuditEvent;
+import com.nursena.payflow.user.domain.model.MfaAuthenticator;
+import com.nursena.payflow.user.domain.model.MfaLifecycleState;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import com.nursena.payflow.user.domain.model.StepUpPurpose;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class DisableMfaService implements DisableMfaUseCase {
+
+    private final UserRepositoryPort userRepository;
+    private final MfaAuthenticatorRepositoryPort authenticatorRepository;
+    private final MfaRecoveryCodeRepositoryPort recoveryCodeRepository;
+    private final StepUpAuthorizationPolicy stepUpAuthorizationPolicy;
+    private final RefreshTokenFamilyRepositoryPort refreshTokenFamilyRepository;
+    private final AccountSecurityAuditPort auditPort;
+    private final Clock clock;
+
+    public DisableMfaService(
+        UserRepositoryPort userRepository,
+        MfaAuthenticatorRepositoryPort authenticatorRepository,
+        MfaRecoveryCodeRepositoryPort recoveryCodeRepository,
+        StepUpAuthorizationPolicy stepUpAuthorizationPolicy,
+        RefreshTokenFamilyRepositoryPort refreshTokenFamilyRepository,
+        AccountSecurityAuditPort auditPort,
+        Clock clock
+    ) {
+        this.userRepository =
+            Objects.requireNonNull(userRepository);
+        this.authenticatorRepository =
+            Objects.requireNonNull(authenticatorRepository);
+        this.recoveryCodeRepository =
+            Objects.requireNonNull(recoveryCodeRepository);
+        this.stepUpAuthorizationPolicy =
+            Objects.requireNonNull(stepUpAuthorizationPolicy);
+        this.refreshTokenFamilyRepository =
+            Objects.requireNonNull(refreshTokenFamilyRepository);
+        this.auditPort =
+            Objects.requireNonNull(auditPort);
+        this.clock =
+            Objects.requireNonNull(clock);
+    }
+
+    @Override
+    public void disable(DisableMfaCommand command) {
+        Objects.requireNonNull(command, "command must not be null");
+
+        UUID userId = command.userId();
+
+        userRepository.findByIdForUpdate(userId)
+            .orElseThrow(UserNotFoundException::new);
+
+        MfaAuthenticator authenticator =
+            authenticatorRepository.findByUserIdForUpdate(userId)
+                .orElseThrow(MfaStateConflictException::new);
+
+        if (authenticator.state() != MfaLifecycleState.ENABLED) {
+            throw new MfaStateConflictException();
+        }
+
+        stepUpAuthorizationPolicy.requireAndConsume(
+            userId,
+            StepUpPurpose.MFA_DISABLE,
+            command.stepUpGrant()
+        );
+
+        Instant occurredAt = clock.instant();
+
+        recoveryCodeRepository.deleteAllByUserId(userId);
+        authenticatorRepository.delete(authenticator);
+
+        refreshTokenFamilyRepository.revokeAllActiveByUserId(
+            userId,
+            occurredAt,
+            RefreshTokenFamilyRevocationReason.MFA_DISABLED
+        );
+
+        auditPort.append(
+            AccountSecurityAuditEvent.mfaDisabled(
+                UUID.randomUUID(),
+                userId,
+                occurredAt
+            )
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/AccountSecurityAuditAction.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/AccountSecurityAuditAction.java
@@ -1,0 +1,5 @@
+package com.nursena.payflow.user.domain.model;
+
+public enum AccountSecurityAuditAction {
+    MFA_DISABLED
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/AccountSecurityAuditEvent.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/AccountSecurityAuditEvent.java
@@ -1,0 +1,33 @@
+package com.nursena.payflow.user.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+public record AccountSecurityAuditEvent(
+    UUID id,
+    UUID subjectUserId,
+    AccountSecurityAuditAction action,
+    Instant occurredAt
+) {
+
+    public AccountSecurityAuditEvent {
+        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(subjectUserId, "subjectUserId must not be null");
+        Objects.requireNonNull(action, "action must not be null");
+        Objects.requireNonNull(occurredAt, "occurredAt must not be null");
+    }
+
+    public static AccountSecurityAuditEvent mfaDisabled(
+        UUID id,
+        UUID subjectUserId,
+        Instant occurredAt
+    ) {
+        return new AccountSecurityAuditEvent(
+            id,
+            subjectUserId,
+            AccountSecurityAuditAction.MFA_DISABLED,
+            occurredAt
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyRevocationReason.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/RefreshTokenFamilyRevocationReason.java
@@ -6,5 +6,6 @@ public enum RefreshTokenFamilyRevocationReason {
     REUSE_DETECTED,
     USER_ACCOUNT_UNAVAILABLE,
     PASSWORD_RECOVERY,
+    MFA_DISABLED,
     ADMINISTRATIVE_REVOCATION
 }

--- a/src/main/resources/db/migration/V22__create_account_security_audits.sql
+++ b/src/main/resources/db/migration/V22__create_account_security_audits.sql
@@ -1,0 +1,20 @@
+CREATE TABLE account_security_audits (
+    id UUID PRIMARY KEY,
+    subject_user_id UUID NOT NULL,
+    action VARCHAR(64) NOT NULL,
+    occurred_at TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT fk_account_security_audits_subject_user
+        FOREIGN KEY (subject_user_id)
+        REFERENCES users(id)
+        ON DELETE RESTRICT,
+
+    CONSTRAINT chk_account_security_audits_action
+        CHECK (action IN ('MFA_DISABLED'))
+);
+
+CREATE INDEX ix_account_security_audits_subject_occurred_at
+    ON account_security_audits (
+        subject_user_id,
+        occurred_at DESC
+    );

--- a/src/main/resources/db/migration/V23__expand_refresh_token_family_revocation_reasons.sql
+++ b/src/main/resources/db/migration/V23__expand_refresh_token_family_revocation_reasons.sql
@@ -1,0 +1,17 @@
+ALTER TABLE refresh_token_families
+    DROP CONSTRAINT chk_refresh_token_families_revocation_reason;
+
+ALTER TABLE refresh_token_families
+    ADD CONSTRAINT chk_refresh_token_families_revocation_reason
+    CHECK (
+        revocation_reason IS NULL
+        OR revocation_reason IN (
+            'CURRENT_SESSION_LOGOUT',
+            'ALL_SESSIONS_LOGOUT',
+            'REUSE_DETECTED',
+            'USER_ACCOUNT_UNAVAILABLE',
+            'PASSWORD_RECOVERY',
+            'MFA_DISABLED',
+            'ADMINISTRATIVE_REVOCATION'
+        )
+    );

--- a/src/test/java/com/nursena/payflow/maildelivery/integration/MailOutboxMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/maildelivery/integration/MailOutboxMigrationIntegrationTest.java
@@ -48,7 +48,7 @@ class MailOutboxMigrationIntegrationTest {
         assertThat(tableExists("mail_outbox_messages")).isFalse();
 
         migrateToLatestVersion();
-        assertThat(currentSchemaVersion()).isEqualTo("21");
+        assertThat(currentSchemaVersion()).isEqualTo("23");
 
         UUID userId = UUID.randomUUID();
         UUID credentialId = UUID.randomUUID();

--- a/src/test/java/com/nursena/payflow/user/adapter/out/persistence/AccountSecurityAuditPersistenceAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/persistence/AccountSecurityAuditPersistenceAdapterTest.java
@@ -1,0 +1,88 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions
+    .assertThat;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.user.domain.model
+    .AccountSecurityAuditAction;
+import com.nursena.payflow.user.domain.model
+    .AccountSecurityAuditEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AccountSecurityAuditPersistenceAdapterTest {
+
+    private static final UUID AUDIT_ID =
+        UUID.fromString(
+            "48915435-5ebc-48fb-8ef1-c0968bab9fa3"
+        );
+
+    private static final UUID SUBJECT_USER_ID =
+        UUID.fromString(
+            "0d147a7c-7232-4145-902f-b4655cc903ba"
+        );
+
+    private static final Instant OCCURRED_AT =
+        Instant.parse("2026-08-11T12:00:00Z");
+
+    @Mock
+    private SpringDataAccountSecurityAuditRepository
+        repository;
+
+    private AccountSecurityAuditPersistenceAdapter
+        adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter =
+            new AccountSecurityAuditPersistenceAdapter(
+                repository
+            );
+    }
+
+    @Test
+    void shouldAppendAuditEvent() {
+        AccountSecurityAuditEvent event =
+            new AccountSecurityAuditEvent(
+                AUDIT_ID,
+                SUBJECT_USER_ID,
+                AccountSecurityAuditAction.MFA_DISABLED,
+                OCCURRED_AT
+            );
+
+        adapter.append(event);
+
+        ArgumentCaptor<AccountSecurityAuditJpaEntity>
+            entityCaptor =
+                ArgumentCaptor.forClass(
+                    AccountSecurityAuditJpaEntity.class
+                );
+
+        verify(repository).saveAndFlush(
+            entityCaptor.capture()
+        );
+
+        AccountSecurityAuditJpaEntity persisted =
+            entityCaptor.getValue();
+
+        assertThat(persisted.getId())
+            .isEqualTo(AUDIT_ID);
+        assertThat(persisted.getSubjectUserId())
+            .isEqualTo(SUBJECT_USER_ID);
+        assertThat(persisted.getAction())
+            .isEqualTo(
+                AccountSecurityAuditAction.MFA_DISABLED
+            );
+        assertThat(persisted.getOccurredAt())
+            .isEqualTo(OCCURRED_AT);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/adapter/out/persistence/MfaRecoveryCodePersistenceAdapterIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/out/persistence/MfaRecoveryCodePersistenceAdapterIntegrationTest.java
@@ -1,0 +1,144 @@
+package com.nursena.payflow.user.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.out
+    .MfaRecoveryCodeRepositoryPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class MfaRecoveryCodePersistenceAdapterIntegrationTest {
+
+    private static final Instant NOW =
+        Instant.parse("2026-08-11T12:00:00Z");
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    @Autowired
+    private MfaRecoveryCodeRepositoryPort repository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update("DELETE FROM mfa_recovery_codes");
+        jdbcTemplate.update("DELETE FROM users");
+    }
+
+    @Test
+    void shouldDeleteAllCodesForOnlyRequestedUser() {
+        UUID targetUserId = insertUser();
+        UUID otherUserId = insertUser();
+
+        insertRecoveryCode(targetUserId, digest((byte) 1));
+        insertRecoveryCode(targetUserId, digest((byte) 2));
+        insertRecoveryCode(otherUserId, digest((byte) 3));
+
+        TransactionTemplate transaction =
+            new TransactionTemplate(transactionManager);
+
+        transaction.executeWithoutResult(status ->
+            repository.deleteAllByUserId(targetUserId)
+        );
+
+        assertThat(recoveryCodeCount(targetUserId))
+            .isZero();
+        assertThat(recoveryCodeCount(otherUserId))
+            .isEqualTo(1);
+    }
+
+    private UUID insertUser() {
+        UUID userId = UUID.randomUUID();
+        Timestamp timestamp = Timestamp.from(NOW);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                email_verified_at,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, 'test-password-hash',
+                    'USER', 'ACTIVE', ?, ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            timestamp,
+            timestamp,
+            timestamp
+        );
+
+        return userId;
+    }
+
+    private void insertRecoveryCode(
+        UUID userId,
+        byte[] digest
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO mfa_recovery_codes (
+                id,
+                user_id,
+                code_digest,
+                created_at,
+                consumed_at
+            )
+            VALUES (?, ?, ?, ?, NULL)
+            """,
+            UUID.randomUUID(),
+            userId,
+            digest,
+            Timestamp.from(NOW)
+        );
+    }
+
+    private int recoveryCodeCount(UUID userId) {
+        Integer count = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM mfa_recovery_codes
+            WHERE user_id = ?
+            """,
+            Integer.class,
+            userId
+        );
+
+        return count == null ? 0 : count;
+    }
+
+    private static byte[] digest(byte value) {
+        byte[] digest = new byte[32];
+        Arrays.fill(digest, value);
+        return digest;
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/DisableMfaServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/DisableMfaServiceTest.java
@@ -1,0 +1,239 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.DisableMfaCommand;
+import com.nursena.payflow.user.application.port.in.StepUpAuthorizationPolicy;
+import com.nursena.payflow.user.application.port.out.AccountSecurityAuditPort;
+import com.nursena.payflow.user.application.port.out.MfaAuthenticatorRepositoryPort;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeRepositoryPort;
+import com.nursena.payflow.user.application.port.out.RefreshTokenFamilyRepositoryPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.InvalidStepUpGrantException;
+import com.nursena.payflow.user.domain.exception.MfaStateConflictException;
+import com.nursena.payflow.user.domain.exception.UserNotFoundException;
+import com.nursena.payflow.user.domain.model.AccountSecurityAuditAction;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.MfaAuthenticator;
+import com.nursena.payflow.user.domain.model.ProtectedMfaSecret;
+import com.nursena.payflow.user.domain.model.RefreshTokenFamilyRevocationReason;
+import com.nursena.payflow.user.domain.model.StepUpPurpose;
+import com.nursena.payflow.user.domain.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DisableMfaServiceTest {
+
+    private static final Instant NOW =
+        Instant.parse("2026-08-11T10:00:00Z");
+    private static final String STEP_UP_GRANT = "step-up-grant";
+
+    @Mock UserRepositoryPort userRepository;
+    @Mock MfaAuthenticatorRepositoryPort authenticatorRepository;
+    @Mock MfaRecoveryCodeRepositoryPort recoveryCodeRepository;
+    @Mock StepUpAuthorizationPolicy stepUpAuthorizationPolicy;
+    @Mock RefreshTokenFamilyRepositoryPort refreshTokenFamilyRepository;
+    @Mock AccountSecurityAuditPort auditPort;
+
+    private DisableMfaService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DisableMfaService(
+            userRepository,
+            authenticatorRepository,
+            recoveryCodeRepository,
+            stepUpAuthorizationPolicy,
+            refreshTokenFamilyRepository,
+            auditPort,
+            Clock.fixed(NOW, ZoneOffset.UTC)
+        );
+    }
+
+    @Test
+    void shouldDisableActiveMfaAndRevokeExistingSessions() {
+        User user = activeUser();
+        MfaAuthenticator authenticator = activeAuthenticator(user.id());
+
+        when(userRepository.findByIdForUpdate(user.id()))
+            .thenReturn(Optional.of(user));
+        when(authenticatorRepository.findByUserIdForUpdate(user.id()))
+            .thenReturn(Optional.of(authenticator));
+
+        service.disable(new DisableMfaCommand(user.id(), STEP_UP_GRANT));
+
+        InOrder ordered = inOrder(
+            userRepository,
+            authenticatorRepository,
+            stepUpAuthorizationPolicy,
+            recoveryCodeRepository,
+            refreshTokenFamilyRepository,
+            auditPort
+        );
+
+        ordered.verify(userRepository).findByIdForUpdate(user.id());
+        ordered.verify(authenticatorRepository)
+            .findByUserIdForUpdate(user.id());
+        ordered.verify(stepUpAuthorizationPolicy).requireAndConsume(
+            user.id(),
+            StepUpPurpose.MFA_DISABLE,
+            STEP_UP_GRANT
+        );
+        ordered.verify(recoveryCodeRepository)
+            .deleteAllByUserId(user.id());
+        ordered.verify(authenticatorRepository).delete(authenticator);
+        ordered.verify(refreshTokenFamilyRepository)
+            .revokeAllActiveByUserId(
+                user.id(),
+                NOW,
+                RefreshTokenFamilyRevocationReason.MFA_DISABLED
+            );
+        ordered.verify(auditPort).append(argThat(event ->
+            event.id() != null
+                && event.subjectUserId().equals(user.id())
+                && event.action()
+                    == AccountSecurityAuditAction.MFA_DISABLED
+                && event.occurredAt().equals(NOW)
+        ));
+    }
+
+    @Test
+    void shouldRejectUnknownUserBeforeInspectingMfaState() {
+        UUID userId = UUID.randomUUID();
+
+        when(userRepository.findByIdForUpdate(userId))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            service.disable(new DisableMfaCommand(userId, STEP_UP_GRANT))
+        ).isInstanceOf(UserNotFoundException.class);
+
+        verifyNoInteractions(
+            authenticatorRepository,
+            recoveryCodeRepository,
+            stepUpAuthorizationPolicy,
+            refreshTokenFamilyRepository,
+            auditPort
+        );
+    }
+
+    @Test
+    void shouldRejectWhenAuthenticatorDoesNotExist() {
+        User user = activeUser();
+
+        when(userRepository.findByIdForUpdate(user.id()))
+            .thenReturn(Optional.of(user));
+        when(authenticatorRepository.findByUserIdForUpdate(user.id()))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            service.disable(
+                new DisableMfaCommand(user.id(), STEP_UP_GRANT)
+            )
+        ).isInstanceOf(MfaStateConflictException.class);
+
+        verifyNoInteractions(
+            recoveryCodeRepository,
+            stepUpAuthorizationPolicy,
+            refreshTokenFamilyRepository,
+            auditPort
+        );
+    }
+
+    @Test
+    void shouldRejectWhenAuthenticatorIsNotActive() {
+        User user = activeUser();
+        MfaAuthenticator pending = pendingAuthenticator(user.id());
+
+        when(userRepository.findByIdForUpdate(user.id()))
+            .thenReturn(Optional.of(user));
+        when(authenticatorRepository.findByUserIdForUpdate(user.id()))
+            .thenReturn(Optional.of(pending));
+
+        assertThatThrownBy(() ->
+            service.disable(
+                new DisableMfaCommand(user.id(), STEP_UP_GRANT)
+            )
+        ).isInstanceOf(MfaStateConflictException.class);
+
+        verify(authenticatorRepository, never()).delete(any());
+        verifyNoInteractions(
+            recoveryCodeRepository,
+            stepUpAuthorizationPolicy,
+            refreshTokenFamilyRepository,
+            auditPort
+        );
+    }
+
+    @Test
+    void shouldNotMutateMfaStateWhenStepUpGrantIsRejected() {
+        User user = activeUser();
+        MfaAuthenticator authenticator = activeAuthenticator(user.id());
+
+        when(userRepository.findByIdForUpdate(user.id()))
+            .thenReturn(Optional.of(user));
+        when(authenticatorRepository.findByUserIdForUpdate(user.id()))
+            .thenReturn(Optional.of(authenticator));
+
+        doThrow(new InvalidStepUpGrantException())
+            .when(stepUpAuthorizationPolicy)
+            .requireAndConsume(
+                user.id(),
+                StepUpPurpose.MFA_DISABLE,
+                STEP_UP_GRANT
+            );
+
+        assertThatThrownBy(() ->
+            service.disable(
+                new DisableMfaCommand(user.id(), STEP_UP_GRANT)
+            )
+        ).isInstanceOf(InvalidStepUpGrantException.class);
+
+        verify(authenticatorRepository, never()).delete(any());
+        verifyNoInteractions(
+            recoveryCodeRepository,
+            refreshTokenFamilyRepository,
+            auditPort
+        );
+    }
+
+    private static User activeUser() {
+        return User.register(
+            EmailAddress.of("user@example.com"),
+            "password-hash",
+            NOW.minusSeconds(60)
+        );
+    }
+
+    private static MfaAuthenticator pendingAuthenticator(UUID userId) {
+        return MfaAuthenticator.beginEnrollment(
+            userId,
+            ProtectedMfaSecret.of(new byte[49]),
+            NOW.minusSeconds(30),
+            NOW.plusSeconds(570)
+        );
+    }
+
+    private static MfaAuthenticator activeAuthenticator(UUID userId) {
+        return pendingAuthenticator(userId).activate(NOW);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/DisableMfaTransactionIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/DisableMfaTransactionIntegrationTest.java
@@ -1,0 +1,371 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in
+    .DisableMfaCommand;
+import com.nursena.payflow.user.application.port.out
+    .AccountSecurityAuditPort;
+import com.nursena.payflow.user.application.port.out
+    .StepUpGrantDigestPort;
+import com.nursena.payflow.user.domain.model
+    .AccountSecurityAuditEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+@Import(
+    DisableMfaTransactionIntegrationTest
+        .FailureInjectionConfiguration.class
+)
+class DisableMfaTransactionIntegrationTest {
+
+    private static final String STEP_UP_GRANT =
+        "disable-mfa-rollback-grant";
+
+    private static final String FAILURE_MESSAGE =
+        "disable-mfa audit persistence failed";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    @Autowired
+    private DisableMfaService service;
+
+    @Autowired
+    private StepUpGrantDigestPort stepUpGrantDigestPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM account_security_audits"
+        );
+        jdbcTemplate.update("DELETE FROM step_up_grants");
+        jdbcTemplate.update(
+            "DELETE FROM mfa_recovery_codes"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM mfa_authenticators"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+        jdbcTemplate.update("DELETE FROM users");
+    }
+
+    @Test
+    void shouldRollbackEntireTransactionWhenAuditFails() {
+        Instant now = Instant.now();
+        UUID userId = insertUser(now);
+        UUID familyId = insertActiveFamily(userId, now);
+        UUID grantId = insertStepUpGrant(userId, now);
+
+        insertEnabledAuthenticator(userId, now);
+        insertRecoveryCode(userId, now);
+
+        assertThatThrownBy(() ->
+            service.disable(
+                new DisableMfaCommand(
+                    userId,
+                    STEP_UP_GRANT
+                )
+            )
+        )
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(FAILURE_MESSAGE);
+
+        assertThat(rowCount(
+            "mfa_authenticators",
+            "user_id",
+            userId
+        )).isEqualTo(1);
+
+        assertThat(rowCount(
+            "mfa_recovery_codes",
+            "user_id",
+            userId
+        )).isEqualTo(1);
+
+        assertThat(stepUpGrantConsumedAt(grantId))
+            .isNull();
+
+        assertFamilyUnrevoked(familyId);
+
+        assertThat(rowCount(
+            "account_security_audits",
+            "subject_user_id",
+            userId
+        )).isZero();
+    }
+
+    private UUID insertUser(Instant now) {
+        UUID userId = UUID.randomUUID();
+        Timestamp timestamp = Timestamp.from(now);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                email_verified_at,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, 'USER', 'ACTIVE', ?, ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            "test-password-hash",
+            timestamp,
+            timestamp,
+            timestamp
+        );
+
+        return userId;
+    }
+
+    private void insertEnabledAuthenticator(
+        UUID userId,
+        Instant now
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO mfa_authenticators (
+                user_id,
+                state,
+                protected_secret,
+                enrollment_expires_at,
+                activated_at,
+                created_at,
+                updated_at
+            )
+            VALUES (?, 'ENABLED', ?, NULL, ?, ?, ?)
+            """,
+            userId,
+            protectedSecret(),
+            Timestamp.from(now.minusSeconds(30)),
+            Timestamp.from(now.minusSeconds(60)),
+            Timestamp.from(now)
+        );
+    }
+
+    private void insertRecoveryCode(
+        UUID userId,
+        Instant now
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO mfa_recovery_codes (
+                id,
+                user_id,
+                code_digest,
+                created_at,
+                consumed_at
+            )
+            VALUES (?, ?, ?, ?, NULL)
+            """,
+            UUID.randomUUID(),
+            userId,
+            digest((byte) 7),
+            Timestamp.from(now.minusSeconds(30))
+        );
+    }
+
+    private UUID insertActiveFamily(
+        UUID userId,
+        Instant now
+    ) {
+        UUID familyId = UUID.randomUUID();
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO refresh_token_families (
+                id,
+                user_id,
+                created_at,
+                expires_at,
+                revoked_at,
+                revocation_reason
+            )
+            VALUES (?, ?, ?, ?, NULL, NULL)
+            """,
+            familyId,
+            userId,
+            Timestamp.from(now.minusSeconds(60)),
+            Timestamp.from(now.plusSeconds(3_600))
+        );
+
+        return familyId;
+    }
+
+    private UUID insertStepUpGrant(
+        UUID userId,
+        Instant now
+    ) {
+        UUID grantId = UUID.randomUUID();
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO step_up_grants (
+                id,
+                subject_id,
+                purpose,
+                grant_digest,
+                issued_at,
+                expires_at,
+                consumed_at,
+                superseded_at
+            )
+            VALUES (?, ?, 'mfa-disable', ?, ?, ?, NULL, NULL)
+            """,
+            grantId,
+            userId,
+            stepUpGrantDigestPort
+                .digest(STEP_UP_GRANT)
+                .value(),
+            Timestamp.from(now.minusSeconds(60)),
+            Timestamp.from(now.plusSeconds(600))
+        );
+
+        return grantId;
+    }
+
+    private Timestamp stepUpGrantConsumedAt(UUID grantId) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT consumed_at
+            FROM step_up_grants
+            WHERE id = ?
+            """,
+            Timestamp.class,
+            grantId
+        );
+    }
+
+    private void assertFamilyUnrevoked(UUID familyId) {
+        FamilyState state = jdbcTemplate.queryForObject(
+            """
+            SELECT revoked_at, revocation_reason
+            FROM refresh_token_families
+            WHERE id = ?
+            """,
+            (resultSet, rowNumber) ->
+                new FamilyState(
+                    resultSet.getTimestamp("revoked_at"),
+                    resultSet.getString(
+                        "revocation_reason"
+                    )
+                ),
+            familyId
+        );
+
+        assertThat(state).isNotNull();
+        assertThat(state.revokedAt()).isNull();
+        assertThat(state.reason()).isNull();
+    }
+
+    private int rowCount(
+        String table,
+        String userColumn,
+        UUID userId
+    ) {
+        Integer count = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM "
+                + table
+                + " WHERE "
+                + userColumn
+                + " = ?",
+            Integer.class,
+            userId
+        );
+
+        return count == null ? 0 : count;
+    }
+
+    private static byte[] protectedSecret() {
+        byte[] value = new byte[49];
+        Arrays.fill(value, (byte) 11);
+        return value;
+    }
+
+    private static byte[] digest(byte value) {
+        byte[] digest = new byte[32];
+        Arrays.fill(digest, value);
+        return digest;
+    }
+
+    private record FamilyState(
+        Timestamp revokedAt,
+        String reason
+    ) {
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class FailureInjectionConfiguration {
+
+        @Bean
+        @Primary
+        FailureInjectingAuditPort
+        failureInjectingAuditPort(
+            @Qualifier(
+                "accountSecurityAuditPersistenceAdapter"
+            )
+            AccountSecurityAuditPort delegate
+        ) {
+            return new FailureInjectingAuditPort(delegate);
+        }
+    }
+
+    static final class FailureInjectingAuditPort
+        implements AccountSecurityAuditPort {
+
+        private final AccountSecurityAuditPort delegate;
+
+        FailureInjectingAuditPort(
+            AccountSecurityAuditPort delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void append(
+            AccountSecurityAuditEvent event
+        ) {
+            delegate.append(event);
+            throw new IllegalStateException(
+                FAILURE_MESSAGE
+            );
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/AccountActionCredentialMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/AccountActionCredentialMigrationIntegrationTest.java
@@ -66,7 +66,7 @@ class AccountActionCredentialMigrationIntegrationTest {
 
         migrateToLatestVersion();
 
-        assertThat(currentSchemaVersion()).isEqualTo("21");
+        assertThat(currentSchemaVersion()).isEqualTo("23");
         assertThat(migrationApplied("15")).isTrue();
         assertThat(migrationApplied("16")).isTrue();
         assertThat(tableExists(

--- a/src/test/java/com/nursena/payflow/user/integration/AccountSecurityAuditMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/AccountSecurityAuditMigrationIntegrationTest.java
@@ -1,0 +1,273 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class AccountSecurityAuditMigrationIntegrationTest {
+
+    private static final Instant OCCURRED_AT =
+        Instant.parse("2026-08-11T12:00:00Z");
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    private static JdbcTemplate jdbcTemplate;
+
+    @BeforeAll
+    static void configureJdbcTemplate() {
+        jdbcTemplate = new JdbcTemplate(
+            new DriverManagerDataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+        );
+    }
+
+    @BeforeEach
+    void resetDatabase() {
+        Flyway.configure()
+            .cleanDisabled(false)
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .load()
+            .clean();
+    }
+
+    @Test
+    void shouldUpgradeV21ToAccountSecurityAuditSchema() {
+        migrateTo("21");
+
+        assertThat(tableExists("account_security_audits"))
+            .isFalse();
+
+        flyway().migrate();
+
+        assertThat(currentSchemaVersion())
+            .isEqualTo("23");
+        assertThat(tableExists("account_security_audits"))
+            .isTrue();
+    }
+
+    @Test
+    void shouldStoreOnlySupportedAuditFields() {
+        flyway().migrate();
+
+        UUID userId = insertUser();
+        UUID auditId = UUID.randomUUID();
+
+        insertAudit(
+            auditId,
+            userId,
+            "MFA_DISABLED",
+            OCCURRED_AT
+        );
+
+        Integer storedRows = jdbcTemplate.queryForObject("""
+            SELECT COUNT(*)
+            FROM account_security_audits
+            WHERE id = ?
+              AND subject_user_id = ?
+              AND action = ?
+              AND occurred_at = ?
+            """,
+            Integer.class,
+            auditId,
+            userId,
+            "MFA_DISABLED",
+            Timestamp.from(OCCURRED_AT)
+        );
+
+        assertThat(storedRows).isEqualTo(1);
+
+        List<String> columns = jdbcTemplate.queryForList("""
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'account_security_audits'
+            ORDER BY ordinal_position
+            """,
+            String.class
+        );
+
+        assertThat(columns).containsExactly(
+            "id",
+            "subject_user_id",
+            "action",
+            "occurred_at"
+        );
+    }
+
+    @Test
+    void shouldEnforceSubjectActionAndAuditRetention() {
+        flyway().migrate();
+
+        UUID userId = insertUser();
+
+        assertThatThrownBy(() -> insertAudit(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "MFA_DISABLED",
+            OCCURRED_AT
+        )).isInstanceOf(DataIntegrityViolationException.class);
+
+        assertThatThrownBy(() -> insertAudit(
+            UUID.randomUUID(),
+            userId,
+            "UNKNOWN_ACTION",
+            OCCURRED_AT
+        )).isInstanceOf(DataIntegrityViolationException.class);
+
+        insertAudit(
+            UUID.randomUUID(),
+            userId,
+            "MFA_DISABLED",
+            OCCURRED_AT
+        );
+
+        assertThatThrownBy(() -> jdbcTemplate.update(
+            "DELETE FROM users WHERE id = ?",
+            userId
+        )).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void shouldCreateSubjectTimelineIndex() {
+        flyway().migrate();
+
+        String indexDefinition = jdbcTemplate.queryForObject("""
+            SELECT indexdef
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname =
+                  'ix_account_security_audits_subject_occurred_at'
+            """,
+            String.class
+        );
+
+        assertThat(indexDefinition)
+            .contains("(subject_user_id, occurred_at DESC)");
+    }
+
+    private static UUID insertUser() {
+        UUID userId = UUID.randomUUID();
+        Timestamp now = Timestamp.from(OCCURRED_AT);
+
+        jdbcTemplate.update("""
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                email_verified_at,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, 'hash', 'USER', 'ACTIVE', ?, ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            now,
+            now,
+            now
+        );
+
+        return userId;
+    }
+
+    private static void insertAudit(
+        UUID auditId,
+        UUID subjectUserId,
+        String action,
+        Instant occurredAt
+    ) {
+        jdbcTemplate.update("""
+            INSERT INTO account_security_audits (
+                id,
+                subject_user_id,
+                action,
+                occurred_at
+            )
+            VALUES (?, ?, ?, ?)
+            """,
+            auditId,
+            subjectUserId,
+            action,
+            Timestamp.from(occurredAt)
+        );
+    }
+
+    private static Flyway flyway() {
+        return Flyway.configure()
+            .cleanDisabled(false)
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .load();
+    }
+
+    private static void migrateTo(String version) {
+        Flyway.configure()
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .target(version)
+            .load()
+            .migrate();
+    }
+
+    private static boolean tableExists(String tableName) {
+        Boolean exists = jdbcTemplate.queryForObject("""
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = 'public'
+                  AND table_name = ?
+            )
+            """,
+            Boolean.class,
+            tableName
+        );
+
+        return Boolean.TRUE.equals(exists);
+    }
+
+    private static String currentSchemaVersion() {
+        return jdbcTemplate.queryForObject("""
+            SELECT version
+            FROM flyway_schema_history
+            WHERE success = TRUE
+              AND version IS NOT NULL
+            ORDER BY installed_rank DESC
+            LIMIT 1
+            """,
+            String.class
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/MfaAuthenticatorMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/MfaAuthenticatorMigrationIntegrationTest.java
@@ -58,7 +58,7 @@ class MfaAuthenticatorMigrationIntegrationTest {
         migrateTo("17");
         assertThat(tableExists("mfa_authenticators")).isFalse();
         flyway().migrate();
-        assertThat(currentSchemaVersion()).isEqualTo("21");
+        assertThat(currentSchemaVersion()).isEqualTo("23");
         assertThat(tableExists("mfa_authenticators")).isTrue();
     }
 

--- a/src/test/java/com/nursena/payflow/user/integration/MfaLoginChallengeMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/MfaLoginChallengeMigrationIntegrationTest.java
@@ -52,7 +52,7 @@ class MfaLoginChallengeMigrationIntegrationTest {
         migrateTo("18");
         assertThat(tableExists("mfa_login_challenges")).isFalse();
         flyway().migrate();
-        assertThat(currentSchemaVersion()).isEqualTo("21");
+        assertThat(currentSchemaVersion()).isEqualTo("23");
         assertThat(tableExists("mfa_login_challenges")).isTrue();
     }
 

--- a/src/test/java/com/nursena/payflow/user/integration/MfaRecoveryCodeMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/MfaRecoveryCodeMigrationIntegrationTest.java
@@ -60,7 +60,7 @@ class MfaRecoveryCodeMigrationIntegrationTest {
 
         flyway().migrate();
 
-        assertThat(currentSchemaVersion()).isEqualTo("21");
+        assertThat(currentSchemaVersion()).isEqualTo("23");
         assertThat(tableExists("mfa_recovery_codes")).isTrue();
     }
 

--- a/src/test/java/com/nursena/payflow/user/integration/PasswordRecoveryMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/PasswordRecoveryMigrationIntegrationTest.java
@@ -65,7 +65,7 @@ class PasswordRecoveryMigrationIntegrationTest {
 
         migrateToLatestVersion();
 
-        assertThat(currentSchemaVersion()).isEqualTo("21");
+        assertThat(currentSchemaVersion()).isEqualTo("23");
 
         assertThat(revoke(
             familyId,

--- a/src/test/java/com/nursena/payflow/user/integration/RefreshSessionMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RefreshSessionMigrationIntegrationTest.java
@@ -74,7 +74,7 @@ class RefreshSessionMigrationIntegrationTest {
         migrateToLatestVersion();
 
         assertThat(currentSchemaVersion())
-            .isEqualTo("21");
+            .isEqualTo("23");
 
         assertThat(migrationApplied("13"))
             .isTrue();

--- a/src/test/java/com/nursena/payflow/user/integration/RefreshTokenFamilyRevocationReasonMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RefreshTokenFamilyRevocationReasonMigrationIntegrationTest.java
@@ -1,0 +1,217 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class RefreshTokenFamilyRevocationReasonMigrationIntegrationTest {
+
+    private static final Instant NOW =
+        Instant.parse("2026-08-11T12:00:00Z");
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    private static JdbcTemplate jdbcTemplate;
+
+    @BeforeAll
+    static void configureJdbcTemplate() {
+        jdbcTemplate = new JdbcTemplate(
+            new DriverManagerDataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+        );
+    }
+
+    @BeforeEach
+    void resetDatabase() {
+        flyway()
+            .clean();
+    }
+
+    @Test
+    void shouldExpandSupportedRevocationReasonsInV23() {
+        migrateTo("22");
+
+        UUID userId = insertUser();
+        UUID mfaDisabledFamilyId =
+            insertActiveFamily(userId);
+        UUID passwordRecoveryFamilyId =
+            insertActiveFamily(userId);
+        UUID unknownReasonFamilyId =
+            insertActiveFamily(userId);
+
+        assertThatThrownBy(() -> revoke(
+            mfaDisabledFamilyId,
+            "MFA_DISABLED"
+        )).isInstanceOf(
+            DataIntegrityViolationException.class
+        );
+
+        flyway()
+            .migrate();
+
+        assertThat(currentSchemaVersion())
+            .isEqualTo("23");
+
+        revoke(
+            mfaDisabledFamilyId,
+            "MFA_DISABLED"
+        );
+        revoke(
+            passwordRecoveryFamilyId,
+            "PASSWORD_RECOVERY"
+        );
+
+        assertThat(revocationReason(mfaDisabledFamilyId))
+            .isEqualTo("MFA_DISABLED");
+        assertThat(revocationReason(passwordRecoveryFamilyId))
+            .isEqualTo("PASSWORD_RECOVERY");
+
+        assertThatThrownBy(() -> revoke(
+            unknownReasonFamilyId,
+            "UNKNOWN_REASON"
+        )).isInstanceOf(
+            DataIntegrityViolationException.class
+        );
+    }
+
+    private static UUID insertUser() {
+        UUID userId = UUID.randomUUID();
+        Timestamp timestamp = Timestamp.from(NOW);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                email_verified_at,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, 'test-password-hash',
+                    'USER', 'ACTIVE', ?, ?, ?)
+            """,
+            userId,
+            userId + "@example.com",
+            timestamp,
+            timestamp,
+            timestamp
+        );
+
+        return userId;
+    }
+
+    private static UUID insertActiveFamily(UUID userId) {
+        UUID familyId = UUID.randomUUID();
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO refresh_token_families (
+                id,
+                user_id,
+                created_at,
+                expires_at,
+                revoked_at,
+                revocation_reason
+            )
+            VALUES (?, ?, ?, ?, NULL, NULL)
+            """,
+            familyId,
+            userId,
+            Timestamp.from(NOW),
+            Timestamp.from(NOW.plusSeconds(3_600))
+        );
+
+        return familyId;
+    }
+
+    private static void revoke(
+        UUID familyId,
+        String reason
+    ) {
+        jdbcTemplate.update(
+            """
+            UPDATE refresh_token_families
+            SET revoked_at = ?,
+                revocation_reason = ?
+            WHERE id = ?
+            """,
+            Timestamp.from(NOW.plusSeconds(60)),
+            reason,
+            familyId
+        );
+    }
+
+    private static String revocationReason(
+        UUID familyId
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT revocation_reason
+            FROM refresh_token_families
+            WHERE id = ?
+            """,
+            String.class,
+            familyId
+        );
+    }
+
+    private static void migrateTo(String version) {
+        Flyway.configure()
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .target(version)
+            .load()
+            .migrate();
+    }
+
+    private static Flyway flyway() {
+        return Flyway.configure()
+            .cleanDisabled(false)
+            .dataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+            )
+            .load();
+    }
+
+    private static String currentSchemaVersion() {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT version
+            FROM flyway_schema_history
+            WHERE success = TRUE
+              AND version IS NOT NULL
+            ORDER BY installed_rank DESC
+            LIMIT 1
+            """,
+            String.class
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/StepUpGrantMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/StepUpGrantMigrationIntegrationTest.java
@@ -49,7 +49,7 @@ class StepUpGrantMigrationIntegrationTest {
         migrateTo("20");
         assertThat(tableExists("step_up_grants")).isFalse();
         flyway().migrate();
-        assertThat(currentSchemaVersion()).isEqualTo("21");
+        assertThat(currentSchemaVersion()).isEqualTo("23");
         assertThat(tableExists("step_up_grants")).isTrue();
     }
 


### PR DESCRIPTION
## Summary

Adds a transactional MFA disable workflow protected by step-up authorization.

## Changes

- Add the DisableMfaUseCase application boundary and implementation.
- Consume the step-up grant before disabling MFA.
- Remove MFA authenticators and recovery codes atomically.
- Revoke active refresh-token families with an explicit MFA-disabled reason.
- Persist account-security audit events.
- Add Flyway migrations for audit storage and revocation reasons.
- Extend persistence ports and adapters without crossing hexagonal architecture boundaries.

## Transaction guarantees

The complete operation executes within one transaction. A failure while persisting the security audit rolls back step-up grant consumption, credential deletion, session revocation, and audit persistence.

## Database migrations

- V22 creates account-security audit storage and indexes.
- V23 adds the MFA-disabled refresh-token family revocation reason.
- PostgreSQL integration tests cover schema constraints and supported migration paths.

## Verification

- mvn clean verify
- 1,438 tests passed
- 0 failures, errors, or skipped tests
- Transaction rollback verified against PostgreSQL
- PR diff passes git diff --check

## Reviewer checklist

- [ ] Verify step-up authorization ordering.
- [ ] Verify transaction atomicity.
- [ ] Review audit data for security and privacy.
- [ ] Review Flyway deployment compatibility.
- [ ] Verify refresh-token revocation semantics.
- [ ] Review success, rejection, and rollback tests.

## Follow-up

The successful full suite can require Surefire to terminate its fork after the exit timeout because test Spring contexts and infrastructure resources remain alive during shutdown. Test lifecycle cleanup will be handled separately.