### PR TITLE
chore(release): open v0.15.0 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Advanced the active development version to `0.15.0-SNAPSHOT`.
+- Defined the v0.15.0 generalized abuse-protection, performance-evidence, dashboard, and alert roadmap through issue #149.
+
 ## [0.14.0] - 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Completed capabilities include:
 - operator-only, paginated command-audit queries and chronological command timelines
 - Prometheus metrics, Grafana dashboards, and alert rules for Kafka consumer failures
 
-OpenAPI documentation covers the implemented API, while executable Postman workflows remain aligned with released end-to-end flows. PayFlow v0.14.0 is the latest published release, and the Maven version is `0.14.0`. The release delivers TOTP multi-factor authentication, digest-only single-use recovery codes, purpose-bound step-up grants, transactional MFA disable, and recovery-code rotation without changing the simulated-money boundary.
+OpenAPI documentation covers the implemented API, while executable Postman workflows remain aligned with released end-to-end flows. PayFlow v0.14.0 is the latest published release, and the active development line uses `0.15.0-SNAPSHOT`. The v0.15.0 milestone targets generalized abuse protection, reproducible load and performance evidence, and operational dashboards and alerts without changing the simulated-money boundary.
 
 The immutable v0.14.0 publication record is anchored to annotated tag `v0.14.0`, merge commit `d65929b98bb66b22f208d26f75a764e1ade78b6a`, and successful release workflow run [31728977714](https://github.com/nursena-pc/payflow/actions/runs/31728977714). The published `payflow-0.14.0.jar` is 100200050 bytes and its independently verified SHA-256 is `A6533039C5DDBE610D9DDB986DDBDAFE192DD56BE664E86B65A72AECF51F116E`.
 
@@ -173,6 +173,13 @@ Authenticated users can obtain a short-lived, subject-bound, purpose-bound step-
 MFA disable and recovery-code rotation consume exact step-up purposes. MFA disable removes authenticator and recovery-code state, revokes active refresh-token families, and appends credential-free audit evidence atomically. Recovery-code rotation atomically replaces the complete digest set and returns replacement plaintext once. Active-authenticator replacement remains deferred until a safe two-stage replacement lifecycle is designed and verified.
 
 See the [v0.14.0 release notes](docs/releases/v0.14.0.md), [ADR 0014](docs/adr/0014-mfa-and-step-up-authentication.md), the [MFA threat model](docs/security/mfa-threat-model.md), the [MFA operations guide](docs/operations/mfa-security.md), the [TOTP enrollment contract](docs/security/mfa-enrollment.md), the [MFA login challenge contract](docs/security/mfa-login-challenge.md), the [recovery-code contract](docs/security/mfa-recovery-codes.md), and the [step-up contract](docs/security/step-up-authentication.md).
+## v0.15.0 active development
+
+The active `0.15.0-SNAPSHOT` line introduces generalized abuse protection for sensitive identity workflows through an application-facing policy independent from controllers and servlet APIs. The design reuses the trusted effective-client-address boundary, supports bounded per-identity and per-client decisions, and keeps Redis state atomic, explicitly expiring, and free of credential material.
+
+The milestone also defines reproducible latency, throughput, concurrency, and overload evidence. Low-cardinality metrics, provisioned Grafana dashboards, actionable alert rules, and documented investigation procedures must remain free of email addresses, raw client addresses, credentials, Redis keys, and counter contents.
+
+Development is tracked by [issue #149](https://github.com/nursena-pc/payflow/issues/149). Active-authenticator replacement, CAPTCHA services, external bot detection, WAF or API-gateway deployment, and adaptive risk scoring remain outside the v0.15.0 scope.
 ## Implemented API
 
 | Method | Endpoint | Authentication | Description |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 ## Current delivery focus
 
-PayFlow v0.14.0 is the latest tagged release. The Maven version is `0.14.0`.
+PayFlow v0.14.0 is the latest tagged release. The Maven version is `0.15.0-SNAPSHOT`.
 
 The v0.14.0 MFA and step-up release was published from verified merge commit
 `d65929b98bb66b22f208d26f75a764e1ade78b6a` through successful release workflow run `31728977714`.
@@ -11,6 +11,11 @@ The published `100200050`-byte JAR has independently verified SHA-256
 recovery codes, and bounded step-up authentication while preserving the
 existing anti-enumeration, refresh-session, and logging boundaries.
 
+The active v0.15.0 development line delivers generalized abuse protection,
+reproducible load and performance evidence, and operational dashboards and
+alerts. The milestone is tracked by issue `#149` and preserves the existing
+anti-enumeration, trusted-client, credential-redaction, and modular-monolith
+boundaries.
 PayFlow remains a modular monolith. PostgreSQL is the system of record; Redis is
 used only for bounded, explicitly expiring abuse-control state.
 
@@ -696,8 +701,91 @@ The release is ready only when:
 - published JAR SHA-256: `A6533039C5DDBE610D9DDB986DDBDAFE192DD56BE664E86B65A72AECF51F116E`
 - release checksum verification: passed
 
+## v0.15.0 — Active Development: Generalized Abuse Protection and Performance Evidence
+
+Tracking issue: [#149](https://github.com/nursena-pc/payflow/issues/149)
+
+### Increment 1 — Threat model, policy contract, and configuration
+
+- [ ] Define protected workflows, attacker capabilities, bypass risks, and trust boundaries
+- [ ] Introduce an application-facing abuse-protection policy independent from controllers and servlet APIs
+- [ ] Define endpoint-specific per-identity and per-client limits through validated configuration
+- [ ] Reuse the trusted effective-client-address boundary without trusting attacker-controlled forwarding headers
+- [ ] Specify deterministic fail-closed or fail-open behavior for every protected workflow
+- [ ] Preserve generic public responses and anti-enumeration behavior under quota decisions and dependency failures
+- [ ] Add executable development contracts for the approved v0.15.0 scope
+
+### Increment 2 — Shared Redis enforcement foundation
+
+- [ ] Implement atomic Redis decisions with explicit expiration and bounded key cardinality
+- [ ] Keep raw identities, email addresses, client addresses, credentials, and proofs out of Redis keys and values
+- [ ] Define collision-resistant bounded identifiers for identity and client quota dimensions
+- [ ] Verify window boundaries, expiration, concurrency, timeout, and Redis-unavailable behavior
+- [ ] Preserve existing login-rate-limit behavior while sharing only approved infrastructure
+
+### Increment 3 — Account-action request protection
+
+- [ ] Protect email-verification requests with per-identity and per-client decisions
+- [ ] Protect password-recovery requests with the same anti-enumeration response shape
+- [ ] Evaluate registration protection from documented threat and performance evidence
+- [ ] Verify unknown, closed, verified, and eligible accounts expose no distinguishable quota behavior
+- [ ] Verify concurrent requests cannot exceed the documented bounded outcome
+
+### Increment 4 — MFA challenge and step-up protection
+
+- [ ] Protect MFA login-challenge confirmation without exposing challenge or account validity
+- [ ] Protect step-up grant issuance without weakening subject, purpose, expiry, or single-use semantics
+- [ ] Keep TOTP values, recovery codes, challenge tokens, and step-up grants outside quota state and observable output
+- [ ] Verify abuse decisions do not consume valid single-use credentials unless the protected workflow executes
+
+### Increment 5 — Metrics, dashboards, alerts, and operations
+
+- [ ] Expose bounded decision and Redis-failure metrics without identity or client labels
+- [ ] Provision Grafana dashboards for quota outcomes, dependency failures, and protected-workflow health
+- [ ] Provision actionable alert rules with documented thresholds, duration, severity, and response guidance
+- [ ] Document investigation, safe mitigation, rollback, and false-positive handling
+- [ ] Verify logs, metrics, traces, dashboards, and alerts contain no sensitive material
+
+### Increment 6 — Reproducible load and performance evidence
+
+- [ ] Define latency, throughput, concurrency, saturation, and overload budgets
+- [ ] Add reproducible load scenarios for representative protected workflows
+- [ ] Record environment, dataset, duration, warm-up, measurement method, and limitations
+- [ ] Verify abuse protection remains effective under concurrent and overload conditions
+- [ ] Keep load tooling outside the normal unit-test lifecycle while retaining repeatable commands
+
+### Increment 7 — Contract alignment and release preparation
+
+- [ ] Align OpenAPI, Postman, README, changelog, ADRs, threat model, and operations guidance
+- [ ] Add focused unit, Redis, HTTP, concurrency, redaction, and dependency-failure tests
+- [ ] Run the complete Maven verification suite and production Docker smoke
+- [ ] Pass protected `build-and-test` and `docker-smoke` checks for every increment
+- [ ] Prepare versioned release notes and immutable publication evidence
+
+## Explicit v0.15.0 non-goals
+
+- Active-authenticator replacement
+- CAPTCHA or third-party bot-detection services
+- CDN, WAF, API-gateway, or Kubernetes deployment
+- Adaptive machine-learning risk scoring
+- Frontend implementation
+- Real-money operation or regulatory certification
+
+## v0.15.0 release exit criteria
+
+- [ ] selected identity workflows enforce documented per-identity and per-client limits
+- [ ] anti-enumeration behavior remains stable under quota and dependency failures
+- [ ] Redis operations are atomic, expiring, bounded, and concurrency-tested
+- [ ] observable output contains no sensitive identity or credential material
+- [ ] latency, throughput, concurrency, and overload budgets are documented
+- [ ] reproducible load-test evidence satisfies the approved budgets
+- [ ] dashboards and actionable alerts are provisioned and verified
+- [ ] focused unit, Redis, HTTP, concurrency, and failure-path tests pass
+- [ ] the complete Maven suite and production Docker smoke pass
+- [ ] protected feature and release-preparation pull requests are merged
+- [ ] the v0.15.0 tag, JAR, checksum, and GitHub Release are published
+
 ## Later v1.0 candidates
 
-Later v1.0 candidates include generalized abuse protection, load/performance
-evidence, backup/restore rehearsal, API freeze, SBOM generation, and release
-stabilization.
+Later v1.0 candidates include backup/restore rehearsal, API freeze, SBOM
+generation, and release stabilization.

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.nursena</groupId>
     <artifactId>payflow</artifactId>
-    <version>0.14.0</version>
+    <version>0.15.0-SNAPSHOT</version>
     <name>PayFlow</name>
     <description>Digital wallet and simulated payment transaction platform</description>
 

--- a/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/RoadmapContractTest.java
@@ -22,7 +22,7 @@ class RoadmapContractTest {
         Path.of("docs", "roadmap.md");
 
     @Test
-    void shouldAlignRoadmapWithPublishedRelease()
+    void shouldAlignRoadmapWithActiveDevelopmentVersion()
         throws Exception {
 
         String projectVersion = readProjectVersion();
@@ -30,7 +30,7 @@ class RoadmapContractTest {
         String normalizedRoadmap = normalizeWhitespace(roadmap);
 
         assertThat(projectVersion)
-            .isEqualTo("0.14.0");
+            .isEqualTo("0.15.0-SNAPSHOT");
 
         assertThat(roadmap)
             .contains(
@@ -41,11 +41,12 @@ class RoadmapContractTest {
                 "## v0.12.0 — Released: JWT Signing-Key Rotation",
                 "## v0.13.0 — Released: Account Recovery and Secure Mail Delivery",
                 "## v0.14.0 — Released: MFA and Step-Up Authentication",
+                "## v0.15.0 — Active Development: Generalized Abuse Protection and Performance Evidence",
                 "d65929b98bb66b22f208d26f75a764e1ade78b6a",
                 "31728977714"
             )
             .doesNotContain(
-                "0.13.0-SNAPSHOT",
+                "0.14.0-SNAPSHOT",
                 "## v0.14.0 — Release Candidate",
                 "## v0.14.0 — Release Preparation"
             );
@@ -54,7 +55,10 @@ class RoadmapContractTest {
             .contains(
                 "TOTP multi-factor authentication",
                 "digest-only recovery codes",
-                "bounded step-up authentication"
+                "bounded step-up authentication",
+                "generalized abuse protection",
+                "load and performance evidence",
+                "operational dashboards and alerts"
             );
     }
 

--- a/src/test/java/com/nursena/payflow/configuration/V014DevelopmentContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V014DevelopmentContractTest.java
@@ -24,12 +24,12 @@ class V014DevelopmentContractTest {
         assertThat(Files.readString(README))
             .contains(
                 "PayFlow v0.14.0 is the latest published release",
-                "the Maven version is `0.14.0`",
+                "The immutable v0.14.0 publication record is anchored to annotated tag `v0.14.0`",
                 "## v0.14.0 release",
                 "TOTP-based multi-factor authentication",
                 "digest-only login challenge",
-                "single-use recovery codes",
-                "purpose-bound step-up grants",
+                "ten independent 128-bit canonical Base64URL recovery codes",
+                "purpose-bound step-up authentication",
                 "/api/v1/users/me/mfa/recovery-codes/rotation",
                 "`DELETE` | `/api/v1/users/me/mfa`"
             )

--- a/src/test/java/com/nursena/payflow/configuration/V015DevelopmentContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V015DevelopmentContractTest.java
@@ -1,0 +1,94 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class V015DevelopmentContractTest {
+
+    private static final Path POM =
+        Path.of("pom.xml");
+
+    private static final Path README =
+        Path.of("README.md");
+
+    private static final Path CHANGELOG =
+        Path.of("CHANGELOG.md");
+
+    private static final Path ROADMAP =
+        Path.of("docs", "roadmap.md");
+
+    @Test
+    void shouldOpenV015DevelopmentLine()
+        throws IOException {
+
+        assertThat(Files.readString(POM))
+            .contains(
+                "<version>0.15.0-SNAPSHOT</version>"
+            );
+
+        assertThat(Files.readString(README))
+            .contains(
+                "PayFlow v0.14.0 is the latest published release",
+                "the active development line uses `0.15.0-SNAPSHOT`",
+                "## v0.15.0 active development",
+                "generalized abuse protection",
+                "reproducible load and performance evidence",
+                "operational dashboards and alerts",
+                "issue #149"
+            );
+    }
+
+    @Test
+    void shouldDefineIncrementalDeliveryPlan()
+        throws IOException {
+
+        assertThat(Files.readString(ROADMAP))
+            .contains(
+                "## v0.15.0 — Active Development: Generalized Abuse Protection and Performance Evidence",
+                "Tracking issue: [#149]",
+                "### Increment 1 — Threat model, policy contract, and configuration",
+                "### Increment 2 — Shared Redis enforcement foundation",
+                "### Increment 3 — Account-action request protection",
+                "### Increment 4 — MFA challenge and step-up protection",
+                "### Increment 5 — Metrics, dashboards, alerts, and operations",
+                "### Increment 6 — Reproducible load and performance evidence",
+                "### Increment 7 — Contract alignment and release preparation"
+            );
+    }
+
+    @Test
+    void shouldFreezeSecurityAndPrivacyBoundaries()
+        throws IOException {
+
+        assertThat(Files.readString(ROADMAP))
+            .contains(
+                "application-facing abuse-protection policy independent from controllers and servlet APIs",
+                "trusted effective-client-address boundary",
+                "atomic Redis decisions with explicit expiration and bounded key cardinality",
+                "Preserve generic public responses and anti-enumeration behavior",
+                "## Explicit v0.15.0 non-goals",
+                "Active-authenticator replacement",
+                "CAPTCHA or third-party bot-detection services",
+                "Adaptive machine-learning risk scoring"
+            );
+    }
+
+    @Test
+    void shouldAdvanceUnreleasedMetadata()
+        throws IOException {
+
+        assertThat(Files.readString(CHANGELOG))
+            .contains(
+                "## [Unreleased]",
+                "Advanced the active development version to `0.15.0-SNAPSHOT`",
+                "issue #149",
+                "[0.14.0]: https://github.com/nursena-pc/payflow/compare/v0.13.0...v0.14.0",
+                "[Unreleased]: https://github.com/nursena-pc/payflow/compare/v0.14.0...HEAD"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- advance the active Maven version to `0.15.0-SNAPSHOT`
- open the v0.15.0 generalized abuse-protection milestone
- define seven delivery increments for policy, Redis enforcement, protected workflows, observability, and performance evidence
- preserve the immutable v0.14.0 publication record
- add executable v0.15 development contracts

Tracks #149.
Relates to #106.

## Scope boundaries

- active-authenticator replacement remains outside v0.15.0
- no CAPTCHA, third-party bot detection, WAF, API gateway, Kubernetes, or adaptive risk scoring
- existing anti-enumeration, trusted-client, credential-redaction, and modular-monolith boundaries remain mandatory

## Verification

- `mvn clean verify`
- 1469 tests, 0 failures, 0 errors, 0 skipped
- `git diff --check`
- UTF-8 corruption scan
- Maven version verified as `0.15.0-SNAPSHOT`