### PR TITLE
feat(security): add Redis abuse enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Shared atomic Redis abuse-enforcement foundation with expiring, domain-separated digest-only identity and client quota keys ([#153](https://github.com/nursena-pc/payflow/issues/153)).
+- Typed generalized abuse-protection request, decision, dimension, dependency-failure, and enforcement-port contracts.
+- Real Redis verification for window boundaries, TTL repair, concurrency, and combined quota decisions while preserving the existing login limiter.
+
+### Added
+
 - Application-facing generalized abuse-protection policy with five bounded workflow identifiers and no controller, servlet, HTTP, or Redis coupling.
 - Validated endpoint-specific windows, identity/client limits, and explicit dependency-failure modes under `payflow.security.abuse-protection`.
 - ADR 0015, generalized abuse-protection threat model, configuration guidance, and executable Increment 1 contracts tracked by issue #151.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Increment 1 freezes five bounded workflow identifiers, an application-facing `Ab
 
 See [ADR 0015](docs/adr/0015-generalized-abuse-protection.md), the [generalized abuse-protection threat model](docs/security/abuse-protection-threat-model.md), and the [policy configuration guide](docs/abuse-protection.md). Increment 1 is tracked by [issue #151](https://github.com/nursena-pc/payflow/issues/151).
 
+Increment 2 adds a separate atomic Redis enforcement foundation tracked by [issue #153](https://github.com/nursena-pc/payflow/issues/153). It evaluates identity and trusted-client quotas in one operation, uses expiring digest-only keys, follows explicit dependency-failure policy, and leaves endpoint wiring and the existing login limiter unchanged.
+
 Development is tracked by [issue #149](https://github.com/nursena-pc/payflow/issues/149). Active-authenticator replacement, CAPTCHA services, external bot detection, WAF or API-gateway deployment, and adaptive risk scoring remain outside the v0.15.0 scope.
 ## Implemented API
 

--- a/docs/abuse-protection.md
+++ b/docs/abuse-protection.md
@@ -2,9 +2,12 @@
 
 ## Current delivery state
 
-Increment 1 defines and validates policy configuration. Generalized Redis
-enforcement is not active yet: `ABUSE_PROTECTION_ENABLED` defaults to `false`.
-The existing login limiter remains independently active and unchanged.
+Increment 2 provides the shared Redis enforcement foundation. One atomic Lua
+operation evaluates identity and client quotas, establishes or repairs bounded
+expiration, and returns the longest applicable positive retry delay. Endpoint
+wiring remains deferred. Generalized Redis enforcement is not active yet at
+protected endpoints, so `ABUSE_PROTECTION_ENABLED` continues to default to
+`false`. The existing login limiter remains independently active and unchanged.
 
 ## Policy contract
 
@@ -56,8 +59,21 @@ observable output.
 ## Compatibility
 
 `payflow.security.login-rate-limit` and the corresponding
-`LOGIN_RATE_LIMIT_*` variables remain unchanged. Increment 1 does not replace,
-adapt, disable, or reset the login limiter.
+`LOGIN_RATE_LIMIT_*` variables remain unchanged. Increment 2 adds a separate
+adapter and script; it does not replace, adapt, disable, or reset the login
+limiter.
+
+## Redis state contract
+
+- one Lua invocation increments identity and client counters atomically
+- every new key receives expiration and a missing expiration is repaired
+- key prefixes contain only bounded workflow and dimension identifiers
+- key suffixes are domain-separated 64-character SHA-256 digests
+- values contain counters only
+- malformed results, timeouts, and connection failures follow the workflow's
+  explicit dependency-failure mode
+- `FAIL_OPEN` permits work only when selected explicitly; `FAIL_CLOSED` raises a
+  coarse dependency-unavailable outcome without sensitive detail
 
 See [ADR 0015](adr/0015-generalized-abuse-protection.md), the
 [threat model](security/abuse-protection-threat-model.md),

--- a/docs/adr/0015-generalized-abuse-protection.md
+++ b/docs/adr/0015-generalized-abuse-protection.md
@@ -16,8 +16,8 @@ controller, or servlet behavior.
 
 The policy must preserve anti-enumeration responses and must not expose email
 addresses, client addresses, credentials, proofs, Redis keys, or counter state.
-The first increment freezes policy and configuration only. Redis enforcement
-and endpoint wiring remain later increments.
+The first increment froze policy and configuration. Increment 2 adds a separate
+atomic Redis enforcement adapter while endpoint wiring remains deferred.
 
 ## Decision
 
@@ -98,7 +98,7 @@ decision.
 
 ## Non-goals
 
-This ADR does not implement Redis counters, endpoint interception, public error
-changes, dashboards, alerts, load tests, CAPTCHA, third-party bot detection,
-WAF or API-gateway deployment, adaptive scoring, or active-authenticator
-replacement.
+Increment 2 implements Redis counters but does not implement endpoint
+interception, public error changes, dashboards, alerts, load tests, CAPTCHA,
+third-party bot detection, WAF or API-gateway deployment, adaptive scoring, or
+active-authenticator replacement.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -719,11 +719,13 @@ The accepted Increment 1 foundation is tracked by [#151](https://github.com/nurs
 
 ### Increment 2 — Shared Redis enforcement foundation
 
-- [ ] Implement atomic Redis decisions with explicit expiration and bounded key cardinality
-- [ ] Keep raw identities, email addresses, client addresses, credentials, and proofs out of Redis keys and values
-- [ ] Define collision-resistant bounded identifiers for identity and client quota dimensions
-- [ ] Verify window boundaries, expiration, concurrency, timeout, and Redis-unavailable behavior
-- [ ] Preserve existing login-rate-limit behavior while sharing only approved infrastructure
+- [x] Implement atomic Redis decisions with explicit expiration and bounded key cardinality
+- [x] Keep raw identities, email addresses, client addresses, credentials, and proofs out of Redis keys and values
+- [x] Define collision-resistant bounded identifiers for identity and client quota dimensions
+- [x] Verify window boundaries, expiration, concurrency, timeout, and Redis-unavailable behavior
+- [x] Preserve existing login-rate-limit behavior while sharing only approved infrastructure
+
+Increment 2 is implemented by issue [#153](https://github.com/nursena-pc/payflow/issues/153). One Lua operation evaluates both quota dimensions, creates or repairs positive expiration, and returns the longest applicable retry delay. Redis keys contain bounded workflow and dimension prefixes plus domain-separated fixed-length digests; values contain counters only. Endpoint wiring remains deferred to later increments, and the existing login limiter remains unchanged.
 
 ### Increment 3 — Account-action request protection
 

--- a/docs/security/abuse-protection-threat-model.md
+++ b/docs/security/abuse-protection-threat-model.md
@@ -43,8 +43,8 @@ read server-side digests, or directly choose the resolved effective address.
    evaluation.
 4. The application-facing policy contains only bounded workflow and policy
    types; it has no servlet or Redis dependency.
-5. A later Redis adapter will digest sensitive dimensions and own atomic,
-   expiring counter state.
+5. The Increment 2 Redis adapter digests sensitive dimensions and owns atomic,
+   expiring counter state without exposing raw inputs.
 6. Logs, metrics, traces, errors, and audits are disclosure boundaries and may
    contain only bounded coarse classifications.
 
@@ -95,8 +95,9 @@ must map failures to the workflow-specific public behavior above.
 
 Missing expiration can create durable personal-data-derived state, while
 attacker-selected metric labels can exhaust monitoring systems. Configuration
-bounds windows and limits. Increment 2 must use one atomic operation with
-explicit expiration and finite workflow, dimension, outcome, and failure tags.
+bounds windows and limits. Increment 2 uses one atomic operation, creates or
+repairs explicit expiration, and limits keys to finite workflow and dimension
+prefixes plus fixed-length domain-separated digests.
 
 ### Credential disclosure
 

--- a/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionKeyFactory.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionKeyFactory.java
@@ -1,0 +1,99 @@
+package com.nursena.payflow.abuseprotection.adapter.out.redis;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Objects;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+
+final class AbuseProtectionKeyFactory {
+
+    private static final String KEY_PREFIX =
+        "payflow:security:abuse:v1:";
+
+    private static final String DIGEST_DOMAIN =
+        "payflow-abuse-protection-v1";
+
+    private AbuseProtectionKeyFactory() {
+    }
+
+    static String identityKey(
+        AbuseProtectionWorkflow workflow,
+        String normalizedIdentity
+    ) {
+        Objects.requireNonNull(
+            normalizedIdentity,
+            "normalizedIdentity must not be null"
+        );
+
+        return key(
+            workflow,
+            "identity",
+            normalizedIdentity
+        );
+    }
+
+    static String clientKey(
+        AbuseProtectionWorkflow workflow,
+        String effectiveClientAddress
+    ) {
+        Objects.requireNonNull(
+            effectiveClientAddress,
+            "effectiveClientAddress must not be null"
+        );
+
+        return key(
+            workflow,
+            "client",
+            effectiveClientAddress
+        );
+    }
+
+    private static String key(
+        AbuseProtectionWorkflow workflow,
+        String dimension,
+        String sensitiveValue
+    ) {
+        AbuseProtectionWorkflow validatedWorkflow =
+            Objects.requireNonNull(
+                workflow,
+                "workflow must not be null"
+            );
+
+        String digestInput =
+            DIGEST_DOMAIN
+                + "\u0000"
+                + validatedWorkflow.configurationKey()
+                + "\u0000"
+                + dimension
+                + "\u0000"
+                + sensitiveValue;
+
+        return KEY_PREFIX
+            + validatedWorkflow.configurationKey()
+            + ":"
+            + dimension
+            + ":"
+            + sha256(digestInput);
+    }
+
+    private static String sha256(String value) {
+        try {
+            MessageDigest digest =
+                MessageDigest.getInstance("SHA-256");
+
+            return HexFormat.of().formatHex(
+                digest.digest(
+                    value.getBytes(StandardCharsets.UTF_8)
+                )
+            );
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(
+                "SHA-256 is not available",
+                exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionRedisConfiguration.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionRedisConfiguration.java
@@ -1,0 +1,92 @@
+package com.nursena.payflow.abuseprotection.adapter.out.redis;
+
+import java.util.List;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicyProvider;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@Configuration(proxyBeanMethods = false)
+class AbuseProtectionRedisConfiguration {
+
+    private static final String SCRIPT = """
+        local window_seconds = tonumber(ARGV[1])
+        local identity_limit = tonumber(ARGV[2])
+        local client_limit = tonumber(ARGV[3])
+
+        local identity_count = redis.call('INCR', KEYS[1])
+        if identity_count == 1 then
+            redis.call('EXPIRE', KEYS[1], window_seconds)
+        end
+
+        local client_count = redis.call('INCR', KEYS[2])
+        if client_count == 1 then
+            redis.call('EXPIRE', KEYS[2], window_seconds)
+        end
+
+        local identity_ttl = redis.call('TTL', KEYS[1])
+        if identity_ttl < 0 then
+            redis.call('EXPIRE', KEYS[1], window_seconds)
+            identity_ttl = window_seconds
+        end
+
+        local client_ttl = redis.call('TTL', KEYS[2])
+        if client_ttl < 0 then
+            redis.call('EXPIRE', KEYS[2], window_seconds)
+            client_ttl = window_seconds
+        end
+
+        local identity_blocked = 0
+        if identity_count > identity_limit then
+            identity_blocked = 1
+        end
+
+        local client_blocked = 0
+        if client_count > client_limit then
+            client_blocked = 1
+        end
+
+        local retry_after = 0
+        if identity_blocked == 1 then
+            retry_after = identity_ttl
+        end
+
+        if client_blocked == 1 and client_ttl > retry_after then
+            retry_after = client_ttl
+        end
+
+        return {
+            identity_blocked,
+            client_blocked,
+            retry_after
+        }
+        """;
+
+    @Bean("abuseProtectionRedisScript")
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    RedisScript<List<Long>> abuseProtectionRedisScript() {
+        return (RedisScript) new DefaultRedisScript<>(
+            SCRIPT,
+            List.class
+        );
+    }
+
+    @Bean
+    AbuseProtectionEnforcementPort abuseProtectionEnforcementPort(
+        StringRedisTemplate redisTemplate,
+        @Qualifier("abuseProtectionRedisScript")
+        RedisScript<List<Long>> script,
+        AbuseProtectionPolicyProvider policyProvider
+    ) {
+        return new RedisAbuseProtectionAdapter(
+            redisTemplate,
+            script,
+            policyProvider
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/redis/RedisAbuseProtectionAdapter.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/redis/RedisAbuseProtectionAdapter.java
@@ -1,0 +1,197 @@
+package com.nursena.payflow.abuseprotection.adapter.out.redis;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+import com.nursena.payflow.abuseprotection.application.exception.AbuseProtectionUnavailableException;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionFailureMode;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicy;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicyProvider;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDimension;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionRequest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+
+final class RedisAbuseProtectionAdapter
+    implements AbuseProtectionEnforcementPort {
+
+    private static final int RESULT_SIZE = 3;
+    private static final int IDENTITY_BLOCKED_INDEX = 0;
+    private static final int CLIENT_BLOCKED_INDEX = 1;
+    private static final int RETRY_AFTER_INDEX = 2;
+
+    private final StringRedisTemplate redisTemplate;
+    private final RedisScript<List<Long>> script;
+    private final AbuseProtectionPolicyProvider policyProvider;
+
+    RedisAbuseProtectionAdapter(
+        StringRedisTemplate redisTemplate,
+        RedisScript<List<Long>> script,
+        AbuseProtectionPolicyProvider policyProvider
+    ) {
+        this.redisTemplate = Objects.requireNonNull(
+            redisTemplate,
+            "redisTemplate must not be null"
+        );
+
+        this.script = Objects.requireNonNull(
+            script,
+            "script must not be null"
+        );
+
+        this.policyProvider = Objects.requireNonNull(
+            policyProvider,
+            "policyProvider must not be null"
+        );
+    }
+
+    @Override
+    public AbuseProtectionDecision evaluate(
+        AbuseProtectionRequest request
+    ) {
+        AbuseProtectionRequest validatedRequest =
+            Objects.requireNonNull(
+                request,
+                "request must not be null"
+            );
+
+        AbuseProtectionPolicy policy =
+            Objects.requireNonNull(
+                policyProvider.policyFor(
+                    validatedRequest.workflow()
+                ),
+                "policy must not be null"
+            );
+
+        if (!policy.enabled()) {
+            return AbuseProtectionDecision.allowed();
+        }
+
+        List<String> keys = List.of(
+            AbuseProtectionKeyFactory.identityKey(
+                validatedRequest.workflow(),
+                validatedRequest.normalizedIdentity()
+            ),
+            AbuseProtectionKeyFactory.clientKey(
+                validatedRequest.workflow(),
+                validatedRequest
+                    .effectiveClientAddress()
+                    .value()
+            )
+        );
+
+        try {
+            List<Long> result = redisTemplate.execute(
+                script,
+                keys,
+                Long.toString(
+                    expirationSeconds(policy.window())
+                ),
+                Integer.toString(policy.identityLimit()),
+                Integer.toString(policy.clientLimit())
+            );
+
+            return parseDecision(result);
+        } catch (RuntimeException exception) {
+            if (
+                policy.dependencyFailureMode()
+                    == AbuseProtectionFailureMode.FAIL_OPEN
+            ) {
+                return AbuseProtectionDecision.allowed();
+            }
+
+            throw new AbuseProtectionUnavailableException(
+                validatedRequest.workflow(),
+                policy.dependencyFailureMode(),
+                exception
+            );
+        }
+    }
+
+    private static long expirationSeconds(Duration window) {
+        long millis = window.toMillis();
+        return Math.max(1L, (millis + 999L) / 1000L);
+    }
+
+    private static AbuseProtectionDecision parseDecision(
+        List<Long> result
+    ) {
+        if (result == null || result.size() != RESULT_SIZE) {
+            throw invalidResult();
+        }
+
+        long identityFlag = numericValue(
+            result.get(IDENTITY_BLOCKED_INDEX)
+        );
+
+        long clientFlag = numericValue(
+            result.get(CLIENT_BLOCKED_INDEX)
+        );
+
+        long retryAfter = numericValue(
+            result.get(RETRY_AFTER_INDEX)
+        );
+
+        if (
+            (identityFlag != 0L && identityFlag != 1L)
+                || (clientFlag != 0L && clientFlag != 1L)
+        ) {
+            throw invalidResult();
+        }
+
+        boolean identityBlocked = identityFlag == 1L;
+        boolean clientBlocked = clientFlag == 1L;
+
+        if (!identityBlocked && !clientBlocked) {
+            if (retryAfter != 0L) {
+                throw invalidResult();
+            }
+
+            return AbuseProtectionDecision.allowed();
+        }
+
+        if (retryAfter <= 0L) {
+            throw invalidResult();
+        }
+
+        return AbuseProtectionDecision.blocked(
+            blockedDimension(
+                identityBlocked,
+                clientBlocked
+            ),
+            Duration.ofSeconds(retryAfter)
+        );
+    }
+
+    private static long numericValue(Long value) {
+        if (value == null) {
+            throw invalidResult();
+        }
+
+        return value;
+    }
+
+    private static AbuseProtectionDimension blockedDimension(
+        boolean identityBlocked,
+        boolean clientBlocked
+    ) {
+        if (identityBlocked && clientBlocked) {
+            return AbuseProtectionDimension.BOTH;
+        }
+
+        if (identityBlocked) {
+            return AbuseProtectionDimension.IDENTITY;
+        }
+
+        return AbuseProtectionDimension.CLIENT;
+    }
+
+    private static IllegalStateException invalidResult() {
+        return new IllegalStateException(
+            "Redis script returned an invalid result"
+        );
+    }
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/application/exception/AbuseProtectionUnavailableException.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/application/exception/AbuseProtectionUnavailableException.java
@@ -1,0 +1,45 @@
+package com.nursena.payflow.abuseprotection.application.exception;
+
+import java.util.Objects;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionFailureMode;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+
+public final class AbuseProtectionUnavailableException
+    extends RuntimeException {
+
+    private final AbuseProtectionWorkflow workflow;
+    private final AbuseProtectionFailureMode failureMode;
+
+    public AbuseProtectionUnavailableException(
+        AbuseProtectionWorkflow workflow,
+        AbuseProtectionFailureMode failureMode,
+        Throwable cause
+    ) {
+        super(
+            "Abuse protection is temporarily unavailable.",
+            Objects.requireNonNull(
+                cause,
+                "cause must not be null"
+            )
+        );
+
+        this.workflow = Objects.requireNonNull(
+            workflow,
+            "workflow must not be null"
+        );
+
+        this.failureMode = Objects.requireNonNull(
+            failureMode,
+            "failureMode must not be null"
+        );
+    }
+
+    public AbuseProtectionWorkflow workflow() {
+        return workflow;
+    }
+
+    public AbuseProtectionFailureMode failureMode() {
+        return failureMode;
+    }
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionDecision.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionDecision.java
@@ -1,0 +1,65 @@
+package com.nursena.payflow.abuseprotection.application.port.out;
+
+import java.time.Duration;
+import java.util.Objects;
+
+public record AbuseProtectionDecision(
+    AbuseProtectionDimension blockedDimension,
+    Duration retryAfter
+) {
+
+    public AbuseProtectionDecision {
+        Objects.requireNonNull(
+            blockedDimension,
+            "blockedDimension must not be null"
+        );
+
+        Objects.requireNonNull(
+            retryAfter,
+            "retryAfter must not be null"
+        );
+
+        if (blockedDimension == AbuseProtectionDimension.NONE) {
+            if (!retryAfter.isZero()) {
+                throw new IllegalArgumentException(
+                    "allowed decision retryAfter must be zero"
+                );
+            }
+        } else if (
+            retryAfter.isZero()
+                || retryAfter.isNegative()
+        ) {
+            throw new IllegalArgumentException(
+                "blocked decision retryAfter must be positive"
+            );
+        }
+    }
+
+    public static AbuseProtectionDecision allowed() {
+        return new AbuseProtectionDecision(
+            AbuseProtectionDimension.NONE,
+            Duration.ZERO
+        );
+    }
+
+    public static AbuseProtectionDecision blocked(
+        AbuseProtectionDimension dimension,
+        Duration retryAfter
+    ) {
+        if (dimension == AbuseProtectionDimension.NONE) {
+            throw new IllegalArgumentException(
+                "blocked dimension must not be NONE"
+            );
+        }
+
+        return new AbuseProtectionDecision(
+            dimension,
+            retryAfter
+        );
+    }
+
+    public boolean isAllowed() {
+        return blockedDimension
+            == AbuseProtectionDimension.NONE;
+    }
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionDimension.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionDimension.java
@@ -1,0 +1,8 @@
+package com.nursena.payflow.abuseprotection.application.port.out;
+
+public enum AbuseProtectionDimension {
+    NONE,
+    IDENTITY,
+    CLIENT,
+    BOTH
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionEnforcementPort.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionEnforcementPort.java
@@ -1,0 +1,9 @@
+package com.nursena.payflow.abuseprotection.application.port.out;
+
+@FunctionalInterface
+public interface AbuseProtectionEnforcementPort {
+
+    AbuseProtectionDecision evaluate(
+        AbuseProtectionRequest request
+    );
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionRequest.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionRequest.java
@@ -1,0 +1,52 @@
+package com.nursena.payflow.abuseprotection.application.port.out;
+
+import java.util.Objects;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+
+public record AbuseProtectionRequest(
+    AbuseProtectionWorkflow workflow,
+    String normalizedIdentity,
+    IpAddress effectiveClientAddress
+) {
+
+    private static final int MAXIMUM_IDENTITY_LENGTH = 1024;
+
+    public AbuseProtectionRequest {
+        Objects.requireNonNull(
+            workflow,
+            "workflow must not be null"
+        );
+
+        Objects.requireNonNull(
+            normalizedIdentity,
+            "normalizedIdentity must not be null"
+        );
+
+        Objects.requireNonNull(
+            effectiveClientAddress,
+            "effectiveClientAddress must not be null"
+        );
+
+        if (
+            normalizedIdentity.isBlank()
+                || !normalizedIdentity.equals(
+                    normalizedIdentity.trim()
+                )
+        ) {
+            throw new IllegalArgumentException(
+                "normalizedIdentity must be non-blank and trimmed"
+            );
+        }
+
+        if (
+            normalizedIdentity.length()
+                > MAXIMUM_IDENTITY_LENGTH
+        ) {
+            throw new IllegalArgumentException(
+                "normalizedIdentity must not exceed 1024 characters"
+            );
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionKeyFactoryTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionKeyFactoryTest.java
@@ -1,0 +1,56 @@
+package com.nursena.payflow.abuseprotection.adapter.out.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import org.junit.jupiter.api.Test;
+
+class AbuseProtectionKeyFactoryTest {
+
+    @Test
+    void shouldCreateBoundedDomainSeparatedKeys() {
+        String identityKey =
+            AbuseProtectionKeyFactory.identityKey(
+                AbuseProtectionWorkflow.REGISTRATION,
+                "nursena@example.com"
+            );
+
+        String clientKey =
+            AbuseProtectionKeyFactory.clientKey(
+                AbuseProtectionWorkflow.REGISTRATION,
+                "203.0.113.10"
+            );
+
+        assertThat(identityKey)
+            .startsWith(
+                "payflow:security:abuse:v1:registration:identity:"
+            )
+            .doesNotContain("nursena@example.com")
+            .matches(".*:[0-9a-f]{64}$")
+            .hasSizeLessThanOrEqualTo(180);
+
+        assertThat(clientKey)
+            .startsWith(
+                "payflow:security:abuse:v1:registration:client:"
+            )
+            .doesNotContain("203.0.113.10")
+            .matches(".*:[0-9a-f]{64}$")
+            .hasSizeLessThanOrEqualTo(180)
+            .isNotEqualTo(identityKey);
+    }
+
+    @Test
+    void shouldSeparateWorkflowDomains() {
+        assertThat(
+            AbuseProtectionKeyFactory.identityKey(
+                AbuseProtectionWorkflow.REGISTRATION,
+                "same-subject"
+            )
+        ).isNotEqualTo(
+            AbuseProtectionKeyFactory.identityKey(
+                AbuseProtectionWorkflow.PASSWORD_RECOVERY_REQUEST,
+                "same-subject"
+            )
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionRedisConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionRedisConfigurationTest.java
@@ -1,0 +1,51 @@
+package com.nursena.payflow.abuseprotection.adapter.out.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicyProvider;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+
+class AbuseProtectionRedisConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+        new ApplicationContextRunner()
+            .withBean(
+                StringRedisTemplate.class,
+                () -> mock(StringRedisTemplate.class)
+            )
+            .withBean(
+                AbuseProtectionPolicyProvider.class,
+                () -> workflow -> null
+            )
+            .withUserConfiguration(
+                AbuseProtectionRedisConfiguration.class
+            );
+
+    @Test
+    void shouldExposeAtomicScriptAndEnforcementPort() {
+        contextRunner.run(context -> {
+            assertThat(context)
+                .hasNotFailed()
+                .hasSingleBean(
+                    AbuseProtectionEnforcementPort.class
+                )
+                .hasSingleBean(RedisScript.class);
+
+            RedisScript<?> script =
+                context.getBean(RedisScript.class);
+
+            assertThat(script.getScriptAsString())
+                .contains(
+                    "redis.call('INCR'",
+                    "redis.call('EXPIRE'",
+                    "redis.call('TTL'",
+                    "return {"
+                );
+        });
+    }
+}

--- a/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/RedisAbuseProtectionAdapterIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/RedisAbuseProtectionAdapterIntegrationTest.java
@@ -1,0 +1,294 @@
+package com.nursena.payflow.abuseprotection.adapter.out.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionFailureMode;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicy;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDimension;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionRequest;
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class RedisAbuseProtectionAdapterIntegrationTest {
+
+    private static final int REDIS_PORT = 6379;
+
+    @Container
+    private static final GenericContainer<?> REDIS =
+        new GenericContainer<>(
+            DockerImageName.parse("redis:8-alpine")
+        ).withExposedPorts(REDIS_PORT);
+
+    private LettuceConnectionFactory connectionFactory;
+    private StringRedisTemplate redisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        RedisStandaloneConfiguration configuration =
+            new RedisStandaloneConfiguration(
+                REDIS.getHost(),
+                REDIS.getMappedPort(REDIS_PORT)
+            );
+
+        connectionFactory =
+            new LettuceConnectionFactory(configuration);
+        connectionFactory.afterPropertiesSet();
+        connectionFactory.start();
+
+        redisTemplate =
+            new StringRedisTemplate(connectionFactory);
+        redisTemplate.afterPropertiesSet();
+        flushRedis();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (connectionFactory != null) {
+            connectionFactory.destroy();
+        }
+    }
+
+    @Test
+    void shouldApplyBothDimensionsAndReturnLongestTtl() {
+        RedisAbuseProtectionAdapter adapter = adapter(
+            Duration.ofSeconds(30),
+            1,
+            2
+        );
+
+        assertThat(adapter.evaluate(request("identity-a")).isAllowed())
+            .isTrue();
+
+        AbuseProtectionDecision identityBlocked =
+            adapter.evaluate(request("identity-a"));
+
+        assertThat(identityBlocked.blockedDimension())
+            .isEqualTo(AbuseProtectionDimension.IDENTITY);
+
+        AbuseProtectionDecision bothBlocked =
+            adapter.evaluate(request("identity-a"));
+
+        assertThat(bothBlocked.blockedDimension())
+            .isEqualTo(AbuseProtectionDimension.BOTH);
+        assertThat(bothBlocked.retryAfter()).isPositive();
+    }
+
+    @Test
+    void shouldSetAndRepairPositiveExpiration() {
+        RedisAbuseProtectionAdapter adapter = adapter(
+            Duration.ofSeconds(20),
+            5,
+            20
+        );
+
+        AbuseProtectionRequest request = request("identity-a");
+        String identityKey = AbuseProtectionKeyFactory.identityKey(
+            request.workflow(),
+            request.normalizedIdentity()
+        );
+
+        redisTemplate.opsForValue().set(identityKey, "1");
+
+        assertThat(redisTemplate.getExpire(identityKey))
+            .isEqualTo(-1L);
+
+        adapter.evaluate(request);
+
+        assertThat(
+            redisTemplate.getExpire(
+                identityKey,
+                TimeUnit.SECONDS
+            )
+        ).isBetween(1L, 20L);
+    }
+
+    @Test
+    void shouldOpenFreshWindowAfterExpiration()
+        throws Exception {
+
+        RedisAbuseProtectionAdapter adapter = adapter(
+            Duration.ofSeconds(2),
+            1,
+            10
+        );
+
+        AbuseProtectionRequest request = request("identity-a");
+
+        assertThat(adapter.evaluate(request).isAllowed())
+            .isTrue();
+        assertThat(adapter.evaluate(request).isAllowed())
+            .isFalse();
+
+        awaitExpiration(
+            AbuseProtectionKeyFactory.identityKey(
+                request.workflow(),
+                request.normalizedIdentity()
+            ),
+            AbuseProtectionKeyFactory.clientKey(
+                request.workflow(),
+                request.effectiveClientAddress().value()
+            )
+        );
+
+        assertThat(adapter.evaluate(request).isAllowed())
+            .isTrue();
+    }
+
+    @Test
+    void shouldRemainAtomicUnderConcurrentLoad()
+        throws Exception {
+
+        int operationCount = 24;
+        int limit = 5;
+
+        RedisAbuseProtectionAdapter adapter = adapter(
+            Duration.ofSeconds(30),
+            limit,
+            100
+        );
+
+        AbuseProtectionRequest request = request("identity-a");
+        ExecutorService executor =
+            Executors.newFixedThreadPool(operationCount);
+        CountDownLatch ready =
+            new CountDownLatch(operationCount);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<AbuseProtectionDecision>> futures =
+            new ArrayList<>();
+
+        try {
+            for (int index = 0; index < operationCount; index++) {
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    if (!start.await(10, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException(
+                            "Concurrent abuse decision start timed out."
+                        );
+                    }
+                    return adapter.evaluate(request);
+                }));
+            }
+
+            assertThat(ready.await(10, TimeUnit.SECONDS))
+                .isTrue();
+            start.countDown();
+
+            long allowed = 0L;
+            for (Future<AbuseProtectionDecision> future : futures) {
+                if (future.get(10, TimeUnit.SECONDS).isAllowed()) {
+                    allowed++;
+                }
+            }
+
+            assertThat(allowed).isEqualTo(limit);
+
+            String identityKey =
+                AbuseProtectionKeyFactory.identityKey(
+                    request.workflow(),
+                    request.normalizedIdentity()
+                );
+
+            assertThat(redisTemplate.opsForValue().get(identityKey))
+                .isEqualTo(Integer.toString(operationCount));
+        } finally {
+            executor.shutdownNow();
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            ).isTrue();
+        }
+    }
+
+    private RedisAbuseProtectionAdapter adapter(
+        Duration window,
+        int identityLimit,
+        int clientLimit
+    ) {
+        AbuseProtectionPolicy policy =
+            new AbuseProtectionPolicy(
+                true,
+                window,
+                identityLimit,
+                clientLimit,
+                AbuseProtectionFailureMode.FAIL_CLOSED
+            );
+
+        return new RedisAbuseProtectionAdapter(
+            redisTemplate,
+            new AbuseProtectionRedisConfiguration()
+                .abuseProtectionRedisScript(),
+            workflow -> policy
+        );
+    }
+
+    private static AbuseProtectionRequest request(
+        String identity
+    ) {
+        return new AbuseProtectionRequest(
+            AbuseProtectionWorkflow.REGISTRATION,
+            identity,
+            IpAddress.parse("203.0.113.10")
+        );
+    }
+
+    private void flushRedis() {
+        redisTemplate.execute(
+            (RedisCallback<Void>) connection -> {
+                connection.serverCommands().flushDb();
+                return null;
+            }
+        );
+    }
+
+    private void awaitExpiration(String... keys)
+        throws Exception {
+
+        long deadline = System.nanoTime()
+            + Duration.ofSeconds(6).toNanos();
+
+        while (System.nanoTime() < deadline) {
+            boolean anyPresent = false;
+
+            for (String key : keys) {
+                if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
+                    anyPresent = true;
+                    break;
+                }
+            }
+
+            if (!anyPresent) {
+                return;
+            }
+
+            Thread.sleep(50L);
+        }
+
+        throw new AssertionError(
+            "Redis abuse-protection keys did not expire in time."
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/RedisAbuseProtectionAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/RedisAbuseProtectionAdapterTest.java
@@ -1,0 +1,194 @@
+package com.nursena.payflow.abuseprotection.adapter.out.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.List;
+
+import com.nursena.payflow.abuseprotection.application.exception.AbuseProtectionUnavailableException;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionFailureMode;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicy;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDimension;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionRequest;
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+
+class RedisAbuseProtectionAdapterTest {
+
+    private RecordingRedisTemplate redisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate = new RecordingRedisTemplate();
+    }
+
+    @Test
+    void shouldAllowAndUseOnlyHashedSensitiveKeys() {
+        RedisAbuseProtectionAdapter adapter = adapter(
+            policy(true, AbuseProtectionFailureMode.FAIL_CLOSED)
+        );
+
+        AbuseProtectionDecision decision =
+            adapter.evaluate(request());
+
+        assertThat(decision.isAllowed()).isTrue();
+        assertThat(redisTemplate.keys)
+            .hasSize(2)
+            .allSatisfy(key ->
+                assertThat(key).doesNotContain(
+                    "nursena@example.com",
+                    "203.0.113.10"
+                )
+            );
+        assertThat(redisTemplate.arguments)
+            .containsExactly("900", "5", "20");
+    }
+
+    @Test
+    void shouldMapEveryBlockedDimension() {
+        RedisAbuseProtectionAdapter adapter = adapter(
+            policy(true, AbuseProtectionFailureMode.FAIL_CLOSED)
+        );
+
+        redisTemplate.result = List.of(1L, 0L, 20L);
+        assertThat(adapter.evaluate(request()).blockedDimension())
+            .isEqualTo(AbuseProtectionDimension.IDENTITY);
+
+        redisTemplate.result = List.of(0L, 1L, 19L);
+        assertThat(adapter.evaluate(request()).blockedDimension())
+            .isEqualTo(AbuseProtectionDimension.CLIENT);
+
+        redisTemplate.result = List.of(1L, 1L, 18L);
+        assertThat(adapter.evaluate(request()).blockedDimension())
+            .isEqualTo(AbuseProtectionDimension.BOTH);
+    }
+
+    @Test
+    void shouldSkipRedisWhenPolicyIsDisabled() {
+        AbuseProtectionDecision decision = adapter(
+            policy(false, AbuseProtectionFailureMode.FAIL_CLOSED)
+        ).evaluate(request());
+
+        assertThat(decision.isAllowed()).isTrue();
+        assertThat(redisTemplate.executions).isZero();
+    }
+
+    @Test
+    void shouldFailClosedWithoutLeakingDependencyDetails() {
+        IllegalStateException failure =
+            new IllegalStateException("redis.internal:6379 unavailable");
+        redisTemplate.failure = failure;
+
+        assertThatThrownBy(() -> adapter(
+            policy(true, AbuseProtectionFailureMode.FAIL_CLOSED)
+        ).evaluate(request()))
+            .isInstanceOf(AbuseProtectionUnavailableException.class)
+            .hasMessage(
+                "Abuse protection is temporarily unavailable."
+            )
+            .hasMessageNotContaining("redis.internal")
+            .hasCause(failure)
+            .satisfies(exception -> {
+                AbuseProtectionUnavailableException unavailable =
+                    (AbuseProtectionUnavailableException) exception;
+                assertThat(unavailable.workflow())
+                    .isEqualTo(AbuseProtectionWorkflow.REGISTRATION);
+                assertThat(unavailable.failureMode())
+                    .isEqualTo(AbuseProtectionFailureMode.FAIL_CLOSED);
+            });
+    }
+
+    @Test
+    void shouldFailOpenOnlyWhenPolicyExplicitlySelectsIt() {
+        redisTemplate.failure =
+            new IllegalStateException("unavailable");
+
+        assertThat(adapter(
+            policy(true, AbuseProtectionFailureMode.FAIL_OPEN)
+        ).evaluate(request()).isAllowed()).isTrue();
+    }
+
+    @Test
+    void shouldTreatMalformedResultsAsDependencyFailures() {
+        redisTemplate.result = List.of(0L, 0L, 7L);
+
+        assertThatThrownBy(() -> adapter(
+            policy(true, AbuseProtectionFailureMode.FAIL_CLOSED)
+        ).evaluate(request()))
+            .isInstanceOf(AbuseProtectionUnavailableException.class);
+    }
+
+    private RedisAbuseProtectionAdapter adapter(
+        AbuseProtectionPolicy policy
+    ) {
+        return new RedisAbuseProtectionAdapter(
+            redisTemplate,
+            script(),
+            workflow -> policy
+        );
+    }
+
+    private static AbuseProtectionPolicy policy(
+        boolean enabled,
+        AbuseProtectionFailureMode failureMode
+    ) {
+        return new AbuseProtectionPolicy(
+            enabled,
+            Duration.ofMinutes(15),
+            5,
+            20,
+            failureMode
+        );
+    }
+
+    private static AbuseProtectionRequest request() {
+        return new AbuseProtectionRequest(
+            AbuseProtectionWorkflow.REGISTRATION,
+            "nursena@example.com",
+            IpAddress.parse("203.0.113.10")
+        );
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static RedisScript<List<Long>> script() {
+        return (RedisScript) new DefaultRedisScript<>(
+            "return {0, 0, 0}",
+            List.class
+        );
+    }
+
+    private static final class RecordingRedisTemplate
+        extends StringRedisTemplate {
+
+        private List<?> result = List.of(0L, 0L, 0L);
+        private RuntimeException failure;
+        private int executions;
+        private List<String> keys;
+        private Object[] arguments;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T execute(
+            RedisScript<T> script,
+            List<String> keys,
+            Object... args
+        ) {
+            executions++;
+
+            if (failure != null) {
+                throw failure;
+            }
+
+            this.keys = List.copyOf(keys);
+            this.arguments = args.clone();
+            return (T) result;
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionDecisionTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionDecisionTest.java
@@ -1,0 +1,52 @@
+package com.nursena.payflow.abuseprotection.application.port.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class AbuseProtectionDecisionTest {
+
+    @Test
+    void shouldCreateAllowedDecision() {
+        AbuseProtectionDecision decision =
+            AbuseProtectionDecision.allowed();
+
+        assertThat(decision.isAllowed()).isTrue();
+        assertThat(decision.blockedDimension())
+            .isEqualTo(AbuseProtectionDimension.NONE);
+        assertThat(decision.retryAfter()).isZero();
+    }
+
+    @Test
+    void shouldCreateBlockedDecision() {
+        AbuseProtectionDecision decision =
+            AbuseProtectionDecision.blocked(
+                AbuseProtectionDimension.BOTH,
+                Duration.ofSeconds(30)
+            );
+
+        assertThat(decision.isAllowed()).isFalse();
+        assertThat(decision.retryAfter())
+            .isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void shouldRejectInvalidDecisionShapes() {
+        assertThatThrownBy(() ->
+            AbuseProtectionDecision.blocked(
+                AbuseProtectionDimension.NONE,
+                Duration.ofSeconds(1)
+            )
+        ).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() ->
+            AbuseProtectionDecision.blocked(
+                AbuseProtectionDimension.IDENTITY,
+                Duration.ZERO
+            )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionRequestTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionRequestTest.java
@@ -1,0 +1,45 @@
+package com.nursena.payflow.abuseprotection.application.port.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+import org.junit.jupiter.api.Test;
+
+class AbuseProtectionRequestTest {
+
+    @Test
+    void shouldRetainNormalizedInputs() {
+        AbuseProtectionRequest request =
+            new AbuseProtectionRequest(
+                AbuseProtectionWorkflow.REGISTRATION,
+                "nursena@example.com",
+                IpAddress.parse("203.0.113.10")
+            );
+
+        assertThat(request.normalizedIdentity())
+            .isEqualTo("nursena@example.com");
+        assertThat(request.effectiveClientAddress().value())
+            .isEqualTo("203.0.113.10");
+    }
+
+    @Test
+    void shouldRejectBlankOrUntrimmedIdentity() {
+        assertThatThrownBy(() -> request(" "))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> request(" identity "))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static AbuseProtectionRequest request(
+        String identity
+    ) {
+        return new AbuseProtectionRequest(
+            AbuseProtectionWorkflow.REGISTRATION,
+            identity,
+            IpAddress.parse("203.0.113.10")
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/V015RedisAbuseEnforcementContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V015RedisAbuseEnforcementContractTest.java
@@ -1,0 +1,125 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class V015RedisAbuseEnforcementContractTest {
+
+    private static final Path MAIN = Path.of(
+        "src", "main", "java", "com", "nursena", "payflow"
+    );
+
+    @Test
+    void shouldKeepApplicationPortFreeOfAdapterDependencies()
+        throws IOException {
+
+        Path portDirectory = MAIN.resolve(Path.of(
+            "abuseprotection", "application", "port", "out"
+        ));
+
+        try (var paths = Files.list(portDirectory)) {
+            for (Path path : paths.toList()) {
+                assertThat(Files.readString(path))
+                    .doesNotContain(
+                        "org.springframework",
+                        "jakarta.servlet",
+                        "StringRedisTemplate",
+                        "RedisScript"
+                    );
+            }
+        }
+    }
+
+    @Test
+    void shouldUseAtomicExpiringDigestOnlyRedisState()
+        throws IOException {
+
+        Path redisDirectory = MAIN.resolve(Path.of(
+            "abuseprotection", "adapter", "out", "redis"
+        ));
+
+        String configuration = Files.readString(
+            redisDirectory.resolve(
+                "AbuseProtectionRedisConfiguration.java"
+            )
+        );
+
+        String keyFactory = Files.readString(
+            redisDirectory.resolve(
+                "AbuseProtectionKeyFactory.java"
+            )
+        );
+
+        assertThat(configuration)
+            .contains(
+                "redis.call('INCR'",
+                "redis.call('EXPIRE'",
+                "redis.call('TTL'",
+                "identity_blocked",
+                "client_blocked",
+                "retry_after"
+            );
+
+        assertThat(keyFactory)
+            .contains(
+                "SHA-256",
+                "payflow-abuse-protection-v1",
+                "validatedWorkflow.configurationKey()",
+                "identity",
+                "client"
+            );
+    }
+
+    @Test
+    void shouldRetainExistingLoginLimiterContract()
+        throws IOException {
+
+        Path loginDirectory = MAIN.resolve(Path.of(
+            "user", "adapter", "out", "ratelimit"
+        ));
+
+        assertThat(Files.readString(
+            loginDirectory.resolve(
+                "RedisLoginRateLimitAdapter.java"
+            )
+        )).contains(
+            "implements LoginRateLimitPort",
+            "resetIdentity",
+            "LoginRateLimitMetrics"
+        );
+
+        assertThat(Files.readString(
+            loginDirectory.resolve(
+                "LoginRateLimitKeyFactory.java"
+            )
+        )).contains(
+            "payflow:security:login:identity:",
+            "payflow:security:login:client:"
+        );
+    }
+
+    @Test
+    void shouldRecordCompletedIncrementTwo()
+        throws IOException {
+
+        assertThat(Files.readString(
+            Path.of("docs", "roadmap.md")
+        )).contains(
+            "- [x] Implement atomic Redis decisions with explicit expiration and bounded key cardinality",
+            "- [x] Preserve existing login-rate-limit behavior while sharing only approved infrastructure",
+            "Increment 2 is implemented by issue [#153]"
+        );
+
+        assertThat(Files.readString(
+            Path.of("docs", "abuse-protection.md")
+        )).contains(
+            "Increment 2 provides the shared Redis enforcement foundation",
+            "wiring remains deferred"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add application-facing generalized abuse-protection request, decision, dimension, and enforcement contracts
- evaluate identity and trusted-client quotas through one atomic Redis operation
- create and repair bounded expiration for every quota key
- use workflow-separated, dimension-separated, fixed-length SHA-256 identifiers
- return the longest applicable positive retry delay for blocked decisions
- map Redis and malformed-result failures through explicit fail-open or fail-closed policy
- preserve the existing login limiter without modifying its API, script, metrics, reset behavior, or HTTP contracts
- complete v0.15.0 roadmap Increment 2

## Security boundaries

- Redis keys never contain raw identities, email addresses, or client addresses
- Redis values contain counters only
- application contracts contain no Spring, servlet, controller, or Redis dependencies
- effective client addresses use the existing validated client-context type
- generalized endpoint enforcement remains disabled until later wiring increments
- dependency failures expose only a coarse, credential-free error
- CAPTCHA, WAF, API gateway, adaptive scoring, and authenticator replacement remain out of scope

## Verification

- `mvn clean verify`
- 1506 tests, 0 failures, 0 errors, 0 skipped
- 516 analyzed classes
- real Redis expiration, TTL repair, window, and concurrency tests
- focused legacy login-limiter regression tests
- application dependency-boundary scan
- login-limiter immutability check
- `git diff --check`
- UTF-8 corruption scan
- no unchecked Increment 2 roadmap items

Relates to #149.

Closes #153
