### PR TITLE
feat(security): protect account-action requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Generalized per-identity and trusted-client Redis enforcement for email-verification and password-recovery requests before account lookup.
+- Real-Redis HTTP concurrency and anti-enumeration evidence for bounded account-action side effects.
+
+### Security
+
+- Blocked and fail-closed account-action requests preserve the empty `202` response while suppressing credential and delivery work.
+- Registration enforcement remains deferred until reproducible performance and overload evidence supports its public failure contract.
+
+### Added
+
 - Shared atomic Redis abuse-enforcement foundation with expiring, domain-separated digest-only identity and client quota keys ([#153](https://github.com/nursena-pc/payflow/issues/153)).
 - Typed generalized abuse-protection request, decision, dimension, dependency-failure, and enforcement-port contracts.
 - Real Redis verification for window boundaries, TTL repair, concurrency, and combined quota decisions while preserving the existing login limiter.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ See [ADR 0015](docs/adr/0015-generalized-abuse-protection.md), the [generalized 
 Increment 2 adds a separate atomic Redis enforcement foundation tracked by [issue #153](https://github.com/nursena-pc/payflow/issues/153). It evaluates identity and trusted-client quotas in one operation, uses expiring digest-only keys, follows explicit dependency-failure policy, and leaves endpoint wiring and the existing login limiter unchanged.
 
 Development is tracked by [issue #149](https://github.com/nursena-pc/payflow/issues/149). Active-authenticator replacement, CAPTCHA services, external bot detection, WAF or API-gateway deployment, and adaptive risk scoring remain outside the v0.15.0 scope.
+
+Increment 3 protects email-verification and password-recovery requests before account lookup with normalized-identity and trusted-client Redis quotas. Limited, dependency-failed, unknown, closed, verified, eligible, and otherwise ineligible requests retain the same empty `202` response; blocked work creates no account-action credential or delivery side effect. Registration enforcement remains deferred until reproducible performance and overload evidence is available.
 ## Implemented API
 
 | Method | Endpoint | Authentication | Description |

--- a/docs/abuse-protection.md
+++ b/docs/abuse-protection.md
@@ -2,12 +2,13 @@
 
 ## Current delivery state
 
-Increment 2 provides the shared Redis enforcement foundation. One atomic Lua
-operation evaluates identity and client quotas, establishes or repairs bounded
-expiration, and returns the longest applicable positive retry delay. Endpoint
-wiring remains deferred. Generalized Redis enforcement is not active yet at
-protected endpoints, so `ABUSE_PROTECTION_ENABLED` continues to default to
-`false`. The existing login limiter remains independently active and unchanged.
+Increment 3 wires the shared Redis foundation into email-verification and
+password-recovery request workflows. Both evaluate normalized identity and the
+trusted effective client address before account lookup. Allowed requests retain
+their existing eligibility rules; blocked and fail-closed requests suppress
+credential and mail-outbox side effects while returning the same empty `202`
+response. `ABUSE_PROTECTION_ENABLED` remains `false` by default so activation
+is an explicit deployment decision. The login limiter remains unchanged.
 
 ## Policy contract
 
@@ -48,6 +49,24 @@ settings. The global switch is `ABUSE_PROTECTION_ENABLED`.
 Changing a failure mode to `FAIL_OPEN` requires a security review, updated ADR
 and threat-model evidence, public-contract tests, and explicit operational
 approval. It must never be used as an automatic response to Redis instability.
+
+## Account-action HTTP contract
+
+- email-verification and password-recovery requests evaluate policy before any
+  account lookup or row lock
+- normalized email is the identity dimension
+- only `ClientAddressResolver` supplies the effective client dimension
+- allowed, limited, unknown, closed, verified, and otherwise ineligible
+  outcomes retain an empty `202 Accepted` response
+- blocked and fail-closed outcomes create no credential or mail-outbox work
+- concurrent requests cannot create more protected side effects than the
+  configured identity or client limit
+
+Registration was evaluated but is not wired in Increment 3. Its existing
+`201`/`409` contract, BCrypt cost, and initial verification-mail side effect
+require the reproducible performance and overload evidence planned for
+Increment 6 before an activation decision. This is a documented deferral, not
+an implicit exemption from later review.
 
 ## Privacy and observability
 

--- a/docs/adr/0015-generalized-abuse-protection.md
+++ b/docs/adr/0015-generalized-abuse-protection.md
@@ -96,6 +96,19 @@ decision.
   semantics into unrelated workflows
 - silent fail-open behavior: turns Redis failure into an abuse-control bypass
 
+## Increment 3 endpoint integration
+
+Email-verification and password-recovery request controllers reuse the trusted
+client-address resolver and pass its typed result into application commands.
+The application service normalizes email and evaluates the shared enforcement
+port before repository lookup. A blocked decision or fail-closed dependency
+outcome returns normally to preserve the existing empty `202` response and
+prevents credential or delivery side effects.
+
+Registration is evaluated and deferred until reproducible load evidence is
+available. Increment 3 does not change its `201`/`409` contract or add partial
+enforcement without an approved performance and failure-mode decision.
+
 ## Non-goals
 
 Increment 2 implements Redis counters but does not implement endpoint

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -729,11 +729,13 @@ Increment 2 is implemented by issue [#153](https://github.com/nursena-pc/payflow
 
 ### Increment 3 — Account-action request protection
 
-- [ ] Protect email-verification requests with per-identity and per-client decisions
-- [ ] Protect password-recovery requests with the same anti-enumeration response shape
-- [ ] Evaluate registration protection from documented threat and performance evidence
-- [ ] Verify unknown, closed, verified, and eligible accounts expose no distinguishable quota behavior
-- [ ] Verify concurrent requests cannot exceed the documented bounded outcome
+- [x] Protect email-verification requests with per-identity and per-client decisions
+- [x] Protect password-recovery requests with the same anti-enumeration response shape
+- [x] Evaluate registration protection from documented threat and performance evidence
+- [x] Verify unknown, closed, verified, and eligible accounts expose no distinguishable quota behavior
+- [x] Verify concurrent requests cannot exceed the documented bounded outcome
+
+Increment 3 is implemented by issue [#155](https://github.com/nursena-pc/payflow/issues/155). Email-verification and password-recovery requests now evaluate normalized identity and trusted client quotas before account lookup while preserving an empty `202` response for every eligibility, quota, and fail-closed outcome. Real-Redis HTTP concurrency tests bound credential and delivery side effects. Registration was evaluated and remains deferred pending Increment 6 performance evidence.
 
 ### Increment 4 — MFA challenge and step-up protection
 

--- a/docs/security/abuse-protection-threat-model.md
+++ b/docs/security/abuse-protection-threat-model.md
@@ -112,6 +112,22 @@ Missing workflow policy, sub-second or greater-than-one-day windows, non-positiv
 limits, limits above one million, and absent failure modes fail application
 startup. The global policy switch defaults off until enforcement is wired.
 
+## Increment 3 account-action decision
+
+Email-verification and password-recovery request policy runs before account
+lookup, eligibility inspection, credential creation, and mail-outbox work.
+Every allowed, blocked, dependency-failed, unknown, closed, verified, or
+otherwise ineligible request retains the same empty `202` public response.
+Real-Redis HTTP concurrency tests prove that accepted response volume cannot
+increase protected side effects beyond the configured bound.
+
+Registration protection remains deferred pending Increment 6 evidence. Unlike
+the two generic account-action request endpoints, registration already has
+distinct `201` and duplicate-account `409` behavior and performs BCrypt plus
+initial verification preparation. Latency, overload, and false-positive data
+must be recorded before choosing its public failure contract and activation
+policy.
+
 ## Verification obligations
 
 - unit-test policy bounds and complete workflow configuration

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/EmailVerificationController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/EmailVerificationController.java
@@ -5,6 +5,8 @@ import static org.springframework.http.MediaType
 
 import java.util.Objects;
 
+import com.nursena.payflow.clientcontext.adapter.in.web.ClientAddressResolver;
+import com.nursena.payflow.clientcontext.domain.ResolvedClientAddress;
 import com.nursena.payflow.common.api.ApiError;
 import com.nursena.payflow.configuration.OpenApiExamples;
 import com.nursena.payflow.user.application.port.in
@@ -16,6 +18,7 @@ import com.nursena.payflow.user.application.port.in
 import com.nursena.payflow.user.application.port.in
     .RequestEmailVerificationUseCase;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,6 +27,7 @@ import io.swagger.v3.oas.annotations.responses
 import io.swagger.v3.oas.annotations.responses
     .ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,12 +52,14 @@ public class EmailVerificationController {
         requestEmailVerification;
     private final ConfirmEmailVerificationUseCase
         confirmEmailVerification;
+    private final ClientAddressResolver clientAddressResolver;
 
     public EmailVerificationController(
         RequestEmailVerificationUseCase
             requestEmailVerification,
         ConfirmEmailVerificationUseCase
-            confirmEmailVerification
+            confirmEmailVerification,
+        ClientAddressResolver clientAddressResolver
     ) {
         this.requestEmailVerification =
             Objects.requireNonNull(
@@ -66,6 +72,11 @@ public class EmailVerificationController {
                 confirmEmailVerification,
                 "confirmEmailVerification "
                     + "must not be null"
+            );
+        this.clientAddressResolver =
+            Objects.requireNonNull(
+                clientAddressResolver,
+                "clientAddressResolver must not be null"
             );
     }
 
@@ -101,11 +112,17 @@ public class EmailVerificationController {
     @PostMapping("/requests")
     public ResponseEntity<Void> request(
         @Valid @RequestBody
-        EmailVerificationRequest request
+        EmailVerificationRequest request,
+        @Parameter(hidden = true)
+        HttpServletRequest servletRequest
     ) {
+        ResolvedClientAddress clientAddress =
+            clientAddressResolver.resolve(servletRequest);
+
         requestEmailVerification.request(
             new RequestEmailVerificationCommand(
-                request.email()
+                request.email(),
+                clientAddress.address()
             )
         );
 

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/PasswordRecoveryController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/PasswordRecoveryController.java
@@ -5,6 +5,8 @@ import static org.springframework.http.MediaType
 
 import java.util.Objects;
 
+import com.nursena.payflow.clientcontext.adapter.in.web.ClientAddressResolver;
+import com.nursena.payflow.clientcontext.domain.ResolvedClientAddress;
 import com.nursena.payflow.common.api.ApiError;
 import com.nursena.payflow.configuration.OpenApiExamples;
 import com.nursena.payflow.user.application.port.in
@@ -16,6 +18,7 @@ import com.nursena.payflow.user.application.port.in
 import com.nursena.payflow.user.application.port.in
     .RequestPasswordRecoveryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,6 +27,7 @@ import io.swagger.v3.oas.annotations.responses
 import io.swagger.v3.oas.annotations.responses
     .ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,12 +52,14 @@ public class PasswordRecoveryController {
         requestPasswordRecovery;
     private final ConfirmPasswordRecoveryUseCase
         confirmPasswordRecovery;
+    private final ClientAddressResolver clientAddressResolver;
 
     public PasswordRecoveryController(
         RequestPasswordRecoveryUseCase
             requestPasswordRecovery,
         ConfirmPasswordRecoveryUseCase
-            confirmPasswordRecovery
+            confirmPasswordRecovery,
+        ClientAddressResolver clientAddressResolver
     ) {
         this.requestPasswordRecovery =
             Objects.requireNonNull(
@@ -64,6 +70,11 @@ public class PasswordRecoveryController {
             Objects.requireNonNull(
                 confirmPasswordRecovery,
                 "confirmPasswordRecovery must not be null"
+            );
+        this.clientAddressResolver =
+            Objects.requireNonNull(
+                clientAddressResolver,
+                "clientAddressResolver must not be null"
             );
     }
 
@@ -99,11 +110,17 @@ public class PasswordRecoveryController {
     @PostMapping("/requests")
     public ResponseEntity<Void> request(
         @Valid @RequestBody
-        PasswordRecoveryRequest request
+        PasswordRecoveryRequest request,
+        @Parameter(hidden = true)
+        HttpServletRequest servletRequest
     ) {
+        ResolvedClientAddress clientAddress =
+            clientAddressResolver.resolve(servletRequest);
+
         requestPasswordRecovery.request(
             new RequestPasswordRecoveryCommand(
-                request.email()
+                request.email(),
+                clientAddress.address()
             )
         );
 

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RequestEmailVerificationCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RequestEmailVerificationCommand.java
@@ -2,14 +2,21 @@ package com.nursena.payflow.user.application.port.in;
 
 import java.util.Objects;
 
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+
 public record RequestEmailVerificationCommand(
-    String email
+    String email,
+    IpAddress effectiveClientAddress
 ) {
 
     public RequestEmailVerificationCommand {
         Objects.requireNonNull(
             email,
             "email must not be null"
+        );
+        Objects.requireNonNull(
+            effectiveClientAddress,
+            "effectiveClientAddress must not be null"
         );
     }
 

--- a/src/main/java/com/nursena/payflow/user/application/port/in/RequestPasswordRecoveryCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/RequestPasswordRecoveryCommand.java
@@ -2,14 +2,21 @@ package com.nursena.payflow.user.application.port.in;
 
 import java.util.Objects;
 
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+
 public record RequestPasswordRecoveryCommand(
-    String email
+    String email,
+    IpAddress effectiveClientAddress
 ) {
 
     public RequestPasswordRecoveryCommand {
         Objects.requireNonNull(
             email,
             "email must not be null"
+        );
+        Objects.requireNonNull(
+            effectiveClientAddress,
+            "effectiveClientAddress must not be null"
         );
     }
 

--- a/src/main/java/com/nursena/payflow/user/application/service/RequestEmailVerificationService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RequestEmailVerificationService.java
@@ -2,32 +2,37 @@ package com.nursena.payflow.user.application.service;
 
 import java.util.Objects;
 
-import com.nursena.payflow.user.application.port.in
-    .RequestEmailVerificationCommand;
-import com.nursena.payflow.user.application.port.in
-    .RequestEmailVerificationUseCase;
-import com.nursena.payflow.user.application.port.out
-    .UserRepositoryPort;
+import com.nursena.payflow.abuseprotection.application.exception.AbuseProtectionUnavailableException;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionRequest;
+import com.nursena.payflow.user.application.port.in.RequestEmailVerificationCommand;
+import com.nursena.payflow.user.application.port.in.RequestEmailVerificationUseCase;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.model.EmailAddress;
 import com.nursena.payflow.user.domain.model.User;
 import com.nursena.payflow.user.domain.model.UserStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation
-    .Transactional;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class RequestEmailVerificationService
     implements RequestEmailVerificationUseCase {
 
+    private final AbuseProtectionEnforcementPort abuseProtection;
     private final UserRepositoryPort userRepository;
-    private final EmailVerificationPreparationService
-        preparationService;
+    private final EmailVerificationPreparationService preparationService;
 
     public RequestEmailVerificationService(
+        AbuseProtectionEnforcementPort abuseProtection,
         UserRepositoryPort userRepository,
-        EmailVerificationPreparationService
-            preparationService
+        EmailVerificationPreparationService preparationService
     ) {
+        this.abuseProtection = Objects.requireNonNull(
+            abuseProtection,
+            "abuseProtection must not be null"
+        );
         this.userRepository = Objects.requireNonNull(
             userRepository,
             "userRepository must not be null"
@@ -40,9 +45,7 @@ public class RequestEmailVerificationService
 
     @Override
     @Transactional
-    public void request(
-        RequestEmailVerificationCommand command
-    ) {
+    public void request(RequestEmailVerificationCommand command) {
         RequestEmailVerificationCommand checkedCommand =
             Objects.requireNonNull(
                 command,
@@ -53,6 +56,10 @@ public class RequestEmailVerificationService
             checkedCommand.email()
         );
 
+        if (!isAllowed(checkedCommand, email)) {
+            return;
+        }
+
         User user = userRepository
             .findByEmailForUpdate(email)
             .orElse(null);
@@ -61,10 +68,28 @@ public class RequestEmailVerificationService
             return;
         }
 
-        preparationService.prepare(
-            user.id(),
-            user.email()
-        );
+        preparationService.prepare(user.id(), user.email());
+    }
+
+    private boolean isAllowed(
+        RequestEmailVerificationCommand command,
+        EmailAddress email
+    ) {
+        try {
+            AbuseProtectionDecision decision =
+                abuseProtection.evaluate(
+                    new AbuseProtectionRequest(
+                        AbuseProtectionWorkflow
+                            .EMAIL_VERIFICATION_REQUEST,
+                        email.value(),
+                        command.effectiveClientAddress()
+                    )
+                );
+
+            return decision.isAllowed();
+        } catch (AbuseProtectionUnavailableException exception) {
+            return false;
+        }
     }
 
     private static boolean isEligible(User user) {

--- a/src/main/java/com/nursena/payflow/user/application/service/RequestPasswordRecoveryService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/RequestPasswordRecoveryService.java
@@ -2,32 +2,37 @@ package com.nursena.payflow.user.application.service;
 
 import java.util.Objects;
 
-import com.nursena.payflow.user.application.port.in
-    .RequestPasswordRecoveryCommand;
-import com.nursena.payflow.user.application.port.in
-    .RequestPasswordRecoveryUseCase;
-import com.nursena.payflow.user.application.port.out
-    .UserRepositoryPort;
+import com.nursena.payflow.abuseprotection.application.exception.AbuseProtectionUnavailableException;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionRequest;
+import com.nursena.payflow.user.application.port.in.RequestPasswordRecoveryCommand;
+import com.nursena.payflow.user.application.port.in.RequestPasswordRecoveryUseCase;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
 import com.nursena.payflow.user.domain.model.EmailAddress;
 import com.nursena.payflow.user.domain.model.User;
 import com.nursena.payflow.user.domain.model.UserStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation
-    .Transactional;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class RequestPasswordRecoveryService
     implements RequestPasswordRecoveryUseCase {
 
+    private final AbuseProtectionEnforcementPort abuseProtection;
     private final UserRepositoryPort userRepository;
-    private final PasswordRecoveryPreparationService
-        preparationService;
+    private final PasswordRecoveryPreparationService preparationService;
 
     public RequestPasswordRecoveryService(
+        AbuseProtectionEnforcementPort abuseProtection,
         UserRepositoryPort userRepository,
-        PasswordRecoveryPreparationService
-            preparationService
+        PasswordRecoveryPreparationService preparationService
     ) {
+        this.abuseProtection = Objects.requireNonNull(
+            abuseProtection,
+            "abuseProtection must not be null"
+        );
         this.userRepository = Objects.requireNonNull(
             userRepository,
             "userRepository must not be null"
@@ -40,9 +45,7 @@ public class RequestPasswordRecoveryService
 
     @Override
     @Transactional
-    public void request(
-        RequestPasswordRecoveryCommand command
-    ) {
+    public void request(RequestPasswordRecoveryCommand command) {
         RequestPasswordRecoveryCommand checkedCommand =
             Objects.requireNonNull(
                 command,
@@ -53,6 +56,10 @@ public class RequestPasswordRecoveryService
             checkedCommand.email()
         );
 
+        if (!isAllowed(checkedCommand, email)) {
+            return;
+        }
+
         User user = userRepository
             .findByEmailForUpdate(email)
             .orElse(null);
@@ -61,10 +68,28 @@ public class RequestPasswordRecoveryService
             return;
         }
 
-        preparationService.prepare(
-            user.id(),
-            user.email()
-        );
+        preparationService.prepare(user.id(), user.email());
+    }
+
+    private boolean isAllowed(
+        RequestPasswordRecoveryCommand command,
+        EmailAddress email
+    ) {
+        try {
+            AbuseProtectionDecision decision =
+                abuseProtection.evaluate(
+                    new AbuseProtectionRequest(
+                        AbuseProtectionWorkflow
+                            .PASSWORD_RECOVERY_REQUEST,
+                        email.value(),
+                        command.effectiveClientAddress()
+                    )
+                );
+
+            return decision.isAllowed();
+        } catch (AbuseProtectionUnavailableException exception) {
+            return false;
+        }
     }
 
     private static boolean isEligible(User user) {

--- a/src/test/java/com/nursena/payflow/configuration/PublicApiDocumentationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/PublicApiDocumentationTest.java
@@ -99,7 +99,8 @@ class PublicApiDocumentationTest {
             EmailVerificationController.class
                 .getDeclaredMethod(
                     "request",
-                    EmailVerificationRequest.class
+                    EmailVerificationRequest.class,
+                    jakarta.servlet.http.HttpServletRequest.class
                 );
 
         assertDocumentation(
@@ -143,7 +144,8 @@ class PublicApiDocumentationTest {
             PasswordRecoveryController.class
                 .getDeclaredMethod(
                     "request",
-                    PasswordRecoveryRequest.class
+                    PasswordRecoveryRequest.class,
+                    jakarta.servlet.http.HttpServletRequest.class
                 );
 
         assertDocumentation(

--- a/src/test/java/com/nursena/payflow/configuration/V015AbuseProtectionFoundationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V015AbuseProtectionFoundationContractTest.java
@@ -177,10 +177,10 @@ class V015AbuseProtectionFoundationContractTest {
 
         assertThat(guide)
             .contains(
-                "Generalized Redis enforcement is not active yet",
+                "Increment 3 wires the shared Redis foundation",
                 "windows range from one second through one day",
                 "limits range from one through one million",
-                "The existing login limiter remains independently active and unchanged"
+                "The login limiter remains unchanged"
             );
     }
 

--- a/src/test/java/com/nursena/payflow/configuration/V015AccountActionAbuseProtectionContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V015AccountActionAbuseProtectionContractTest.java
@@ -1,0 +1,99 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class V015AccountActionAbuseProtectionContractTest {
+
+    private static final Path MAIN = Path.of(
+        "src", "main", "java", "com", "nursena", "payflow"
+    );
+
+    @Test
+    void shouldResolveTrustedClientAtBothHttpBoundaries()
+        throws IOException {
+
+        assertThat(source(
+            "user/adapter/in/web/EmailVerificationController.java"
+        )).contains(
+            "ClientAddressResolver",
+            "clientAddressResolver.resolve(servletRequest)",
+            "clientAddress.address()"
+        );
+        assertThat(source(
+            "user/adapter/in/web/PasswordRecoveryController.java"
+        )).contains(
+            "ClientAddressResolver",
+            "clientAddressResolver.resolve(servletRequest)",
+            "clientAddress.address()"
+        );
+    }
+
+    @Test
+    void shouldEvaluateBeforeEligibilityAndSuppressBlockedWork()
+        throws IOException {
+
+        for (String service : new String[] {
+            "RequestEmailVerificationService.java",
+            "RequestPasswordRecoveryService.java"
+        }) {
+            String content = source(
+                "user/application/service/" + service
+            );
+            assertThat(content).contains(
+                "AbuseProtectionEnforcementPort",
+                "AbuseProtectionRequest",
+                "decision.isAllowed()",
+                "catch (AbuseProtectionUnavailableException"
+            );
+            assertThat(content.indexOf("if (!isAllowed("))
+                .isLessThan(
+                    content.indexOf("findByEmailForUpdate")
+                );
+        }
+    }
+
+    @Test
+    void shouldRecordCompletedIncrementAndRegistrationDeferral()
+        throws IOException {
+
+        String roadmap = Files.readString(
+            Path.of("docs", "roadmap.md")
+        );
+        String guide = Files.readString(
+            Path.of("docs", "abuse-protection.md")
+        );
+        String threatModel = Files.readString(
+            Path.of(
+                "docs", "security",
+                "abuse-protection-threat-model.md"
+            )
+        );
+
+        assertThat(roadmap).contains(
+            "Increment 3 is implemented by issue [#155]",
+            "- [x] Protect email-verification requests",
+            "- [x] Protect password-recovery requests",
+            "- [x] Evaluate registration protection",
+            "- [x] Verify concurrent requests"
+        );
+        assertThat(guide).contains(
+            "empty `202 Accepted` response",
+            "Registration was evaluated but is not wired"
+        );
+        assertThat(threatModel).contains(
+            "Real-Redis HTTP concurrency tests",
+            "Registration protection remains deferred"
+        );
+    }
+
+    private static String source(String relative)
+        throws IOException {
+        return Files.readString(MAIN.resolve(relative));
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/V015RedisAbuseEnforcementContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V015RedisAbuseEnforcementContractTest.java
@@ -118,8 +118,9 @@ class V015RedisAbuseEnforcementContractTest {
         assertThat(Files.readString(
             Path.of("docs", "abuse-protection.md")
         )).contains(
-            "Increment 2 provides the shared Redis enforcement foundation",
-            "wiring remains deferred"
+            "Increment 3 wires the shared Redis foundation",
+            "trusted effective client address before account lookup",
+            "ABUSE_PROTECTION_ENABLED` remains `false` by default"
         );
     }
 }

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/EmailVerificationControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/EmailVerificationControllerTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request
     .MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result
@@ -12,6 +14,9 @@ import static org.springframework.test.web.servlet.result
 import static org.springframework.test.web.servlet.result
     .MockMvcResultMatchers.status;
 
+import com.nursena.payflow.clientcontext.adapter.in.web.ClientAddressResolver;
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+import com.nursena.payflow.clientcontext.domain.ResolvedClientAddress;
 import com.nursena.payflow.configuration
     .SecurityConfiguration;
 import com.nursena.payflow.observability.adapter.in.web
@@ -26,6 +31,7 @@ import com.nursena.payflow.user.application.port.in
     .RequestEmailVerificationUseCase;
 import com.nursena.payflow.user.domain.exception
     .InvalidAccountActionCredentialException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation
     .Autowired;
@@ -63,6 +69,20 @@ class EmailVerificationControllerTest {
     @MockitoBean
     private JwtDecoder jwtDecoder;
 
+    @MockitoBean
+    private ClientAddressResolver clientAddressResolver;
+
+    @BeforeEach
+    void setUpClientAddress() {
+        ResolvedClientAddress resolved =
+            mock(ResolvedClientAddress.class);
+        when(resolved.address()).thenReturn(
+            IpAddress.parse("203.0.113.10")
+        );
+        when(clientAddressResolver.resolve(any()))
+            .thenReturn(resolved);
+    }
+
     @Test
     void shouldAcceptRequestWithoutDisclosingEligibility()
         throws Exception {
@@ -87,6 +107,9 @@ class EmailVerificationControllerTest {
                 command.email().equals(
                     "Nursena@Example.COM"
                 )
+                    && command.effectiveClientAddress().equals(
+                        IpAddress.parse("203.0.113.10")
+                    )
             )
         );
     }
@@ -187,7 +210,10 @@ class EmailVerificationControllerTest {
         EmailVerificationRequest request =
             new EmailVerificationRequest(email);
         RequestEmailVerificationCommand command =
-            new RequestEmailVerificationCommand(email);
+            new RequestEmailVerificationCommand(
+                email,
+                IpAddress.parse("203.0.113.10")
+            );
 
         assertThat(request.toString())
             .doesNotContain(email);

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/PasswordRecoveryControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/PasswordRecoveryControllerTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request
     .MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result
@@ -12,6 +14,9 @@ import static org.springframework.test.web.servlet.result
 import static org.springframework.test.web.servlet.result
     .MockMvcResultMatchers.status;
 
+import com.nursena.payflow.clientcontext.adapter.in.web.ClientAddressResolver;
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+import com.nursena.payflow.clientcontext.domain.ResolvedClientAddress;
 import com.nursena.payflow.configuration
     .SecurityConfiguration;
 import com.nursena.payflow.observability.adapter.in.web
@@ -27,6 +32,7 @@ import com.nursena.payflow.user.application.port.in
 import com.nursena.payflow.user.domain.exception
     .InvalidAccountActionCredentialException;
 import jakarta.validation.constraints.Size;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation
     .Autowired;
@@ -67,6 +73,20 @@ class PasswordRecoveryControllerTest {
     @MockitoBean
     private JwtDecoder jwtDecoder;
 
+    @MockitoBean
+    private ClientAddressResolver clientAddressResolver;
+
+    @BeforeEach
+    void setUpClientAddress() {
+        ResolvedClientAddress resolved =
+            mock(ResolvedClientAddress.class);
+        when(resolved.address()).thenReturn(
+            IpAddress.parse("203.0.113.10")
+        );
+        when(clientAddressResolver.resolve(any()))
+            .thenReturn(resolved);
+    }
+
     @Test
     void shouldAcceptRequestWithoutDisclosingEligibility()
         throws Exception {
@@ -91,6 +111,9 @@ class PasswordRecoveryControllerTest {
                 command.email().equals(
                     "Nursena@Example.COM"
                 )
+                    && command.effectiveClientAddress().equals(
+                        IpAddress.parse("203.0.113.10")
+                    )
             )
         );
     }
@@ -253,7 +276,10 @@ class PasswordRecoveryControllerTest {
         PasswordRecoveryRequest request =
             new PasswordRecoveryRequest(email);
         RequestPasswordRecoveryCommand requestCommand =
-            new RequestPasswordRecoveryCommand(email);
+            new RequestPasswordRecoveryCommand(
+                email,
+                IpAddress.parse("203.0.113.10")
+            );
         PasswordRecoveryConfirmRequest confirmRequest =
             new PasswordRecoveryConfirmRequest(
                 CREDENTIAL,

--- a/src/test/java/com/nursena/payflow/user/application/service/AccountActionAbuseProtectionServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/AccountActionAbuseProtectionServiceTest.java
@@ -1,0 +1,160 @@
+package com.nursena.payflow.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import com.nursena.payflow.abuseprotection.application.exception.AbuseProtectionUnavailableException;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionFailureMode;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDimension;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionRequest;
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+import com.nursena.payflow.user.application.port.in.RequestEmailVerificationCommand;
+import com.nursena.payflow.user.application.port.in.RequestPasswordRecoveryCommand;
+import com.nursena.payflow.user.application.port.out.UserRepositoryPort;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AccountActionAbuseProtectionServiceTest {
+
+    private static final IpAddress CLIENT =
+        IpAddress.parse("203.0.113.10");
+
+    @Mock
+    private AbuseProtectionEnforcementPort abuseProtection;
+
+    @Mock
+    private UserRepositoryPort userRepository;
+
+    @Mock
+    private EmailVerificationPreparationService emailPreparation;
+
+    @Mock
+    private PasswordRecoveryPreparationService recoveryPreparation;
+
+    @Test
+    void shouldNormalizeIdentityAndEvaluateBeforeEmailLookup() {
+        when(abuseProtection.evaluate(any()))
+            .thenReturn(AbuseProtectionDecision.allowed());
+
+        RequestEmailVerificationService service =
+            new RequestEmailVerificationService(
+                abuseProtection,
+                userRepository,
+                emailPreparation
+            );
+
+        service.request(
+            new RequestEmailVerificationCommand(
+                "  Nursena@Example.COM  ",
+                CLIENT
+            )
+        );
+
+        ArgumentCaptor<AbuseProtectionRequest> request =
+            ArgumentCaptor.forClass(
+                AbuseProtectionRequest.class
+            );
+        InOrder order = inOrder(
+            abuseProtection,
+            userRepository
+        );
+        order.verify(abuseProtection).evaluate(request.capture());
+        order.verify(userRepository).findByEmailForUpdate(any());
+
+        assertThat(request.getValue().workflow()).isEqualTo(
+            AbuseProtectionWorkflow.EMAIL_VERIFICATION_REQUEST
+        );
+        assertThat(request.getValue().normalizedIdentity())
+            .isEqualTo("nursena@example.com");
+        assertThat(request.getValue().effectiveClientAddress())
+            .isEqualTo(CLIENT);
+    }
+
+    @Test
+    void shouldSuppressEmailSideEffectsWhenBlocked() {
+        when(abuseProtection.evaluate(any())).thenReturn(
+            AbuseProtectionDecision.blocked(
+                AbuseProtectionDimension.BOTH,
+                Duration.ofSeconds(30)
+            )
+        );
+
+        new RequestEmailVerificationService(
+            abuseProtection,
+            userRepository,
+            emailPreparation
+        ).request(
+            new RequestEmailVerificationCommand(
+                "nursena@example.com",
+                CLIENT
+            )
+        );
+
+        verifyNoInteractions(userRepository, emailPreparation);
+    }
+
+    @Test
+    void shouldSuppressRecoverySideEffectsWhenBlocked() {
+        when(abuseProtection.evaluate(any())).thenReturn(
+            AbuseProtectionDecision.blocked(
+                AbuseProtectionDimension.IDENTITY,
+                Duration.ofSeconds(30)
+            )
+        );
+
+        new RequestPasswordRecoveryService(
+            abuseProtection,
+            userRepository,
+            recoveryPreparation
+        ).request(
+            new RequestPasswordRecoveryCommand(
+                "nursena@example.com",
+                CLIENT
+            )
+        );
+
+        verifyNoInteractions(userRepository, recoveryPreparation);
+    }
+
+    @Test
+    void shouldFailClosedWithoutLookupOrSideEffect() {
+        when(abuseProtection.evaluate(any())).thenThrow(
+            new AbuseProtectionUnavailableException(
+                AbuseProtectionWorkflow
+                    .PASSWORD_RECOVERY_REQUEST,
+                AbuseProtectionFailureMode.FAIL_CLOSED,
+                new IllegalStateException("redis unavailable")
+            )
+        );
+
+        new RequestPasswordRecoveryService(
+            abuseProtection,
+            userRepository,
+            recoveryPreparation
+        ).request(
+            new RequestPasswordRecoveryCommand(
+                "nursena@example.com",
+                CLIENT
+            )
+        );
+
+        verify(userRepository, never())
+            .findByEmailForUpdate(any());
+        verifyNoInteractions(recoveryPreparation);
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/RequestEmailVerificationServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RequestEmailVerificationServiceTest.java
@@ -1,5 +1,7 @@
 package com.nursena.payflow.user.application.service;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -8,6 +10,9 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
+import com.nursena.payflow.clientcontext.domain.IpAddress;
 import com.nursena.payflow.user.application.port.in
     .RequestEmailVerificationCommand;
 import com.nursena.payflow.user.application.port.out
@@ -37,6 +42,9 @@ class RequestEmailVerificationServiceTest {
         EmailAddress.of("nursena@example.com");
 
     @Mock
+    private AbuseProtectionEnforcementPort abuseProtection;
+
+    @Mock
     private UserRepositoryPort userRepository;
 
     @Mock
@@ -47,7 +55,10 @@ class RequestEmailVerificationServiceTest {
 
     @BeforeEach
     void setUp() {
+        lenient().when(abuseProtection.evaluate(any()))
+            .thenReturn(AbuseProtectionDecision.allowed());
         service = new RequestEmailVerificationService(
+            abuseProtection,
             userRepository,
             preparationService
         );
@@ -59,7 +70,7 @@ class RequestEmailVerificationServiceTest {
             .thenReturn(Optional.of(unverifiedUser()));
 
         service.request(
-            new RequestEmailVerificationCommand(
+            emailCommand(
                 "  Nursena@Example.COM  "
             )
         );
@@ -73,7 +84,7 @@ class RequestEmailVerificationServiceTest {
             .thenReturn(Optional.empty());
 
         service.request(
-            new RequestEmailVerificationCommand(
+            emailCommand(
                 EMAIL.value()
             )
         );
@@ -87,7 +98,7 @@ class RequestEmailVerificationServiceTest {
             .thenReturn(Optional.of(verifiedUser()));
 
         service.request(
-            new RequestEmailVerificationCommand(
+            emailCommand(
                 EMAIL.value()
             )
         );
@@ -101,7 +112,7 @@ class RequestEmailVerificationServiceTest {
             .thenReturn(Optional.of(closedUser()));
 
         service.request(
-            new RequestEmailVerificationCommand(
+            emailCommand(
                 EMAIL.value()
             )
         );
@@ -147,4 +158,12 @@ class RequestEmailVerificationServiceTest {
             NOW
         );
     }
-}
+
+    private static RequestEmailVerificationCommand emailCommand(
+        String email
+    ) {
+        return new RequestEmailVerificationCommand(
+            email,
+            IpAddress.parse("203.0.113.10")
+        );
+    }}

--- a/src/test/java/com/nursena/payflow/user/application/service/RequestPasswordRecoveryServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/RequestPasswordRecoveryServiceTest.java
@@ -1,5 +1,7 @@
 package com.nursena.payflow.user.application.service;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -8,6 +10,9 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
+import com.nursena.payflow.clientcontext.domain.IpAddress;
 import com.nursena.payflow.user.application.port.in
     .RequestPasswordRecoveryCommand;
 import com.nursena.payflow.user.application.port.out
@@ -37,6 +42,9 @@ class RequestPasswordRecoveryServiceTest {
         EmailAddress.of("nursena@example.com");
 
     @Mock
+    private AbuseProtectionEnforcementPort abuseProtection;
+
+    @Mock
     private UserRepositoryPort userRepository;
 
     @Mock
@@ -47,7 +55,10 @@ class RequestPasswordRecoveryServiceTest {
 
     @BeforeEach
     void setUp() {
+        lenient().when(abuseProtection.evaluate(any()))
+            .thenReturn(AbuseProtectionDecision.allowed());
         service = new RequestPasswordRecoveryService(
+            abuseProtection,
             userRepository,
             preparationService
         );
@@ -61,7 +72,7 @@ class RequestPasswordRecoveryServiceTest {
             )));
 
         service.request(
-            new RequestPasswordRecoveryCommand(
+            recoveryCommand(
                 "  Nursena@Example.COM  "
             )
         );
@@ -75,7 +86,7 @@ class RequestPasswordRecoveryServiceTest {
             .thenReturn(Optional.empty());
 
         service.request(
-            new RequestPasswordRecoveryCommand(
+            recoveryCommand(
                 EMAIL.value()
             )
         );
@@ -89,7 +100,7 @@ class RequestPasswordRecoveryServiceTest {
             .thenReturn(Optional.of(unverifiedUser()));
 
         service.request(
-            new RequestPasswordRecoveryCommand(
+            recoveryCommand(
                 EMAIL.value()
             )
         );
@@ -105,7 +116,7 @@ class RequestPasswordRecoveryServiceTest {
             )));
 
         service.request(
-            new RequestPasswordRecoveryCommand(
+            recoveryCommand(
                 EMAIL.value()
             )
         );
@@ -138,4 +149,12 @@ class RequestPasswordRecoveryServiceTest {
             NOW
         );
     }
-}
+
+    private static RequestPasswordRecoveryCommand recoveryCommand(
+        String email
+    ) {
+        return new RequestPasswordRecoveryCommand(
+            email,
+            IpAddress.parse("203.0.113.10")
+        );
+    }}

--- a/src/test/java/com/nursena/payflow/user/integration/AccountActionAbuseProtectionIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/AccountActionAbuseProtectionIntegrationTest.java
@@ -1,0 +1,319 @@
+package com.nursena.payflow.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(properties = {
+    "payflow.security.abuse-protection.enabled=true",
+    "payflow.security.abuse-protection.email-verification-request.identity-limit=3",
+    "payflow.security.abuse-protection.email-verification-request.client-limit=3",
+    "payflow.security.abuse-protection.password-recovery-request.identity-limit=3",
+    "payflow.security.abuse-protection.password-recovery-request.client-limit=3",
+    "payflow.security.login-rate-limit.enabled=false"
+})
+@AutoConfigureMockMvc
+@Testcontainers
+class AccountActionAbuseProtectionIntegrationTest {
+
+    private static final String PASSWORD =
+        "StrongPassword123!";
+
+    private static final int ATTEMPTS = 8;
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:17-alpine");
+
+    @Container
+    @ServiceConnection(name = "redis")
+    private static final GenericContainer<?> REDIS =
+        new GenericContainer<>(
+            DockerImageName.parse("redis:8-alpine")
+        ).withExposedPorts(6379);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @BeforeEach
+    void cleanState() {
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM account_action_credentials"
+        );
+        jdbcTemplate.update("DELETE FROM users");
+
+        redisTemplate.execute(
+            (RedisCallback<Void>) connection -> {
+                connection.serverCommands().flushAll();
+                return null;
+            }
+        );
+    }
+
+    @Test
+    void shouldBoundConcurrentEmailVerificationSideEffects()
+        throws Exception {
+
+        String email = "limited.verification@example.com";
+        register(email);
+        jdbcTemplate.update(
+            "DELETE FROM account_action_credentials"
+        );
+
+        List<Integer> statuses = concurrentRequests(
+            "/api/v1/auth/email-verification/requests",
+            email
+        );
+
+        assertThat(statuses).hasSize(ATTEMPTS)
+            .allMatch(status -> status == 202);
+        assertThat(credentialCount("EMAIL_VERIFICATION"))
+            .isEqualTo(3);
+    }
+
+    @Test
+    void shouldBoundConcurrentPasswordRecoverySideEffects()
+        throws Exception {
+
+        String email = "limited.recovery@example.com";
+        register(email);
+        jdbcTemplate.update(
+            "UPDATE users SET email_verified_at = CURRENT_TIMESTAMP "
+                + "WHERE email = ?",
+            email
+        );
+        jdbcTemplate.update(
+            "DELETE FROM account_action_credentials"
+        );
+
+        List<Integer> statuses = concurrentRequests(
+            "/api/v1/auth/password-recovery/requests",
+            email
+        );
+
+        assertThat(statuses).hasSize(ATTEMPTS)
+            .allMatch(status -> status == 202);
+        assertThat(credentialCount("PASSWORD_RECOVERY"))
+            .isEqualTo(3);
+    }
+
+    @Test
+    void shouldKeepEligibilityAndQuotaOutcomesPubliclyGeneric()
+        throws Exception {
+
+        String eligible = "eligible@example.com";
+        String verified = "verified@example.com";
+        String closed = "closed@example.com";
+        String unknown = "unknown@example.com";
+
+        register(eligible);
+        register(verified);
+        register(closed);
+        jdbcTemplate.update(
+            "UPDATE users SET email_verified_at = CURRENT_TIMESTAMP "
+                + "WHERE email = ?",
+            verified
+        );
+        jdbcTemplate.update(
+            "UPDATE users SET status = 'CLOSED' WHERE email = ?",
+            closed
+        );
+        jdbcTemplate.update(
+            "DELETE FROM account_action_credentials"
+        );
+        redisTemplate.execute(
+            (RedisCallback<Void>) connection -> {
+                connection.serverCommands().flushAll();
+                return null;
+            }
+        );
+
+        List<String> identities = List.of(
+            eligible,
+            verified,
+            closed,
+            unknown
+        );
+
+        for (int index = 0; index < identities.size(); index++) {
+            String body = request(
+                "/api/v1/auth/email-verification/requests",
+                identities.get(index),
+                "203.0.113." + (20 + index)
+            );
+            assertThat(body).isEmpty();
+        }
+
+        assertThat(credentialCount("EMAIL_VERIFICATION"))
+            .isEqualTo(1);
+    }
+
+    private List<Integer> concurrentRequests(
+        String path,
+        String email
+    ) throws Exception {
+        ExecutorService executor =
+            Executors.newFixedThreadPool(ATTEMPTS);
+        CountDownLatch ready = new CountDownLatch(ATTEMPTS);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<Integer>> futures = new ArrayList<>();
+
+        try {
+            for (int index = 0; index < ATTEMPTS; index++) {
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    if (!start.await(10, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException(
+                            "concurrent start timed out"
+                        );
+                    }
+
+                    return emailStatus(
+                        path,
+                        email,
+                        "203.0.113.10"
+                    );
+                }));
+            }
+
+            assertThat(ready.await(10, TimeUnit.SECONDS))
+                .isTrue();
+            start.countDown();
+
+            List<Integer> statuses = new ArrayList<>();
+            for (Future<Integer> future : futures) {
+                statuses.add(future.get(30, TimeUnit.SECONDS));
+            }
+            return statuses;
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    private void register(String email) throws Exception {
+        int status = rawStatus(
+            "/api/v1/auth/register",
+            """
+            {
+              "email": "%s",
+              "password": "%s"
+            }
+            """.formatted(email, PASSWORD),
+            "198.51.100.10"
+        );
+        assertThat(status).isEqualTo(201);
+    }
+
+    private int emailStatus(
+        String path,
+        String email,
+        String remoteAddress
+    ) throws Exception {
+        return rawStatus(
+            path,
+            """
+            {
+              "email": "%s"
+            }
+            """.formatted(email),
+            remoteAddress
+        );
+    }
+
+    private int rawStatus(
+        String path,
+        String json,
+        String remoteAddress
+    ) throws Exception {
+        return mockMvc.perform(
+                requestBuilder(path, json, remoteAddress)
+            )
+            .andReturn()
+            .getResponse()
+            .getStatus();
+    }
+
+    private String request(
+        String path,
+        String email,
+        String remoteAddress
+    ) throws Exception {
+        return mockMvc.perform(
+                requestBuilder(
+                    path,
+                    """
+                    {
+                      "email": "%s"
+                    }
+                    """.formatted(email),
+                    remoteAddress
+                )
+            )
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    }
+
+    private static MockHttpServletRequestBuilder requestBuilder(
+        String path,
+        String json,
+        String remoteAddress
+    ) {
+        return post(path)
+            .with(request -> {
+                request.setRemoteAddr(remoteAddress);
+                return request;
+            })
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json);
+    }
+
+    private int credentialCount(String purpose) {
+        Integer count = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM account_action_credentials "
+                + "WHERE purpose = ?",
+            Integer.class,
+            purpose
+        );
+        return count == null ? 0 : count;
+    }
+}


### PR DESCRIPTION
## Summary

- protect email-verification and password-recovery requests with normalized-identity and trusted-client quotas
- resolve the effective client address through the existing trusted client-context boundary
- evaluate abuse policy before account lookup, eligibility inspection, row locking, credential creation, or mail delivery
- preserve the same empty `202 Accepted` response for eligible, ineligible, limited, unknown, closed, verified, and fail-closed outcomes
- suppress account-action credentials and delivery work when blocked or when Redis fails closed
- add real-Redis HTTP concurrency evidence proving configured limits bound protected side effects
- align README, changelog, ADR 0015, threat model, roadmap, public API reflection, and executable contracts
- complete v0.15.0 roadmap Increment 3

## Security boundaries

- raw email addresses and client addresses remain outside Redis keys and observable output
- controllers accept only the typed effective address returned by `ClientAddressResolver`
- application services normalize identity and enforce policy before account lookup
- blocked and fail-closed outcomes do not disclose account existence or eligibility
- all public account-action request outcomes retain an empty `202` response
- the existing login limiter remains unchanged
- generalized enforcement remains disabled by default until explicitly enabled by deployment configuration
- registration enforcement remains deferred pending reproducible performance and overload evidence
- MFA challenge and step-up enforcement remain assigned to Increment 4

## Verification

- `mvn clean verify`
- 1516 tests, 0 failures, 0 errors, 0 skipped
- 516 analyzed classes
- PostgreSQL and real-Redis HTTP concurrency tests
- blocked and Redis-unavailable service tests
- public API and v0.15.0 executable contract tests
- `git diff --check`
- UTF-8 corruption scan
- stable 22-file changeset
- no unchecked Increment 3 roadmap items

Relates to #149.

Closes #155
