### PR TITLE
feat(user): expose transactional MFA disable endpoint

### DIFF
--- a/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/SecurityConfiguration.java
@@ -70,6 +70,7 @@ public class SecurityConfiguration {
                 .requestMatchers(
                     POST,
                     "/api/v1/auth/logout-all",
+                    "/api/v1/users/me/mfa",
                     "/api/v1/users/me/mfa/enrollment",
                     "/api/v1/users/me/mfa/enrollment/confirm",
                     "/api/v1/users/me/mfa/recovery-codes/rotation",
@@ -81,6 +82,7 @@ public class SecurityConfiguration {
                 .authenticated()
                 .requestMatchers(
                     DELETE,
+                    "/api/v1/users/me/mfa",
                     "/api/v1/users/me/mfa/enrollment"
                 )
                 .authenticated()

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/DisableMfaController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/DisableMfaController.java
@@ -1,0 +1,42 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import java.util.UUID;
+
+import com.nursena.payflow.user.application.port.in.DisableMfaCommand;
+import com.nursena.payflow.user.application.port.in.DisableMfaUseCase;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users/me/mfa")
+public class DisableMfaController {
+
+    private final DisableMfaUseCase useCase;
+
+    public DisableMfaController(
+        DisableMfaUseCase useCase
+    ) {
+        this.useCase = useCase;
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> disable(
+        @AuthenticationPrincipal Jwt jwt,
+        @Valid @RequestBody DisableMfaRequest request
+    ) {
+        useCase.disable(
+            new DisableMfaCommand(
+                UUID.fromString(jwt.getSubject()),
+                request.stepUpGrant()
+            )
+        );
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/DisableMfaRequest.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/DisableMfaRequest.java
@@ -1,0 +1,13 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DisableMfaRequest(
+    @NotBlank String stepUpGrant
+) {
+
+    @Override
+    public String toString() {
+        return "DisableMfaRequest[stepUpGrant=<redacted>]";
+    }
+}

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/StepUpExceptionHandler.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/StepUpExceptionHandler.java
@@ -25,7 +25,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RestControllerAdvice(assignableTypes = {
     StepUpGrantController.class,
-    RotateMfaRecoveryCodesController.class
+    RotateMfaRecoveryCodesController.class,
+    DisableMfaController.class
 })
 public class StepUpExceptionHandler {
 

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/DisableMfaControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/DisableMfaControllerTest.java
@@ -1,0 +1,177 @@
+package com.nursena.payflow.user.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.nursena.payflow.configuration.SecurityConfiguration;
+import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
+import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
+import com.nursena.payflow.user.application.port.in.DisableMfaCommand;
+import com.nursena.payflow.user.application.port.in.DisableMfaUseCase;
+import com.nursena.payflow.user.domain.exception.InvalidStepUpGrantException;
+import com.nursena.payflow.user.domain.exception.MfaStateConflictException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(DisableMfaController.class)
+@Import({
+    RequestCorrelationConfiguration.class,
+    SecurityConfiguration.class,
+    StepUpExceptionHandler.class
+})
+class DisableMfaControllerTest {
+
+    private static final String ENDPOINT =
+        "/api/v1/users/me/mfa";
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "10000000-0000-0000-0000-000000000105"
+        );
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean DisableMfaUseCase useCase;
+    @MockitoBean JwtDecoder jwtDecoder;
+
+    @Test
+    void shouldRequireBearerAuthentication() throws Exception {
+        mockMvc.perform(delete(ENDPOINT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequest()))
+            .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(useCase);
+    }
+
+    @Test
+    void shouldRejectBlankStepUpGrant() throws Exception {
+        mockJwt();
+
+        mockMvc.perform(delete(ENDPOINT)
+                .header(AUTHORIZATION, "Bearer token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "stepUpGrant": " "
+                    }
+                    """))
+            .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(useCase);
+    }
+
+    @Test
+    void shouldDisableMfaForAuthenticatedSubject()
+        throws Exception {
+
+        mockJwt();
+
+        performValid()
+            .andExpect(status().isNoContent());
+
+        verify(useCase).disable(argThat(command ->
+            command.userId().equals(USER_ID)
+                && command.stepUpGrant().equals(
+                    "opaque-grant"
+                )
+        ));
+    }
+
+    @Test
+    void shouldExposeStableCoarseFailureContracts()
+        throws Exception {
+
+        mockJwt();
+
+        doThrow(new InvalidStepUpGrantException())
+            .doThrow(new MfaStateConflictException())
+            .doThrow(new MfaSecurityUnavailableException())
+            .when(useCase)
+            .disable(any(DisableMfaCommand.class));
+
+        performValid()
+            .andExpect(status().isForbidden())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("STEP_UP_INVALID")
+            );
+
+        performValid()
+            .andExpect(status().isConflict())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("MFA_STATE_CONFLICT")
+            );
+
+        performValid()
+            .andExpect(status().isServiceUnavailable())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("MFA_SECURITY_UNAVAILABLE")
+            );
+    }
+
+    @Test
+    void shouldRedactStepUpGrantFromToString() {
+        DisableMfaRequest request =
+            new DisableMfaRequest("opaque-grant");
+
+        assertThat(request.toString())
+            .doesNotContain("opaque-grant");
+    }
+
+    private ResultActions performValid() throws Exception {
+        return mockMvc.perform(delete(ENDPOINT)
+            .header(AUTHORIZATION, "Bearer token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validRequest()));
+    }
+
+    private static String validRequest() {
+        return """
+            {
+              "stepUpGrant": "opaque-grant"
+            }
+            """;
+    }
+
+    private void mockJwt() {
+        when(jwtDecoder.decode("token")).thenReturn(
+            Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .subject(USER_ID.toString())
+                .claim("role", "USER")
+                .issuedAt(
+                    Instant.parse(
+                        "2026-08-10T09:55:00Z"
+                    )
+                )
+                .expiresAt(
+                    Instant.parse(
+                        "2026-08-10T10:15:00Z"
+                    )
+                )
+                .build()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Exposes the existing transactional MFA-disable use case through an authenticated HTTP adapter.

## Changes

- Add `DELETE /api/v1/users/me/mfa`.
- Accept only the purpose-bound step-up grant in the request body.
- Resolve account ownership exclusively from the authenticated JWT subject.
- Return `204 No Content` after successful MFA disablement.
- Add the endpoint to the authenticated security allowlist.
- Extend stable step-up and MFA exception handling to the new controller.
- Redact the step-up grant from request string representations.
- Add focused MockMvc coverage for authentication, validation, command mapping, success, and failure contracts.

## Architecture and security

- Preserve the hexagonal boundary by delegating directly to `DisableMfaUseCase`.
- Keep purpose validation and single-use grant consumption inside the transactional application service.
- Do not accept an account identifier from the client.
- Preserve coarse `STEP_UP_INVALID`, `MFA_STATE_CONFLICT`, and `MFA_SECURITY_UNAVAILABLE` responses.
- Reuse the existing transactional behavior that deletes authenticator and recovery-code state, revokes active refresh-token families, and appends credential-free audit evidence atomically.

## Verification

- `mvn clean verify`
- 1,456 tests passed
- 0 failures, errors, or skipped tests
- Targeted web tests: 16 passed
- `git diff --check` passed
- Working tree clean

## Reviewer checklist

- [ ] Verify JWT-subject ownership and absence of client-supplied user IDs.
- [ ] Verify exact-purpose step-up enforcement remains in the application service.
- [ ] Review the `204 No Content` success contract.
- [ ] Review stable coarse failure mappings.
- [ ] Verify request credential redaction and authenticated endpoint configuration.