### PR TITLE
feat(security): protect MFA confirmation and step-up issuance

### DIFF
--- a/docs/abuse-protection.md
+++ b/docs/abuse-protection.md
@@ -2,13 +2,16 @@
 
 ## Current delivery state
 
-Increment 3 wires the shared Redis foundation into email-verification and
-password-recovery request workflows. Both evaluate normalized identity and the
-trusted effective client address before account lookup. Allowed requests retain
-their existing eligibility rules; blocked and fail-closed requests suppress
-credential and mail-outbox side effects while returning the same empty `202`
-response. `ABUSE_PROTECTION_ENABLED` remains `false` by default so activation
-is an explicit deployment decision. The login limiter remains unchanged.
+Increment 4 extends the shared Redis foundation across email-verification,
+password-recovery, MFA login-challenge confirmation, and step-up grant issuance.
+Account-action requests evaluate normalized email and the trusted effective
+client before account lookup. MFA challenge confirmation evaluates a
+fixed-length, non-reversible challenge identifier and the trusted effective
+client before challenge lookup or sensitive state mutation. Step-up issuance
+evaluates the authenticated JWT subject and trusted effective client before user
+or authenticator locking, second-factor consumption, or grant creation.
+`ABUSE_PROTECTION_ENABLED` remains `false` by default so activation is an
+explicit deployment decision. The login limiter remains unchanged.
 
 ## Policy contract
 
@@ -67,6 +70,23 @@ Registration was evaluated but is not wired in Increment 3. Its existing
 require the reproducible performance and overload evidence planned for
 Increment 6 before an activation decision. This is a documented deferral, not
 an implicit exemption from later review.
+
+## MFA and step-up HTTP contract
+
+- MFA challenge confirmation derives its identity quota from a fixed-length,
+  non-reversible challenge identifier rather than plaintext challenge material
+- malformed challenge input participates in the same fail-closed enforcement
+  boundary before any challenge repository access
+- challenge quota rejection does not decrement attempts, consume recovery
+  codes, consume challenge state, or issue access/refresh credentials
+- step-up grant issuance uses only the authenticated JWT subject as its identity
+  dimension; account identity is never accepted from the request body
+- step-up quota rejection runs before user/authenticator locking, second-factor
+  consumption, and grant creation or supersession
+- only `ClientAddressResolver` supplies the effective client dimension for both
+  workflows, so untrusted forwarding headers cannot rotate client quota
+- Redis dependency failure remains fail closed and maps to the existing coarse
+  `MFA_SECURITY_UNAVAILABLE` public contract without sensitive mutation
 
 ## Privacy and observability
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -739,10 +739,19 @@ Increment 3 is implemented by issue [#155](https://github.com/nursena-pc/payflow
 
 ### Increment 4 — MFA challenge and step-up protection
 
-- [ ] Protect MFA login-challenge confirmation without exposing challenge or account validity
-- [ ] Protect step-up grant issuance without weakening subject, purpose, expiry, or single-use semantics
-- [ ] Keep TOTP values, recovery codes, challenge tokens, and step-up grants outside quota state and observable output
-- [ ] Verify abuse decisions do not consume valid single-use credentials unless the protected workflow executes
+- [x] Protect MFA login-challenge confirmation without exposing challenge or account validity
+- [x] Protect step-up grant issuance without weakening subject, purpose, expiry, or single-use semantics
+- [x] Keep TOTP values, recovery codes, challenge tokens, and step-up grants outside quota state and observable output
+- [x] Verify abuse decisions do not consume valid single-use credentials unless the protected workflow executes
+
+Increment 4 is implemented by issue [#159](https://github.com/nursena-pc/payflow/issues/159)
+and protected pull request [#160](https://github.com/nursena-pc/payflow/pull/160).
+MFA challenge confirmation now enforces fixed-length non-reversible challenge
+identity and trusted-client quotas before challenge state access. Step-up grant
+issuance enforces authenticated-subject and trusted-client quotas before
+second-factor or grant mutation. Real-Redis HTTP/concurrency coverage proves
+bounded side effects, forwarding-header resistance, Redis-key privacy, and
+fail-closed dependency behavior.
 
 ### Increment 5 — Metrics, dashboards, alerts, and operations
 

--- a/docs/security/abuse-protection-threat-model.md
+++ b/docs/security/abuse-protection-threat-model.md
@@ -55,7 +55,7 @@ read server-side digests, or directly choose the resolved effective address.
 | Registration | normalized proposed email | trusted effective address | fail closed | stable coarse rejection |
 | Email-verification request | normalized email | trusted effective address | fail closed | generic accepted response; no side effect |
 | Password-recovery request | normalized email | trusted effective address | fail closed | generic accepted response; no side effect |
-| MFA challenge confirmation | challenge subject | trusted effective address | fail closed | stable coarse rejection |
+| MFA challenge confirmation | fixed-length non-reversible challenge identifier | trusted effective address | fail closed | stable coarse rejection |
 | Step-up grant issuance | authenticated subject | trusted effective address | fail closed | stable coarse rejection |
 
 The table defines policy intent, not active endpoint enforcement in Increment 1.
@@ -127,6 +127,25 @@ distinct `201` and duplicate-account `409` behavior and performs BCrypt plus
 initial verification preparation. Latency, overload, and false-positive data
 must be recorded before choosing its public failure contract and activation
 policy.
+
+## Increment 4 MFA and step-up decision
+
+MFA login-challenge confirmation derives a fixed-length non-reversible identity
+before generalized enforcement and evaluates policy before challenge lookup,
+row locking, attempt mutation, recovery-code consumption, challenge
+consumption, or credential issuance. Malformed challenge input also enters the
+enforcement boundary without exposing plaintext challenge material.
+
+Step-up grant issuance uses the authenticated JWT subject as its identity
+dimension and the trusted effective client as its client dimension. Enforcement
+runs before user or authenticator locking, TOTP or recovery-code consumption,
+and grant creation or supersession. Purpose parsing remains application-owned.
+
+Real-Redis HTTP and concurrency tests prove configured identity and client
+limits bound protected side effects. Untrusted forwarding headers cannot change
+the client quota. Redis-unavailable tests prove both workflows fail closed with
+the coarse `MFA_SECURITY_UNAVAILABLE` contract while challenge attempts,
+recovery codes, credentials, and grants remain untouched.
 
 ## Verification obligations
 

--- a/src/main/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionRequest.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionRequest.java
@@ -49,4 +49,9 @@ public record AbuseProtectionRequest(
             );
         }
     }
+
+    @Override
+    public String toString() {
+        return "AbuseProtectionRequest[redacted]";
+    }
 }

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/ConfirmMfaLoginChallengeController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/ConfirmMfaLoginChallengeController.java
@@ -4,16 +4,20 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.Objects;
 
