### PR TITLE
feat(security): define abuse protection policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Application-facing generalized abuse-protection policy with five bounded workflow identifiers and no controller, servlet, HTTP, or Redis coupling.
+- Validated endpoint-specific windows, identity/client limits, and explicit dependency-failure modes under `payflow.security.abuse-protection`.
+- ADR 0015, generalized abuse-protection threat model, configuration guidance, and executable Increment 1 contracts tracked by issue #151.
+
 ### Changed
 
 - Advanced the active development version to `0.15.0-SNAPSHOT`.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ The active `0.15.0-SNAPSHOT` line introduces generalized abuse protection for se
 
 The milestone also defines reproducible latency, throughput, concurrency, and overload evidence. Low-cardinality metrics, provisioned Grafana dashboards, actionable alert rules, and documented investigation procedures must remain free of email addresses, raw client addresses, credentials, Redis keys, and counter contents.
 
+Increment 1 freezes five bounded workflow identifiers, an application-facing `AbuseProtectionPolicyProvider`, explicit `FAIL_CLOSED` or `FAIL_OPEN` dependency behavior, and validated endpoint-specific windows and identity/client limits. The global generalized policy switch defaults off until the shared Redis enforcement and endpoint-wiring increments are delivered; the existing login limiter remains unchanged.
+
+See [ADR 0015](docs/adr/0015-generalized-abuse-protection.md), the [generalized abuse-protection threat model](docs/security/abuse-protection-threat-model.md), and the [policy configuration guide](docs/abuse-protection.md). Increment 1 is tracked by [issue #151](https://github.com/nursena-pc/payflow/issues/151).
+
 Development is tracked by [issue #149](https://github.com/nursena-pc/payflow/issues/149). Active-authenticator replacement, CAPTCHA services, external bot detection, WAF or API-gateway deployment, and adaptive risk scoring remain outside the v0.15.0 scope.
 ## Implemented API
 

--- a/docs/abuse-protection.md
+++ b/docs/abuse-protection.md
@@ -1,0 +1,65 @@
+# Generalized Abuse-Protection Policy
+
+## Current delivery state
+
+Increment 1 defines and validates policy configuration. Generalized Redis
+enforcement is not active yet: `ABUSE_PROTECTION_ENABLED` defaults to `false`.
+The existing login limiter remains independently active and unchanged.
+
+## Policy contract
+
+The application-facing contract consists of:
+
+- `AbuseProtectionWorkflow`: five stable, bounded workflow identifiers
+- `AbuseProtectionFailureMode`: explicit `FAIL_CLOSED` or `FAIL_OPEN`
+- `AbuseProtectionPolicy`: enabled state, window, identity limit, client limit,
+  and failure behavior
+- `AbuseProtectionPolicyProvider`: adapter-independent lookup by workflow
+
+Policy code contains no controller, servlet, HTTP, Spring, or Redis dependency.
+
+## Validation
+
+- every workflow configuration is required
+- windows range from one second through one day
+- identity and client limits range from one through one million
+- every workflow declares a dependency-failure mode
+- the global switch can disable enforcement without discarding validated policy
+
+Invalid configuration fails application startup.
+
+## Configuration
+
+| Workflow | Window | Identity limit | Client limit | Failure mode |
+|---|---:|---:|---:|---|
+| Registration | 15 minutes | 5 | 20 | `FAIL_CLOSED` |
+| Email-verification request | 15 minutes | 3 | 20 | `FAIL_CLOSED` |
+| Password-recovery request | 15 minutes | 3 | 20 | `FAIL_CLOSED` |
+| MFA login-challenge confirmation | 5 minutes | 5 | 20 | `FAIL_CLOSED` |
+| Step-up grant issuance | 5 minutes | 5 | 20 | `FAIL_CLOSED` |
+
+Environment variables use the `ABUSE_PROTECTION_` prefix. Each workflow exposes
+`ENABLED`, `WINDOW`, `IDENTITY_LIMIT`, `CLIENT_LIMIT`, and `FAILURE_MODE`
+settings. The global switch is `ABUSE_PROTECTION_ENABLED`.
+
+Changing a failure mode to `FAIL_OPEN` requires a security review, updated ADR
+and threat-model evidence, public-contract tests, and explicit operational
+approval. It must never be used as an automatic response to Redis instability.
+
+## Privacy and observability
+
+Future enforcement may emit only finite workflow, dimension, decision, and
+failure classifications. Email addresses, raw client addresses, credentials,
+proofs, tokens, digests, Redis keys, counts, and TTL values are prohibited from
+observable output.
+
+## Compatibility
+
+`payflow.security.login-rate-limit` and the corresponding
+`LOGIN_RATE_LIMIT_*` variables remain unchanged. Increment 1 does not replace,
+adapt, disable, or reset the login limiter.
+
+See [ADR 0015](adr/0015-generalized-abuse-protection.md), the
+[threat model](security/abuse-protection-threat-model.md),
+[ADR 0010](adr/0010-redis-login-rate-limiting.md), and
+[ADR 0011](adr/0011-trusted-client-context.md).

--- a/docs/adr/0015-generalized-abuse-protection.md
+++ b/docs/adr/0015-generalized-abuse-protection.md
@@ -1,0 +1,104 @@
+# ADR 0015: Establish a generalized abuse-protection policy boundary
+
+- Status: Accepted
+- Date: 2026-08-14
+- Tracking issue: [#151](https://github.com/nursena-pc/payflow/issues/151)
+- Milestone: [#149](https://github.com/nursena-pc/payflow/issues/149)
+
+## Context
+
+PayFlow already protects password login with a Redis-backed fixed-window
+limiter and resolves an effective client address through a trusted-proxy
+boundary. Email-verification requests, password-recovery requests,
+registration, MFA login-challenge confirmation, and step-up grant issuance
+need endpoint-specific protection without copying login-specific Redis,
+controller, or servlet behavior.
+
+The policy must preserve anti-enumeration responses and must not expose email
+addresses, client addresses, credentials, proofs, Redis keys, or counter state.
+The first increment freezes policy and configuration only. Redis enforcement
+and endpoint wiring remain later increments.
+
+## Decision
+
+PayFlow introduces a package-bounded `abuseprotection` capability. Its
+application policy has no Spring, servlet, HTTP, controller, or Redis
+dependency.
+
+`AbuseProtectionWorkflow` is a closed enum with five bounded identifiers:
+
+- `registration`
+- `email-verification-request`
+- `password-recovery-request`
+- `mfa-login-challenge-confirmation`
+- `step-up-grant-issuance`
+
+`AbuseProtectionPolicy` defines whether a workflow is enabled, its fixed
+window, positive per-identity and per-client limits, and its deterministic
+dependency-failure mode. Windows are bounded from one second through one day.
+Each limit is bounded from one through one million. These bounds prevent
+invalid duration, non-expiring state, and accidental unbounded configuration.
+
+`AbuseProtectionPolicyProvider` is the application-facing lookup boundary.
+Configuration is supplied by an outbound configuration adapter under
+`payflow.security.abuse-protection`. The global switch defaults to `false`
+until Redis enforcement and protected workflow wiring are delivered.
+
+## Failure policy
+
+Every initially selected workflow is configured `FAIL_CLOSED`. The meaning of
+fail-closed is workflow-specific and must retain its established public
+contract:
+
+- email-verification and password-recovery request endpoints keep their generic
+  accepted response while suppressing the protected side effect
+- registration, MFA challenge confirmation, and step-up issuance reject the
+  operation through a stable coarse dependency-unavailable response
+- no fallback bypasses client or identity policy by trusting forwarding headers
+
+`FAIL_OPEN` remains a typed policy value for an explicitly reviewed future
+workflow. It is never selected implicitly after a timeout, malformed result,
+or partial Redis failure.
+
+## Identity and client boundaries
+
+The policy does not accept servlet requests or forwarding headers. A later
+inbound adapter must reuse `ClientAddressResolver` and its validated direct-peer
+fallback. Identity material must be normalized by the owning application
+workflow and transformed into a fixed-length digest before any Redis key is
+created. Raw identity and client material must never become a metric label,
+log field, trace attribute, error detail, or audit payload.
+
+## Compatibility
+
+The existing `LoginRateLimitPort`, configuration prefix, public errors,
+metrics, Redis script, and reset behavior remain unchanged. Migration or reuse
+of login enforcement requires separate evidence and is not part of this
+decision.
+
+## Consequences
+
+- endpoint policy becomes explicit and testable before enforcement is added
+- configuration fails startup when a selected policy is absent or invalid
+- bounded workflow enums can safely support future low-cardinality metrics
+- Redis implementation and HTTP behavior remain independently replaceable
+- policy defaults cannot be mistaken for active enforcement because the global
+  switch remains disabled in this increment
+
+## Rejected alternatives
+
+- controller annotations: couple policy to HTTP adapters and obscure failure
+  behavior
+- one global quota: cannot represent workflow-specific risk and response
+  contracts
+- accepting raw forwarding headers: permits attacker-controlled quota bypass
+- reusing the login port directly: leaks login-specific identity and reset
+  semantics into unrelated workflows
+- silent fail-open behavior: turns Redis failure into an abuse-control bypass
+
+## Non-goals
+
+This ADR does not implement Redis counters, endpoint interception, public error
+changes, dashboards, alerts, load tests, CAPTCHA, third-party bot detection,
+WAF or API-gateway deployment, adaptive scoring, or active-authenticator
+replacement.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -707,13 +707,15 @@ Tracking issue: [#149](https://github.com/nursena-pc/payflow/issues/149)
 
 ### Increment 1 — Threat model, policy contract, and configuration
 
-- [ ] Define protected workflows, attacker capabilities, bypass risks, and trust boundaries
-- [ ] Introduce an application-facing abuse-protection policy independent from controllers and servlet APIs
-- [ ] Define endpoint-specific per-identity and per-client limits through validated configuration
-- [ ] Reuse the trusted effective-client-address boundary without trusting attacker-controlled forwarding headers
-- [ ] Specify deterministic fail-closed or fail-open behavior for every protected workflow
-- [ ] Preserve generic public responses and anti-enumeration behavior under quota decisions and dependency failures
-- [ ] Add executable development contracts for the approved v0.15.0 scope
+- [x] Define protected workflows, attacker capabilities, bypass risks, and trust boundaries
+- [x] Introduce an application-facing abuse-protection policy independent from controllers and servlet APIs
+- [x] Define endpoint-specific per-identity and per-client limits through validated configuration
+- [x] Reuse the trusted effective-client-address boundary without trusting attacker-controlled forwarding headers
+- [x] Specify deterministic fail-closed or fail-open behavior for every protected workflow
+- [x] Preserve generic public responses and anti-enumeration behavior under quota decisions and dependency failures
+- [x] Add executable development contracts for the approved v0.15.0 scope
+
+The accepted Increment 1 foundation is tracked by [#151](https://github.com/nursena-pc/payflow/issues/151) and documented in [ADR 0015](adr/0015-generalized-abuse-protection.md), the [generalized abuse-protection threat model](security/abuse-protection-threat-model.md), and the [policy configuration guide](abuse-protection.md). Generalized enforcement remains disabled until the shared Redis and endpoint integration increments are delivered; the existing login limiter remains unchanged.
 
 ### Increment 2 — Shared Redis enforcement foundation
 

--- a/docs/security/abuse-protection-threat-model.md
+++ b/docs/security/abuse-protection-threat-model.md
@@ -1,0 +1,131 @@
+# Generalized Abuse-Protection Threat Model
+
+## Scope
+
+This threat model covers the v0.15.0 policy foundation for registration,
+email-verification requests, password-recovery requests, MFA login-challenge
+confirmation, and step-up grant issuance. Password login retains its existing
+rate limiter. Redis enforcement and endpoint wiring are delivered separately.
+
+## Security objectives
+
+- bound automated attempts by normalized identity and effective client
+- prevent untrusted forwarding headers from changing the client dimension
+- preserve generic account-action responses and anti-enumeration behavior
+- make dependency-failure behavior deterministic for every workflow
+- keep secrets, personal data, keys, and counters outside observable output
+- keep workflow, dimension, decision, and failure labels finite
+
+## Protected assets
+
+- account existence and eligibility
+- email-verification and password-recovery delivery capacity
+- passwords, TOTP proofs, recovery codes, challenge tokens, and step-up grants
+- normalized email addresses and effective client addresses
+- Redis key names, digests, counts, expiration, and remaining quota
+- application availability and operator confidence in metrics
+
+## Attacker capabilities
+
+An unauthenticated attacker can submit concurrent requests, rotate supplied
+identity values, reuse one client, distribute traffic across clients, send
+malformed or duplicated forwarding headers, measure coarse responses, and time
+requests. An authenticated attacker can submit invalid MFA proofs or request
+step-up grants repeatedly. An attacker cannot configure trusted proxy CIDRs,
+read server-side digests, or directly choose the resolved effective address.
+
+## Trust boundaries
+
+1. The public HTTP boundary accepts attacker-controlled payloads and headers.
+2. `ClientAddressResolver` accepts forwarding data only when the direct peer is
+   a configured trusted proxy and otherwise uses the direct peer.
+3. The owning user or MFA workflow normalizes identity material before policy
+   evaluation.
+4. The application-facing policy contains only bounded workflow and policy
+   types; it has no servlet or Redis dependency.
+5. A later Redis adapter will digest sensitive dimensions and own atomic,
+   expiring counter state.
+6. Logs, metrics, traces, errors, and audits are disclosure boundaries and may
+   contain only bounded coarse classifications.
+
+## Workflow policy
+
+| Workflow | Identity dimension | Client dimension | Dependency mode | Public behavior |
+|---|---|---|---|---|
+| Registration | normalized proposed email | trusted effective address | fail closed | stable coarse rejection |
+| Email-verification request | normalized email | trusted effective address | fail closed | generic accepted response; no side effect |
+| Password-recovery request | normalized email | trusted effective address | fail closed | generic accepted response; no side effect |
+| MFA challenge confirmation | challenge subject | trusted effective address | fail closed | stable coarse rejection |
+| Step-up grant issuance | authenticated subject | trusted effective address | fail closed | stable coarse rejection |
+
+The table defines policy intent, not active endpoint enforcement in Increment 1.
+
+## Threats and controls
+
+### Forwarding-header spoofing
+
+An attacker supplies `Forwarded` or `X-Forwarded-For` to rotate the client
+quota. The application must reuse the trusted-proxy resolver. Untrusted peers,
+malformed chains, excessive hops, and oversized headers fall back to the direct
+peer according to ADR 0011.
+
+### Identity spraying and quota evasion
+
+An attacker rotates identities or clients to avoid one dimension. Selected
+workflows require both dimensions with endpoint-specific limits. Neither raw
+value may become a Redis key; a later adapter must use domain-separated,
+fixed-length digests and bounded key prefixes.
+
+### Account enumeration
+
+Different quota or dependency outcomes can disclose whether an account exists.
+Email-verification and password-recovery request endpoints retain the same
+generic accepted status and body whether the identity is absent, ineligible,
+limited, or blocked by a dependency failure. Observable labels never include
+identity or eligibility.
+
+### Dependency-failure bypass
+
+Timeouts, connection failures, malformed Redis results, and partial operations
+must not silently permit protected work. Each configured workflow has an
+explicit failure mode. The initial policy set is fail closed. Later adapters
+must map failures to the workflow-specific public behavior above.
+
+### Counter persistence and cardinality
+
+Missing expiration can create durable personal-data-derived state, while
+attacker-selected metric labels can exhaust monitoring systems. Configuration
+bounds windows and limits. Increment 2 must use one atomic operation with
+explicit expiration and finite workflow, dimension, outcome, and failure tags.
+
+### Credential disclosure
+
+Passwords, account-action tokens, MFA proofs, recovery codes, login challenges,
+step-up grants, email addresses, client addresses, digests, Redis keys, counts,
+and TTLs are prohibited from logs, metrics, traces, errors, and audits. Tests
+must inspect success, rejection, and dependency-failure paths.
+
+### Configuration mistakes
+
+Missing workflow policy, sub-second or greater-than-one-day windows, non-positive
+limits, limits above one million, and absent failure modes fail application
+startup. The global policy switch defaults off until enforcement is wired.
+
+## Verification obligations
+
+- unit-test policy bounds and complete workflow configuration
+- prove application policy source contains no Spring, servlet, HTTP, or Redis
+  imports
+- test trusted-client integration during Increment 2
+- test atomic expiration and concurrency with real Redis during Increment 2
+- verify generic public behavior during endpoint increments
+- scan logs, metrics, traces, errors, and audits for prohibited material
+- retain the existing login-rate-limit contract suite unchanged
+
+## Residual risks
+
+Distributed clients and identity rotation can still consume resources within
+configured bounds. Fixed windows can permit boundary bursts. These risks are
+accepted for v0.15.0 and must be measured by the load and performance increment.
+CAPTCHA, external bot intelligence, adaptive risk scoring, and edge enforcement
+remain explicit non-goals.

--- a/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/configuration/AbuseProtectionConfiguration.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/configuration/AbuseProtectionConfiguration.java
@@ -1,0 +1,23 @@
+package com.nursena.payflow.abuseprotection.adapter.out.configuration;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicyProvider;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(
+    AbuseProtectionProperties.class
+)
+class AbuseProtectionConfiguration {
+
+    @Bean
+    AbuseProtectionPolicyProvider
+        abuseProtectionPolicyProvider(
+            AbuseProtectionProperties properties
+        ) {
+        return new ConfiguredAbuseProtectionPolicyProvider(
+            properties
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/configuration/AbuseProtectionProperties.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/configuration/AbuseProtectionProperties.java
@@ -1,0 +1,105 @@
+package com.nursena.payflow.abuseprotection.adapter.out.configuration;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionFailureMode;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicy;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(
+    prefix = "payflow.security.abuse-protection"
+)
+public record AbuseProtectionProperties(
+    boolean enabled,
+    WorkflowPolicyProperties registration,
+    WorkflowPolicyProperties emailVerificationRequest,
+    WorkflowPolicyProperties passwordRecoveryRequest,
+    WorkflowPolicyProperties mfaLoginChallengeConfirmation,
+    WorkflowPolicyProperties stepUpGrantIssuance
+) {
+
+    public AbuseProtectionProperties {
+        Objects.requireNonNull(
+            registration,
+            "registration policy must not be null"
+        );
+
+        Objects.requireNonNull(
+            emailVerificationRequest,
+            "emailVerificationRequest policy must not be null"
+        );
+
+        Objects.requireNonNull(
+            passwordRecoveryRequest,
+            "passwordRecoveryRequest policy must not be null"
+        );
+
+        Objects.requireNonNull(
+            mfaLoginChallengeConfirmation,
+            "mfaLoginChallengeConfirmation policy must not be null"
+        );
+
+        Objects.requireNonNull(
+            stepUpGrantIssuance,
+            "stepUpGrantIssuance policy must not be null"
+        );
+    }
+
+    AbuseProtectionPolicy policyFor(
+        AbuseProtectionWorkflow workflow
+    ) {
+        Objects.requireNonNull(
+            workflow,
+            "workflow must not be null"
+        );
+
+        WorkflowPolicyProperties configuredPolicy =
+            switch (workflow) {
+                case REGISTRATION ->
+                    registration;
+                case EMAIL_VERIFICATION_REQUEST ->
+                    emailVerificationRequest;
+                case PASSWORD_RECOVERY_REQUEST ->
+                    passwordRecoveryRequest;
+                case MFA_LOGIN_CHALLENGE_CONFIRMATION ->
+                    mfaLoginChallengeConfirmation;
+                case STEP_UP_GRANT_ISSUANCE ->
+                    stepUpGrantIssuance;
+            };
+
+        return configuredPolicy.toPolicy(enabled);
+    }
+
+    public record WorkflowPolicyProperties(
+        boolean enabled,
+        Duration window,
+        int identityLimit,
+        int clientLimit,
+        AbuseProtectionFailureMode dependencyFailureMode
+    ) {
+
+        public WorkflowPolicyProperties {
+            new AbuseProtectionPolicy(
+                enabled,
+                window,
+                identityLimit,
+                clientLimit,
+                dependencyFailureMode
+            );
+        }
+
+        AbuseProtectionPolicy toPolicy(
+            boolean globallyEnabled
+        ) {
+            return new AbuseProtectionPolicy(
+                globallyEnabled && enabled,
+                window,
+                identityLimit,
+                clientLimit,
+                dependencyFailureMode
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/configuration/ConfiguredAbuseProtectionPolicyProvider.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/configuration/ConfiguredAbuseProtectionPolicyProvider.java
@@ -1,0 +1,30 @@
+package com.nursena.payflow.abuseprotection.adapter.out.configuration;
+
+import java.util.Objects;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicy;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicyProvider;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+
+final class ConfiguredAbuseProtectionPolicyProvider
+    implements AbuseProtectionPolicyProvider {
+
+    private final AbuseProtectionProperties properties;
+
+    ConfiguredAbuseProtectionPolicyProvider(
+        AbuseProtectionProperties properties
+    ) {
+        this.properties =
+            Objects.requireNonNull(
+                properties,
+                "properties must not be null"
+            );
+    }
+
+    @Override
+    public AbuseProtectionPolicy policyFor(
+        AbuseProtectionWorkflow workflow
+    ) {
+        return properties.policyFor(workflow);
+    }
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/application/policy/AbuseProtectionFailureMode.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/application/policy/AbuseProtectionFailureMode.java
@@ -1,0 +1,6 @@
+package com.nursena.payflow.abuseprotection.application.policy;
+
+public enum AbuseProtectionFailureMode {
+    FAIL_CLOSED,
+    FAIL_OPEN
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/application/policy/AbuseProtectionPolicy.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/application/policy/AbuseProtectionPolicy.java
@@ -1,0 +1,75 @@
+package com.nursena.payflow.abuseprotection.application.policy;
+
+import java.time.Duration;
+import java.util.Objects;
+
+public record AbuseProtectionPolicy(
+    boolean enabled,
+    Duration window,
+    int identityLimit,
+    int clientLimit,
+    AbuseProtectionFailureMode dependencyFailureMode
+) {
+
+    private static final Duration MINIMUM_WINDOW =
+        Duration.ofSeconds(1);
+
+    private static final Duration MAXIMUM_WINDOW =
+        Duration.ofDays(1);
+
+    private static final int MAXIMUM_LIMIT =
+        1_000_000;
+
+    public AbuseProtectionPolicy {
+        Objects.requireNonNull(
+            window,
+            "window must not be null"
+        );
+
+        Objects.requireNonNull(
+            dependencyFailureMode,
+            "dependencyFailureMode must not be null"
+        );
+
+        if (window.compareTo(MINIMUM_WINDOW) < 0) {
+            throw new IllegalArgumentException(
+                "window must be at least one second"
+            );
+        }
+
+        if (window.compareTo(MAXIMUM_WINDOW) > 0) {
+            throw new IllegalArgumentException(
+                "window must not exceed one day"
+            );
+        }
+
+        requireBoundedLimit(
+            identityLimit,
+            "identityLimit"
+        );
+
+        requireBoundedLimit(
+            clientLimit,
+            "clientLimit"
+        );
+    }
+
+    private static void requireBoundedLimit(
+        int value,
+        String propertyName
+    ) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(
+                propertyName + " must be positive"
+            );
+        }
+
+        if (value > MAXIMUM_LIMIT) {
+            throw new IllegalArgumentException(
+                propertyName
+                    + " must not exceed "
+                    + MAXIMUM_LIMIT
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/application/policy/AbuseProtectionPolicyProvider.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/application/policy/AbuseProtectionPolicyProvider.java
@@ -1,0 +1,9 @@
+package com.nursena.payflow.abuseprotection.application.policy;
+
+@FunctionalInterface
+public interface AbuseProtectionPolicyProvider {
+
+    AbuseProtectionPolicy policyFor(
+        AbuseProtectionWorkflow workflow
+    );
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/application/policy/AbuseProtectionWorkflow.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/application/policy/AbuseProtectionWorkflow.java
@@ -1,0 +1,29 @@
+package com.nursena.payflow.abuseprotection.application.policy;
+
+public enum AbuseProtectionWorkflow {
+    REGISTRATION("registration"),
+    EMAIL_VERIFICATION_REQUEST(
+        "email-verification-request"
+    ),
+    PASSWORD_RECOVERY_REQUEST(
+        "password-recovery-request"
+    ),
+    MFA_LOGIN_CHALLENGE_CONFIRMATION(
+        "mfa-login-challenge-confirmation"
+    ),
+    STEP_UP_GRANT_ISSUANCE(
+        "step-up-grant-issuance"
+    );
+
+    private final String configurationKey;
+
+    AbuseProtectionWorkflow(
+        String configurationKey
+    ) {
+        this.configurationKey = configurationKey;
+    }
+
+    public String configurationKey() {
+        return configurationKey;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -114,6 +114,38 @@ payflow:
       secret-protection:
         provider-mode: ${MFA_SECRET_PROTECTION_MODE:ephemeral}
         key-base64: ${MFA_SECRET_ENCRYPTION_KEY:}
+    abuse-protection:
+      enabled: ${ABUSE_PROTECTION_ENABLED:false}
+      registration:
+        enabled: ${ABUSE_PROTECTION_REGISTRATION_ENABLED:true}
+        window: ${ABUSE_PROTECTION_REGISTRATION_WINDOW:15m}
+        identity-limit: ${ABUSE_PROTECTION_REGISTRATION_IDENTITY_LIMIT:5}
+        client-limit: ${ABUSE_PROTECTION_REGISTRATION_CLIENT_LIMIT:20}
+        dependency-failure-mode: ${ABUSE_PROTECTION_REGISTRATION_FAILURE_MODE:FAIL_CLOSED}
+      email-verification-request:
+        enabled: ${ABUSE_PROTECTION_EMAIL_VERIFICATION_ENABLED:true}
+        window: ${ABUSE_PROTECTION_EMAIL_VERIFICATION_WINDOW:15m}
+        identity-limit: ${ABUSE_PROTECTION_EMAIL_VERIFICATION_IDENTITY_LIMIT:3}
+        client-limit: ${ABUSE_PROTECTION_EMAIL_VERIFICATION_CLIENT_LIMIT:20}
+        dependency-failure-mode: ${ABUSE_PROTECTION_EMAIL_VERIFICATION_FAILURE_MODE:FAIL_CLOSED}
+      password-recovery-request:
+        enabled: ${ABUSE_PROTECTION_PASSWORD_RECOVERY_ENABLED:true}
+        window: ${ABUSE_PROTECTION_PASSWORD_RECOVERY_WINDOW:15m}
+        identity-limit: ${ABUSE_PROTECTION_PASSWORD_RECOVERY_IDENTITY_LIMIT:3}
+        client-limit: ${ABUSE_PROTECTION_PASSWORD_RECOVERY_CLIENT_LIMIT:20}
+        dependency-failure-mode: ${ABUSE_PROTECTION_PASSWORD_RECOVERY_FAILURE_MODE:FAIL_CLOSED}
+      mfa-login-challenge-confirmation:
+        enabled: ${ABUSE_PROTECTION_MFA_CHALLENGE_ENABLED:true}
+        window: ${ABUSE_PROTECTION_MFA_CHALLENGE_WINDOW:5m}
+        identity-limit: ${ABUSE_PROTECTION_MFA_CHALLENGE_IDENTITY_LIMIT:5}
+        client-limit: ${ABUSE_PROTECTION_MFA_CHALLENGE_CLIENT_LIMIT:20}
+        dependency-failure-mode: ${ABUSE_PROTECTION_MFA_CHALLENGE_FAILURE_MODE:FAIL_CLOSED}
+      step-up-grant-issuance:
+        enabled: ${ABUSE_PROTECTION_STEP_UP_ENABLED:true}
+        window: ${ABUSE_PROTECTION_STEP_UP_WINDOW:5m}
+        identity-limit: ${ABUSE_PROTECTION_STEP_UP_IDENTITY_LIMIT:5}
+        client-limit: ${ABUSE_PROTECTION_STEP_UP_CLIENT_LIMIT:20}
+        dependency-failure-mode: ${ABUSE_PROTECTION_STEP_UP_FAILURE_MODE:FAIL_CLOSED}
     login-rate-limit:
       enabled: ${LOGIN_RATE_LIMIT_ENABLED:true}
       window: ${LOGIN_RATE_LIMIT_WINDOW:15m}

--- a/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/configuration/AbuseProtectionConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/configuration/AbuseProtectionConfigurationTest.java
@@ -1,0 +1,191 @@
+package com.nursena.payflow.abuseprotection.adapter.out.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionFailureMode;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicyProvider;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class AbuseProtectionConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+        new ApplicationContextRunner()
+            .withUserConfiguration(
+                AbuseProtectionConfiguration.class
+            );
+
+    @Test
+    void shouldBindValidatedWorkflowPolicies() {
+        contextRunner
+            .withPropertyValues(validProperties())
+            .run(context -> {
+                assertThat(context)
+                    .hasNotFailed()
+                    .hasSingleBean(
+                        AbuseProtectionProperties.class
+                    )
+                    .hasSingleBean(
+                        AbuseProtectionPolicyProvider.class
+                    );
+
+                AbuseProtectionPolicyProvider provider =
+                    context.getBean(
+                        AbuseProtectionPolicyProvider.class
+                    );
+
+                assertThat(
+                    provider
+                        .policyFor(
+                            AbuseProtectionWorkflow
+                                .EMAIL_VERIFICATION_REQUEST
+                        )
+                        .window()
+                ).isEqualTo(Duration.ofMinutes(15));
+
+                assertThat(
+                    provider
+                        .policyFor(
+                            AbuseProtectionWorkflow
+                                .EMAIL_VERIFICATION_REQUEST
+                        )
+                        .dependencyFailureMode()
+                ).isEqualTo(
+                    AbuseProtectionFailureMode.FAIL_CLOSED
+                );
+            });
+    }
+
+    @Test
+    void shouldRejectInvalidWorkflowConfiguration() {
+        String[] properties = validProperties();
+        properties[2] =
+            "payflow.security.abuse-protection."
+                + "registration.window=500ms";
+
+        contextRunner
+            .withPropertyValues(properties)
+            .run(context ->
+                assertThat(context).hasFailed()
+            );
+    }
+
+    private static String[] validProperties() {
+        return new String[] {
+            "payflow.security.abuse-protection.enabled=true",
+            workflowProperty(
+                "registration",
+                "enabled=true"
+            ),
+            workflowProperty(
+                "registration",
+                "window=15m"
+            ),
+            workflowProperty(
+                "registration",
+                "identity-limit=5"
+            ),
+            workflowProperty(
+                "registration",
+                "client-limit=20"
+            ),
+            workflowProperty(
+                "registration",
+                "dependency-failure-mode=FAIL_CLOSED"
+            ),
+            workflowProperty(
+                "email-verification-request",
+                "enabled=true"
+            ),
+            workflowProperty(
+                "email-verification-request",
+                "window=15m"
+            ),
+            workflowProperty(
+                "email-verification-request",
+                "identity-limit=3"
+            ),
+            workflowProperty(
+                "email-verification-request",
+                "client-limit=20"
+            ),
+            workflowProperty(
+                "email-verification-request",
+                "dependency-failure-mode=FAIL_CLOSED"
+            ),
+            workflowProperty(
+                "password-recovery-request",
+                "enabled=true"
+            ),
+            workflowProperty(
+                "password-recovery-request",
+                "window=15m"
+            ),
+            workflowProperty(
+                "password-recovery-request",
+                "identity-limit=3"
+            ),
+            workflowProperty(
+                "password-recovery-request",
+                "client-limit=20"
+            ),
+            workflowProperty(
+                "password-recovery-request",
+                "dependency-failure-mode=FAIL_CLOSED"
+            ),
+            workflowProperty(
+                "mfa-login-challenge-confirmation",
+                "enabled=true"
+            ),
+            workflowProperty(
+                "mfa-login-challenge-confirmation",
+                "window=5m"
+            ),
+            workflowProperty(
+                "mfa-login-challenge-confirmation",
+                "identity-limit=5"
+            ),
+            workflowProperty(
+                "mfa-login-challenge-confirmation",
+                "client-limit=20"
+            ),
+            workflowProperty(
+                "mfa-login-challenge-confirmation",
+                "dependency-failure-mode=FAIL_CLOSED"
+            ),
+            workflowProperty(
+                "step-up-grant-issuance",
+                "enabled=true"
+            ),
+            workflowProperty(
+                "step-up-grant-issuance",
+                "window=5m"
+            ),
+            workflowProperty(
+                "step-up-grant-issuance",
+                "identity-limit=5"
+            ),
+            workflowProperty(
+                "step-up-grant-issuance",
+                "client-limit=20"
+            ),
+            workflowProperty(
+                "step-up-grant-issuance",
+                "dependency-failure-mode=FAIL_CLOSED"
+            )
+        };
+    }
+
+    private static String workflowProperty(
+        String workflow,
+        String property
+    ) {
+        return "payflow.security.abuse-protection."
+            + workflow
+            + "."
+            + property;
+    }
+}

--- a/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/configuration/AbuseProtectionPropertiesTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/configuration/AbuseProtectionPropertiesTest.java
@@ -1,0 +1,108 @@
+package com.nursena.payflow.abuseprotection.adapter.out.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionFailureMode;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import org.junit.jupiter.api.Test;
+
+class AbuseProtectionPropertiesTest {
+
+    @Test
+    void shouldResolveEveryWorkflowPolicy() {
+        AbuseProtectionProperties properties =
+            properties(true);
+
+        for (
+            AbuseProtectionWorkflow workflow
+                : AbuseProtectionWorkflow.values()
+        ) {
+            assertThat(
+                properties.policyFor(workflow).enabled()
+            ).isTrue();
+
+            assertThat(
+                properties
+                    .policyFor(workflow)
+                    .dependencyFailureMode()
+            ).isEqualTo(
+                AbuseProtectionFailureMode.FAIL_CLOSED
+            );
+        }
+    }
+
+    @Test
+    void shouldApplyGlobalDisableWithoutLosingPolicy() {
+        AbuseProtectionProperties properties =
+            properties(false);
+
+        assertThat(
+            properties
+                .policyFor(
+                    AbuseProtectionWorkflow.REGISTRATION
+                )
+                .enabled()
+        ).isFalse();
+
+        assertThat(
+            properties
+                .policyFor(
+                    AbuseProtectionWorkflow.REGISTRATION
+                )
+                .window()
+        ).isEqualTo(Duration.ofMinutes(15));
+    }
+
+    @Test
+    void shouldRequireEveryWorkflowPolicy() {
+        AbuseProtectionProperties.WorkflowPolicyProperties policy =
+            policy();
+
+        assertThatThrownBy(() ->
+            new AbuseProtectionProperties(
+                true,
+                policy,
+                null,
+                policy,
+                policy,
+                policy
+            )
+        )
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(
+                "emailVerificationRequest policy "
+                    + "must not be null"
+            );
+    }
+
+    private static AbuseProtectionProperties properties(
+        boolean enabled
+    ) {
+        AbuseProtectionProperties.WorkflowPolicyProperties policy =
+            policy();
+
+        return new AbuseProtectionProperties(
+            enabled,
+            policy,
+            policy,
+            policy,
+            policy,
+            policy
+        );
+    }
+
+    private static AbuseProtectionProperties.WorkflowPolicyProperties
+        policy() {
+        return new AbuseProtectionProperties
+            .WorkflowPolicyProperties(
+                true,
+                Duration.ofMinutes(15),
+                5,
+                20,
+                AbuseProtectionFailureMode.FAIL_CLOSED
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/abuseprotection/application/policy/AbuseProtectionPolicyTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/application/policy/AbuseProtectionPolicyTest.java
@@ -1,0 +1,92 @@
+package com.nursena.payflow.abuseprotection.application.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class AbuseProtectionPolicyTest {
+
+    @Test
+    void shouldRetainValidatedPolicy() {
+        AbuseProtectionPolicy policy =
+            new AbuseProtectionPolicy(
+                true,
+                Duration.ofMinutes(15),
+                5,
+                20,
+                AbuseProtectionFailureMode.FAIL_CLOSED
+            );
+
+        assertThat(policy.enabled()).isTrue();
+        assertThat(policy.window())
+            .isEqualTo(Duration.ofMinutes(15));
+        assertThat(policy.identityLimit()).isEqualTo(5);
+        assertThat(policy.clientLimit()).isEqualTo(20);
+        assertThat(policy.dependencyFailureMode())
+            .isEqualTo(
+                AbuseProtectionFailureMode.FAIL_CLOSED
+            );
+    }
+
+    @Test
+    void shouldRejectSubSecondWindow() {
+        assertThatThrownBy(() ->
+            policy(
+                Duration.ofMillis(999),
+                5,
+                20
+            )
+        )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(
+                "window must be at least one second"
+            );
+    }
+
+    @Test
+    void shouldRejectWindowLongerThanOneDay() {
+        assertThatThrownBy(() ->
+            policy(
+                Duration.ofDays(1).plusSeconds(1),
+                5,
+                20
+            )
+        )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(
+                "window must not exceed one day"
+            );
+    }
+
+    @Test
+    void shouldRejectUnboundedLimit() {
+        assertThatThrownBy(() ->
+            policy(
+                Duration.ofMinutes(15),
+                1_000_001,
+                20
+            )
+        )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(
+                "identityLimit must not exceed 1000000"
+            );
+    }
+
+    private static AbuseProtectionPolicy policy(
+        Duration window,
+        int identityLimit,
+        int clientLimit
+    ) {
+        return new AbuseProtectionPolicy(
+            true,
+            window,
+            identityLimit,
+            clientLimit,
+            AbuseProtectionFailureMode.FAIL_CLOSED
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/abuseprotection/application/policy/AbuseProtectionWorkflowTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/application/policy/AbuseProtectionWorkflowTest.java
@@ -1,0 +1,36 @@
+package com.nursena.payflow.abuseprotection.application.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+class AbuseProtectionWorkflowTest {
+
+    @Test
+    void shouldExposeBoundedStableConfigurationKeys() {
+        assertThat(
+            Arrays.stream(
+                AbuseProtectionWorkflow.values()
+            )
+                .map(
+                    AbuseProtectionWorkflow::configurationKey
+                )
+        )
+            .containsExactlyInAnyOrder(
+                "registration",
+                "email-verification-request",
+                "password-recovery-request",
+                "mfa-login-challenge-confirmation",
+                "step-up-grant-issuance"
+            )
+            .allMatch(key ->
+                key.length() <= 64
+                    && key.matches(
+                        "[a-z0-9]+(?:-[a-z0-9]+)*"
+                    )
+            )
+            .doesNotHaveDuplicates();
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/V015AbuseProtectionFoundationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V015AbuseProtectionFoundationContractTest.java
@@ -1,0 +1,220 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class V015AbuseProtectionFoundationContractTest {
+
+    private static final Path POLICY_DIRECTORY =
+        Path.of(
+            "src",
+            "main",
+            "java",
+            "com",
+            "nursena",
+            "payflow",
+            "abuseprotection",
+            "application",
+            "policy"
+        );
+
+    private static final Path APPLICATION_YAML =
+        Path.of(
+            "src",
+            "main",
+            "resources",
+            "application.yml"
+        );
+
+    private static final Path ADR =
+        Path.of(
+            "docs",
+            "adr",
+            "0015-generalized-abuse-protection.md"
+        );
+
+    private static final Path THREAT_MODEL =
+        Path.of(
+            "docs",
+            "security",
+            "abuse-protection-threat-model.md"
+        );
+
+    private static final Path GUIDE =
+        Path.of(
+            "docs",
+            "abuse-protection.md"
+        );
+
+    private static final Path README =
+        Path.of("README.md");
+
+    private static final Path CHANGELOG =
+        Path.of("CHANGELOG.md");
+
+    private static final Path ROADMAP =
+        Path.of("docs", "roadmap.md");
+
+    @Test
+    void shouldKeepApplicationPolicyAdapterIndependent()
+        throws IOException {
+
+        List<Path> policyFiles;
+
+        try (var paths = Files.list(POLICY_DIRECTORY)) {
+            policyFiles = paths
+                .filter(path ->
+                    path.getFileName()
+                        .toString()
+                        .endsWith(".java")
+                )
+                .toList();
+        }
+
+        assertThat(policyFiles).hasSize(4);
+
+        for (Path policyFile : policyFiles) {
+            assertThat(Files.readString(policyFile))
+                .doesNotContain(
+                    "org.springframework",
+                    "jakarta.servlet",
+                    "javax.servlet",
+                    "HttpServlet",
+                    "Redis",
+                    "Controller"
+                );
+        }
+    }
+
+    @Test
+    void shouldDefineBoundedWorkflowAndPolicyTypes()
+        throws IOException {
+
+        String workflow = Files.readString(
+            POLICY_DIRECTORY.resolve(
+                "AbuseProtectionWorkflow.java"
+            )
+        );
+
+        String policy = Files.readString(
+            POLICY_DIRECTORY.resolve(
+                "AbuseProtectionPolicy.java"
+            )
+        );
+
+        assertThat(workflow)
+            .contains(
+                "REGISTRATION",
+                "EMAIL_VERIFICATION_REQUEST",
+                "PASSWORD_RECOVERY_REQUEST",
+                "MFA_LOGIN_CHALLENGE_CONFIRMATION",
+                "STEP_UP_GRANT_ISSUANCE"
+            );
+
+        assertThat(policy)
+            .contains(
+                "Duration.ofSeconds(1)",
+                "Duration.ofDays(1)",
+                "1_000_000",
+                "AbuseProtectionFailureMode"
+            );
+    }
+
+    @Test
+    void shouldConfigureEverySelectedWorkflow()
+        throws IOException {
+
+        assertThat(Files.readString(APPLICATION_YAML))
+            .contains(
+                "abuse-protection:",
+                "${ABUSE_PROTECTION_ENABLED:false}",
+                "registration:",
+                "email-verification-request:",
+                "password-recovery-request:",
+                "mfa-login-challenge-confirmation:",
+                "step-up-grant-issuance:",
+                "dependency-failure-mode:",
+                "FAIL_CLOSED",
+                "login-rate-limit:"
+            );
+    }
+
+    @Test
+    void shouldDocumentThreatsAndFailureContracts()
+        throws IOException {
+
+        String adr = normalizeWhitespace(
+            Files.readString(ADR)
+        );
+
+        String guide = normalizeWhitespace(
+            Files.readString(GUIDE)
+        );
+
+        assertThat(adr)
+            .contains(
+                "application policy has no Spring, servlet, HTTP, controller, or Redis dependency",
+                "global switch defaults to `false`",
+                "generic accepted response while suppressing the protected side effect",
+                "existing `LoginRateLimitPort`"
+            );
+
+        assertThat(Files.readString(THREAT_MODEL))
+            .contains(
+                "Attacker capabilities",
+                "Trust boundaries",
+                "Forwarding-header spoofing",
+                "Account enumeration",
+                "Dependency-failure bypass",
+                "Credential disclosure"
+            );
+
+        assertThat(guide)
+            .contains(
+                "Generalized Redis enforcement is not active yet",
+                "windows range from one second through one day",
+                "limits range from one through one million",
+                "The existing login limiter remains independently active and unchanged"
+            );
+    }
+
+    @Test
+    void shouldRecordCompletedIncrementWithoutClaimingEnforcement()
+        throws IOException {
+
+        assertThat(Files.readString(README))
+            .contains(
+                "Increment 1 freezes five bounded workflow identifiers",
+                "global generalized policy switch defaults off",
+                "issue #151"
+            );
+
+        assertThat(Files.readString(CHANGELOG))
+            .contains(
+                "Application-facing generalized abuse-protection policy",
+                "Validated endpoint-specific windows",
+                "issue #151"
+            );
+
+        assertThat(Files.readString(ROADMAP))
+            .contains(
+                "- [x] Define protected workflows, attacker capabilities, bypass risks, and trust boundaries",
+                "- [x] Add executable development contracts for the approved v0.15.0 scope",
+                "Generalized enforcement remains disabled",
+                "### Increment 2",
+                "Shared Redis enforcement foundation"
+            );
+    }
+
+    private static String normalizeWhitespace(
+        String value
+    ) {
+        return value.replaceAll("\\s+", " ").trim();
+    }
+}


### PR DESCRIPTION
## Summary

- introduce a package-bounded, application-facing generalized abuse-protection policy
- define five stable protected-workflow identifiers
- validate endpoint-specific windows, identity/client limits, and dependency-failure modes
- default generalized enforcement off until Redis and endpoint integration are delivered
- preserve the existing login limiter and trusted effective-client-address boundary
- add ADR 0015, threat model, configuration guidance, and executable contracts
- complete v0.15.0 roadmap Increment 1

## Security boundaries

- application policy has no controller, servlet, HTTP, Spring, or Redis coupling
- all initial workflows use deterministic fail-closed policy
- generic email-verification and password-recovery responses remain mandatory
- raw identities, client addresses, credentials, digests, Redis keys, counters, and TTLs remain outside observable output
- active-authenticator replacement and external bot-detection systems remain out of scope

## Verification

- `mvn clean verify`
- 1484 tests, 0 failures, 0 errors, 0 skipped
- `git diff --check`
- application policy dependency scan
- UTF-8 corruption scan
- no unchecked v0.15.0 Increment 1 roadmap items

Closes #151.
Relates to #149.