### PR TITLE
feat(user): add MFA recovery-code rotation

### DIFF
--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -72,6 +72,7 @@ public class SecurityConfiguration {
                     "/api/v1/auth/logout-all",
                     "/api/v1/users/me/mfa/enrollment",
                     "/api/v1/users/me/mfa/enrollment/confirm",
+                    "/api/v1/users/me/mfa/recovery-codes/rotation",
                     "/api/v1/users/me/step-up/grants",
                     "/api/v1/wallets",
                     "/api/v1/wallets/me/top-ups",

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateMfaRecoveryCodesController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateMfaRecoveryCodesController.java
@@ -1,0 +1,46 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.RotateMfaRecoveryCodesCommand;
+import com.nursena.payflow.user.application.port.in.RotateMfaRecoveryCodesResult;
+import com.nursena.payflow.user.application.port.in.RotateMfaRecoveryCodesUseCase;
+import jakarta.validation.Valid;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users/me/mfa/recovery-codes")
+public class RotateMfaRecoveryCodesController {
+
+    private final RotateMfaRecoveryCodesUseCase useCase;
+
+    public RotateMfaRecoveryCodesController(
+        RotateMfaRecoveryCodesUseCase useCase
+    ) {
+        this.useCase = useCase;
+    }
+
+    @PostMapping("/rotation")
+    public ResponseEntity<RotateMfaRecoveryCodesResponse> rotate(
+        @AuthenticationPrincipal Jwt jwt,
+        @Valid @RequestBody RotateMfaRecoveryCodesRequest request
+    ) {
+        RotateMfaRecoveryCodesResult result = useCase.rotate(
+            new RotateMfaRecoveryCodesCommand(
+                UUID.fromString(jwt.getSubject()),
+                request.stepUpGrant()
+            )
+        );
+
+        return ResponseEntity.ok()
+            .cacheControl(CacheControl.noStore())
+            .body(RotateMfaRecoveryCodesResponse.from(result));
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateMfaRecoveryCodesRequest.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateMfaRecoveryCodesRequest.java
@@ -1,0 +1,13 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RotateMfaRecoveryCodesRequest(
+    @NotBlank String stepUpGrant
+) {
+
+    @Override
+    public String toString() {
+        return "RotateMfaRecoveryCodesRequest[stepUpGrant=<redacted>]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateMfaRecoveryCodesResponse.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/RotateMfaRecoveryCodesResponse.java
@@ -1,0 +1,27 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import java.util.List;
+
+import com.nursena.payflow.user.application.port.in.RotateMfaRecoveryCodesResult;
+
+public record RotateMfaRecoveryCodesResponse(
+    List<String> recoveryCodes
+) {
+
+    public RotateMfaRecoveryCodesResponse {
+        recoveryCodes = List.copyOf(recoveryCodes);
+    }
+
+    static RotateMfaRecoveryCodesResponse from(
+        RotateMfaRecoveryCodesResult result
+    ) {
+        return new RotateMfaRecoveryCodesResponse(
+            result.recoveryCodes()
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "RotateMfaRecoveryCodesResponse[recoveryCodes=<redacted>]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/StepUpExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/StepUpExceptionHandler.java
@@ -23,7 +23,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
-@RestControllerAdvice(assignableTypes = StepUpGrantController.class)
+@RestControllerAdvice(assignableTypes = {
+    StepUpGrantController.class,
+    RotateMfaRecoveryCodesController.class
+})
 public class StepUpExceptionHandler {
 
     @ExceptionHandler(InvalidStepUpPurposeException.class)

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RotateMfaRecoveryCodesCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RotateMfaRecoveryCodesCommand.java
@@ -1,0 +1,34 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public final class RotateMfaRecoveryCodesCommand {
+
+    private final UUID userId;
+    private final String stepUpGrant;
+
+    public RotateMfaRecoveryCodesCommand(
+        UUID userId,
+        String stepUpGrant
+    ) {
+        this.userId =
+            Objects.requireNonNull(userId, "userId must not be null");
+        this.stepUpGrant = stepUpGrant;
+    }
+
+    public UUID userId() {
+        return userId;
+    }
+
+    public String stepUpGrant() {
+        return stepUpGrant;
+    }
+
+    @Override
+    public String toString() {
+        return "RotateMfaRecoveryCodesCommand[userId="
+            + userId
+            + ", stepUpGrant=[REDACTED]]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RotateMfaRecoveryCodesResult.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RotateMfaRecoveryCodesResult.java
@@ -1,0 +1,24 @@
+package com.nursena.payflow.user.application.port.in;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class RotateMfaRecoveryCodesResult {
+
+    private final List<String> recoveryCodes;
+
+    public RotateMfaRecoveryCodesResult(
+        List<String> recoveryCodes
+    ) {
+        this.recoveryCodes = List.copyOf(
+            Objects.requireNonNull(
+                recoveryCodes,
+                "recoveryCodes must not be null"
+            )
+        );
+    }
+
+    public List<String> recoveryCodes() {
+        return recoveryCodes;
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RotateMfaRecoveryCodesUseCase.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RotateMfaRecoveryCodesUseCase.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.user.application.port.in;
+
+public interface RotateMfaRecoveryCodesUseCase {
+
+    RotateMfaRecoveryCodesResult rotate(
+        RotateMfaRecoveryCodesCommand command
+    );
+}

--- a/src/main/java/com/nursena/payflow/user/application/service/RotateMfaRecoveryCodesService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RotateMfaRecoveryCodesService.java
@@ -1,0 +1,109 @@
+package com.nursena.payflow.user.application.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.RotateMfaRecoveryCodesCommand;
+import com.nursena.payflow.user.application.port.in.RotateMfaRecoveryCodesResult;
+import com.nursena.payflow.user.application.port.in.RotateMfaRecoveryCodesUseCase;
+import com.nursena.payflow.user.application.port.in.StepUpAuthorizationPolicy;
+import com.nursena.payflow.user.application.port.out.AccountSecurityAuditPort;
+import com.nursena.payflow.user.application.port.out.MfaAuthenticatorRepositoryPort;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeRepositoryPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.MfaStateConflictException;
+import com.nursena.payflow.user.domain.exception.UserNotFoundException;
+import com.nursena.payflow.user.domain.model.AccountSecurityAuditEvent;
+import com.nursena.payflow.user.domain.model.MfaAuthenticator;
+import com.nursena.payflow.user.domain.model.MfaLifecycleState;
+import com.nursena.payflow.user.domain.model.StepUpPurpose;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class RotateMfaRecoveryCodesService
+    implements RotateMfaRecoveryCodesUseCase {
+
+    private final UserRepositoryPort userRepository;
+    private final MfaAuthenticatorRepositoryPort authenticatorRepository;
+    private final MfaRecoveryCodeRepositoryPort recoveryCodeRepository;
+    private final MfaRecoveryCodeIssuer recoveryCodeIssuer;
+    private final StepUpAuthorizationPolicy stepUpAuthorizationPolicy;
+    private final AccountSecurityAuditPort auditPort;
+    private final Clock clock;
+
+    public RotateMfaRecoveryCodesService(
+        UserRepositoryPort userRepository,
+        MfaAuthenticatorRepositoryPort authenticatorRepository,
+        MfaRecoveryCodeRepositoryPort recoveryCodeRepository,
+        MfaRecoveryCodeIssuer recoveryCodeIssuer,
+        StepUpAuthorizationPolicy stepUpAuthorizationPolicy,
+        AccountSecurityAuditPort auditPort,
+        Clock clock
+    ) {
+        this.userRepository =
+            Objects.requireNonNull(userRepository);
+        this.authenticatorRepository =
+            Objects.requireNonNull(authenticatorRepository);
+        this.recoveryCodeRepository =
+            Objects.requireNonNull(recoveryCodeRepository);
+        this.recoveryCodeIssuer =
+            Objects.requireNonNull(recoveryCodeIssuer);
+        this.stepUpAuthorizationPolicy =
+            Objects.requireNonNull(stepUpAuthorizationPolicy);
+        this.auditPort =
+            Objects.requireNonNull(auditPort);
+        this.clock =
+            Objects.requireNonNull(clock);
+    }
+
+    @Override
+    public RotateMfaRecoveryCodesResult rotate(
+        RotateMfaRecoveryCodesCommand command
+    ) {
+        Objects.requireNonNull(
+            command,
+            "command must not be null"
+        );
+
+        UUID userId = command.userId();
+
+        userRepository.findByIdForUpdate(userId)
+            .orElseThrow(UserNotFoundException::new);
+
+        MfaAuthenticator authenticator =
+            authenticatorRepository.findByUserIdForUpdate(userId)
+                .orElseThrow(MfaStateConflictException::new);
+
+        if (authenticator.state() != MfaLifecycleState.ENABLED) {
+            throw new MfaStateConflictException();
+        }
+
+        stepUpAuthorizationPolicy.requireAndConsume(
+            userId,
+            StepUpPurpose.RECOVERY_CODE_ROTATION,
+            command.stepUpGrant()
+        );
+
+        Instant occurredAt = clock.instant();
+
+        recoveryCodeRepository.deleteAllByUserId(userId);
+
+        List<String> recoveryCodes =
+            recoveryCodeIssuer.issue(userId, occurredAt);
+
+        auditPort.append(
+            AccountSecurityAuditEvent.recoveryCodesRotated(
+                UUID.randomUUID(),
+                userId,
+                occurredAt
+            )
+        );
+
+        return new RotateMfaRecoveryCodesResult(recoveryCodes);
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/domain/model/AccountSecurityAuditAction.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/AccountSecurityAuditAction.java
@@ -1,5 +1,6 @@
 package com.nursena.payflow.user.domain.model;
 
 public enum AccountSecurityAuditAction {
-    MFA_DISABLED
+    MFA_DISABLED,
+    RECOVERY_CODES_ROTATED
 }

--- a/src/main/java/com/nursena/payflow/user/domain/model/AccountSecurityAuditEvent.java
+++ b/src/main/java/com/nursena/payflow/user/domain/model/AccountSecurityAuditEvent.java
@@ -30,4 +30,17 @@ public record AccountSecurityAuditEvent(
             occurredAt
         );
     }
+
+    public static AccountSecurityAuditEvent recoveryCodesRotated(
+        UUID id,
+        UUID subjectUserId,
+        Instant occurredAt
+    ) {
+        return new AccountSecurityAuditEvent(
+            id,
+            subjectUserId,
+            AccountSecurityAuditAction.RECOVERY_CODES_ROTATED,
+            occurredAt
+        );
+    }
 }

--- a/src/main/resources/db/migration/V24__expand_account_security_audit_actions.sql
+++ b/src/main/resources/db/migration/V24__expand_account_security_audit_actions.sql
@@ -1,0 +1,9 @@
+ALTER TABLE account_security_audits
+    DROP CONSTRAINT chk_account_security_audits_action;
+
+ALTER TABLE account_security_audits
+    ADD CONSTRAINT chk_account_security_audits_action
+    CHECK (action IN (
+        'MFA_DISABLED',
+        'RECOVERY_CODES_ROTATED'
+    ));

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -82,6 +82,8 @@ class OpenApiJsonContractIntegrationTest {
     private static final String MFA_ENROLLMENT_CONFIRM_PATH =
         MFA_ENROLLMENT_PATH + "/confirm";
 
+    private static final String MFA_RECOVERY_CODE_ROTATION_PATH =
+        "/api/v1/users/me/mfa/recovery-codes/rotation";
     private static final String STEP_UP_GRANTS_PATH =
         "/api/v1/users/me/step-up/grants";
 
@@ -228,6 +230,7 @@ class OpenApiJsonContractIntegrationTest {
             MFA_STATUS_PATH,
             MFA_ENROLLMENT_PATH,
             MFA_ENROLLMENT_CONFIRM_PATH,
+            MFA_RECOVERY_CODE_ROTATION_PATH,
             STEP_UP_GRANTS_PATH,
             WALLETS_PATH,
             CURRENT_WALLET_PATH,

--- a/src/test/java/com/nursena/payflow/maildelivery/integration/MailOutboxMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/maildelivery/integration/MailOutboxMigrationIntegrationTest.java
@@ -48,7 +48,7 @@ class MailOutboxMigrationIntegrationTest {
         assertThat(tableExists("mail_outbox_messages")).isFalse();
 
         migrateToLatestVersion();
-        assertThat(currentSchemaVersion()).isEqualTo("23");
+        assertThat(currentSchemaVersion()).isEqualTo("24");
 
         UUID userId = UUID.randomUUID();
         UUID credentialId = UUID.randomUUID();

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/RotateMfaRecoveryCodesControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/RotateMfaRecoveryCodesControllerTest.java
@@ -1,0 +1,190 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CACHE_CONTROL;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
+import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
+import com.nursena.payflow.user.application.port.in.RotateMfaRecoveryCodesCommand;
+import com.nursena.payflow.user.application.port.in.RotateMfaRecoveryCodesResult;
+import com.nursena.payflow.user.application.port.in.RotateMfaRecoveryCodesUseCase;
+import com.nursena.payflow.user.domain.exception.InvalidStepUpGrantException;
+import com.nursena.payflow.user.domain.exception.MfaStateConflictException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(RotateMfaRecoveryCodesController.class)
+@Import({
+    RequestCorrelationConfiguration.class,
+    SecurityConfiguration.class,
+    StepUpExceptionHandler.class
+})
+class RotateMfaRecoveryCodesControllerTest {
+
+    private static final String ENDPOINT =
+        "/api/v1/users/me/mfa/recovery-codes/rotation";
+
+    private static final UUID USER_ID =
+        UUID.fromString("10000000-0000-0000-0000-000000000105");
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean RotateMfaRecoveryCodesUseCase useCase;
+    @MockitoBean JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldRequireBearerAuthentication() throws Exception {
+        mockMvc.perform(post(ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequest()))
+            .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(useCase);
+    }
+
+    @Test
+    void shouldRejectBlankStepUpGrant() throws Exception {
+        mockJwt();
+
+        mockMvc.perform(post(ENDPOINT)
+                .header(AUTHORIZATION, "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "stepUpGrant": " "
+                    }
+                    """))
+            .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(useCase);
+    }
+
+    @Test
+    void shouldRotateRecoveryCodesForAuthenticatedSubject()
+        throws Exception {
+
+        mockJwt();
+
+        when(useCase.rotate(any(RotateMfaRecoveryCodesCommand.class)))
+            .thenReturn(result());
+
+        performValid()
+            .andExpect(status().isOk())
+            .andExpect(header().string(CACHE_CONTROL, "no-store"))
+            .andExpect(jsonPath("$.recoveryCodes.length()").value(2))
+            .andExpect(
+                jsonPath("$.recoveryCodes[0]")
+                    .value("recovery-code-one")
+            )
+            .andExpect(
+                jsonPath("$.recoveryCodes[1]")
+                    .value("recovery-code-two")
+            );
+
+        verify(useCase).rotate(argThat(command ->
+            command.userId().equals(USER_ID)
+                && command.stepUpGrant().equals("opaque-grant")
+        ));
+    }
+
+    @Test
+    void shouldExposeStableCoarseFailureContracts() throws Exception {
+        mockJwt();
+
+        when(useCase.rotate(any()))
+            .thenThrow(new InvalidStepUpGrantException())
+            .thenThrow(new MfaStateConflictException())
+            .thenThrow(new MfaSecurityUnavailableException());
+
+        performValid()
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("STEP_UP_INVALID"));
+
+        performValid()
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("MFA_STATE_CONFLICT"));
+
+        performValid()
+            .andExpect(status().isServiceUnavailable())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("MFA_SECURITY_UNAVAILABLE")
+            );
+    }
+
+    @Test
+    void shouldRedactGrantAndRecoveryCodesFromToString() {
+        RotateMfaRecoveryCodesRequest request =
+            new RotateMfaRecoveryCodesRequest("opaque-grant");
+
+        RotateMfaRecoveryCodesResponse response =
+            RotateMfaRecoveryCodesResponse.from(result());
+
+        assertThat(request.toString())
+            .doesNotContain("opaque-grant");
+
+        assertThat(response.toString())
+            .doesNotContain(
+                "recovery-code-one",
+                "recovery-code-two"
+            );
+    }
+
+    private ResultActions performValid() throws Exception {
+        return mockMvc.perform(post(ENDPOINT)
+            .header(AUTHORIZATION, "Bearer token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validRequest()));
+    }
+
+    private static String validRequest() {
+        return """
+            {
+              "stepUpGrant": "opaque-grant"
+            }
+            """;
+    }
+
+    private static RotateMfaRecoveryCodesResult result() {
+        return new RotateMfaRecoveryCodesResult(
+            List.of(
+                "recovery-code-one",
+                "recovery-code-two"
+            )
+        );
+    }
+
+    private void mockJwt() {
+        when(jwtDecoder.decode("token")).thenReturn(
+            Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .subject(USER_ID.toString())
+                .claim("role", "USER")
+                .issuedAt(Instant.parse("2026-08-10T09:55:00Z"))
+                .expiresAt(Instant.parse("2026-08-10T10:15:00Z"))
+                .build()
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/RotateMfaRecoveryCodesServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RotateMfaRecoveryCodesServiceTest.java
@@ -1,0 +1,302 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.RotateMfaRecoveryCodesCommand;
+import com.nursena.payflow.user.application.port.in.RotateMfaRecoveryCodesResult;
+import com.nursena.payflow.user.application.port.in.StepUpAuthorizationPolicy;
+import com.nursena.payflow.user.application.port.out.AccountSecurityAuditPort;
+import com.nursena.payflow.user.application.port.out.MfaAuthenticatorRepositoryPort;
+import com.nursena.payflow.user.application.port.out.MfaRecoveryCodeRepositoryPort;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import com.nursena.payflow.user.domain.exception.InvalidStepUpGrantException;
+import com.nursena.payflow.user.domain.exception.MfaStateConflictException;
+import com.nursena.payflow.user.domain.exception.UserNotFoundException;
+import com.nursena.payflow.user.domain.model.AccountSecurityAuditAction;
+import com.nursena.payflow.user.domain.model.EmailAddress;
+import com.nursena.payflow.user.domain.model.MfaAuthenticator;
+import com.nursena.payflow.user.domain.model.ProtectedMfaSecret;
+import com.nursena.payflow.user.domain.model.StepUpPurpose;
+import com.nursena.payflow.user.domain.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RotateMfaRecoveryCodesServiceTest {
+
+    private static final Instant NOW =
+        Instant.parse("2026-08-11T11:00:00Z");
+    private static final String STEP_UP_GRANT = "step-up-grant";
+
+    @Mock UserRepositoryPort userRepository;
+    @Mock MfaAuthenticatorRepositoryPort authenticatorRepository;
+    @Mock MfaRecoveryCodeRepositoryPort recoveryCodeRepository;
+    @Mock MfaRecoveryCodeIssuer recoveryCodeIssuer;
+    @Mock StepUpAuthorizationPolicy stepUpAuthorizationPolicy;
+    @Mock AccountSecurityAuditPort auditPort;
+
+    private RotateMfaRecoveryCodesService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RotateMfaRecoveryCodesService(
+            userRepository,
+            authenticatorRepository,
+            recoveryCodeRepository,
+            recoveryCodeIssuer,
+            stepUpAuthorizationPolicy,
+            auditPort,
+            Clock.fixed(NOW, ZoneOffset.UTC)
+        );
+    }
+
+    @Test
+    void shouldRotateRecoveryCodesAfterLockingMfaState() {
+        User user = activeUser();
+        MfaAuthenticator authenticator =
+            activeAuthenticator(user.id());
+        List<String> issuedCodes = new ArrayList<>(
+            List.of("code-1", "code-2")
+        );
+
+        when(userRepository.findByIdForUpdate(user.id()))
+            .thenReturn(Optional.of(user));
+        when(authenticatorRepository.findByUserIdForUpdate(user.id()))
+            .thenReturn(Optional.of(authenticator));
+        when(recoveryCodeIssuer.issue(user.id(), NOW))
+            .thenReturn(issuedCodes);
+
+        RotateMfaRecoveryCodesResult result = service.rotate(
+            new RotateMfaRecoveryCodesCommand(
+                user.id(),
+                STEP_UP_GRANT
+            )
+        );
+
+        assertThat(result.recoveryCodes())
+            .containsExactly("code-1", "code-2");
+
+        issuedCodes.add("late-mutation");
+
+        assertThat(result.recoveryCodes())
+            .containsExactly("code-1", "code-2");
+        assertThatThrownBy(() ->
+            result.recoveryCodes().add("forbidden")
+        ).isInstanceOf(UnsupportedOperationException.class);
+
+        InOrder ordered = inOrder(
+            userRepository,
+            authenticatorRepository,
+            stepUpAuthorizationPolicy,
+            recoveryCodeRepository,
+            recoveryCodeIssuer,
+            auditPort
+        );
+
+        ordered.verify(userRepository)
+            .findByIdForUpdate(user.id());
+        ordered.verify(authenticatorRepository)
+            .findByUserIdForUpdate(user.id());
+        ordered.verify(stepUpAuthorizationPolicy)
+            .requireAndConsume(
+                user.id(),
+                StepUpPurpose.RECOVERY_CODE_ROTATION,
+                STEP_UP_GRANT
+            );
+        ordered.verify(recoveryCodeRepository)
+            .deleteAllByUserId(user.id());
+        ordered.verify(recoveryCodeIssuer)
+            .issue(user.id(), NOW);
+        ordered.verify(auditPort).append(argThat(event ->
+            event.id() != null
+                && event.subjectUserId().equals(user.id())
+                && event.action()
+                    == AccountSecurityAuditAction.RECOVERY_CODES_ROTATED
+                && event.occurredAt().equals(NOW)
+        ));
+    }
+
+    @Test
+    void shouldRejectUnknownUserBeforeInspectingMfaState() {
+        UUID userId = UUID.randomUUID();
+
+        when(userRepository.findByIdForUpdate(userId))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.rotate(
+            new RotateMfaRecoveryCodesCommand(
+                userId,
+                STEP_UP_GRANT
+            )
+        )).isInstanceOf(UserNotFoundException.class);
+
+        verifyNoInteractions(
+            authenticatorRepository,
+            recoveryCodeRepository,
+            recoveryCodeIssuer,
+            stepUpAuthorizationPolicy,
+            auditPort
+        );
+    }
+
+    @Test
+    void shouldRejectWhenAuthenticatorDoesNotExist() {
+        User user = activeUser();
+
+        when(userRepository.findByIdForUpdate(user.id()))
+            .thenReturn(Optional.of(user));
+        when(authenticatorRepository.findByUserIdForUpdate(user.id()))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.rotate(
+            new RotateMfaRecoveryCodesCommand(
+                user.id(),
+                STEP_UP_GRANT
+            )
+        )).isInstanceOf(MfaStateConflictException.class);
+
+        verifyNoInteractions(
+            recoveryCodeRepository,
+            recoveryCodeIssuer,
+            stepUpAuthorizationPolicy,
+            auditPort
+        );
+    }
+
+    @Test
+    void shouldRejectWhenAuthenticatorIsNotActive() {
+        User user = activeUser();
+        MfaAuthenticator pending =
+            pendingAuthenticator(user.id());
+
+        when(userRepository.findByIdForUpdate(user.id()))
+            .thenReturn(Optional.of(user));
+        when(authenticatorRepository.findByUserIdForUpdate(user.id()))
+            .thenReturn(Optional.of(pending));
+
+        assertThatThrownBy(() -> service.rotate(
+            new RotateMfaRecoveryCodesCommand(
+                user.id(),
+                STEP_UP_GRANT
+            )
+        )).isInstanceOf(MfaStateConflictException.class);
+
+        verify(recoveryCodeRepository, never())
+            .deleteAllByUserId(user.id());
+        verifyNoInteractions(
+            recoveryCodeIssuer,
+            stepUpAuthorizationPolicy,
+            auditPort
+        );
+    }
+
+    @Test
+    void shouldNotReplaceCodesWhenStepUpGrantIsRejected() {
+        User user = activeUser();
+        MfaAuthenticator authenticator =
+            activeAuthenticator(user.id());
+
+        when(userRepository.findByIdForUpdate(user.id()))
+            .thenReturn(Optional.of(user));
+        when(authenticatorRepository.findByUserIdForUpdate(user.id()))
+            .thenReturn(Optional.of(authenticator));
+
+        doThrow(new InvalidStepUpGrantException())
+            .when(stepUpAuthorizationPolicy)
+            .requireAndConsume(
+                user.id(),
+                StepUpPurpose.RECOVERY_CODE_ROTATION,
+                STEP_UP_GRANT
+            );
+
+        assertThatThrownBy(() -> service.rotate(
+            new RotateMfaRecoveryCodesCommand(
+                user.id(),
+                STEP_UP_GRANT
+            )
+        )).isInstanceOf(InvalidStepUpGrantException.class);
+
+        verify(recoveryCodeRepository, never())
+            .deleteAllByUserId(user.id());
+        verifyNoInteractions(recoveryCodeIssuer, auditPort);
+    }
+
+    @Test
+    void shouldPropagateAuditFailureForTransactionRollback() {
+        User user = activeUser();
+        MfaAuthenticator authenticator =
+            activeAuthenticator(user.id());
+        RuntimeException auditFailure =
+            new RuntimeException("audit unavailable");
+
+        when(userRepository.findByIdForUpdate(user.id()))
+            .thenReturn(Optional.of(user));
+        when(authenticatorRepository.findByUserIdForUpdate(user.id()))
+            .thenReturn(Optional.of(authenticator));
+        when(recoveryCodeIssuer.issue(user.id(), NOW))
+            .thenReturn(List.of("code-1", "code-2"));
+
+        doThrow(auditFailure)
+            .when(auditPort)
+            .append(argThat(event ->
+                event.action()
+                    == AccountSecurityAuditAction.RECOVERY_CODES_ROTATED
+            ));
+
+        assertThatThrownBy(() -> service.rotate(
+            new RotateMfaRecoveryCodesCommand(
+                user.id(),
+                STEP_UP_GRANT
+            )
+        )).isSameAs(auditFailure);
+
+        verify(recoveryCodeRepository)
+            .deleteAllByUserId(user.id());
+        verify(recoveryCodeIssuer).issue(user.id(), NOW);
+    }
+
+    private static User activeUser() {
+        return User.register(
+            EmailAddress.of("user@example.com"),
+            "password-hash",
+            NOW.minusSeconds(60)
+        );
+    }
+
+    private static MfaAuthenticator pendingAuthenticator(
+        UUID userId
+    ) {
+        return MfaAuthenticator.beginEnrollment(
+            userId,
+            ProtectedMfaSecret.of(new byte[49]),
+            NOW.minusSeconds(30),
+            NOW.plusSeconds(570)
+        );
+    }
+
+    private static MfaAuthenticator activeAuthenticator(
+        UUID userId
+    ) {
+        return pendingAuthenticator(userId).activate(NOW);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/domain/model/AccountSecurityAuditEventTest.java
+++ b/src/test/java/com/nursena/payflow/user/domain/model/AccountSecurityAuditEventTest.java
@@ -1,0 +1,35 @@
+package com.nursena.payflow.user.domain.model;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class AccountSecurityAuditEventTest {
+
+    @Test
+    void recoveryCodesRotatedCreatesExpectedAuditEvent() {
+        UUID id = UUID.randomUUID();
+        UUID subjectUserId = UUID.randomUUID();
+        Instant occurredAt = Instant.parse("2026-08-11T10:15:30Z");
+
+        AccountSecurityAuditEvent event =
+            AccountSecurityAuditEvent.recoveryCodesRotated(
+                id,
+                subjectUserId,
+                occurredAt
+            );
+
+        assertAll(
+            () -> assertEquals(id, event.id()),
+            () -> assertEquals(subjectUserId, event.subjectUserId()),
+            () -> assertEquals(
+                AccountSecurityAuditAction.RECOVERY_CODES_ROTATED,
+                event.action()
+            ),
+            () -> assertEquals(occurredAt, event.occurredAt())
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/AccountActionCredentialMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/AccountActionCredentialMigrationIntegrationTest.java
@@ -66,7 +66,7 @@ class AccountActionCredentialMigrationIntegrationTest {
 
         migrateToLatestVersion();
 
-        assertThat(currentSchemaVersion()).isEqualTo("23");
+        assertThat(currentSchemaVersion()).isEqualTo("24");
         assertThat(migrationApplied("15")).isTrue();
         assertThat(migrationApplied("16")).isTrue();
         assertThat(tableExists(

--- a/src/test/java/com/nursena/payflow/user/integration/AccountSecurityAuditMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/AccountSecurityAuditMigrationIntegrationTest.java
@@ -65,9 +65,58 @@ class AccountSecurityAuditMigrationIntegrationTest {
         flyway().migrate();
 
         assertThat(currentSchemaVersion())
-            .isEqualTo("23");
+            .isEqualTo("24");
         assertThat(tableExists("account_security_audits"))
             .isTrue();
+    }
+
+    @Test
+    void shouldExpandSupportedAuditActionsInV24() {
+        migrateTo("23");
+
+        UUID userId = insertUser();
+
+        assertThatThrownBy(() -> insertAudit(
+            UUID.randomUUID(),
+            userId,
+            "RECOVERY_CODES_ROTATED",
+            OCCURRED_AT
+        )).isInstanceOf(DataIntegrityViolationException.class);
+
+        flyway().migrate();
+
+        assertThat(currentSchemaVersion()).isEqualTo("24");
+
+        insertAudit(
+            UUID.randomUUID(),
+            userId,
+            "MFA_DISABLED",
+            OCCURRED_AT
+        );
+        insertAudit(
+            UUID.randomUUID(),
+            userId,
+            "RECOVERY_CODES_ROTATED",
+            OCCURRED_AT
+        );
+
+        Integer storedRows = jdbcTemplate.queryForObject("""
+            SELECT COUNT(*)
+            FROM account_security_audits
+            WHERE subject_user_id = ?
+            """,
+            Integer.class,
+            userId
+        );
+
+        assertThat(storedRows).isEqualTo(2);
+
+        assertThatThrownBy(() -> insertAudit(
+            UUID.randomUUID(),
+            userId,
+            "UNKNOWN_ACTION",
+            OCCURRED_AT
+        )).isInstanceOf(DataIntegrityViolationException.class);
     }
 
     @Test

--- a/src/test/java/com/nursena/payflow/user/integration/MfaAuthenticatorMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/MfaAuthenticatorMigrationIntegrationTest.java
@@ -58,7 +58,7 @@ class MfaAuthenticatorMigrationIntegrationTest {
         migrateTo("17");
         assertThat(tableExists("mfa_authenticators")).isFalse();
         flyway().migrate();
-        assertThat(currentSchemaVersion()).isEqualTo("23");
+        assertThat(currentSchemaVersion()).isEqualTo("24");
         assertThat(tableExists("mfa_authenticators")).isTrue();
     }
 

--- a/src/test/java/com/nursena/payflow/user/integration/MfaLoginChallengeMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/MfaLoginChallengeMigrationIntegrationTest.java
@@ -52,7 +52,7 @@ class MfaLoginChallengeMigrationIntegrationTest {
         migrateTo("18");
         assertThat(tableExists("mfa_login_challenges")).isFalse();
         flyway().migrate();
-        assertThat(currentSchemaVersion()).isEqualTo("23");
+        assertThat(currentSchemaVersion()).isEqualTo("24");
         assertThat(tableExists("mfa_login_challenges")).isTrue();
     }
 

--- a/src/test/java/com/nursena/payflow/user/integration/MfaRecoveryCodeMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/MfaRecoveryCodeMigrationIntegrationTest.java
@@ -60,7 +60,7 @@ class MfaRecoveryCodeMigrationIntegrationTest {
 
         flyway().migrate();
 
-        assertThat(currentSchemaVersion()).isEqualTo("23");
+        assertThat(currentSchemaVersion()).isEqualTo("24");
         assertThat(tableExists("mfa_recovery_codes")).isTrue();
     }
 

--- a/src/test/java/com/nursena/payflow/user/integration/PasswordRecoveryMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/PasswordRecoveryMigrationIntegrationTest.java
@@ -65,7 +65,7 @@ class PasswordRecoveryMigrationIntegrationTest {
 
         migrateToLatestVersion();
 
-        assertThat(currentSchemaVersion()).isEqualTo("23");
+        assertThat(currentSchemaVersion()).isEqualTo("24");
 
         assertThat(revoke(
             familyId,

--- a/src/test/java/com/nursena/payflow/user/integration/RefreshSessionMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RefreshSessionMigrationIntegrationTest.java
@@ -74,7 +74,7 @@ class RefreshSessionMigrationIntegrationTest {
         migrateToLatestVersion();
 
         assertThat(currentSchemaVersion())
-            .isEqualTo("23");
+            .isEqualTo("24");
 
         assertThat(migrationApplied("13"))
             .isTrue();

--- a/src/test/java/com/nursena/payflow/user/integration/RefreshTokenFamilyRevocationReasonMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/RefreshTokenFamilyRevocationReasonMigrationIntegrationTest.java
@@ -70,7 +70,7 @@ class RefreshTokenFamilyRevocationReasonMigrationIntegrationTest {
             .migrate();
 
         assertThat(currentSchemaVersion())
-            .isEqualTo("23");
+            .isEqualTo("24");
 
         revoke(
             mfaDisabledFamilyId,

--- a/src/test/java/com/nursena/payflow/user/integration/StepUpGrantMigrationIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/StepUpGrantMigrationIntegrationTest.java
@@ -49,7 +49,7 @@ class StepUpGrantMigrationIntegrationTest {
         migrateTo("20");
         assertThat(tableExists("step_up_grants")).isFalse();
         flyway().migrate();
-        assertThat(currentSchemaVersion()).isEqualTo("23");
+        assertThat(currentSchemaVersion()).isEqualTo("24");
         assertThat(tableExists("step_up_grants")).isTrue();
     }
 


### PR DESCRIPTION
## Summary

Adds transactional, step-up-authorized MFA recovery-code rotation with auditable security events and an authenticated REST endpoint.

## Changes

- Add recovery-code rotation application ports and service.
- Require and consume a purpose-bound step-up grant before rotation.
- Replace existing recovery codes with a newly generated single-use set.
- Extend account-security audit actions and events for rotation outcomes.
- Add the V24 Flyway migration for the expanded audit-action constraint.
- Expose `POST /api/v1/users/me/mfa/recovery-codes/rotation`.
- Resolve the account exclusively from the authenticated JWT subject.
- Return recovery codes once with `Cache-Control: no-store`.
- Redact the step-up grant and recovery codes from DTO string representations.
- Extend stable step-up and MFA error contracts to the new endpoint.
- Update the authenticated endpoint allowlist and OpenAPI path contract.

## Architecture and security

- Preserve the hexagonal boundary: the web adapter maps HTTP input to the existing use case.
- Keep step-up validation and consumption inside the application service.
- Do not accept an account identifier from the client.
- Keep recovery credentials out of logs and cacheable responses.
- Preserve coarse-grained API errors for invalid grants and MFA state failures.

## Database migration

- V24 expands the account-security audit-action constraint for recovery-code rotation events.
- Migration integration tests cover the supported schema upgrade paths.

## Verification

- `mvn clean verify`
- 1,451 tests passed
- 0 failures, errors, or skipped tests
- Controller security, validation, error mapping, redaction, and no-store behavior verified
- OpenAPI public-path contract updated and verified
- `git diff --check` passed
- Working tree clean and branch synchronized with origin

## Reviewer checklist

- [ ] Verify purpose-bound step-up authorization and consumption ordering.
- [ ] Review recovery-code replacement and transactional behavior.
- [ ] Review audit-event semantics and V24 migration compatibility.
- [ ] Verify JWT subject ownership and absence of client-supplied account IDs.
- [ ] Review response caching and credential-redaction safeguards.
- [ ] Review stable HTTP error contracts and OpenAPI exposure.