### PR TITLE
chore(repo): align contribution workflow with release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,16 @@
-# Contributing
+﻿# Contributing
 
 ## Branching
 
-- `main`: stable and releasable history
-- `develop`: integration branch while the project is under active development
+- `main`: protected, stable, and releasable integration history
 - `feat/<short-name>`: new product or technical capability
 - `fix/<short-name>`: defect correction
 - `docs/<short-name>`: documentation-only change
 - `chore/<short-name>`: maintenance, tooling, or repository configuration
+- `release/<version>-<purpose>`: bounded release preparation and finalization
 
-Branches must be created from the latest `develop` branch. Related issues are linked from the pull request rather than encoded into the branch name.
+Branches must be created from the latest `main` branch. Related issues are linked from the pull request rather than encoded into the branch name. Release branches are used only for bounded release-preparation work and are deleted after the release PR is merged and verified.
+
 ## Commit convention
 
 Use Conventional Commits:
@@ -22,8 +23,10 @@ Use Conventional Commits:
 ## Pull request rules
 
 1. Keep pull requests focused and reasonably small.
-2. Link the related issue.
-3. Add tests for business behavior.
-4. Explain database, security, and concurrency implications.
-5. Require CI to pass before merging.
-6. Prefer squash merge to keep the main history readable.
+2. Link the related issue and state explicit non-goals where scope could expand.
+3. Add tests for business behavior and executable contracts where applicable.
+4. Explain database, security, concurrency, migration, and observability implications when relevant.
+5. Require protected CI checks to pass before merging.
+6. Verify that the reviewed PR HEAD matches the expected commit before merge.
+7. Use merge commits to preserve pull-request and release provenance; do not rewrite published history.
+8. Delete merged feature and release branches after merge-state and target-branch verification.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-﻿# Contributing
+# Contributing
 
 ## Branching
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ PayFlow starts as a **modular monolith**. Business modules use inward-facing dep
 
 ```text
 HTTP / Persistence / Messaging adapters
-                 ↓
+                 â†“
          Application use cases
-                 ↓
+                 â†“
              Domain model
 ```
 
@@ -583,13 +583,14 @@ Broker unavailability after the database commit does not roll back the completed
 
 ## Git workflow
 
-- Work begins from the latest `develop` branch.
-- Branches use `feat/<short-name>`, `fix/<short-name>`, `docs/<short-name>`, or `chore/<short-name>`.
-- Features are divided into small, testable checkpoints.
+- Work begins from the latest protected `main` branch.
+- Branches use `feat/<short-name>`, `fix/<short-name>`, `docs/<short-name>`, `chore/<short-name>`, or `release/<version>-<purpose>`.
+- Features are divided into small, testable checkpoints and remain scoped to a linked issue.
 - Commits follow Conventional Commits.
-- Pull requests represent complete and reviewable value increments.
-- CI must pass and conflicts must be resolved before merging.
-- Squash merge is preferred for a readable `develop` history.
+- Pull requests represent complete and reviewable value increments and target `main`.
+- Required CI checks must pass, the reviewed PR HEAD must match the expected commit, and conflicts must be resolved before merging.
+- Merge commits are retained to preserve pull-request and release provenance; published history is never rewritten.
+- Merged feature and release branches are removed after merge verification so `main` and published tags remain the durable history.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 


### PR DESCRIPTION
## Summary

- align `README.md` and `CONTRIBUTING.md` with the protected-`main` delivery model used by current PayFlow releases
- document bounded feature/release branches, protected CI, reviewed HEAD verification, merge-commit provenance, and post-merge branch cleanup
- remove stale `develop`-based and squash-merge guidance

## Scope

Documentation-only repository governance alignment. No runtime, dependency, schema, configuration, or release-tag changes are included.

## Verification

- exact changed paths: `README.md`, `CONTRIBUTING.md`
- branch is based on `620f5d8a693489ec44eda6e75362191eb6d37d21`
- branch is 2 commits ahead and 0 behind `main`
- UTF-8 BOM introduced by Windows PowerShell was removed in a follow-up commit without rewriting published branch history
- `git diff --check` passed before push

Closes #157
