### PR TITLE
docs(release): record v0.14.0 publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,13 @@ Completed capabilities include:
 - operator-only, paginated command-audit queries and chronological command timelines
 - Prometheus metrics, Grafana dashboards, and alert rules for Kafka consumer failures
 
-OpenAPI documentation covers the implemented API, while executable Postman workflows remain aligned with released end-to-end flows. PayFlow v0.13.0 is the latest published release, and the current release-preparation line uses `0.14.0`. The v0.14.0 release delivers TOTP multi-factor authentication, digest-only single-use recovery codes, purpose-bound step-up grants, transactional MFA disable, and recovery-code rotation without changing the simulated-money boundary.
+OpenAPI documentation covers the implemented API, while executable Postman workflows remain aligned with released end-to-end flows. PayFlow v0.14.0 is the latest published release, and the Maven version is `0.14.0`. The release delivers TOTP multi-factor authentication, digest-only single-use recovery codes, purpose-bound step-up grants, transactional MFA disable, and recovery-code rotation without changing the simulated-money boundary.
 
-The immutable v0.13.0 publication record is anchored to annotated tag `v0.13.0`, merge commit `726f631a0de800870813ccb0c00b2676eb5d172b`, and successful release workflow run [31115952987](https://github.com/nursena-pc/payflow/actions/runs/31115952987). The published `payflow-0.13.0.jar` is 100015861 bytes and its independently verified SHA-256 is `78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA`.
+The immutable v0.14.0 publication record is anchored to annotated tag `v0.14.0`, merge commit `d65929b98bb66b22f208d26f75a764e1ade78b6a`, and successful release workflow run [31728977714](https://github.com/nursena-pc/payflow/actions/runs/31728977714). The published `payflow-0.14.0.jar` is 100200050 bytes and its independently verified SHA-256 is `A6533039C5DDBE610D9DDB986DDBDAFE192DD56BE664E86B65A72AECF51F116E`.
 
-See the [v0.13.0 release notes](docs/releases/v0.13.0.md), the [published GitHub Release](https://github.com/nursena-pc/payflow/releases/tag/v0.13.0), the [account-action mail-delivery operations guide](docs/operations/account-action-mail-delivery.md), [ADR 0013](docs/adr/0013-secure-mail-outbox-and-smtp-delivery.md), the [v0.12.0 release notes](docs/releases/v0.12.0.md), and the [roadmap](docs/roadmap.md).
+The immutable v0.13.0 publication record remains anchored to annotated tag `v0.13.0`, merge commit `726f631a0de800870813ccb0c00b2676eb5d172b`, and successful release workflow run [31115952987](https://github.com/nursena-pc/payflow/actions/runs/31115952987). The published `payflow-0.13.0.jar` is 100015861 bytes and its independently verified SHA-256 is `78520B04BA3FDAF1BCEB3EAF29FCBE96C46265DF691C52C9048CEE6B5D58F4DA`.
+
+See the [v0.14.0 release notes](docs/releases/v0.14.0.md), the [published GitHub Release](https://github.com/nursena-pc/payflow/releases/tag/v0.14.0), the [MFA operations guide](docs/operations/mfa-security.md), [ADR 0014](docs/adr/0014-mfa-and-step-up-authentication.md), the [v0.13.0 release notes](docs/releases/v0.13.0.md), and the [roadmap](docs/roadmap.md).
 
 ## Structured logging
 
@@ -156,9 +158,9 @@ Per-identity and per-client Redis quotas for account-action requests remain expl
 
 See the [v0.13.0 release notes](docs/releases/v0.13.0.md), [ADR 0013](docs/adr/0013-secure-mail-outbox-and-smtp-delivery.md), and the [mail-delivery operations guide](docs/operations/account-action-mail-delivery.md).
 
-## v0.14.0 release preparation
+## v0.14.0 release
 
-The `0.14.0` release-preparation line delivers TOTP-based multi-factor authentication and purpose-bound step-up authentication as a package-bounded identity-security capability. Authenticator state, cryptographic policy, application use cases, persistence, and HTTP adapters remain separated by the existing modular-monolith boundaries.
+PayFlow v0.14.0 delivers TOTP-based multi-factor authentication and purpose-bound step-up authentication as a package-bounded identity-security capability. Authenticator state, cryptographic policy, application use cases, persistence, and HTTP adapters remain separated by the existing modular-monolith boundaries.
 
 Authenticated enrollment creates a pending 160-bit TOTP secret, protects it with AES-256-GCM before PostgreSQL V18 persistence, and activates it only after a valid proof. The plaintext secret and `otpauth://` provisioning value cross only the response that created them. Production requires dedicated MFA encryption material independent from JWT and mail keys.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,15 +2,14 @@
 
 ## Current delivery focus
 
-PayFlow v0.13.0 is the latest tagged release. The active development line uses
-the Maven version `0.14.0`.
+PayFlow v0.14.0 is the latest tagged release. The Maven version is `0.14.0`.
 
-The v0.13.0 account-recovery and secure-mail-delivery release was published
-from verified merge commit `726f631a0de800870813ccb0c00b2676eb5d172b`
-through successful release workflow run `31115952987`. The v0.14.0 milestone
-adds TOTP multi-factor authentication, digest-only recovery codes, and bounded
-step-up authentication while preserving the existing anti-enumeration,
-refresh-session, and logging boundaries.
+The v0.14.0 MFA and step-up release was published from verified merge commit
+`d65929b98bb66b22f208d26f75a764e1ade78b6a` through successful release workflow run `31728977714`.
+The published `100200050`-byte JAR has independently verified SHA-256
+`A6533039C5DDBE610D9DDB986DDBDAFE192DD56BE664E86B65A72AECF51F116E`. The release adds TOTP multi-factor authentication, digest-only
+recovery codes, and bounded step-up authentication while preserving the
+existing anti-enumeration, refresh-session, and logging boundaries.
 
 PayFlow remains a modular monolith. PostgreSQL is the system of record; Redis is
 used only for bounded, explicitly expiring abuse-control state.
@@ -519,7 +518,7 @@ The release is ready only when:
 - release checksum verification: passed
 - publication-evidence JSON SHA-256: `4FDD37BC1BF5D058A391A23784CCF87DED3FADCC3F9DB564806A8A52DC1F7B51`
 
-## v0.14.0 — Release Preparation: MFA and Step-Up Authentication
+## v0.14.0 — Released: MFA and Step-Up Authentication
 
 ### Product outcome
 
@@ -648,7 +647,7 @@ candidates without changing their current runtime authorization.
 - [x] Add an MFA threat model, ADR, and operations guide
 - [x] Verify production startup fails safely without configured MFA secret-protection material
 - [x] Run the complete Maven verification suite and production Docker smoke
-- [ ] Pass protected `build-and-test` and `docker-smoke` checks for every increment
+- [x] Pass protected `build-and-test` and `docker-smoke` checks for every increment
 
 ## Explicit v0.14.0 non-goals
 
@@ -682,8 +681,20 @@ The release is ready only when:
 - [x] focused unit, PostgreSQL, HTTP, OpenAPI, and Postman tests pass
 - [x] the complete Maven suite and production Docker smoke pass
 - [x] threat model, ADR, operations guide, configuration, and implementation agree
-- [ ] protected feature and release-preparation pull requests are merged
-- [ ] the v0.14.0 tag, JAR, checksum, and GitHub Release are published
+- [x] protected feature and release-preparation pull requests are merged
+- [x] the v0.14.0 tag, JAR, checksum, and GitHub Release are published
+
+### Publication record
+
+- release-preparation PR: `#147`
+- release-candidate commit: `1fba2dacc239d8c43149cebdf192e3086be356c3`
+- published merge and tag commit: `d65929b98bb66b22f208d26f75a764e1ade78b6a`
+- annotated tag object: `826c77a724915c386c375c2cc227597ae0331dda`
+- release workflow run: [`31728977714`](https://github.com/nursena-pc/payflow/actions/runs/31728977714)
+- published at: `2026-08-13T18:13:33Z`
+- published JAR size: `100200050` bytes
+- published JAR SHA-256: `A6533039C5DDBE610D9DDB986DDBDAFE192DD56BE664E86B65A72AECF51F116E`
+- release checksum verification: passed
 
 ## Later v1.0 candidates
 

--- a/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
@@ -22,7 +22,7 @@ class RoadmapContractTest {
         Path.of("docs", "roadmap.md");
 
     @Test
-    void shouldAlignRoadmapWithReleaseVersion()
+    void shouldAlignRoadmapWithPublishedRelease()
         throws Exception {
 
         String projectVersion = readProjectVersion();
@@ -34,20 +34,20 @@ class RoadmapContractTest {
 
         assertThat(roadmap)
             .contains(
-                "PayFlow v0.13.0 is the latest tagged release",
-                "the Maven version `" + projectVersion + "`",
+                "PayFlow v0.14.0 is the latest tagged release",
+                "The Maven version is `" + projectVersion + "`",
                 "## v0.10.0 — Released: Trusted Client Context",
                 "## v0.11.0 — Released: Structured Logging and Request Correlation",
                 "## v0.12.0 — Released: JWT Signing-Key Rotation",
                 "## v0.13.0 — Released: Account Recovery and Secure Mail Delivery",
-                "## v0.14.0 — Release Preparation: MFA and Step-Up Authentication",
-                "726f631a0de800870813ccb0c00b2676eb5d172b",
-                "31115952987"
+                "## v0.14.0 — Released: MFA and Step-Up Authentication",
+                "d65929b98bb66b22f208d26f75a764e1ade78b6a",
+                "31728977714"
             )
             .doesNotContain(
                 "0.13.0-SNAPSHOT",
                 "## v0.14.0 — Release Candidate",
-                "## v0.14.0 — Released"
+                "## v0.14.0 — Release Preparation"
             );
 
         assertThat(normalizedRoadmap)
@@ -59,7 +59,7 @@ class RoadmapContractTest {
     }
 
     @Test
-    void shouldFreezeV013PublicationAndOpenV014Boundaries()
+    void shouldFreezeV013AndV014PublicationBoundaries()
         throws IOException {
 
         assertThat(Files.readString(ROADMAP))
@@ -85,7 +85,10 @@ class RoadmapContractTest {
                 "Protect every pending or active TOTP secret before PostgreSQL persistence",
                 "Persist only fixed-length recovery-code digests",
                 "Introduce an application-facing step-up policy independent from controller annotations",
-                "generalized registration, refresh, recovery, or operations rate-limit policy; that remains a v0.15.0 concern"
+                "generalized registration, refresh, recovery, or operations rate-limit policy; that remains a v0.15.0 concern",
+                "- [x] protected feature and release-preparation pull requests are merged",
+                "- [x] the v0.14.0 tag, JAR, checksum, and GitHub Release are published",
+                "A6533039C5DDBE610D9DDB986DDBDAFE192DD56BE664E86B65A72AECF51F116E"
             );
     }
 

--- a/src/test/java/com/nursena/payflow/configuration/V013ReleasePublicationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V013ReleasePublicationContractTest.java
@@ -39,7 +39,7 @@ class V013ReleasePublicationContractTest {
 
         assertThat(Files.readString(README))
             .contains(
-                "PayFlow v0.13.0 is the latest published release",
+                "The immutable v0.13.0 publication record remains anchored",
                 "## v0.13.0 release",
                 "annotated tag `v0.13.0`",
                 "726f631a0de800870813ccb0c00b2676eb5d172b",

--- a/src/test/java/com/nursena/payflow/configuration/V014DevelopmentContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V014DevelopmentContractTest.java
@@ -19,13 +19,13 @@ class V014DevelopmentContractTest {
     private static final Path ROADMAP =
         Path.of("docs", "roadmap.md");
     @Test
-    void shouldExposeV014ReleasePreparationStatus()
+    void shouldExposeV014PublishedReleaseStatus()
         throws IOException {
         assertThat(Files.readString(README))
             .contains(
-                "PayFlow v0.13.0 is the latest published release",
-                "current release-preparation line uses `0.14.0`",
-                "## v0.14.0 release preparation",
+                "PayFlow v0.14.0 is the latest published release",
+                "the Maven version is `0.14.0`",
+                "## v0.14.0 release",
                 "TOTP-based multi-factor authentication",
                 "digest-only login challenge",
                 "single-use recovery codes",

--- a/src/test/java/com/nursena/payflow/configuration/V014MfaFoundationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V014MfaFoundationContractTest.java
@@ -207,7 +207,7 @@ class V014MfaFoundationContractTest {
 
         assertThat(readme)
             .contains(
-                "The `0.14.0` release-preparation line delivers TOTP-based multi-factor authentication and purpose-bound step-up authentication",
+                "PayFlow v0.14.0 delivers TOTP-based multi-factor authentication and purpose-bound step-up authentication",
                 "Authenticator state, cryptographic policy, application use cases, persistence, and HTTP adapters remain separated by the existing modular-monolith boundaries"
             );
 

--- a/src/test/java/com/nursena/payflow/configuration/V014ReleasePublicationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V014ReleasePublicationContractTest.java
@@ -1,0 +1,110 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class V014ReleasePublicationContractTest {
+
+    private static final Path README =
+        Path.of("README.md");
+
+    private static final Path CHANGELOG =
+        Path.of("CHANGELOG.md");
+
+    private static final Path ROADMAP =
+        Path.of("docs", "roadmap.md");
+
+    private static final Path RELEASE_NOTES =
+        Path.of("docs", "releases", "v0.14.0.md");
+
+    private static final Path RELEASE_WORKFLOW =
+        Path.of(
+            ".github",
+            "workflows",
+            "release.yml"
+        );
+
+    @Test
+    void shouldExposePublishedReleaseStatus()
+        throws IOException {
+
+        assertThat(Files.readString(README))
+            .contains(
+                "PayFlow v0.14.0 is the latest published release",
+                "## v0.14.0 release",
+                "annotated tag `v0.14.0`",
+                "d65929b98bb66b22f208d26f75a764e1ade78b6a",
+                "31728977714",
+                "100200050 bytes",
+                "A6533039C5DDBE610D9DDB986DDBDAFE192DD56BE664E86B65A72AECF51F116E"
+            )
+            .doesNotContain(
+                "v0.14.0 release preparation",
+                "release-preparation line"
+            );
+    }
+
+    @Test
+    void shouldFreezeVersionedReleaseMetadata()
+        throws IOException {
+
+        assertThat(Files.readString(CHANGELOG))
+            .contains(
+                "## [Unreleased]",
+                "## [0.14.0] - 2026-08-12",
+                "[0.14.0]: https://github.com/nursena-pc/payflow/compare/v0.13.0...v0.14.0",
+                "[Unreleased]: https://github.com/nursena-pc/payflow/compare/v0.14.0...HEAD"
+            );
+
+        assertThat(Files.readString(RELEASE_NOTES))
+            .contains(
+                "# PayFlow v0.14.0",
+                "v0.13.0...v0.14.0",
+                "TOTP",
+                "rotation requires an exact purpose-bound step-up grant"
+            )
+            .doesNotContain("0.14.0-SNAPSHOT");
+    }
+
+    @Test
+    void shouldRecordPublishedRoadmapEvidence()
+        throws IOException {
+
+        assertThat(Files.readString(ROADMAP))
+            .contains(
+                "## v0.14.0 — Released: MFA and Step-Up Authentication",
+                "- [x] Pass protected `build-and-test` and `docker-smoke` checks for every increment",
+                "- [x] protected feature and release-preparation pull requests are merged",
+                "- [x] the v0.14.0 tag, JAR, checksum, and GitHub Release are published",
+                "release-preparation PR: `#147`",
+                "release-candidate commit: `1fba2dacc239d8c43149cebdf192e3086be356c3`",
+                "published merge and tag commit: `d65929b98bb66b22f208d26f75a764e1ade78b6a`",
+                "annotated tag object: `826c77a724915c386c375c2cc227597ae0331dda`",
+                "release workflow run: [`31728977714`]",
+                "published at: `2026-08-13T18:13:33Z`",
+                "published JAR size: `100200050` bytes",
+                "published JAR SHA-256: `A6533039C5DDBE610D9DDB986DDBDAFE192DD56BE664E86B65A72AECF51F116E`",
+                "release checksum verification: passed"
+            );
+    }
+
+    @Test
+    void shouldRetainProtectedTagPublicationWorkflow()
+        throws IOException {
+
+        assertThat(Files.readString(RELEASE_WORKFLOW))
+            .contains(
+                "Release tags cannot publish a snapshot version",
+                "git merge-base --is-ancestor",
+                "mvn -B -ntp clean verify",
+                "sha256sum",
+                "gh release create",
+                "--verify-tag"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- record the published v0.14.0 tag, merge commit, release workflow, JAR, and SHA-256
- mark the v0.14.0 roadmap milestone as released
- retain the immutable v0.13.0 publication record
- add and update publication contract coverage

## Verification

- `mvn clean verify`
- 1465 tests, 0 failures, 0 errors, 0 skipped
- `git diff --check`
- UTF-8 corruption scan