+import com.nursena.payflow.clientcontext.adapter.in.web.ClientAddressResolver;
+import com.nursena.payflow.clientcontext.domain.ResolvedClientAddress;
 import com.nursena.payflow.common.api.ApiError;
 import com.nursena.payflow.user.application.port.in.AuthenticatedUserResult;
 import com.nursena.payflow.user.application.port.in.ConfirmMfaLoginChallengeCommand;
 import com.nursena.payflow.user.application.port.in.ConfirmMfaLoginChallengeUseCase;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,11 +31,20 @@ public class ConfirmMfaLoginChallengeController {
 
     private static final String TOKEN_TYPE = "Bearer";
     private final ConfirmMfaLoginChallengeUseCase useCase;
+    private final ClientAddressResolver clientAddressResolver;
 
     public ConfirmMfaLoginChallengeController(
-        ConfirmMfaLoginChallengeUseCase useCase
+        ConfirmMfaLoginChallengeUseCase useCase,
+        ClientAddressResolver clientAddressResolver
     ) {
-        this.useCase = Objects.requireNonNull(useCase, "useCase must not be null");
+        this.useCase = Objects.requireNonNull(
+            useCase,
+            "useCase must not be null"
+        );
+        this.clientAddressResolver = Objects.requireNonNull(
+            clientAddressResolver,
+            "clientAddressResolver must not be null"
+        );
     }
 
     @Operation(
@@ -70,12 +83,17 @@ public class ConfirmMfaLoginChallengeController {
     })
     @PostMapping("/confirm")
     public ResponseEntity<AuthenticateUserResponse> confirm(
-        @RequestBody(required = false) ConfirmMfaLoginChallengeRequest request
+        @RequestBody(required = false) ConfirmMfaLoginChallengeRequest request,
+        @Parameter(hidden = true) HttpServletRequest servletRequest
     ) {
+        ResolvedClientAddress clientAddress =
+            clientAddressResolver.resolve(servletRequest);
+
         AuthenticatedUserResult result = useCase.confirm(
             new ConfirmMfaLoginChallengeCommand(
                 request == null ? null : request.challengeToken(),
-                request == null ? null : request.code()
+                request == null ? null : request.code(),
+                clientAddress.address()
             )
         );
         return ResponseEntity.ok(toResponse(result));

--- a/src/main/java/com/nursena/payflow/user/adapter/in/web/StepUpGrantController.java
+++ b/src/main/java/com/nursena/payflow/user/adapter/in/web/StepUpGrantController.java
@@ -2,8 +2,11 @@ package com.nursena.payflow.user.adapter.in.web;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import java.util.Objects;
 import java.util.UUID;
 
+import com.nursena.payflow.clientcontext.adapter.in.web.ClientAddressResolver;
+import com.nursena.payflow.clientcontext.domain.ResolvedClientAddress;
 import com.nursena.payflow.common.api.ApiError;
 import com.nursena.payflow.configuration.OpenApiConfiguration;
 import com.nursena.payflow.user.application.port.in.IssueStepUpGrantCommand;
@@ -17,6 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -35,9 +39,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class StepUpGrantController {
 
     private final IssueStepUpGrantUseCase issueUseCase;
+    private final ClientAddressResolver clientAddressResolver;
 
-    public StepUpGrantController(IssueStepUpGrantUseCase issueUseCase) {
-        this.issueUseCase = issueUseCase;
+    public StepUpGrantController(
+        IssueStepUpGrantUseCase issueUseCase,
+        ClientAddressResolver clientAddressResolver
+    ) {
+        this.issueUseCase = Objects.requireNonNull(
+            issueUseCase,
+            "issueUseCase must not be null"
+        );
+        this.clientAddressResolver = Objects.requireNonNull(
+            clientAddressResolver,
+            "clientAddressResolver must not be null"
+        );
     }
 
     @Operation(
@@ -75,13 +90,18 @@ public class StepUpGrantController {
     public ResponseEntity<StepUpGrantResponse> issue(
         @Parameter(hidden = true)
         @AuthenticationPrincipal Jwt jwt,
-        @Valid @RequestBody IssueStepUpGrantRequest request
+        @Valid @RequestBody IssueStepUpGrantRequest request,
+        @Parameter(hidden = true) HttpServletRequest servletRequest
     ) {
+        ResolvedClientAddress clientAddress =
+            clientAddressResolver.resolve(servletRequest);
+
         IssueStepUpGrantResult result = issueUseCase.issue(
             new IssueStepUpGrantCommand(
                 UUID.fromString(jwt.getSubject()),
                 request.purpose(),
-                request.code()
+                request.code(),
+                clientAddress.address()
             )
         );
         return ResponseEntity.ok(StepUpGrantResponse.from(result));

--- a/src/main/java/com/nursena/payflow/user/application/port/in/ConfirmMfaLoginChallengeCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/ConfirmMfaLoginChallengeCommand.java
@@ -1,9 +1,21 @@
 package com.nursena.payflow.user.application.port.in;
 
+import java.util.Objects;
+
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+
 public record ConfirmMfaLoginChallengeCommand(
     String challengeToken,
-    String code
+    String code,
+    IpAddress effectiveClientAddress
 ) {
+    public ConfirmMfaLoginChallengeCommand {
+        Objects.requireNonNull(
+            effectiveClientAddress,
+            "effectiveClientAddress must not be null"
+        );
+    }
+
     @Override
     public String toString() {
         return "ConfirmMfaLoginChallengeCommand[redacted]";

--- a/src/main/java/com/nursena/payflow/user/application/port/in/IssueStepUpGrantCommand.java
+++ b/src/main/java/com/nursena/payflow/user/application/port/in/IssueStepUpGrantCommand.java
@@ -3,21 +3,27 @@ package com.nursena.payflow.user.application.port.in;
 import java.util.Objects;
 import java.util.UUID;
 
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+
 public record IssueStepUpGrantCommand(
     UUID subjectId,
     String purpose,
-    String code
+    String code,
+    IpAddress effectiveClientAddress
 ) {
     public IssueStepUpGrantCommand {
-        Objects.requireNonNull(subjectId, "subjectId must not be null");
+        Objects.requireNonNull(
+            subjectId,
+            "subjectId must not be null"
+        );
+        Objects.requireNonNull(
+            effectiveClientAddress,
+            "effectiveClientAddress must not be null"
+        );
     }
 
     @Override
     public String toString() {
-        return "IssueStepUpGrantCommand[subjectId="
-            + subjectId
-            + ", purpose="
-            + purpose
-            + ", code=redacted]";
+        return "IssueStepUpGrantCommand[redacted]";
     }
 }

--- a/src/main/java/com/nursena/payflow/user/application/service/ConfirmMfaLoginChallengeService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/ConfirmMfaLoginChallengeService.java
@@ -3,9 +3,17 @@ package com.nursena.payflow.user.application.service;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.HexFormat;
 import java.util.Objects;
 import java.util.UUID;
 
+import com.nursena.payflow.abuseprotection.application.exception.AbuseProtectionUnavailableException;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionRequest;
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
 import com.nursena.payflow.user.application.port.in.AuthenticatedUserResult;
 import com.nursena.payflow.user.application.port.in.ConfirmMfaLoginChallengeCommand;
 import com.nursena.payflow.user.application.port.in.ConfirmMfaLoginChallengeUseCase;
@@ -28,7 +36,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class ConfirmMfaLoginChallengeService
     implements ConfirmMfaLoginChallengeUseCase {
 
+    private static final MfaLoginChallengeDigest
+        MALFORMED_CHALLENGE_ABUSE_DIGEST =
+            MfaLoginChallengeDigest.of(
+                HexFormat.of().parseHex("f".repeat(64))
+            );
+
     private final MfaLoginChallengeDigestPort digestPort;
+    private final AbuseProtectionEnforcementPort abuseProtection;
     private final MfaLoginChallengeRepositoryPort challengeRepository;
     private final UserRepositoryPort userRepository;
     private final MfaAuthenticatorRepositoryPort authenticatorRepository;
@@ -38,6 +53,7 @@ public class ConfirmMfaLoginChallengeService
 
     public ConfirmMfaLoginChallengeService(
         MfaLoginChallengeDigestPort digestPort,
+        AbuseProtectionEnforcementPort abuseProtection,
         MfaLoginChallengeRepositoryPort challengeRepository,
         UserRepositoryPort userRepository,
         MfaAuthenticatorRepositoryPort authenticatorRepository,
@@ -46,6 +62,7 @@ public class ConfirmMfaLoginChallengeService
         Clock clock
     ) {
         this.digestPort = digestPort;
+        this.abuseProtection = abuseProtection;
         this.challengeRepository = challengeRepository;
         this.userRepository = userRepository;
         this.authenticatorRepository = authenticatorRepository;
@@ -61,9 +78,20 @@ public class ConfirmMfaLoginChallengeService
     ) {
         ConfirmMfaLoginChallengeCommand checkedCommand =
             Objects.requireNonNull(command, "command must not be null");
-        MfaLoginChallengeDigest digest = digestSafely(
-            checkedCommand.challengeToken()
+        ChallengeDigestResolution digestResolution =
+            resolveChallengeDigest(
+                checkedCommand.challengeToken()
+            );
+        enforceAbuseProtection(
+            digestResolution.digest(),
+            checkedCommand.effectiveClientAddress()
         );
+        if (!digestResolution.usableForLookup()) {
+            throw new InvalidMfaLoginChallengeException();
+        }
+
+        MfaLoginChallengeDigest digest =
+            digestResolution.digest();
         UUID candidateUserId = challengeRepository
             .findUserIdByDigest(digest)
             .orElseThrow(InvalidMfaLoginChallengeException::new);
@@ -107,19 +135,71 @@ public class ConfirmMfaLoginChallengeService
         return credentialIssuer.issue(user, now);
     }
 
-    private MfaLoginChallengeDigest digestSafely(String value) {
+    private void enforceAbuseProtection(
+        MfaLoginChallengeDigest digest,
+        IpAddress effectiveClientAddress
+    ) {
+        try {
+            AbuseProtectionDecision decision =
+                abuseProtection.evaluate(
+                    new AbuseProtectionRequest(
+                        AbuseProtectionWorkflow
+                            .MFA_LOGIN_CHALLENGE_CONFIRMATION,
+                        HexFormat.of().formatHex(digest.value()),
+                        effectiveClientAddress
+                    )
+                );
+
+            if (!decision.isAllowed()) {
+                throw new InvalidMfaLoginChallengeException();
+            }
+        }
+        catch (AbuseProtectionUnavailableException exception) {
+            throw new MfaSecurityUnavailableException();
+        }
+    }
+
+    private ChallengeDigestResolution resolveChallengeDigest(
+        String value
+    ) {
         if (value == null || value.isBlank() || value.length() > 256) {
-            throw new InvalidMfaLoginChallengeException();
+            return ChallengeDigestResolution.malformed();
         }
         try {
-            return digestPort.digest(value);
+            return ChallengeDigestResolution.usable(
+                digestPort.digest(value)
+            );
         }
         catch (IllegalArgumentException exception) {
-            throw new InvalidMfaLoginChallengeException();
+            return ChallengeDigestResolution.malformed();
         }
     }
 
     private static boolean isEligible(User user) {
         return user.status() == UserStatus.ACTIVE && user.isEmailVerified();
+    }
+
+    private record ChallengeDigestResolution(
+        MfaLoginChallengeDigest digest,
+        boolean usableForLookup
+    ) {
+        private static ChallengeDigestResolution usable(
+            MfaLoginChallengeDigest digest
+        ) {
+            return new ChallengeDigestResolution(
+                Objects.requireNonNull(
+                    digest,
+                    "digest must not be null"
+                ),
+                true
+            );
+        }
+
+        private static ChallengeDigestResolution malformed() {
+            return new ChallengeDigestResolution(
+                MALFORMED_CHALLENGE_ABUSE_DIGEST,
+                false
+            );
+        }
     }
 }

--- a/src/main/java/com/nursena/payflow/user/application/service/IssueStepUpGrantService.java
+++ b/src/main/java/com/nursena/payflow/user/application/service/IssueStepUpGrantService.java
@@ -5,6 +5,12 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 
+import com.nursena.payflow.abuseprotection.application.exception.AbuseProtectionUnavailableException;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionRequest;
+import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
 import com.nursena.payflow.user.application.port.in.IssueStepUpGrantCommand;
 import com.nursena.payflow.user.application.port.in.IssueStepUpGrantResult;
 import com.nursena.payflow.user.application.port.in.IssueStepUpGrantUseCase;
@@ -28,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class IssueStepUpGrantService implements IssueStepUpGrantUseCase {
 
+    private final AbuseProtectionEnforcementPort abuseProtection;
     private final UserRepositoryPort userRepository;
     private final MfaAuthenticatorRepositoryPort authenticatorRepository;
     private final MfaSecondFactorVerifier secondFactorVerifier;
@@ -35,12 +42,14 @@ public class IssueStepUpGrantService implements IssueStepUpGrantUseCase {
     private final Clock clock;
 
     public IssueStepUpGrantService(
+        AbuseProtectionEnforcementPort abuseProtection,
         UserRepositoryPort userRepository,
         MfaAuthenticatorRepositoryPort authenticatorRepository,
         MfaSecondFactorVerifier secondFactorVerifier,
         StepUpGrantIssuer grantIssuer,
         Clock clock
     ) {
+        this.abuseProtection = abuseProtection;
         this.userRepository = userRepository;
         this.authenticatorRepository = authenticatorRepository;
         this.secondFactorVerifier = secondFactorVerifier;
@@ -56,6 +65,8 @@ public class IssueStepUpGrantService implements IssueStepUpGrantUseCase {
             "command must not be null"
         );
         StepUpPurpose purpose = parsePurpose(checked.purpose());
+        enforceAbuseProtection(checked);
+
         User user = userRepository.findByIdForUpdate(checked.subjectId())
             .orElseThrow(UserNotFoundException::new);
 
@@ -82,6 +93,29 @@ public class IssueStepUpGrantService implements IssueStepUpGrantUseCase {
         }
 
         return grantIssuer.issue(user.id(), purpose, now);
+    }
+
+    private void enforceAbuseProtection(
+        IssueStepUpGrantCommand command
+    ) {
+        try {
+            AbuseProtectionDecision decision =
+                abuseProtection.evaluate(
+                    new AbuseProtectionRequest(
+                        AbuseProtectionWorkflow
+                            .STEP_UP_GRANT_ISSUANCE,
+                        command.subjectId().toString(),
+                        command.effectiveClientAddress()
+                    )
+                );
+
+            if (!decision.isAllowed()) {
+                throw new InvalidStepUpGrantException();
+            }
+        }
+        catch (AbuseProtectionUnavailableException exception) {
+            throw new MfaSecurityUnavailableException();
+        }
     }
 
     private static StepUpPurpose parsePurpose(String value) {

--- a/src/test/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionRequestTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/application/port/out/AbuseProtectionRequestTest.java
@@ -25,6 +25,23 @@ class AbuseProtectionRequestTest {
     }
 
     @Test
+    void shouldRedactSensitiveInputsFromToString() {
+        AbuseProtectionRequest request =
+            new AbuseProtectionRequest(
+                AbuseProtectionWorkflow.REGISTRATION,
+                "nursena@example.com",
+                IpAddress.parse("203.0.113.10")
+            );
+
+        assertThat(request.toString())
+            .isEqualTo("AbuseProtectionRequest[redacted]")
+            .doesNotContain(
+                "nursena@example.com",
+                "203.0.113.10"
+            );
+    }
+
+    @Test
     void shouldRejectBlankOrUntrimmedIdentity() {
         assertThatThrownBy(() -> request(" "))
             .isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/com/nursena/payflow/configuration/V015AbuseProtectionFoundationContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V015AbuseProtectionFoundationContractTest.java
@@ -177,10 +177,10 @@ class V015AbuseProtectionFoundationContractTest {
 
         assertThat(guide)
             .contains(
-                "Increment 3 wires the shared Redis foundation",
+                "Policy code contains no controller, servlet, HTTP, Spring, or Redis dependency.",
                 "windows range from one second through one day",
                 "limits range from one through one million",
-                "The login limiter remains unchanged"
+                "`LOGIN_RATE_LIMIT_*` variables remain unchanged"
             );
     }
 

--- a/src/test/java/com/nursena/payflow/configuration/V015RedisAbuseEnforcementContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V015RedisAbuseEnforcementContractTest.java
@@ -118,8 +118,8 @@ class V015RedisAbuseEnforcementContractTest {
         assertThat(Files.readString(
             Path.of("docs", "abuse-protection.md")
         )).contains(
-            "Increment 3 wires the shared Redis foundation",
-            "trusted effective client address before account lookup",
+            "## Redis state contract",
+            "key suffixes are domain-separated 64-character SHA-256 digests",
             "ABUSE_PROTECTION_ENABLED` remains `false` by default"
         );
     }

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/ConfirmMfaLoginChallengeControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/ConfirmMfaLoginChallengeControllerTest.java
@@ -3,6 +3,7 @@ package com.nursena.payflow.user.adapter.in.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -11,6 +12,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.Instant;
 
+import com.nursena.payflow.clientcontext.adapter.in.web.ClientAddressResolver;
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+import com.nursena.payflow.clientcontext.domain.ResolvedClientAddress;
 import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import com.nursena.payflow.configuration.SecurityConfiguration;
 import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
@@ -18,6 +22,7 @@ import com.nursena.payflow.user.application.port.in.AuthenticatedUserResult;
 import com.nursena.payflow.user.application.port.in.ConfirmMfaLoginChallengeCommand;
 import com.nursena.payflow.user.application.port.in.ConfirmMfaLoginChallengeUseCase;
 import com.nursena.payflow.user.domain.exception.InvalidMfaLoginChallengeException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -38,6 +43,18 @@ class ConfirmMfaLoginChallengeControllerTest {
     @Autowired MockMvc mockMvc;
     @MockitoBean ConfirmMfaLoginChallengeUseCase useCase;
     @MockitoBean JwtDecoder jwtDecoder;
+    @MockitoBean ClientAddressResolver clientAddressResolver;
+
+    @BeforeEach
+    void setUpClientAddress() {
+        ResolvedClientAddress resolved =
+            mock(ResolvedClientAddress.class);
+        when(resolved.address()).thenReturn(
+            IpAddress.parse("203.0.113.10")
+        );
+        when(clientAddressResolver.resolve(any()))
+            .thenReturn(resolved);
+    }
 
     @Test
     void shouldIssueCredentialsOnlyAfterChallengeConfirmation() throws Exception {
@@ -59,6 +76,9 @@ class ConfirmMfaLoginChallengeControllerTest {
         verify(useCase).confirm(argThat(command ->
             command.challengeToken().equals("challenge")
                 && command.code().equals("123456")
+                && command.effectiveClientAddress().equals(
+                    IpAddress.parse("203.0.113.10")
+                )
         ));
     }
 
@@ -102,6 +122,9 @@ class ConfirmMfaLoginChallengeControllerTest {
         verify(useCase).confirm(argThat(command ->
             command.challengeToken().equals("challenge")
                 && command.code().equals(recoveryCode)
+                && command.effectiveClientAddress().equals(
+                    IpAddress.parse("203.0.113.10")
+                )
         ));
     }
 
@@ -128,7 +151,11 @@ class ConfirmMfaLoginChallengeControllerTest {
             .andExpect(jsonPath("$.code").value("MFA_CHALLENGE_INVALID"));
 
         verify(useCase).confirm(argThat(command ->
-            command.challengeToken() == null && command.code() == null
+            command.challengeToken() == null
+                && command.code() == null
+                && command.effectiveClientAddress().equals(
+                    IpAddress.parse("203.0.113.10")
+                )
         ));
     }
 

--- a/src/test/java/com/nursena/payflow/user/adapter/in/web/StepUpGrantControllerTest.java
+++ b/src/test/java/com/nursena/payflow/user/adapter/in/web/StepUpGrantControllerTest.java
@@ -3,6 +3,7 @@ package com.nursena.payflow.user.adapter.in.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -12,6 +13,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.Instant;
 
+import com.nursena.payflow.clientcontext.adapter.in.web.ClientAddressResolver;
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+import com.nursena.payflow.clientcontext.domain.ResolvedClientAddress;
 import com.nursena.payflow.configuration.SecurityConfiguration;
 import com.nursena.payflow.observability.adapter.in.web.RequestCorrelationConfiguration;
 import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
@@ -22,6 +26,7 @@ import com.nursena.payflow.user.domain.exception.InvalidStepUpGrantException;
 import com.nursena.payflow.user.domain.exception.InvalidStepUpPurposeException;
 import com.nursena.payflow.user.domain.exception.MfaStateConflictException;
 import com.nursena.payflow.user.domain.exception.MfaVerificationFailedException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -46,6 +51,18 @@ class StepUpGrantControllerTest {
     @Autowired MockMvc mockMvc;
     @MockitoBean IssueStepUpGrantUseCase useCase;
     @MockitoBean JwtDecoder jwtDecoder;
+    @MockitoBean ClientAddressResolver clientAddressResolver;
+
+    @BeforeEach
+    void setUpClientAddress() {
+        ResolvedClientAddress resolved =
+            mock(ResolvedClientAddress.class);
+        when(resolved.address()).thenReturn(
+            IpAddress.parse("203.0.113.10")
+        );
+        when(clientAddressResolver.resolve(any()))
+            .thenReturn(resolved);
+    }
 
     @Test
     void shouldRequireBearerAuthentication() throws Exception {
@@ -77,6 +94,9 @@ class StepUpGrantControllerTest {
             command.subjectId().toString().equals(SUBJECT)
                 && command.purpose().equals("mfa-disable")
                 && command.code().equals("123456")
+                && command.effectiveClientAddress().equals(
+                    IpAddress.parse("203.0.113.10")
+                )
         ));
     }
 
@@ -129,7 +149,20 @@ class StepUpGrantControllerTest {
         StepUpGrantResponse response = new StepUpGrantResponse(
             "opaque-grant", "mfa-disable", Instant.parse("2026-08-10T10:05:00Z")
         );
+        IssueStepUpGrantCommand command =
+            new IssueStepUpGrantCommand(
+                java.util.UUID.fromString(SUBJECT),
+                "mfa-disable",
+                "123456",
+                IpAddress.parse("203.0.113.10")
+            );
         assertThat(request.toString()).doesNotContain("123456");
+        assertThat(command.toString()).doesNotContain(
+            SUBJECT,
+            "mfa-disable",
+            "123456",
+            "203.0.113.10"
+        );
         assertThat(response.toString()).doesNotContain("opaque-grant");
     }
 

--- a/src/test/java/com/nursena/payflow/user/application/port/in/ConfirmMfaLoginChallengeCommandTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/in/ConfirmMfaLoginChallengeCommandTest.java
@@ -1,22 +1,34 @@
 package com.nursena.payflow.user.application.port.in;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nursena.payflow.clientcontext.domain.IpAddress;
 import org.junit.jupiter.api.Test;
 
 class ConfirmMfaLoginChallengeCommandTest {
 
+    private static final IpAddress CLIENT_ADDRESS =
+        IpAddress.parse("203.0.113.10");
+
     @Test
     void shouldKeepValuesForApplicationValidation() {
         ConfirmMfaLoginChallengeCommand command =
-            new ConfirmMfaLoginChallengeCommand("challenge", "123456");
+            new ConfirmMfaLoginChallengeCommand(
+                "challenge", "123456", CLIENT_ADDRESS
+            );
         assertThat(command.challengeToken()).isEqualTo("challenge");
         assertThat(command.code()).isEqualTo("123456");
+        assertThat(command.effectiveClientAddress())
+            .isEqualTo(CLIENT_ADDRESS);
     }
 
     @Test
     void shouldRedactChallengeAndCode() {
         ConfirmMfaLoginChallengeCommand command =
-            new ConfirmMfaLoginChallengeCommand("challenge", "123456");
+            new ConfirmMfaLoginChallengeCommand(
+                "challenge", "123456", CLIENT_ADDRESS
+            );
         assertThat(command.toString())
             .isEqualTo("ConfirmMfaLoginChallengeCommand[redacted]")
             .doesNotContain("challenge", "123456");
@@ -25,8 +37,17 @@ class ConfirmMfaLoginChallengeCommandTest {
     @Test
     void shouldAllowNullForStableApplicationFailureContract() {
         ConfirmMfaLoginChallengeCommand command =
-            new ConfirmMfaLoginChallengeCommand(null, null);
+            new ConfirmMfaLoginChallengeCommand(null, null, CLIENT_ADDRESS);
         assertThat(command.challengeToken()).isNull();
         assertThat(command.code()).isNull();
+    }
+
+    @Test
+    void shouldRejectMissingEffectiveClientAddress() {
+        assertThatThrownBy(() ->
+            new ConfirmMfaLoginChallengeCommand(
+                "challenge", "123456", null
+            )
+        ).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/com/nursena/payflow/user/application/port/in/IssueStepUpGrantCommandTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/port/in/IssueStepUpGrantCommandTest.java
@@ -1,0 +1,72 @@
+package com.nursena.payflow.user.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import com.nursena.payflow.clientcontext.domain.IpAddress;
+import org.junit.jupiter.api.Test;
+
+class IssueStepUpGrantCommandTest {
+
+    private static final UUID SUBJECT_ID =
+        UUID.fromString("10000000-0000-0000-0000-000000000105");
+    private static final IpAddress CLIENT_ADDRESS =
+        IpAddress.parse("203.0.113.10");
+
+    @Test
+    void shouldRetainTrustedApplicationInputs() {
+        IssueStepUpGrantCommand command = command();
+
+        assertThat(command.subjectId()).isEqualTo(SUBJECT_ID);
+        assertThat(command.purpose()).isEqualTo("mfa-disable");
+        assertThat(command.code()).isEqualTo("123456");
+        assertThat(command.effectiveClientAddress())
+            .isEqualTo(CLIENT_ADDRESS);
+    }
+
+    @Test
+    void shouldRedactSubjectPurposeProofAndClientAddress() {
+        IssueStepUpGrantCommand command = command();
+
+        assertThat(command.toString())
+            .isEqualTo("IssueStepUpGrantCommand[redacted]")
+            .doesNotContain(
+                SUBJECT_ID.toString(),
+                "mfa-disable",
+                "123456",
+                "203.0.113.10"
+            );
+    }
+
+    @Test
+    void shouldRejectMissingTrustedIdentityInputs() {
+        assertThatThrownBy(() ->
+            new IssueStepUpGrantCommand(
+                null,
+                "mfa-disable",
+                "123456",
+                CLIENT_ADDRESS
+            )
+        ).isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() ->
+            new IssueStepUpGrantCommand(
+                SUBJECT_ID,
+                "mfa-disable",
+                "123456",
+                null
+            )
+        ).isInstanceOf(NullPointerException.class);
+    }
+
+    private static IssueStepUpGrantCommand command() {
+        return new IssueStepUpGrantCommand(
+            SUBJECT_ID,
+            "mfa-disable",
+            "123456",
+            CLIENT_ADDRESS
+        );
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/application/service/ConfirmMfaLoginChallengeServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/ConfirmMfaLoginChallengeServiceTest.java
@@ -2,18 +2,30 @@ package com.nursena.payflow.user.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.nursena.payflow.abuseprotection.application.exception.AbuseProtectionUnavailableException;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionFailureMode;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDimension;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
 import com.nursena.payflow.clientcontext.domain.IpAddress;
+import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
 import com.nursena.payflow.user.application.port.in.AuthenticatedUserResult;
 import com.nursena.payflow.user.application.port.in.ConfirmMfaLoginChallengeCommand;
 import com.nursena.payflow.user.application.port.out.MfaAuthenticatorRepositoryPort;
@@ -34,6 +46,7 @@ import com.nursena.payflow.user.domain.model.UserStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,8 +62,12 @@ class ConfirmMfaLoginChallengeServiceTest {
         Instant.parse("2026-08-08T12:00:00Z");
     private static final MfaLoginChallengeDigest DIGEST =
         MfaLoginChallengeDigest.of(new byte[32]);
+    private static final String ABUSE_IDENTITY = "0".repeat(64);
+    private static final String MALFORMED_ABUSE_IDENTITY =
+        "f".repeat(64);
 
     @Mock MfaLoginChallengeDigestPort digestPort;
+    @Mock AbuseProtectionEnforcementPort abuseProtection;
     @Mock MfaLoginChallengeRepositoryPort challengeRepository;
     @Mock UserRepositoryPort userRepository;
     @Mock MfaAuthenticatorRepositoryPort authenticatorRepository;
@@ -62,8 +79,11 @@ class ConfirmMfaLoginChallengeServiceTest {
 
     @BeforeEach
     void setUp() {
+        lenient().when(abuseProtection.evaluate(any()))
+            .thenReturn(AbuseProtectionDecision.allowed());
         service = new ConfirmMfaLoginChallengeService(
             digestPort,
+            abuseProtection,
             challengeRepository,
             userRepository,
             authenticatorRepository,
@@ -80,6 +100,73 @@ class ConfirmMfaLoginChallengeServiceTest {
             NOW,
             NOW.minusSeconds(60),
             NOW.minusSeconds(60)
+        );
+    }
+
+    @Test
+    void shouldEnforceAbuseProtectionBeforeChallengeLookup() {
+        when(digestPort.digest("unknown")).thenReturn(DIGEST);
+        when(challengeRepository.findUserIdByDigest(DIGEST))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.confirm(
+            command("unknown", "123456")
+        )).isInstanceOf(InvalidMfaLoginChallengeException.class);
+
+        InOrder order = inOrder(abuseProtection, challengeRepository);
+        order.verify(abuseProtection).evaluate(argThat(request ->
+            request.workflow()
+                    == AbuseProtectionWorkflow.MFA_LOGIN_CHALLENGE_CONFIRMATION
+                && request.normalizedIdentity().equals(ABUSE_IDENTITY)
+                && request.effectiveClientAddress().equals(
+                    IpAddress.parse("203.0.113.10")
+                )
+        ));
+        order.verify(challengeRepository).findUserIdByDigest(DIGEST);
+    }
+
+    @Test
+    void shouldRejectBlockedChallengeBeforeSensitiveStateAccess() {
+        when(digestPort.digest("challenge")).thenReturn(DIGEST);
+        when(abuseProtection.evaluate(any()))
+            .thenReturn(AbuseProtectionDecision.blocked(
+                AbuseProtectionDimension.IDENTITY,
+                Duration.ofSeconds(30)
+            ));
+
+        assertThatThrownBy(() -> service.confirm(
+            command("challenge", "123456")
+        )).isInstanceOf(InvalidMfaLoginChallengeException.class);
+
+        verifyNoInteractions(
+            challengeRepository,
+            userRepository,
+            authenticatorRepository,
+            secondFactorVerifier,
+            credentialIssuer
+        );
+    }
+
+    @Test
+    void shouldFailClosedBeforeSensitiveStateAccessWhenAbuseProtectionIsUnavailable() {
+        when(digestPort.digest("challenge")).thenReturn(DIGEST);
+        when(abuseProtection.evaluate(any()))
+            .thenThrow(new AbuseProtectionUnavailableException(
+                AbuseProtectionWorkflow.MFA_LOGIN_CHALLENGE_CONFIRMATION,
+                AbuseProtectionFailureMode.FAIL_CLOSED,
+                new IllegalStateException("redis unavailable")
+            ));
+
+        assertThatThrownBy(() -> service.confirm(
+            command("challenge", "123456")
+        )).isInstanceOf(MfaSecurityUnavailableException.class);
+
+        verifyNoInteractions(
+            challengeRepository,
+            userRepository,
+            authenticatorRepository,
+            secondFactorVerifier,
+            credentialIssuer
         );
     }
 
@@ -231,9 +318,42 @@ class ConfirmMfaLoginChallengeServiceTest {
         assertThatThrownBy(() -> service.confirm(
             command(" ", "123456")
         )).isInstanceOf(InvalidMfaLoginChallengeException.class);
+
+        verify(abuseProtection).evaluate(argThat(request ->
+            request.workflow()
+                    == AbuseProtectionWorkflow.MFA_LOGIN_CHALLENGE_CONFIRMATION
+                && request.normalizedIdentity().equals(
+                    MALFORMED_ABUSE_IDENTITY
+                )
+        ));
         verifyNoInteractions(
+            digestPort,
             challengeRepository,
             userRepository,
+            authenticatorRepository,
+            secondFactorVerifier,
+            credentialIssuer
+        );
+    }
+
+    @Test
+    void shouldFailClosedForMalformedChallengeBeforeStateAccess() {
+        when(abuseProtection.evaluate(any()))
+            .thenThrow(new AbuseProtectionUnavailableException(
+                AbuseProtectionWorkflow.MFA_LOGIN_CHALLENGE_CONFIRMATION,
+                AbuseProtectionFailureMode.FAIL_CLOSED,
+                new IllegalStateException("redis unavailable")
+            ));
+
+        assertThatThrownBy(() -> service.confirm(
+            command(" ", "123456")
+        )).isInstanceOf(MfaSecurityUnavailableException.class);
+
+        verifyNoInteractions(
+            digestPort,
+            challengeRepository,
+            userRepository,
+            authenticatorRepository,
             secondFactorVerifier,
             credentialIssuer
         );

--- a/src/test/java/com/nursena/payflow/user/application/service/ConfirmMfaLoginChallengeServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/ConfirmMfaLoginChallengeServiceTest.java
@@ -13,6 +13,7 @@ import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.nursena.payflow.clientcontext.domain.IpAddress;
 import com.nursena.payflow.user.application.port.in.AuthenticatedUserResult;
 import com.nursena.payflow.user.application.port.in.ConfirmMfaLoginChallengeCommand;
 import com.nursena.payflow.user.application.port.out.MfaAuthenticatorRepositoryPort;
@@ -297,7 +298,11 @@ class ConfirmMfaLoginChallengeServiceTest {
         String token,
         String code
     ) {
-        return new ConfirmMfaLoginChallengeCommand(token, code);
+        return new ConfirmMfaLoginChallengeCommand(
+            token,
+            code,
+            IpAddress.parse("203.0.113.10")
+        );
     }
 
     private static MfaLoginChallenge pending(

--- a/src/test/java/com/nursena/payflow/user/application/service/IssueStepUpGrantServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/IssueStepUpGrantServiceTest.java
@@ -3,18 +3,29 @@ package com.nursena.payflow.user.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.nursena.payflow.abuseprotection.application.exception.AbuseProtectionUnavailableException;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionFailureMode;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDimension;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
 import com.nursena.payflow.clientcontext.domain.IpAddress;
+import com.nursena.payflow.user.application.exception.MfaSecurityUnavailableException;
 import com.nursena.payflow.user.application.port.in.IssueStepUpGrantCommand;
 import com.nursena.payflow.user.application.port.in.IssueStepUpGrantResult;
 import com.nursena.payflow.user.application.port.out.MfaAuthenticatorRepositoryPort;
@@ -23,6 +34,7 @@ import com.nursena.payflow.user.domain.exception.InvalidStepUpGrantException;
 import com.nursena.payflow.user.domain.exception.InvalidStepUpPurposeException;
 import com.nursena.payflow.user.domain.exception.MfaStateConflictException;
 import com.nursena.payflow.user.domain.exception.MfaVerificationFailedException;
+import com.nursena.payflow.user.domain.exception.UserNotFoundException;
 import com.nursena.payflow.user.domain.model.EmailAddress;
 import com.nursena.payflow.user.domain.model.MfaAuthenticator;
 import com.nursena.payflow.user.domain.model.MfaLifecycleState;
@@ -34,6 +46,7 @@ import com.nursena.payflow.user.domain.model.UserStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -45,6 +58,7 @@ class IssueStepUpGrantServiceTest {
     private static final Instant NOW =
         Instant.parse("2026-08-10T10:00:00.123456Z");
 
+    @Mock AbuseProtectionEnforcementPort abuseProtection;
     @Mock UserRepositoryPort userRepository;
     @Mock MfaAuthenticatorRepositoryPort authenticatorRepository;
     @Mock MfaSecondFactorVerifier secondFactorVerifier;
@@ -54,12 +68,76 @@ class IssueStepUpGrantServiceTest {
 
     @BeforeEach
     void setUp() {
+        lenient().when(abuseProtection.evaluate(any()))
+            .thenReturn(AbuseProtectionDecision.allowed());
         service = new IssueStepUpGrantService(
+            abuseProtection,
             userRepository,
             authenticatorRepository,
             secondFactorVerifier,
             grantIssuer,
             Clock.fixed(NOW, ZoneOffset.UTC)
+        );
+    }
+
+    @Test
+    void shouldEnforceAbuseProtectionBeforeLoadingUser() {
+        when(userRepository.findByIdForUpdate(USER_ID))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.issue(
+            command("mfa-disable", "123456")
+        )).isInstanceOf(UserNotFoundException.class);
+
+        InOrder order = inOrder(abuseProtection, userRepository);
+        order.verify(abuseProtection).evaluate(argThat(request ->
+            request.workflow() == AbuseProtectionWorkflow.STEP_UP_GRANT_ISSUANCE
+                && request.normalizedIdentity().equals(USER_ID.toString())
+                && request.effectiveClientAddress().equals(
+                    IpAddress.parse("203.0.113.10")
+                )
+        ));
+        order.verify(userRepository).findByIdForUpdate(USER_ID);
+    }
+
+    @Test
+    void shouldRejectBlockedStepUpBeforeSensitiveStateAccess() {
+        when(abuseProtection.evaluate(any()))
+            .thenReturn(AbuseProtectionDecision.blocked(
+                AbuseProtectionDimension.CLIENT,
+                Duration.ofSeconds(30)
+            ));
+
+        assertThatThrownBy(() -> service.issue(
+            command("mfa-disable", "123456")
+        )).isInstanceOf(InvalidStepUpGrantException.class);
+
+        verifyNoInteractions(
+            userRepository,
+            authenticatorRepository,
+            secondFactorVerifier,
+            grantIssuer
+        );
+    }
+
+    @Test
+    void shouldFailClosedBeforeSensitiveStateAccessWhenAbuseProtectionIsUnavailable() {
+        when(abuseProtection.evaluate(any()))
+            .thenThrow(new AbuseProtectionUnavailableException(
+                AbuseProtectionWorkflow.STEP_UP_GRANT_ISSUANCE,
+                AbuseProtectionFailureMode.FAIL_CLOSED,
+                new IllegalStateException("redis unavailable")
+            ));
+
+        assertThatThrownBy(() -> service.issue(
+            command("mfa-disable", "123456")
+        )).isInstanceOf(MfaSecurityUnavailableException.class);
+
+        verifyNoInteractions(
+            userRepository,
+            authenticatorRepository,
+            secondFactorVerifier,
+            grantIssuer
         );
     }
 
@@ -86,7 +164,13 @@ class IssueStepUpGrantServiceTest {
     void shouldRejectInvalidPurposeBeforeLoadingUser() {
         assertThatThrownBy(() -> service.issue(command("free-form", "123456")))
             .isInstanceOf(InvalidStepUpPurposeException.class);
-        verifyNoInteractions(userRepository, authenticatorRepository, secondFactorVerifier, grantIssuer);
+        verifyNoInteractions(
+            abuseProtection,
+            userRepository,
+            authenticatorRepository,
+            secondFactorVerifier,
+            grantIssuer
+        );
     }
 
     @Test

--- a/src/test/java/com/nursena/payflow/user/application/service/IssueStepUpGrantServiceTest.java
+++ b/src/test/java/com/nursena/payflow/user/application/service/IssueStepUpGrantServiceTest.java
@@ -14,6 +14,7 @@ import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.nursena.payflow.clientcontext.domain.IpAddress;
 import com.nursena.payflow.user.application.port.in.IssueStepUpGrantCommand;
 import com.nursena.payflow.user.application.port.in.IssueStepUpGrantResult;
 import com.nursena.payflow.user.application.port.out.MfaAuthenticatorRepositoryPort;
@@ -144,7 +145,12 @@ class IssueStepUpGrantServiceTest {
     }
 
     private static IssueStepUpGrantCommand command(String purpose, String code) {
-        return new IssueStepUpGrantCommand(USER_ID, purpose, code);
+        return new IssueStepUpGrantCommand(
+            USER_ID,
+            purpose,
+            code,
+            IpAddress.parse("203.0.113.10")
+        );
     }
 
     private static User user(UserRole role, UserStatus status, boolean verified) {

--- a/src/test/java/com/nursena/payflow/user/integration/MfaAbuseProtectionHttpIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/MfaAbuseProtectionHttpIntegrationTest.java
@@ -1,0 +1,722 @@
+package com.nursena.payflow.user.integration;
+
+import static com.nursena.payflow.user.support
+    .MfaSecurityIntegrationTestSupport.currentTotp;
+import static com.nursena.payflow.user.support
+    .MfaSecurityIntegrationTestSupport.differentTotp;
+import static com.nursena.payflow.user.support
+    .MfaSecurityIntegrationTestSupport.insertEnabledMfaUser;
+import static com.nursena.payflow.user.support
+    .MfaSecurityIntegrationTestSupport.insertRecoveryCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request
+    .MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out
+    .MfaSecretProtectionPort;
+import com.nursena.payflow.user.support
+    .MfaSecurityIntegrationTestSupport.MfaUserFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet
+    .AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request
+    .MockHttpServletRequestBuilder;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(properties = {
+    "payflow.security.abuse-protection.enabled=true",
+    "payflow.security.abuse-protection."
+        + "mfa-login-challenge-confirmation.window=5m",
+    "payflow.security.abuse-protection."
+        + "mfa-login-challenge-confirmation.identity-limit=2",
+    "payflow.security.abuse-protection."
+        + "mfa-login-challenge-confirmation.client-limit=3",
+    "payflow.security.mfa.login-challenge.max-attempts=5",
+    "payflow.security.login-rate-limit.enabled=false"
+})
+@AutoConfigureMockMvc
+@Testcontainers
+class MfaAbuseProtectionHttpIntegrationTest {
+
+    private static final String PASSWORD =
+        "StrongPassword123!";
+
+    private static final byte[] TOTP_SECRET =
+        "01234567890123456789"
+            .getBytes(StandardCharsets.US_ASCII);
+
+    private static final String RECOVERY_CODE =
+        "AbCdEfGhIjKlMnOpQrStUv";
+
+    private static final String CLIENT_ADDRESS =
+        "203.0.113.50";
+
+    private static final int CONCURRENT_REQUESTS = 8;
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Container
+    @ServiceConnection(name = "redis")
+    private static final GenericContainer<?> REDIS =
+        new GenericContainer<>(
+            DockerImageName.parse(
+                "redis:8-alpine"
+            )
+        ).withExposedPorts(6379);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private MfaSecretProtectionPort secretProtection;
+
+    @BeforeEach
+    void cleanState() {
+        jdbcTemplate.update(
+            "DELETE FROM mfa_recovery_codes"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM mfa_login_challenges"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM mfa_authenticators"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+
+        redisTemplate.execute(
+            (RedisCallback<Void>) connection -> {
+                connection.serverCommands().flushAll();
+                return null;
+            }
+        );
+    }
+
+    @Test
+    void shouldBlockRepeatedChallengeBeforeSensitiveMutation()
+        throws Exception {
+
+        MfaUserFixture fixture = user();
+        insertRecoveryCode(
+            jdbcTemplate,
+            fixture.userId(),
+            RECOVERY_CODE
+        );
+
+        String challenge =
+            challengeToken(login(fixture.email()));
+
+        String invalidCode =
+            differentTotp(TOTP_SECRET);
+
+        confirm(
+            challenge,
+            invalidCode,
+            CLIENT_ADDRESS,
+            null,
+            null
+        )
+            .andExpect(status().isUnauthorized())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("MFA_CHALLENGE_INVALID")
+            );
+
+        confirm(
+            challenge,
+            invalidCode,
+            CLIENT_ADDRESS,
+            null,
+            null
+        )
+            .andExpect(status().isUnauthorized())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("MFA_CHALLENGE_INVALID")
+            );
+
+        assertThat(
+            attemptsRemaining(fixture)
+        ).isEqualTo(3);
+
+        confirm(
+            challenge,
+            RECOVERY_CODE,
+            CLIENT_ADDRESS,
+            null,
+            null
+        )
+            .andExpect(status().isUnauthorized())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("MFA_CHALLENGE_INVALID")
+            );
+
+        assertThat(
+            attemptsRemaining(fixture)
+        ).isEqualTo(3);
+
+        assertThat(
+            recoveryCodeConsumed(fixture)
+        ).isFalse();
+
+        assertThat(
+            challengeState(fixture)
+        ).isEqualTo("PENDING");
+
+        assertThat(
+            count("refresh_token_families")
+        ).isZero();
+
+        assertThat(
+            count("refresh_token_records")
+        ).isZero();
+
+        assertRedisKeysDoNotExpose(
+            challenge,
+            fixture.userId().toString(),
+            CLIENT_ADDRESS,
+            RECOVERY_CODE,
+            invalidCode
+        );
+    }
+
+    @Test
+    void shouldIgnoreSpoofedForwardingHeadersForClientQuota()
+        throws Exception {
+
+        List<MfaUserFixture> fixtures =
+            new ArrayList<>();
+
+        List<String> challenges =
+            new ArrayList<>();
+
+        for (int index = 0; index < 4; index++) {
+            MfaUserFixture fixture = user();
+            fixtures.add(fixture);
+            challenges.add(
+                challengeToken(
+                    login(fixture.email())
+                )
+            );
+        }
+
+        String invalidCode =
+            differentTotp(TOTP_SECRET);
+
+        for (int index = 0; index < 3; index++) {
+            String spoofed =
+                "198.51.100." + (20 + index);
+
+            confirm(
+                challenges.get(index),
+                invalidCode,
+                CLIENT_ADDRESS,
+                "for=" + spoofed,
+                spoofed
+            )
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                    jsonPath("$.code")
+                        .value(
+                            "MFA_CHALLENGE_INVALID"
+                        )
+                );
+
+            assertThat(
+                attemptsRemaining(
+                    fixtures.get(index)
+                )
+            ).isEqualTo(4);
+        }
+
+        MfaUserFixture blockedFixture =
+            fixtures.get(3);
+
+        insertRecoveryCode(
+            jdbcTemplate,
+            blockedFixture.userId(),
+            RECOVERY_CODE
+        );
+
+        confirm(
+            challenges.get(3),
+            RECOVERY_CODE,
+            CLIENT_ADDRESS,
+            "for=192.0.2.250",
+            "192.0.2.250"
+        )
+            .andExpect(status().isUnauthorized())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("MFA_CHALLENGE_INVALID")
+            );
+
+        assertThat(
+            attemptsRemaining(blockedFixture)
+        ).isEqualTo(5);
+
+        assertThat(
+            recoveryCodeConsumed(blockedFixture)
+        ).isFalse();
+
+        assertThat(
+            count("refresh_token_families")
+        ).isZero();
+
+        assertRedisKeysDoNotExpose(
+            CLIENT_ADDRESS,
+            "198.51.100.20",
+            "198.51.100.21",
+            "198.51.100.22",
+            "192.0.2.250",
+            RECOVERY_CODE
+        );
+    }
+
+    @Test
+    void shouldBoundConcurrentCredentialIssuanceByClientQuota()
+        throws Exception {
+
+        List<MfaUserFixture> fixtures =
+            new ArrayList<>();
+
+        List<String> challenges =
+            new ArrayList<>();
+
+        for (
+            int index = 0;
+            index < CONCURRENT_REQUESTS;
+            index++
+        ) {
+            MfaUserFixture fixture = user();
+            fixtures.add(fixture);
+            challenges.add(
+                challengeToken(
+                    login(fixture.email())
+                )
+            );
+        }
+
+        String validCode =
+            currentTotp(TOTP_SECRET);
+
+        List<Integer> statuses =
+            concurrentConfirmations(
+                challenges,
+                validCode
+            );
+
+        assertThat(statuses)
+            .hasSize(CONCURRENT_REQUESTS)
+            .allMatch(
+                value ->
+                    value == 200
+                        || value == 401
+            );
+
+        long successCount =
+            statuses.stream()
+                .filter(value -> value == 200)
+                .count();
+
+        assertThat(successCount)
+            .isEqualTo(3);
+
+        assertThat(
+            count("refresh_token_families")
+        ).isEqualTo(3);
+
+        assertThat(
+            count("refresh_token_records")
+        ).isEqualTo(3);
+
+        Integer consumedChallenges =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM mfa_login_challenges
+                WHERE state = 'CONSUMED'
+                """,
+                Integer.class
+            );
+
+        assertThat(consumedChallenges)
+            .isEqualTo(3);
+
+        List<String> sensitiveValues =
+            new ArrayList<>();
+
+        sensitiveValues.add(CLIENT_ADDRESS);
+        sensitiveValues.add(validCode);
+        sensitiveValues.addAll(challenges);
+
+        for (MfaUserFixture fixture : fixtures) {
+            sensitiveValues.add(
+                fixture.userId().toString()
+            );
+        }
+
+        assertRedisKeysDoNotExpose(
+            sensitiveValues.toArray(
+                String[]::new
+            )
+        );
+    }
+
+    private List<Integer> concurrentConfirmations(
+        List<String> challenges,
+        String code
+    ) throws Exception {
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(
+                CONCURRENT_REQUESTS
+            );
+
+        CountDownLatch ready =
+            new CountDownLatch(
+                CONCURRENT_REQUESTS
+            );
+
+        CountDownLatch start =
+            new CountDownLatch(1);
+
+        List<Future<Integer>> futures =
+            new ArrayList<>();
+
+        try {
+            for (String challenge : challenges) {
+                futures.add(
+                    executor.submit(() -> {
+                        ready.countDown();
+
+                        if (
+                            !start.await(
+                                10,
+                                TimeUnit.SECONDS
+                            )
+                        ) {
+                            throw new IllegalStateException(
+                                "Concurrent MFA "
+                                    + "confirmation start "
+                                    + "timed out."
+                            );
+                        }
+
+                        return confirm(
+                            challenge,
+                            code,
+                            CLIENT_ADDRESS,
+                            null,
+                            null
+                        )
+                            .andReturn()
+                            .getResponse()
+                            .getStatus();
+                    })
+                );
+            }
+
+            assertThat(
+                ready.await(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            ).isTrue();
+
+            start.countDown();
+
+            List<Integer> statuses =
+                new ArrayList<>();
+
+            for (Future<Integer> future : futures) {
+                statuses.add(
+                    future.get(
+                        30,
+                        TimeUnit.SECONDS
+                    )
+                );
+            }
+
+            return statuses;
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            ).isTrue();
+        }
+    }
+
+    private MfaUserFixture user() {
+        return insertEnabledMfaUser(
+            jdbcTemplate,
+            passwordEncoder,
+            secretProtection,
+            PASSWORD,
+            TOTP_SECRET
+        );
+    }
+
+    private MvcResult login(
+        String email
+    ) throws Exception {
+        return mockMvc.perform(
+                post("/api/v1/auth/login")
+                    .with(request -> {
+                        request.setRemoteAddr(
+                            "198.51.100.10"
+                        );
+                        return request;
+                    })
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new LoginRequest(
+                                email,
+                                PASSWORD
+                            )
+                        )
+                    )
+            )
+            .andReturn();
+    }
+
+    private String challengeToken(
+        MvcResult result
+    ) throws Exception {
+        assertThat(
+            result.getResponse().getStatus()
+        ).isEqualTo(202);
+
+        JsonNode body =
+            objectMapper.readTree(
+                result.getResponse()
+                    .getContentAsByteArray()
+            );
+
+        String challenge =
+            body.path("challengeToken")
+                .asText();
+
+        assertThat(challenge)
+            .isNotBlank();
+
+        return challenge;
+    }
+
+    private ResultActions confirm(
+        String challenge,
+        String code,
+        String remoteAddress,
+        String forwarded,
+        String xForwardedFor
+    ) throws Exception {
+
+        MockHttpServletRequestBuilder builder =
+            post(
+                "/api/v1/auth/mfa/challenges/confirm"
+            )
+                .with(request -> {
+                    request.setRemoteAddr(
+                        remoteAddress
+                    );
+                    return request;
+                })
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    objectMapper.writeValueAsString(
+                        new ChallengeRequest(
+                            challenge,
+                            code
+                        )
+                    )
+                );
+
+        if (forwarded != null) {
+            builder.header(
+                "Forwarded",
+                forwarded
+            );
+        }
+
+        if (xForwardedFor != null) {
+            builder.header(
+                "X-Forwarded-For",
+                xForwardedFor
+            );
+        }
+
+        return mockMvc.perform(builder);
+    }
+
+    private int attemptsRemaining(
+        MfaUserFixture fixture
+    ) {
+        Integer attempts =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT attempts_remaining
+                FROM mfa_login_challenges
+                WHERE user_id = ?
+                """,
+                Integer.class,
+                fixture.userId()
+            );
+
+        return attempts == null
+            ? -1
+            : attempts;
+    }
+
+    private String challengeState(
+        MfaUserFixture fixture
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT state
+            FROM mfa_login_challenges
+            WHERE user_id = ?
+            """,
+            String.class,
+            fixture.userId()
+        );
+    }
+
+    private boolean recoveryCodeConsumed(
+        MfaUserFixture fixture
+    ) {
+        Boolean consumed =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT consumed_at IS NOT NULL
+                FROM mfa_recovery_codes
+                WHERE user_id = ?
+                """,
+                Boolean.class,
+                fixture.userId()
+            );
+
+        return Boolean.TRUE.equals(consumed);
+    }
+
+    private int count(
+        String table
+    ) {
+        Integer value =
+            jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM " + table,
+                Integer.class
+            );
+
+        return value == null
+            ? 0
+            : value;
+    }
+
+    private void assertRedisKeysDoNotExpose(
+        String... sensitiveValues
+    ) {
+        Set<String> keys =
+            redisTemplate.keys(
+                "payflow:security:abuse:v1:*"
+            );
+
+        assertThat(keys)
+            .isNotNull()
+            .isNotEmpty();
+
+        for (String sensitiveValue : sensitiveValues) {
+            assertThat(sensitiveValue)
+                .isNotNull()
+                .isNotBlank();
+
+            assertThat(keys)
+                .allSatisfy(
+                    key ->
+                        assertThat(key)
+                            .doesNotContain(
+                                sensitiveValue
+                            )
+                );
+        }
+    }
+
+    private record LoginRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record ChallengeRequest(
+        String challengeToken,
+        String code
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/MfaAbuseProtectionUnavailableHttpIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/MfaAbuseProtectionUnavailableHttpIntegrationTest.java
@@ -1,0 +1,426 @@
+package com.nursena.payflow.user.integration;
+
+import static com.nursena.payflow.user.support
+    .MfaSecurityIntegrationTestSupport.insertEnabledMfaUser;
+import static com.nursena.payflow.user.support
+    .MfaSecurityIntegrationTestSupport.insertRecoveryCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request
+    .SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request
+    .MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out
+    .MfaSecretProtectionPort;
+import com.nursena.payflow.user.support
+    .MfaSecurityIntegrationTestSupport.MfaUserFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet
+    .AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(properties = {
+    "payflow.security.abuse-protection.enabled=true",
+    "payflow.security.abuse-protection."
+        + "mfa-login-challenge-confirmation.enabled=true",
+    "payflow.security.abuse-protection."
+        + "mfa-login-challenge-confirmation.dependency-failure-mode=FAIL_CLOSED",
+    "payflow.security.abuse-protection."
+        + "step-up-grant-issuance.enabled=true",
+    "payflow.security.abuse-protection."
+        + "step-up-grant-issuance.dependency-failure-mode=FAIL_CLOSED",
+    "payflow.security.mfa.login-challenge.max-attempts=5",
+    "payflow.security.login-rate-limit.enabled=false",
+    "spring.data.redis.host=127.0.0.1",
+    "spring.data.redis.port=1",
+    "spring.data.redis.connect-timeout=250ms",
+    "spring.data.redis.timeout=250ms"
+})
+@AutoConfigureMockMvc
+@Testcontainers
+class MfaAbuseProtectionUnavailableHttpIntegrationTest {
+
+    private static final String PASSWORD =
+        "StrongPassword123!";
+
+    private static final byte[] TOTP_SECRET =
+        "01234567890123456789"
+            .getBytes(StandardCharsets.US_ASCII);
+
+    private static final String RECOVERY_CODE =
+        "AbCdEfGhIjKlMnOpQrStUv";
+
+    private static final String MFA_CLIENT_ADDRESS =
+        "203.0.113.70";
+
+    private static final String STEP_UP_CLIENT_ADDRESS =
+        "203.0.113.71";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private MfaSecretProtectionPort secretProtection;
+
+    @BeforeEach
+    void cleanState() {
+        jdbcTemplate.update(
+            "DELETE FROM step_up_grants"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM mfa_recovery_codes"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM mfa_login_challenges"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM mfa_authenticators"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    @Test
+    void shouldFailClosedForBothMfaWorkflowsWithoutSensitiveMutation()
+        throws Exception {
+
+        MfaUserFixture fixture = insertEnabledMfaUser(
+            jdbcTemplate,
+            passwordEncoder,
+            secretProtection,
+            PASSWORD,
+            TOTP_SECRET
+        );
+
+        insertRecoveryCode(
+            jdbcTemplate,
+            fixture.userId(),
+            RECOVERY_CODE
+        );
+
+        String challenge = challengeToken(
+            login(fixture.email())
+        );
+
+        assertThat(attemptsRemaining(fixture))
+            .isEqualTo(5);
+        assertThat(challengeState(fixture))
+            .isEqualTo("PENDING");
+        assertThat(recoveryCodeConsumed(fixture))
+            .isFalse();
+        assertThat(grantCount())
+            .isZero();
+        assertThat(refreshFamilyCount())
+            .isZero();
+        assertThat(refreshRecordCount())
+            .isZero();
+
+        mockMvc.perform(
+                post(
+                    "/api/v1/auth/mfa/challenges/confirm"
+                )
+                    .with(request -> {
+                        request.setRemoteAddr(
+                            MFA_CLIENT_ADDRESS
+                        );
+                        return request;
+                    })
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new ChallengeRequest(
+                                challenge,
+                                RECOVERY_CODE
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isServiceUnavailable()
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value(503)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "MFA_SECURITY_UNAVAILABLE"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "MFA security processing is "
+                            + "temporarily unavailable."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/auth/mfa/challenges/confirm"
+                    )
+            );
+
+        assertThat(attemptsRemaining(fixture))
+            .isEqualTo(5);
+        assertThat(challengeState(fixture))
+            .isEqualTo("PENDING");
+        assertThat(recoveryCodeConsumed(fixture))
+            .isFalse();
+        assertThat(refreshFamilyCount())
+            .isZero();
+        assertThat(refreshRecordCount())
+            .isZero();
+
+        mockMvc.perform(
+                post(
+                    "/api/v1/users/me/step-up/grants"
+                )
+                    .with(
+                        jwt().jwt(token ->
+                            token.subject(
+                                fixture.userId().toString()
+                            )
+                                .claim("role", "USER")
+                        )
+                    )
+                    .with(request -> {
+                        request.setRemoteAddr(
+                            STEP_UP_CLIENT_ADDRESS
+                        );
+                        return request;
+                    })
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new StepUpRequest(
+                                "mfa-disable",
+                                RECOVERY_CODE
+                            )
+                        )
+                    )
+            )
+            .andExpect(
+                status().isServiceUnavailable()
+            )
+            .andExpect(
+                jsonPath("$.status")
+                    .value(503)
+            )
+            .andExpect(
+                jsonPath("$.code")
+                    .value(
+                        "MFA_SECURITY_UNAVAILABLE"
+                    )
+            )
+            .andExpect(
+                jsonPath("$.message")
+                    .value(
+                        "MFA security processing is "
+                            + "temporarily unavailable."
+                    )
+            )
+            .andExpect(
+                jsonPath("$.path")
+                    .value(
+                        "/api/v1/users/me/step-up/grants"
+                    )
+            );
+
+        assertThat(attemptsRemaining(fixture))
+            .isEqualTo(5);
+        assertThat(challengeState(fixture))
+            .isEqualTo("PENDING");
+        assertThat(recoveryCodeConsumed(fixture))
+            .isFalse();
+        assertThat(grantCount())
+            .isZero();
+        assertThat(refreshFamilyCount())
+            .isZero();
+        assertThat(refreshRecordCount())
+            .isZero();
+    }
+
+    private MvcResult login(
+        String email
+    ) throws Exception {
+        return mockMvc.perform(
+                post("/api/v1/auth/login")
+                    .with(request -> {
+                        request.setRemoteAddr(
+                            "198.51.100.10"
+                        );
+                        return request;
+                    })
+                    .contentType(
+                        MediaType.APPLICATION_JSON
+                    )
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new LoginRequest(
+                                email,
+                                PASSWORD
+                            )
+                        )
+                    )
+            )
+            .andReturn();
+    }
+
+    private String challengeToken(
+        MvcResult result
+    ) throws Exception {
+        assertThat(
+            result.getResponse().getStatus()
+        ).isEqualTo(202);
+
+        JsonNode body = objectMapper.readTree(
+            result.getResponse()
+                .getContentAsByteArray()
+        );
+
+        String challenge = body
+            .path("challengeToken")
+            .asText();
+
+        assertThat(challenge)
+            .isNotBlank();
+
+        return challenge;
+    }
+
+    private int attemptsRemaining(
+        MfaUserFixture fixture
+    ) {
+        Integer value = jdbcTemplate.queryForObject(
+            """
+            SELECT attempts_remaining
+            FROM mfa_login_challenges
+            WHERE user_id = ?
+            """,
+            Integer.class,
+            fixture.userId()
+        );
+
+        return value == null ? -1 : value;
+    }
+
+    private String challengeState(
+        MfaUserFixture fixture
+    ) {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT state
+            FROM mfa_login_challenges
+            WHERE user_id = ?
+            """,
+            String.class,
+            fixture.userId()
+        );
+    }
+
+    private boolean recoveryCodeConsumed(
+        MfaUserFixture fixture
+    ) {
+        Boolean consumed = jdbcTemplate.queryForObject(
+            """
+            SELECT consumed_at IS NOT NULL
+            FROM mfa_recovery_codes
+            WHERE user_id = ?
+            """,
+            Boolean.class,
+            fixture.userId()
+        );
+
+        return Boolean.TRUE.equals(consumed);
+    }
+
+    private int grantCount() {
+        return count("step_up_grants");
+    }
+
+    private int refreshFamilyCount() {
+        return count("refresh_token_families");
+    }
+
+    private int refreshRecordCount() {
+        return count("refresh_token_records");
+    }
+
+    private int count(
+        String table
+    ) {
+        Integer value = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM " + table,
+            Integer.class
+        );
+
+        return value == null ? 0 : value;
+    }
+
+    private record LoginRequest(
+        String email,
+        String password
+    ) {
+    }
+
+    private record ChallengeRequest(
+        String challengeToken,
+        String code
+    ) {
+    }
+
+    private record StepUpRequest(
+        String purpose,
+        String code
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/integration/StepUpAbuseProtectionHttpIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/user/integration/StepUpAbuseProtectionHttpIntegrationTest.java
@@ -1,0 +1,614 @@
+package com.nursena.payflow.user.integration;
+
+import static com.nursena.payflow.user.support
+    .MfaSecurityIntegrationTestSupport.differentTotp;
+import static com.nursena.payflow.user.support
+    .MfaSecurityIntegrationTestSupport.insertEnabledMfaUser;
+import static com.nursena.payflow.user.support
+    .MfaSecurityIntegrationTestSupport.insertRecoveryCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request
+    .SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request
+    .MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.user.application.port.out
+    .MfaSecretProtectionPort;
+import com.nursena.payflow.user.support
+    .MfaSecurityIntegrationTestSupport.MfaUserFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet
+    .AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request
+    .MockHttpServletRequestBuilder;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(properties = {
+    "payflow.security.abuse-protection.enabled=true",
+    "payflow.security.abuse-protection."
+        + "step-up-grant-issuance.window=5m",
+    "payflow.security.abuse-protection."
+        + "step-up-grant-issuance.identity-limit=2",
+    "payflow.security.abuse-protection."
+        + "step-up-grant-issuance.client-limit=3",
+    "payflow.security.login-rate-limit.enabled=false"
+})
+@AutoConfigureMockMvc
+@Testcontainers
+class StepUpAbuseProtectionHttpIntegrationTest {
+
+    private static final String PASSWORD =
+        "StrongPassword123!";
+
+    private static final byte[] TOTP_SECRET =
+        "01234567890123456789"
+            .getBytes(StandardCharsets.US_ASCII);
+
+    private static final String RECOVERY_CODE =
+        "AbCdEfGhIjKlMnOpQrStUv";
+
+    private static final String CLIENT_ADDRESS =
+        "203.0.113.60";
+
+    private static final int CONCURRENT_REQUESTS = 8;
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Container
+    @ServiceConnection(name = "redis")
+    private static final GenericContainer<?> REDIS =
+        new GenericContainer<>(
+            DockerImageName.parse(
+                "redis:8-alpine"
+            )
+        ).withExposedPorts(6379);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private MfaSecretProtectionPort secretProtection;
+
+    @BeforeEach
+    void cleanState() {
+        jdbcTemplate.update(
+            "DELETE FROM step_up_grants"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM mfa_recovery_codes"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM mfa_login_challenges"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_records"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM refresh_token_families"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM mfa_authenticators"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+
+        redisTemplate.execute(
+            (RedisCallback<Void>) connection -> {
+                connection.serverCommands().flushAll();
+                return null;
+            }
+        );
+    }
+
+    @Test
+    void shouldBlockSubjectQuotaBeforeRecoveryCodeOrGrantMutation()
+        throws Exception {
+
+        MfaUserFixture fixture = user();
+        insertRecoveryCode(
+            jdbcTemplate,
+            fixture.userId(),
+            RECOVERY_CODE
+        );
+
+        String invalidCode =
+            differentTotp(TOTP_SECRET);
+
+        stepUp(
+            fixture,
+            invalidCode,
+            CLIENT_ADDRESS,
+            null,
+            null
+        )
+            .andExpect(status().isUnauthorized())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("MFA_VERIFICATION_FAILED")
+            );
+
+        stepUp(
+            fixture,
+            invalidCode,
+            CLIENT_ADDRESS,
+            null,
+            null
+        )
+            .andExpect(status().isUnauthorized())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("MFA_VERIFICATION_FAILED")
+            );
+
+        assertThat(grantCount()).isZero();
+        assertThat(
+            recoveryCodeConsumed(fixture)
+        ).isFalse();
+
+        stepUp(
+            fixture,
+            RECOVERY_CODE,
+            CLIENT_ADDRESS,
+            null,
+            null
+        )
+            .andExpect(status().isForbidden())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("STEP_UP_INVALID")
+            );
+
+        assertThat(grantCount()).isZero();
+        assertThat(
+            recoveryCodeConsumed(fixture)
+        ).isFalse();
+
+        assertRedisKeysDoNotExpose(
+            fixture.userId().toString(),
+            CLIENT_ADDRESS,
+            RECOVERY_CODE,
+            invalidCode
+        );
+    }
+
+    @Test
+    void shouldIgnoreSpoofedForwardingHeadersForClientQuota()
+        throws Exception {
+
+        List<MfaUserFixture> fixtures =
+            new ArrayList<>();
+
+        for (int index = 0; index < 4; index++) {
+            fixtures.add(user());
+        }
+
+        String invalidCode =
+            differentTotp(TOTP_SECRET);
+
+        for (int index = 0; index < 3; index++) {
+            String spoofed =
+                "198.51.100." + (30 + index);
+
+            stepUp(
+                fixtures.get(index),
+                invalidCode,
+                CLIENT_ADDRESS,
+                "for=" + spoofed,
+                spoofed
+            )
+                .andExpect(status().isUnauthorized())
+                .andExpect(
+                    jsonPath("$.code")
+                        .value(
+                            "MFA_VERIFICATION_FAILED"
+                        )
+                );
+        }
+
+        MfaUserFixture blockedFixture =
+            fixtures.get(3);
+
+        insertRecoveryCode(
+            jdbcTemplate,
+            blockedFixture.userId(),
+            RECOVERY_CODE
+        );
+
+        stepUp(
+            blockedFixture,
+            RECOVERY_CODE,
+            CLIENT_ADDRESS,
+            "for=192.0.2.240",
+            "192.0.2.240"
+        )
+            .andExpect(status().isForbidden())
+            .andExpect(
+                jsonPath("$.code")
+                    .value("STEP_UP_INVALID")
+            );
+
+        assertThat(grantCount()).isZero();
+        assertThat(
+            recoveryCodeConsumed(blockedFixture)
+        ).isFalse();
+
+        assertRedisKeysDoNotExpose(
+            CLIENT_ADDRESS,
+            "198.51.100.30",
+            "198.51.100.31",
+            "198.51.100.32",
+            "192.0.2.240",
+            blockedFixture.userId().toString(),
+            RECOVERY_CODE,
+            invalidCode
+        );
+    }
+
+    @Test
+    void shouldBoundConcurrentGrantAndRecoveryCodeConsumptionByClientQuota()
+        throws Exception {
+
+        List<MfaUserFixture> fixtures =
+            new ArrayList<>();
+
+        List<String> recoveryCodes =
+            new ArrayList<>();
+
+        for (
+            int index = 0;
+            index < CONCURRENT_REQUESTS;
+            index++
+        ) {
+            MfaUserFixture fixture = user();
+            String recoveryCode =
+                "ConcurrentCode0"
+                    + index
+                    + "AbCdEf";
+
+            fixtures.add(fixture);
+            recoveryCodes.add(recoveryCode);
+
+            insertRecoveryCode(
+                jdbcTemplate,
+                fixture.userId(),
+                recoveryCode
+            );
+        }
+
+        List<Integer> statuses =
+            concurrentStepUps(
+                fixtures,
+                recoveryCodes
+            );
+
+        assertThat(statuses)
+            .hasSize(CONCURRENT_REQUESTS)
+            .allMatch(
+                value ->
+                    value == 200
+                        || value == 403
+            );
+
+        long successCount =
+            statuses.stream()
+                .filter(value -> value == 200)
+                .count();
+
+        assertThat(successCount)
+            .isEqualTo(3);
+
+        assertThat(grantCount())
+            .isEqualTo(3);
+
+        assertThat(consumedRecoveryCodeCount())
+            .isEqualTo(3);
+
+        List<String> sensitiveValues =
+            new ArrayList<>();
+
+        sensitiveValues.add(CLIENT_ADDRESS);
+        sensitiveValues.addAll(recoveryCodes);
+
+        for (MfaUserFixture fixture : fixtures) {
+            sensitiveValues.add(
+                fixture.userId().toString()
+            );
+        }
+
+        assertRedisKeysDoNotExpose(
+            sensitiveValues.toArray(
+                String[]::new
+            )
+        );
+    }
+
+    private List<Integer> concurrentStepUps(
+        List<MfaUserFixture> fixtures,
+        List<String> recoveryCodes
+    ) throws Exception {
+
+        if (fixtures.size() != recoveryCodes.size()) {
+            throw new IllegalArgumentException(
+                "fixtures and recoveryCodes must align"
+            );
+        }
+
+        ExecutorService executor =
+            Executors.newFixedThreadPool(
+                CONCURRENT_REQUESTS
+            );
+
+        CountDownLatch ready =
+            new CountDownLatch(
+                CONCURRENT_REQUESTS
+            );
+
+        CountDownLatch start =
+            new CountDownLatch(1);
+
+        List<Future<Integer>> futures =
+            new ArrayList<>();
+
+        try {
+            for (int index = 0; index < fixtures.size(); index++) {
+                MfaUserFixture fixture = fixtures.get(index);
+                String recoveryCode = recoveryCodes.get(index);
+
+                futures.add(
+                    executor.submit(() -> {
+                        ready.countDown();
+
+                        if (
+                            !start.await(
+                                10,
+                                TimeUnit.SECONDS
+                            )
+                        ) {
+                            throw new IllegalStateException(
+                                "Concurrent step-up start "
+                                    + "timed out."
+                            );
+                        }
+
+                        return stepUp(
+                            fixture,
+                            recoveryCode,
+                            CLIENT_ADDRESS,
+                            null,
+                            null
+                        )
+                            .andReturn()
+                            .getResponse()
+                            .getStatus();
+                    })
+                );
+            }
+
+            assertThat(
+                ready.await(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            ).isTrue();
+
+            start.countDown();
+
+            List<Integer> statuses =
+                new ArrayList<>();
+
+            for (Future<Integer> future : futures) {
+                statuses.add(
+                    future.get(
+                        30,
+                        TimeUnit.SECONDS
+                    )
+                );
+            }
+
+            return statuses;
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+
+            assertThat(
+                executor.awaitTermination(
+                    10,
+                    TimeUnit.SECONDS
+                )
+            ).isTrue();
+        }
+    }
+
+    private MfaUserFixture user() {
+        return insertEnabledMfaUser(
+            jdbcTemplate,
+            passwordEncoder,
+            secretProtection,
+            PASSWORD,
+            TOTP_SECRET
+        );
+    }
+
+    private ResultActions stepUp(
+        MfaUserFixture fixture,
+        String code,
+        String remoteAddress,
+        String forwarded,
+        String xForwardedFor
+    ) throws Exception {
+
+        MockHttpServletRequestBuilder builder =
+            post(
+                "/api/v1/users/me/step-up/grants"
+            )
+                .with(
+                    jwt().jwt(token ->
+                        token.subject(
+                            fixture.userId().toString()
+                        )
+                            .claim("role", "USER")
+                    )
+                )
+                .with(request -> {
+                    request.setRemoteAddr(
+                        remoteAddress
+                    );
+                    return request;
+                })
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    objectMapper.writeValueAsString(
+                        new StepUpRequest(
+                            "mfa-disable",
+                            code
+                        )
+                    )
+                );
+
+        if (forwarded != null) {
+            builder.header(
+                "Forwarded",
+                forwarded
+            );
+        }
+
+        if (xForwardedFor != null) {
+            builder.header(
+                "X-Forwarded-For",
+                xForwardedFor
+            );
+        }
+
+        return mockMvc.perform(builder);
+    }
+
+    private boolean recoveryCodeConsumed(
+        MfaUserFixture fixture
+    ) {
+        Boolean consumed =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT consumed_at IS NOT NULL
+                FROM mfa_recovery_codes
+                WHERE user_id = ?
+                """,
+                Boolean.class,
+                fixture.userId()
+            );
+
+        return Boolean.TRUE.equals(consumed);
+    }
+
+    private int consumedRecoveryCodeCount() {
+        Integer value =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM mfa_recovery_codes
+                WHERE consumed_at IS NOT NULL
+                """,
+                Integer.class
+            );
+
+        return value == null
+            ? 0
+            : value;
+    }
+
+    private int grantCount() {
+        Integer value =
+            jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM step_up_grants",
+                Integer.class
+            );
+
+        return value == null
+            ? 0
+            : value;
+    }
+
+    private void assertRedisKeysDoNotExpose(
+        String... sensitiveValues
+    ) {
+        Set<String> keys =
+            redisTemplate.keys(
+                "payflow:security:abuse:v1:*"
+            );
+
+        assertThat(keys)
+            .isNotNull()
+            .isNotEmpty();
+
+        for (String sensitiveValue : sensitiveValues) {
+            assertThat(sensitiveValue)
+                .isNotNull()
+                .isNotBlank();
+
+            assertThat(keys)
+                .allSatisfy(
+                    key ->
+                        assertThat(key)
+                            .doesNotContain(
+                                sensitiveValue
+                            )
+                );
+        }
+    }
+
+    private record StepUpRequest(
+        String purpose,
+        String code
+    ) {
+    }
+}

--- a/src/test/java/com/nursena/payflow/user/support/MfaSecurityIntegrationTestSupport.java
+++ b/src/test/java/com/nursena/payflow/user/support/MfaSecurityIntegrationTestSupport.java
@@ -1,0 +1,166 @@
+package com.nursena.payflow.user.support;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.nursena.payflow.user.application.port.out.MfaSecretProtectionPort;
+import com.nursena.payflow.user.domain.model.ProtectedMfaSecret;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public final class MfaSecurityIntegrationTestSupport {
+
+    private MfaSecurityIntegrationTestSupport() {
+    }
+
+    public static MfaUserFixture insertEnabledMfaUser(
+        JdbcTemplate jdbcTemplate,
+        PasswordEncoder passwordEncoder,
+        MfaSecretProtectionPort secretProtection,
+        String password,
+        byte[] totpSecret
+    ) {
+        UUID userId = UUID.randomUUID();
+        String email = userId + "@example.com";
+        Instant now = Instant.now();
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                email_verified_at,
+                created_at,
+                updated_at
+            ) VALUES (?, ?, ?, 'USER', 'ACTIVE', ?, ?, ?)
+            """,
+            userId,
+            email,
+            passwordEncoder.encode(password),
+            Timestamp.from(now),
+            Timestamp.from(now),
+            Timestamp.from(now)
+        );
+
+        ProtectedMfaSecret protectedSecret =
+            secretProtection.protect(
+                userId,
+                Arrays.copyOf(
+                    totpSecret,
+                    totpSecret.length
+                )
+            );
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO mfa_authenticators (
+                user_id,
+                state,
+                protected_secret,
+                enrollment_expires_at,
+                activated_at,
+                created_at,
+                updated_at
+            ) VALUES (?, 'ENABLED', ?, NULL, ?, ?, ?)
+            """,
+            userId,
+            protectedSecret.value(),
+            Timestamp.from(now),
+            Timestamp.from(now.minusSeconds(60)),
+            Timestamp.from(now)
+        );
+
+        return new MfaUserFixture(userId, email);
+    }
+
+    public static void insertRecoveryCode(
+        JdbcTemplate jdbcTemplate,
+        UUID userId,
+        String recoveryCode
+    ) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256")
+            .digest(
+                recoveryCode.getBytes(
+                    StandardCharsets.US_ASCII
+                )
+            );
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO mfa_recovery_codes (
+                id,
+                user_id,
+                code_digest,
+                created_at,
+                consumed_at
+            ) VALUES (?, ?, ?, ?, NULL)
+            """,
+            UUID.randomUUID(),
+            userId,
+            digest,
+            Timestamp.from(Instant.now())
+        );
+    }
+
+    public static String currentTotp(
+        byte[] secret
+    ) throws Exception {
+        long counter = Math.floorDiv(
+            Instant.now().getEpochSecond(),
+            30L
+        );
+
+        Mac mac = Mac.getInstance("HmacSHA1");
+        mac.init(
+            new SecretKeySpec(
+                secret,
+                "HmacSHA1"
+            )
+        );
+
+        byte[] digest = mac.doFinal(
+            ByteBuffer.allocate(Long.BYTES)
+                .putLong(counter)
+                .array()
+        );
+
+        int offset = digest[digest.length - 1] & 0x0f;
+
+        int binary =
+            ((digest[offset] & 0x7f) << 24)
+                | ((digest[offset + 1] & 0xff) << 16)
+                | ((digest[offset + 2] & 0xff) << 8)
+                | (digest[offset + 3] & 0xff);
+
+        return String.format(
+            "%06d",
+            binary % 1_000_000
+        );
+    }
+
+    public static String differentTotp(
+        byte[] secret
+    ) throws Exception {
+        String current = currentTotp(secret);
+
+        return current.substring(0, 5)
+            + (current.endsWith("0") ? "1" : "0");
+    }
+
+    public record MfaUserFixture(
+        UUID userId,
+        String email
+    ) {
+    }
+}


### PR DESCRIPTION
## Summary

Completes v0.15.0 Increment 4 by wiring the generalized abuse-protection foundation into MFA login-challenge confirmation and step-up grant issuance.

- resolves effective client identity through the existing trusted `ClientAddressResolver` boundary
- enforces MFA challenge quotas before challenge lookup/state mutation/second-factor consumption/credential issuance
- derives a fixed-length non-reversible challenge identity for Redis enforcement, including malformed challenge inputs
- enforces step-up quotas from authenticated JWT subject + trusted client before authenticator/proof/grant mutation
- preserves existing coarse public MFA/step-up error contracts and fail-closed Redis dependency behavior
- keeps login limiter semantics, Redis algorithm, observability scope, performance work, and release/Postman work unchanged
- aligns the generalized abuse-protection guide, threat model, v0.15.0 roadmap, and executable documentation contracts with the delivered Increment 4 behavior

## Security verification

Coverage added for:

- blocked MFA confirmation leaving attempt budget, challenge state, recovery codes, and credentials untouched
- blocked step-up issuance leaving recovery codes and grants untouched
- spoofed `Forwarded` / `X-Forwarded-For` values not bypassing client quotas
- concurrent real-Redis requests bounding protected side effects by configured quotas
- Redis key material excluding raw challenges, proofs, recovery codes, subjects, and client addresses
- real Redis dependency failure returning `503 MFA_SECURITY_UNAVAILABLE` without sensitive mutation

## Validation

Local final implementation regression gate on commit `cec4661f78dc8a7b294f18b6bb3c8177390fbbae`:

- focused Increment 4 security regression: passed
- `mvnw.cmd -B -ntp clean verify`: passed
- tests: **1535 passed, 0 failures, 0 errors, 0 skipped**
- artifact: `payflow-0.15.0-SNAPSHOT.jar`
- `git diff --check`: passed

Documentation alignment commit `1d6af81d17dd3a88b51a0e01ecc1d0e99138e932`:

- exactly 3 Markdown files changed
- `git diff --check`: passed
- UTF-8 without BOM verified
- v0.15.0 Increment 4 roadmap contracts marked complete only after executable verification passed

CI contract correction commit `d6a7ac1a4347ef6acbaddaf36ba6df4b73241864`:

- replaces stale Increment 3 documentation literals in two executable configuration contracts with durable invariants
- focused contract regression: passed
- full `mvnw.cmd -B -ntp clean verify`: passed
- tests: **1535 passed, 0 failures, 0 errors, 0 skipped**
- exactly 2 test files changed; no production or documentation changes

Current branch state: **7 commits ahead, 0 behind `main`**.

Protected GitHub checks (`build-and-test` and `docker-smoke`) on the current PR HEAD must pass before merge.

Refs #159
Part of #149