### PR TITLE
feat(observability): add abuse-protection observability

### DIFF
--- a/docs/abuse-protection.md
+++ b/docs/abuse-protection.md
@@ -2,16 +2,21 @@
 
 ## Current delivery state
 
-Increment 4 extends the shared Redis foundation across email-verification,
-password-recovery, MFA login-challenge confirmation, and step-up grant issuance.
-Account-action requests evaluate normalized email and the trusted effective
-client before account lookup. MFA challenge confirmation evaluates a
-fixed-length, non-reversible challenge identifier and the trusted effective
-client before challenge lookup or sensitive state mutation. Step-up issuance
-evaluates the authenticated JWT subject and trusted effective client before user
-or authenticator locking, second-factor consumption, or grant creation.
-`ABUSE_PROTECTION_ENABLED` remains `false` by default so activation is an
-explicit deployment decision. The login limiter remains unchanged.
+Increment 5 builds operational observability on the shared Redis enforcement
+foundation already used by email-verification, password-recovery, MFA
+login-challenge confirmation, and step-up grant issuance. Account-action
+requests evaluate normalized email and the trusted effective client before
+account lookup. MFA challenge confirmation evaluates a fixed-length,
+non-reversible challenge identifier and the trusted effective client before
+challenge lookup or sensitive state mutation. Step-up issuance evaluates the
+authenticated JWT subject and trusted effective client before user or
+authenticator locking, second-factor consumption, or grant creation.
+
+Bounded Micrometer decisions, Redis-failure metrics, a dedicated Grafana
+dashboard, Prometheus alerts, and an operations runbook now cover these
+workflows without changing enforcement semantics. `ABUSE_PROTECTION_ENABLED`
+remains `false` by default so activation is an explicit deployment decision.
+The login limiter remains unchanged.
 
 ## Policy contract
 
@@ -90,10 +95,19 @@ an implicit exemption from later review.
 
 ## Privacy and observability
 
-Future enforcement may emit only finite workflow, dimension, decision, and
-failure classifications. Email addresses, raw client addresses, credentials,
-proofs, tokens, digests, Redis keys, counts, and TTL values are prohibited from
-observable output.
+Generalized enforcement emits only finite application-owned classifications.
+`payflow.security.abuse_protection.decisions` uses bounded `workflow`,
+`outcome`, and `reason` tags. `payflow.security.abuse_protection.redis.failures`
+uses bounded `workflow` and `failure_mode` tags.
+
+Email addresses, user identifiers, JWT subjects, raw client addresses,
+credentials, proofs, tokens, digests, Redis keys, counters, TTL values, request
+URIs, and raw exception classes are prohibited from metric labels, dashboard
+dimensions, alert annotations, and incident notes.
+
+See the [Abuse-Protection Operations
+Runbook](operations/abuse-protection-observability.md) for safe triage,
+mitigation, rollback, and false-positive handling.
 
 ## Compatibility
 

--- a/docs/abuse-protection.md
+++ b/docs/abuse-protection.md
@@ -14,8 +14,9 @@ authenticator locking, second-factor consumption, or grant creation.
 
 Bounded Micrometer decisions, Redis-failure metrics, a dedicated Grafana
 dashboard, Prometheus alerts, and an operations runbook now cover these
-workflows without changing enforcement semantics. `ABUSE_PROTECTION_ENABLED`
-remains `false` by default so activation is an explicit deployment decision.
+workflows without changing enforcement semantics.
+`ABUSE_PROTECTION_ENABLED` remains `false` by default so activation is an
+explicit deployment decision.
 The login limiter remains unchanged.
 
 ## Policy contract

--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -1,12 +1,12 @@
 # Local Alert Notifications
 
-PayFlow uses Prometheus Alertmanager to route transactional outbox alerts and
+PayFlow uses Prometheus Alertmanager to route repository-provisioned alerts and
 Mailpit to capture email notifications in the local development environment.
 
 The local notification flow is:
 
 ```text
-PayFlow metrics
+PayFlow /actuator/prometheus
     |
     v
 Prometheus alert rules
@@ -19,13 +19,184 @@ Mailpit SMTP
     |
     v
 Mailpit web interface
+```
 
 ## Notification flow
+
+Prometheus loads every `*.yml` file under
+`observability/prometheus/rules/` and sends firing alerts to
+`alertmanager:9093`. Alertmanager uses
+`observability/alertmanager/alertmanager.yml` as the repository source of truth.
+
+The Compose `monitoring` profile provisions Prometheus, Alertmanager, Grafana,
+and Mailpit. The `app` profile also starts Mailpit because PayFlow account-action
+mail delivery uses the same local SMTP capture service.
+
 ## Local endpoints
+
+| Component | Address |
+|---|---|
+| Prometheus alerts | http://localhost:9090/alerts |
+| Alertmanager | http://localhost:9093 |
+| Grafana | http://localhost:3000 |
+| Mailpit web interface | http://localhost:8025 |
+| Mailpit SMTP | localhost:1025 |
+
+These ports are intended for local development only.
+
 ## Alert routing
+
+Alertmanager groups on `alertname`, `service`, `component`, and `severity`.
+
+- `severity="critical"` routes to the `critical-email` receiver and local
+  address `oncall@payflow.local`
+- `severity="warning"` routes to the `warning-email` receiver and local
+  address `engineering@payflow.local`
+- unmatched alerts use the `null` receiver
+
+Both email receivers use Mailpit and send resolved notifications. The addresses
+are development-only routing targets; no external mail delivery is implied.
+
+## Generalized abuse-protection alerts
+
+Increment 5 provisions these bounded alerts:
+
+| Alert | Severity | Trigger |
+|---|---|---|
+| `PayFlowAbuseProtectionRedisFailures` | Critical | Redis dependency failure count is greater than zero over five minutes and remains active for one minute |
+| `PayFlowAbuseProtectionBlockingPressure` | Warning | A workflow records at least 25 blocked decisions over ten minutes and remains above the threshold for five minutes |
+| `PayFlowAbuseProtectionDependencyBypass` | Critical | A fail-open dependency bypass occurs over five minutes and remains active for one minute |
+
+The alert rules aggregate only bounded workflow and failure classifications.
+Alert annotations must not contain identities, credentials, raw client
+addresses, Redis keys, request URIs, or raw exception classes.
+
 ## Grouping and inhibition
+
+Alertmanager waits 10 seconds before sending a new group, uses a 30-second group
+interval, and repeats unchanged notifications every four hours.
+
+When `PayFlowMetricsTargetDown` is firing at critical severity, warning alerts
+with the same `service` and `component` are inhibited. This prevents secondary
+warning noise when the metrics target itself is unavailable.
+
 ## Configuration validation
+
+Validate the resolved Compose model:
+
+```powershell
+docker compose `
+    --profile monitoring `
+    config `
+    --quiet
+```
+
+Validate Prometheus and every referenced rule file:
+
+```powershell
+docker compose `
+    --profile monitoring `
+    run `
+    --rm `
+    --no-deps `
+    --entrypoint /bin/promtool `
+    prometheus `
+    check config `
+    /etc/prometheus/prometheus.yml
+```
+
+Validate the generalized abuse-protection rule file directly:
+
+```powershell
+docker compose `
+    --profile monitoring `
+    run `
+    --rm `
+    --no-deps `
+    --entrypoint /bin/promtool `
+    prometheus `
+    check rules `
+    /etc/prometheus/rules/abuse-protection-alerts.yml
+```
+
 ## Notification smoke test
+
+Start the monitoring profile and submit a synthetic warning alert directly to
+the local Alertmanager API. Use only bounded synthetic labels; do not insert real
+user, credential, client, or Redis data.
+
+```powershell
+docker compose `
+    --profile monitoring `
+    up `
+    -d `
+    prometheus alertmanager mailpit
+
+$Now = [DateTimeOffset]::UtcNow
+
+$Body = @(
+    @{
+        labels = @{
+            alertname = 'PayFlowLocalNotificationSmoke'
+            severity = 'warning'
+            service = 'payflow'
+            component = 'abuse-protection'
+        }
+        annotations = @{
+            summary = 'Local notification smoke test'
+            description = 'Synthetic bounded local alert'
+        }
+        startsAt = $Now.ToString('o')
+        endsAt = $Now.AddMinutes(2).ToString('o')
+    }
+) | ConvertTo-Json -Depth 5
+
+Invoke-RestMethod `
+    -Method Post `
+    -Uri 'http://localhost:9093/api/v2/alerts' `
+    -ContentType 'application/json' `
+    -Body $Body
+```
+
+Open Mailpit at `http://localhost:8025` and verify that the warning notification
+arrives for `engineering@payflow.local`. The synthetic alert expires after two
+minutes.
+
 ## Health checks
+
+Use the local readiness endpoints when diagnosing notification delivery:
+
+```powershell
+Invoke-WebRequest -UseBasicParsing http://localhost:9090/-/ready
+Invoke-WebRequest -UseBasicParsing http://localhost:9093/-/ready
+Invoke-WebRequest -UseBasicParsing http://localhost:8025
+```
+
+Also inspect:
+
+```powershell
+docker compose `
+    --profile monitoring `
+    ps
+```
+
 ## Troubleshooting
+
+If Prometheus shows a firing alert but Mailpit remains empty:
+
+1. confirm Alertmanager is reachable from Prometheus at `alertmanager:9093`
+2. inspect Alertmanager status and the active route
+3. confirm the alert has `severity="warning"` or `severity="critical"`
+4. confirm Mailpit is running and SMTP port `1025` is available inside Compose
+5. inspect Alertmanager container logs without copying sensitive request data
+   into tickets or incident notes
+
+For generalized abuse-protection alerts, follow the dedicated
+[operations runbook](operations/abuse-protection-observability.md).
+
 ## Local development scope
+
+Mailpit is a local capture service, not a production notification provider.
+Production routing, retention, access control, and receiver ownership are
+deployment concerns and must be configured outside this repository's local
+Compose defaults.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,13 +1,16 @@
 # Local Monitoring
 
-PayFlow includes a local observability stack for monitoring the transactional outbox publisher.
+PayFlow includes a local observability stack for application health, transactional
+outbox delivery, Kafka consumer failures, and generalized abuse protection.
 
 The stack consists of:
 
 - Spring Boot Actuator and Micrometer
 - Prometheus
-- Grafana
 - Prometheus alerting rules
+- Alertmanager
+- Grafana
+- Mailpit for local notification capture
 
 ## Architecture
 
@@ -17,13 +20,21 @@ The stack consists of:
       v
     Prometheus
       |
-      +-- Metrics and PromQL queries
-      +-- Transactional outbox alert rules
+      +-- Metrics and bounded PromQL queries
+      +-- Outbox, Kafka-consumer, and abuse-protection rules
+      |
+      +------> Alertmanager ------> Mailpit
       |
       v
     Grafana
       |
-      +-- PayFlow Transactional Outbox dashboard
+      +-- Transactional Outbox dashboard
+      +-- Kafka Consumer Failures dashboard
+      +-- Abuse Protection dashboard
+
+Prometheus loads every committed rule file from
+`observability/prometheus/rules/*.yml` and forwards firing alerts to the
+repository-provisioned Alertmanager service.
 
 ## Prerequisites
 
@@ -80,51 +91,58 @@ docker compose `
 | Prometheus | http://localhost:9090 |
 | Prometheus targets | http://localhost:9090/targets |
 | Prometheus alerts | http://localhost:9090/alerts |
+| Alertmanager | http://localhost:9093 |
 | Grafana | http://localhost:3000 |
+| Mailpit | http://localhost:8025 |
 | Outbox dashboard | http://localhost:3000/d/payflow-outbox-overview/payflow-transactional-outbox |
+| Kafka failures dashboard | http://localhost:3000/d/payflow-kafka-consumer-failures/payflow-kafka-consumer-failures |
+| Abuse-protection dashboard | http://localhost:3000/d/payflow-abuse-protection/payflow-abuse-protection |
 
 Grafana credentials are read from the local `.env` file.
 
-## Grafana dashboard
+## Grafana dashboards
 
-Grafana automatically provisions the `PayFlow Transactional Outbox` dashboard from:
+Grafana provisions repository-owned, read-only dashboards from:
 
-    observability/grafana/dashboards/outbox-overview.json
+    observability/grafana/dashboards/
+
+The current dashboards are:
+
+- `outbox-overview.json` — transactional outbox backlog, age, polling, and outcomes
+- `kafka-consumer-failures.json` — bounded consumer failure, retry, and recovery signals
+- `abuse-protection.json` — bounded workflow decisions, rejection reasons, disabled
+  enforcement, dependency bypass, and Redis dependency failures
 
 Dashboard provisioning is configured in:
 
     observability/grafana/provisioning/dashboards/dashboards.yml
 
-The dashboard includes:
-
-- Active outbox backlog
-- Age of the oldest active event
-- Terminal publishing outcomes
-- Polling success ratio
-- Event outcome throughput
-- Average polling duration
-- Backlog history
-- Oldest-event age history
-
-The provisioned dashboard is read-only. Repository files remain the source of truth.
+Repository JSON files remain the source of truth. Dashboard queries must stay
+bounded and must not introduce identity, credential, raw client, Redis-key,
+request-URI, or raw exception dimensions.
 
 ## Prometheus alert rules
 
-Transactional outbox rules are stored in:
+Prometheus loads the committed rule directory:
 
-    observability/prometheus/rules/outbox-alerts.yml
+    observability/prometheus/rules/
+
+Current rule files cover transactional outbox, Kafka consumer failures, and
+generalized abuse protection. Increment 5 adds:
+
+    observability/prometheus/rules/abuse-protection-alerts.yml
 
 | Alert | Severity | Condition |
 |---|---|---|
-| `PayFlowMetricsTargetDown` | Critical | PayFlow cannot be scraped for one minute |
-| `PayFlowOutboxPollingFailures` | Warning | A polling cycle fails within five minutes |
-| `PayFlowOutboxBacklogHigh` | Warning | Backlog remains at or above 100 for five minutes |
-| `PayFlowOutboxOldestEventStale` | Critical | Oldest active event remains at least 120 seconds old |
-| `PayFlowOutboxTerminalFailures` | Critical | A failed or unresolved outcome occurs within ten minutes |
+| `PayFlowAbuseProtectionRedisFailures` | Critical | At least one Redis dependency failure is observed in a five-minute window and remains firing for one minute |
+| `PayFlowAbuseProtectionBlockingPressure` | Warning | A bounded workflow records at least 25 blocked decisions in ten minutes and the condition remains active for five minutes |
+| `PayFlowAbuseProtectionDependencyBypass` | Critical | At least one fail-open dependency-bypass decision is observed in five minutes and remains firing for one minute |
 
-Prometheus evaluates these rules locally.
-
-Alertmanager is not currently part of the PayFlow stack. Alerts are visible in Prometheus, but they are not delivered to external notification channels.
+Alertmanager is part of the monitoring profile. Prometheus forwards firing
+alerts to `alertmanager:9093`; Alertmanager routes warning and critical alerts
+to Mailpit-backed local email receivers. See [Local Alert
+Notifications](alerting.md) and the [Abuse-Protection Operations
+Runbook](operations/abuse-protection-observability.md).
 
 ## Configuration validation
 
@@ -152,7 +170,7 @@ docker compose `
     /etc/prometheus/prometheus.yml
 ~~~
 
-Validate only the transactional outbox rules:
+Validate the generalized abuse-protection rules:
 
 ~~~powershell
 docker compose `
@@ -163,8 +181,11 @@ docker compose `
     --entrypoint /bin/promtool `
     prometheus `
     check rules `
-    /etc/prometheus/rules/outbox-alerts.yml
+    /etc/prometheus/rules/abuse-protection-alerts.yml
 ~~~
+
+The Prometheus configuration loads the complete `*.yml` rule directory, so
+`check config` remains the aggregate provisioning gate.
 
 ## Security considerations
 
@@ -179,6 +200,11 @@ Other Actuator endpoints remain protected.
 The public Prometheus endpoint is intended for local Compose networking. Production deployments should restrict access through private networking, network policies, or authenticated infrastructure.
 
 Grafana anonymous access and public user registration are disabled.
+
+Alertmanager and Mailpit are local-development services in the Compose
+monitoring profile. Production notification routing must use deployment-owned
+private networking, authenticated infrastructure, and organization-approved
+receivers rather than exposing these local ports publicly.
 
 ## Stop the stack
 

--- a/docs/operations/abuse-protection-observability.md
+++ b/docs/operations/abuse-protection-observability.md
@@ -1,0 +1,227 @@
+# Abuse-Protection Operations Runbook
+
+## Scope
+
+This runbook covers the generalized abuse-protection controls introduced in
+v0.15.0 for:
+
+- email-verification requests
+- password-recovery requests
+- MFA login-challenge confirmation
+- step-up grant issuance
+
+Registration remains configured but is not activated until Increment 6
+performance evidence supports a separate decision.
+
+The existing login limiter is a separate control and is not changed by this
+runbook.
+
+## Operational invariants
+
+Operators must preserve these security boundaries during investigation and
+mitigation:
+
+- `ABUSE_PROTECTION_ENABLED` is an explicit deployment gate; it is not an
+  incident-response toggle
+- current workflow defaults are `FAIL_CLOSED`
+- changing a workflow to `FAIL_OPEN` requires prior security review, ADR and
+  threat-model evidence, public-contract tests, and explicit operational
+  approval
+- Redis quota algorithms, expiration, limits, and key privacy are application
+  contracts and must not be changed during incident triage
+- the existing login limiter must remain independent and unchanged
+- every investigation must use bounded aggregate telemetry rather than raw
+  identity or credential material
+
+## Signals
+
+Micrometer emits:
+
+| Metric | Bounded dimensions |
+|---|---|
+| `payflow.security.abuse_protection.decisions` | `workflow`, `outcome`, `reason` |
+| `payflow.security.abuse_protection.redis.failures` | `workflow`, `failure_mode` |
+
+Prometheus exposes these counters with its standard normalized names:
+
+- `payflow_security_abuse_protection_decisions_total`
+- `payflow_security_abuse_protection_redis_failures_total`
+
+The dedicated Grafana dashboard is:
+
+    observability/grafana/dashboards/abuse-protection.json
+
+The alert rules are:
+
+    observability/prometheus/rules/abuse-protection-alerts.yml
+
+## Alert response
+
+### PayFlowAbuseProtectionRedisFailures
+
+Severity: `critical`.
+
+The alert fires when at least one Redis dependency failure is observed in a
+five-minute window and the condition remains active for one minute.
+
+Investigate in this order:
+
+1. confirm the PayFlow Prometheus target is healthy
+2. inspect Redis container/service health and connectivity
+3. inspect the dashboard Redis-failure panel by bounded `workflow` and
+   `failure_mode`
+4. confirm the deployed abuse-protection configuration matches the reviewed
+   configuration
+5. correlate the start time with deployment, Redis, networking, or host changes
+
+For fail-closed workflows, coarse dependency-unavailable behavior is expected
+while Redis cannot make a safe decision. Restore Redis availability or roll back
+the faulty infrastructure/application/configuration change.
+
+Do not switch the affected workflow to `FAIL_OPEN` as an incident workaround.
+
+### PayFlowAbuseProtectionBlockingPressure
+
+Severity: `warning`.
+
+The alert fires when a bounded workflow records at least 25 blocked decisions
+during ten minutes and the condition remains active for five minutes.
+
+Blocking pressure can represent expected hostile traffic, a client integration
+problem, a trusted-client configuration mistake, or a policy false positive.
+
+Investigate using:
+
+1. decision rate by bounded `workflow` and `outcome`
+2. blocked decisions by bounded `workflow` and `reason`
+3. recent deployment and configuration changes
+4. trusted-proxy/client-context configuration and service health
+5. known traffic or test activity during the alert window
+
+Do not search by email address, account identifier, JWT subject, or raw client
+address to explain the alert.
+
+A quota change is not an emergency mitigation. Proposed limit/window changes
+must follow normal review and should be supported by Increment 6 performance and
+false-positive evidence.
+
+### PayFlowAbuseProtectionDependencyBypass
+
+Severity: `critical`.
+
+The current default configuration is fail closed. A dependency-bypass alert
+therefore indicates that a workflow has been explicitly configured to
+`FAIL_OPEN` and Redis enforcement failed during request processing.
+
+Treat this as a security-significant configuration and dependency incident:
+
+1. confirm the exact reviewed deployment configuration
+2. identify why the workflow is operating in `FAIL_OPEN`
+3. restore Redis availability
+4. roll back an unapproved or incorrect configuration deployment
+5. verify bypass decisions stop after recovery
+
+Do not silently disable generalized protection and do not change additional
+workflows to `FAIL_OPEN`.
+
+## Disabled enforcement
+
+`outcome="disabled"` is emitted when generalized enforcement is bypassed because
+the validated policy is disabled before Redis execution.
+
+`ABUSE_PROTECTION_ENABLED=false` is the repository default. In environments
+where generalized enforcement is expected to be active, sustained disabled
+decisions indicate a deployment/configuration mismatch.
+
+Check deployment configuration and roll back or correct the configuration
+through the normal reviewed deployment path. Do not treat disabling protection
+as a safe mitigation for Redis or traffic incidents.
+
+## False-positive handling
+
+A suspected false positive must be evaluated from bounded aggregate evidence:
+
+- affected workflow
+- bounded rejection reason (`identity`, `client`, or `both`)
+- rate and duration of blocking pressure
+- deployment/configuration changes
+- trusted-client configuration
+- approved load/performance evidence
+
+Do not clear individual Redis quota keys as routine mitigation. Targeted key
+deletion weakens active enforcement and requires sensitive request targeting.
+
+Document any proposed policy change through the normal issue/PR process with
+tests and explicit rationale.
+
+## Safe rollback
+
+Rollback is appropriate when a recent application or configuration deployment
+introduced incorrect observability or policy wiring.
+
+A safe rollback:
+
+1. restores the last reviewed application/configuration version
+2. preserves fail-closed dependency behavior
+3. preserves Redis key privacy and expiration semantics
+4. does not reset individual client or identity counters
+5. confirms Prometheus target health and alert recovery after deployment
+6. records only bounded incident evidence
+
+If the issue is Redis availability, restore the dependency rather than weakening
+the enforcement contract.
+
+## Privacy and incident notes
+
+Never copy the following into dashboards, alert labels/annotations, tickets,
+chat messages, or incident notes:
+
+- email addresses
+- user UUIDs or authenticated JWT subjects
+- MFA challenge tokens or digests
+- TOTP values
+- recovery codes
+- step-up grants
+- raw client addresses
+- Redis keys, counters, or TTL values
+- request URIs
+- raw exception classes
+
+Safe incident evidence includes alert name, bounded workflow, outcome, reason,
+failure mode, timestamps, service health, deployment identifier, and aggregate
+counts/rates.
+
+## Validation
+
+Validate Compose and Prometheus provisioning before approving observability
+changes:
+
+```powershell
+docker compose `
+    --profile monitoring `
+    config `
+    --quiet
+
+docker compose `
+    --profile monitoring `
+    run `
+    --rm `
+    --no-deps `
+    --entrypoint /bin/promtool `
+    prometheus `
+    check config `
+    /etc/prometheus/prometheus.yml
+
+docker compose `
+    --profile monitoring `
+    run `
+    --rm `
+    --no-deps `
+    --entrypoint /bin/promtool `
+    prometheus `
+    check rules `
+    /etc/prometheus/rules/abuse-protection-alerts.yml
+```
+
+Then run the focused observability contracts and the complete Maven
+verification suite before merge.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -755,11 +755,18 @@ fail-closed dependency behavior.
 
 ### Increment 5 — Metrics, dashboards, alerts, and operations
 
-- [ ] Expose bounded decision and Redis-failure metrics without identity or client labels
-- [ ] Provision Grafana dashboards for quota outcomes, dependency failures, and protected-workflow health
-- [ ] Provision actionable alert rules with documented thresholds, duration, severity, and response guidance
-- [ ] Document investigation, safe mitigation, rollback, and false-positive handling
-- [ ] Verify logs, metrics, traces, dashboards, and alerts contain no sensitive material
+- [x] Expose bounded decision and Redis-failure metrics without identity or client labels
+- [x] Provision Grafana dashboards for quota outcomes, dependency failures, and protected-workflow health
+- [x] Provision actionable alert rules with documented thresholds, duration, severity, and response guidance
+- [x] Document investigation, safe mitigation, rollback, and false-positive handling
+- [x] Verify logs, metrics, traces, dashboards, and alerts contain no sensitive material
+
+Increment 5 is implemented by issue [#162](https://github.com/nursena-pc/payflow/issues/162)
+and pull request [#163](https://github.com/nursena-pc/payflow/pull/163).
+The delivered contract keeps Micrometer concerns adapter-side, exposes only
+bounded workflow/outcome/reason/failure-mode dimensions, provisions a dedicated
+abuse-protection dashboard and three actionable alerts, and documents safe
+operations without weakening fail-closed defaults or the existing login limiter.
 
 ### Increment 6 — Reproducible load and performance evidence
 

--- a/observability/grafana/dashboards/abuse-protection.json
+++ b/observability/grafana/dashboards/abuse-protection.json
@@ -1,0 +1,491 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Operational overview of bounded PayFlow generalized abuse-protection decisions and Redis dependency health. No identity, client address, credential, Redis key, or request-level dimensions are exposed.",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "payflow-prometheus"
+      },
+      "description": "Blocked generalized abuse-protection decisions during the last ten minutes, aggregated across bounded workflows.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(payflow_security_abuse_protection_decisions_total{outcome=\"blocked\"}[10m]))",
+          "instant": true,
+          "legendFormat": "Blocked Decisions \u2014 10m",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Blocked Decisions \u2014 10m",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "payflow-prometheus"
+      },
+      "description": "Redis dependency failures observed while evaluating generalized abuse protection during the last five minutes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(payflow_security_abuse_protection_redis_failures_total[5m]))",
+          "instant": true,
+          "legendFormat": "Redis Failures \u2014 5m",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Redis Failures \u2014 5m",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "payflow-prometheus"
+      },
+      "description": "Fail-open dependency bypass decisions during the last five minutes. Current default workflow configuration is fail closed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(payflow_security_abuse_protection_decisions_total{outcome=\"dependency_bypass\"}[5m]))",
+          "instant": true,
+          "legendFormat": "Dependency Bypass \u2014 5m",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Dependency Bypass \u2014 5m",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "payflow-prometheus"
+      },
+      "description": "Requests observed while generalized abuse protection was disabled, grouped only in the detailed panel below.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(payflow_security_abuse_protection_decisions_total{outcome=\"disabled\"}[15m]))",
+          "instant": true,
+          "legendFormat": "Disabled Decisions \u2014 15m",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Disabled Decisions \u2014 15m",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "payflow-prometheus"
+      },
+      "description": "Decision throughput grouped only by the finite application-owned workflow and outcome vocabularies.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (workflow, outcome) (rate(payflow_security_abuse_protection_decisions_total[5m]))",
+          "legendFormat": "{{workflow}} \u2014 {{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Decision Rate by Workflow and Outcome",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "payflow-prometheus"
+      },
+      "description": "Blocked decision throughput grouped only by bounded workflow and reason labels.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (workflow, reason) (rate(payflow_security_abuse_protection_decisions_total{outcome=\"blocked\"}[5m]))",
+          "legendFormat": "{{workflow}} \u2014 {{reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Blocked Decisions by Workflow and Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "payflow-prometheus"
+      },
+      "description": "Redis failure throughput grouped by bounded workflow and configured failure mode.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (workflow, failure_mode) (rate(payflow_security_abuse_protection_redis_failures_total[5m]))",
+          "legendFormat": "{{workflow}} \u2014 {{failure_mode}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Redis Dependency Failures by Workflow and Failure Mode",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "payflow-prometheus"
+      },
+      "description": "Operational visibility for disabled enforcement and fail-open dependency bypass using bounded workflow and outcome dimensions.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (workflow, outcome) (rate(payflow_security_abuse_protection_decisions_total{outcome=~\"disabled|dependency_bypass\"}[5m]))",
+          "legendFormat": "{{workflow}} \u2014 {{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Disabled and Dependency-Bypass Decisions",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "15s",
+  "schemaVersion": 41,
+  "tags": [
+    "payflow",
+    "security",
+    "abuse-protection",
+    "observability"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "PayFlow Abuse Protection",
+  "uid": "payflow-abuse-protection",
+  "version": 1,
+  "weekStart": ""
+}

--- a/observability/prometheus/rules/abuse-protection-alerts.yml
+++ b/observability/prometheus/rules/abuse-protection-alerts.yml
@@ -1,0 +1,36 @@
+groups:
+  - name: payflow-abuse-protection
+    interval: 15s
+    rules:
+      - alert: PayFlowAbuseProtectionRedisFailures
+        expr: sum by (workflow, failure_mode) (increase(payflow_security_abuse_protection_redis_failures_total[5m])) > 0
+        for: 1m
+        labels:
+          severity: critical
+          service: payflow
+          component: abuse-protection
+        annotations:
+          summary: Generalized abuse-protection Redis failures detected
+          description: Redis dependency failures have affected generalized abuse-protection decisions during the last five minutes.
+
+      - alert: PayFlowAbuseProtectionBlockingPressure
+        expr: sum by (workflow) (increase(payflow_security_abuse_protection_decisions_total{outcome="blocked"}[10m])) >= 25
+        for: 5m
+        labels:
+          severity: warning
+          service: payflow
+          component: abuse-protection
+        annotations:
+          summary: Generalized abuse-protection blocking pressure is elevated
+          description: A bounded workflow has produced at least 25 blocked decisions during a ten-minute window and the condition has remained active for five minutes.
+
+      - alert: PayFlowAbuseProtectionDependencyBypass
+        expr: sum by (workflow) (increase(payflow_security_abuse_protection_decisions_total{outcome="dependency_bypass"}[5m])) > 0
+        for: 1m
+        labels:
+          severity: critical
+          service: payflow
+          component: abuse-protection
+        annotations:
+          summary: Generalized abuse protection bypassed a failed dependency
+          description: At least one fail-open generalized abuse-protection decision bypassed Redis enforcement during the last five minutes.

--- a/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionMetrics.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionMetrics.java
@@ -1,0 +1,194 @@
+package com.nursena.payflow.abuseprotection.adapter.out.redis;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionFailureMode;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+final class AbuseProtectionMetrics {
+
+    static final String DECISIONS_METRIC =
+        "payflow.security.abuse_protection.decisions";
+
+    static final String REDIS_FAILURES_METRIC =
+        "payflow.security.abuse_protection.redis.failures";
+
+    private static final String WORKFLOW_TAG =
+        "workflow";
+
+    private static final String OUTCOME_TAG =
+        "outcome";
+
+    private static final String REASON_TAG =
+        "reason";
+
+    private static final String FAILURE_MODE_TAG =
+        "failure_mode";
+
+    private final MeterRegistry meterRegistry;
+
+    AbuseProtectionMetrics(
+        MeterRegistry meterRegistry
+    ) {
+        this.meterRegistry =
+            Objects.requireNonNull(
+                meterRegistry,
+                "meterRegistry must not be null"
+            );
+    }
+
+    void recordDecision(
+        AbuseProtectionWorkflow workflow,
+        AbuseProtectionDecision decision
+    ) {
+        AbuseProtectionDecision validatedDecision =
+            Objects.requireNonNull(
+                decision,
+                "decision must not be null"
+            );
+
+        recordDecision(
+            workflow,
+            validatedDecision.isAllowed()
+                ? "allowed"
+                : "blocked",
+            validatedDecision.isAllowed()
+                ? "none"
+                : dimensionName(validatedDecision)
+        );
+    }
+
+    void recordDisabled(
+        AbuseProtectionWorkflow workflow
+    ) {
+        recordDecision(
+            workflow,
+            "disabled",
+            "none"
+        );
+    }
+
+    void recordDependencyBypass(
+        AbuseProtectionWorkflow workflow
+    ) {
+        recordDecision(
+            workflow,
+            "dependency_bypass",
+            "dependency_failure"
+        );
+    }
+
+    void recordRedisFailure(
+        AbuseProtectionWorkflow workflow,
+        AbuseProtectionFailureMode failureMode
+    ) {
+        Counter.builder(
+                REDIS_FAILURES_METRIC
+            )
+            .description(
+                "Number of Redis dependency failures while "
+                    + "enforcing generalized abuse protection."
+            )
+            .baseUnit("failures")
+            .tags(
+                WORKFLOW_TAG,
+                workflowName(workflow),
+                FAILURE_MODE_TAG,
+                failureModeName(failureMode)
+            )
+            .register(meterRegistry)
+            .increment();
+    }
+
+    private void recordDecision(
+        AbuseProtectionWorkflow workflow,
+        String outcome,
+        String reason
+    ) {
+        Counter.builder(
+                DECISIONS_METRIC
+            )
+            .description(
+                "Number of generalized abuse-protection decisions."
+            )
+            .baseUnit("decisions")
+            .tags(
+                WORKFLOW_TAG,
+                workflowName(workflow),
+                OUTCOME_TAG,
+                validateOutcome(outcome),
+                REASON_TAG,
+                validateReason(reason)
+            )
+            .register(meterRegistry)
+            .increment();
+    }
+
+    private static String workflowName(
+        AbuseProtectionWorkflow workflow
+    ) {
+        return Objects.requireNonNull(
+            workflow,
+            "workflow must not be null"
+        ).configurationKey();
+    }
+
+    private static String dimensionName(
+        AbuseProtectionDecision decision
+    ) {
+        return decision
+            .blockedDimension()
+            .name()
+            .toLowerCase(Locale.ROOT);
+    }
+
+    private static String failureModeName(
+        AbuseProtectionFailureMode failureMode
+    ) {
+        return Objects.requireNonNull(
+            failureMode,
+            "failureMode must not be null"
+        )
+            .name()
+            .toLowerCase(Locale.ROOT);
+    }
+
+    private static String validateOutcome(
+        String value
+    ) {
+        if (
+            !"allowed".equals(value)
+                && !"blocked".equals(value)
+                && !"disabled".equals(value)
+                && !"dependency_bypass".equals(value)
+        ) {
+            throw new IllegalArgumentException(
+                "unsupported abuse-protection outcome"
+            );
+        }
+
+        return value;
+    }
+
+    private static String validateReason(
+        String value
+    ) {
+        if (
+            !"none".equals(value)
+                && !"identity".equals(value)
+                && !"client".equals(value)
+                && !"both".equals(value)
+                && !"dependency_failure".equals(value)
+        ) {
+            throw new IllegalArgumentException(
+                "unsupported abuse-protection reason"
+            );
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionRedisConfiguration.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionRedisConfiguration.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicyProvider;
 import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -77,16 +78,27 @@ class AbuseProtectionRedisConfiguration {
     }
 
     @Bean
+    AbuseProtectionMetrics abuseProtectionMetrics(
+        MeterRegistry meterRegistry
+    ) {
+        return new AbuseProtectionMetrics(
+            meterRegistry
+        );
+    }
+
+    @Bean
     AbuseProtectionEnforcementPort abuseProtectionEnforcementPort(
         StringRedisTemplate redisTemplate,
         @Qualifier("abuseProtectionRedisScript")
         RedisScript<List<Long>> script,
-        AbuseProtectionPolicyProvider policyProvider
+        AbuseProtectionPolicyProvider policyProvider,
+        AbuseProtectionMetrics metrics
     ) {
         return new RedisAbuseProtectionAdapter(
             redisTemplate,
             script,
-            policyProvider
+            policyProvider,
+            metrics
         );
     }
 }

--- a/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/redis/RedisAbuseProtectionAdapter.java
+++ b/src/main/java/com/nursena/payflow/abuseprotection/adapter/out/redis/RedisAbuseProtectionAdapter.java
@@ -26,11 +26,13 @@ final class RedisAbuseProtectionAdapter
     private final StringRedisTemplate redisTemplate;
     private final RedisScript<List<Long>> script;
     private final AbuseProtectionPolicyProvider policyProvider;
+    private final AbuseProtectionMetrics metrics;
 
     RedisAbuseProtectionAdapter(
         StringRedisTemplate redisTemplate,
         RedisScript<List<Long>> script,
-        AbuseProtectionPolicyProvider policyProvider
+        AbuseProtectionPolicyProvider policyProvider,
+        AbuseProtectionMetrics metrics
     ) {
         this.redisTemplate = Objects.requireNonNull(
             redisTemplate,
@@ -45,6 +47,11 @@ final class RedisAbuseProtectionAdapter
         this.policyProvider = Objects.requireNonNull(
             policyProvider,
             "policyProvider must not be null"
+        );
+
+        this.metrics = Objects.requireNonNull(
+            metrics,
+            "metrics must not be null"
         );
     }
 
@@ -67,6 +74,9 @@ final class RedisAbuseProtectionAdapter
             );
 
         if (!policy.enabled()) {
+            metrics.recordDisabled(
+                validatedRequest.workflow()
+            );
             return AbuseProtectionDecision.allowed();
         }
 
@@ -83,6 +93,8 @@ final class RedisAbuseProtectionAdapter
             )
         );
 
+        AbuseProtectionDecision decision;
+
         try {
             List<Long> result = redisTemplate.execute(
                 script,
@@ -94,12 +106,20 @@ final class RedisAbuseProtectionAdapter
                 Integer.toString(policy.clientLimit())
             );
 
-            return parseDecision(result);
+            decision = parseDecision(result);
         } catch (RuntimeException exception) {
+            metrics.recordRedisFailure(
+                validatedRequest.workflow(),
+                policy.dependencyFailureMode()
+            );
+
             if (
                 policy.dependencyFailureMode()
                     == AbuseProtectionFailureMode.FAIL_OPEN
             ) {
+                metrics.recordDependencyBypass(
+                    validatedRequest.workflow()
+                );
                 return AbuseProtectionDecision.allowed();
             }
 
@@ -109,6 +129,13 @@ final class RedisAbuseProtectionAdapter
                 exception
             );
         }
+
+        metrics.recordDecision(
+            validatedRequest.workflow(),
+            decision
+        );
+
+        return decision;
     }
 
     private static long expirationSeconds(Duration window) {

--- a/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionMetricsTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionMetricsTest.java
@@ -1,0 +1,161 @@
+package com.nursena.payflow.abuseprotection.adapter.out.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionFailureMode;
+import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionWorkflow;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDecision;
+import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDimension;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AbuseProtectionMetricsTest {
+
+    private SimpleMeterRegistry meterRegistry;
+    private AbuseProtectionMetrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        metrics = new AbuseProtectionMetrics(meterRegistry);
+    }
+
+    @AfterEach
+    void tearDown() {
+        meterRegistry.close();
+    }
+
+    @Test
+    void shouldRecordAllowedBlockedAndDisabledDecisions() {
+        metrics.recordDecision(
+            AbuseProtectionWorkflow.REGISTRATION,
+            AbuseProtectionDecision.allowed()
+        );
+
+        metrics.recordDecision(
+            AbuseProtectionWorkflow.EMAIL_VERIFICATION_REQUEST,
+            AbuseProtectionDecision.blocked(
+                AbuseProtectionDimension.BOTH,
+                Duration.ofSeconds(30)
+            )
+        );
+
+        metrics.recordDisabled(
+            AbuseProtectionWorkflow.PASSWORD_RECOVERY_REQUEST
+        );
+
+        assertDecisionCounter(
+            "registration",
+            "allowed",
+            "none",
+            1.0
+        );
+
+        assertDecisionCounter(
+            "email-verification-request",
+            "blocked",
+            "both",
+            1.0
+        );
+
+        assertDecisionCounter(
+            "password-recovery-request",
+            "disabled",
+            "none",
+            1.0
+        );
+    }
+
+    @Test
+    void shouldRecordDependencyBypassAndFailureWithBoundedTags() {
+        AbuseProtectionWorkflow workflow =
+            AbuseProtectionWorkflow.STEP_UP_GRANT_ISSUANCE;
+
+        metrics.recordRedisFailure(
+            workflow,
+            AbuseProtectionFailureMode.FAIL_OPEN
+        );
+
+        metrics.recordDependencyBypass(workflow);
+
+        assertDecisionCounter(
+            "step-up-grant-issuance",
+            "dependency_bypass",
+            "dependency_failure",
+            1.0
+        );
+
+        Counter failureCounter = meterRegistry
+            .get(AbuseProtectionMetrics.REDIS_FAILURES_METRIC)
+            .tag("workflow", "step-up-grant-issuance")
+            .tag("failure_mode", "fail_open")
+            .counter();
+
+        assertThat(failureCounter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void shouldExposeOnlyClosedApplicationOwnedTagValues() {
+        for (AbuseProtectionWorkflow workflow
+            : AbuseProtectionWorkflow.values()) {
+            metrics.recordDecision(
+                workflow,
+                AbuseProtectionDecision.allowed()
+            );
+        }
+
+        assertThat(
+            meterRegistry.find(
+                AbuseProtectionMetrics.DECISIONS_METRIC
+            ).counters()
+        )
+            .allSatisfy(counter -> {
+                assertThat(counter.getId().getTag("workflow"))
+                    .isIn(
+                        "registration",
+                        "email-verification-request",
+                        "password-recovery-request",
+                        "mfa-login-challenge-confirmation",
+                        "step-up-grant-issuance"
+                    );
+
+                assertThat(counter.getId().getTag("outcome"))
+                    .isIn(
+                        "allowed",
+                        "blocked",
+                        "disabled",
+                        "dependency_bypass"
+                    );
+
+                assertThat(counter.getId().getTag("reason"))
+                    .isIn(
+                        "none",
+                        "identity",
+                        "client",
+                        "both",
+                        "dependency_failure"
+                    );
+            });
+    }
+
+    private void assertDecisionCounter(
+        String workflow,
+        String outcome,
+        String reason,
+        double expectedCount
+    ) {
+        Counter counter = meterRegistry
+            .get(AbuseProtectionMetrics.DECISIONS_METRIC)
+            .tag("workflow", workflow)
+            .tag("outcome", outcome)
+            .tag("reason", reason)
+            .counter();
+
+        assertThat(counter.count()).isEqualTo(expectedCount);
+    }
+}

--- a/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionRedisConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/AbuseProtectionRedisConfigurationTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.mock;
 
 import com.nursena.payflow.abuseprotection.application.policy.AbuseProtectionPolicyProvider;
 import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionEnforcementPort;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -17,6 +19,10 @@ class AbuseProtectionRedisConfigurationTest {
             .withBean(
                 StringRedisTemplate.class,
                 () -> mock(StringRedisTemplate.class)
+            )
+            .withBean(
+                MeterRegistry.class,
+                SimpleMeterRegistry::new
             )
             .withBean(
                 AbuseProtectionPolicyProvider.class,
@@ -34,6 +40,7 @@ class AbuseProtectionRedisConfigurationTest {
                 .hasSingleBean(
                     AbuseProtectionEnforcementPort.class
                 )
+                .hasSingleBean(AbuseProtectionMetrics.class)
                 .hasSingleBean(RedisScript.class);
 
             RedisScript<?> script =

--- a/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/RedisAbuseProtectionAdapterIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/RedisAbuseProtectionAdapterIntegrationTest.java
@@ -18,6 +18,7 @@ import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionD
 import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDimension;
 import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionRequest;
 import com.nursena.payflow.clientcontext.domain.IpAddress;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,7 @@ class RedisAbuseProtectionAdapterIntegrationTest {
 
     private LettuceConnectionFactory connectionFactory;
     private StringRedisTemplate redisTemplate;
+    private SimpleMeterRegistry meterRegistry;
 
     @BeforeEach
     void setUp() {
@@ -60,11 +62,16 @@ class RedisAbuseProtectionAdapterIntegrationTest {
         redisTemplate =
             new StringRedisTemplate(connectionFactory);
         redisTemplate.afterPropertiesSet();
+        meterRegistry = new SimpleMeterRegistry();
         flushRedis();
     }
 
     @AfterEach
     void tearDown() {
+        if (meterRegistry != null) {
+            meterRegistry.close();
+        }
+
         if (connectionFactory != null) {
             connectionFactory.destroy();
         }
@@ -241,7 +248,8 @@ class RedisAbuseProtectionAdapterIntegrationTest {
             redisTemplate,
             new AbuseProtectionRedisConfiguration()
                 .abuseProtectionRedisScript(),
-            workflow -> policy
+            workflow -> policy,
+            new AbuseProtectionMetrics(meterRegistry)
         );
     }
 

--- a/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/RedisAbuseProtectionAdapterTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/adapter/out/redis/RedisAbuseProtectionAdapterTest.java
@@ -14,6 +14,7 @@ import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionD
 import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionDimension;
 import com.nursena.payflow.abuseprotection.application.port.out.AbuseProtectionRequest;
 import com.nursena.payflow.clientcontext.domain.IpAddress;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -23,10 +24,12 @@ import org.springframework.data.redis.core.script.RedisScript;
 class RedisAbuseProtectionAdapterTest {
 
     private RecordingRedisTemplate redisTemplate;
+    private SimpleMeterRegistry meterRegistry;
 
     @BeforeEach
     void setUp() {
         redisTemplate = new RecordingRedisTemplate();
+        meterRegistry = new SimpleMeterRegistry();
     }
 
     @Test
@@ -49,6 +52,11 @@ class RedisAbuseProtectionAdapterTest {
             );
         assertThat(redisTemplate.arguments)
             .containsExactly("900", "5", "20");
+        assertDecisionMetric(
+            "allowed",
+            "none",
+            1.0
+        );
     }
 
     @Test
@@ -78,6 +86,11 @@ class RedisAbuseProtectionAdapterTest {
 
         assertThat(decision.isAllowed()).isTrue();
         assertThat(redisTemplate.executions).isZero();
+        assertDecisionMetric(
+            "disabled",
+            "none",
+            1.0
+        );
     }
 
     @Test
@@ -103,6 +116,16 @@ class RedisAbuseProtectionAdapterTest {
                 assertThat(unavailable.failureMode())
                     .isEqualTo(AbuseProtectionFailureMode.FAIL_CLOSED);
             });
+
+        assertRedisFailureMetric(
+            "fail_closed",
+            1.0
+        );
+        assertThat(
+            meterRegistry.find(
+                AbuseProtectionMetrics.DECISIONS_METRIC
+            ).counters()
+        ).isEmpty();
     }
 
     @Test
@@ -113,6 +136,22 @@ class RedisAbuseProtectionAdapterTest {
         assertThat(adapter(
             policy(true, AbuseProtectionFailureMode.FAIL_OPEN)
         ).evaluate(request()).isAllowed()).isTrue();
+
+        assertRedisFailureMetric(
+            "fail_open",
+            1.0
+        );
+        assertDecisionMetric(
+            "dependency_bypass",
+            "dependency_failure",
+            1.0
+        );
+        assertThat(
+            meterRegistry.find(
+                AbuseProtectionMetrics.DECISIONS_METRIC
+            ).tag("outcome", "allowed")
+            .counters()
+        ).isEmpty();
     }
 
     @Test
@@ -125,13 +164,44 @@ class RedisAbuseProtectionAdapterTest {
             .isInstanceOf(AbuseProtectionUnavailableException.class);
     }
 
+    private void assertDecisionMetric(
+        String outcome,
+        String reason,
+        double expectedCount
+    ) {
+        assertThat(
+            meterRegistry
+                .get(AbuseProtectionMetrics.DECISIONS_METRIC)
+                .tag("workflow", "registration")
+                .tag("outcome", outcome)
+                .tag("reason", reason)
+                .counter()
+                .count()
+        ).isEqualTo(expectedCount);
+    }
+
+    private void assertRedisFailureMetric(
+        String failureMode,
+        double expectedCount
+    ) {
+        assertThat(
+            meterRegistry
+                .get(AbuseProtectionMetrics.REDIS_FAILURES_METRIC)
+                .tag("workflow", "registration")
+                .tag("failure_mode", failureMode)
+                .counter()
+                .count()
+        ).isEqualTo(expectedCount);
+    }
+
     private RedisAbuseProtectionAdapter adapter(
         AbuseProtectionPolicy policy
     ) {
         return new RedisAbuseProtectionAdapter(
             redisTemplate,
             script(),
-            workflow -> policy
+            workflow -> policy,
+            new AbuseProtectionMetrics(meterRegistry)
         );
     }
 

--- a/src/test/java/com/nursena/payflow/abuseprotection/observability/AbuseProtectionObservabilityProvisioningContractTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/observability/AbuseProtectionObservabilityProvisioningContractTest.java
@@ -1,0 +1,152 @@
+package com.nursena.payflow.abuseprotection.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class AbuseProtectionObservabilityProvisioningContractTest {
+
+    private static final Path DASHBOARD =
+        Path.of(
+            "observability",
+            "grafana",
+            "dashboards",
+            "abuse-protection.json"
+        );
+
+    private static final Path DASHBOARD_PROVISIONING =
+        Path.of(
+            "observability",
+            "grafana",
+            "provisioning",
+            "dashboards",
+            "dashboards.yml"
+        );
+
+    private static final Path ALERT_RULES =
+        Path.of(
+            "observability",
+            "prometheus",
+            "rules",
+            "abuse-protection-alerts.yml"
+        );
+
+    private static final Path PROMETHEUS_CONFIGURATION =
+        Path.of(
+            "observability",
+            "prometheus",
+            "prometheus.yml"
+        );
+
+    private static final String DECISIONS_METRIC =
+        "payflow_security_abuse_protection_decisions_total";
+
+    private static final String REDIS_FAILURES_METRIC =
+        "payflow_security_abuse_protection_redis_failures_total";
+
+    private final ObjectMapper objectMapper =
+        new ObjectMapper();
+
+    @Test
+    void shouldProvisionDedicatedBoundedSecurityDashboard()
+        throws IOException {
+
+        JsonNode dashboard = objectMapper.readTree(
+            Files.readString(DASHBOARD)
+        );
+
+        String serialized = dashboard.toString();
+
+        assertThat(dashboard.path("title").asText())
+            .isEqualTo("PayFlow Abuse Protection");
+
+        assertThat(dashboard.path("uid").asText())
+            .isEqualTo("payflow-abuse-protection");
+
+        assertThat(serialized)
+            .contains(
+                DECISIONS_METRIC,
+                REDIS_FAILURES_METRIC,
+                "sum by (workflow, outcome)",
+                "sum by (workflow, reason)",
+                "sum by (workflow, failure_mode)",
+                "outcome=\\\"blocked\\\"",
+                "outcome=~\\\"disabled|dependency_bypass\\\""
+            )
+            .doesNotContain(
+                "email_address",
+                "user_uuid",
+                "jwt_subject",
+                "challenge_token",
+                "recovery_code",
+                "step_up_grant",
+                "client_address",
+                "redis_key",
+                "request_uri",
+                "exception_class"
+            );
+    }
+
+    @Test
+    void shouldProvisionActionableBoundedAlertRules()
+        throws IOException {
+
+        String rules = Files.readString(ALERT_RULES);
+
+        assertThat(rules)
+            .contains(
+                "name: payflow-abuse-protection",
+                "alert: PayFlowAbuseProtectionRedisFailures",
+                "alert: PayFlowAbuseProtectionBlockingPressure",
+                "alert: PayFlowAbuseProtectionDependencyBypass",
+                REDIS_FAILURES_METRIC,
+                DECISIONS_METRIC,
+                "sum by (workflow, failure_mode)",
+                "sum by (workflow)",
+                "component: abuse-protection",
+                "severity: critical",
+                "severity: warning",
+                "for: 1m",
+                "for: 5m",
+                ">= 25"
+            )
+            .doesNotContain(
+                "email_address",
+                "user_uuid",
+                "jwt_subject",
+                "challenge_token",
+                "recovery_code",
+                "step_up_grant",
+                "client_address",
+                "redis_key",
+                "request_uri",
+                "exception_class"
+            );
+    }
+
+    @Test
+    void shouldLoadNewArtifactsThroughExistingDirectoryProvisioning()
+        throws IOException {
+
+        assertThat(
+            Files.readString(PROMETHEUS_CONFIGURATION)
+        )
+            .contains(
+                "/etc/prometheus/rules/*.yml"
+            );
+
+        assertThat(
+            Files.readString(DASHBOARD_PROVISIONING)
+        )
+            .contains(
+                "path: /var/lib/grafana/dashboards",
+                "allowUiUpdates: false"
+            );
+    }
+}

--- a/src/test/java/com/nursena/payflow/abuseprotection/observability/AbuseProtectionOperationsDocumentationContractTest.java
+++ b/src/test/java/com/nursena/payflow/abuseprotection/observability/AbuseProtectionOperationsDocumentationContractTest.java
@@ -1,0 +1,140 @@
+package com.nursena.payflow.abuseprotection.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class AbuseProtectionOperationsDocumentationContractTest {
+
+    private static final Path MONITORING =
+        Path.of("docs", "monitoring.md");
+
+    private static final Path ALERTING =
+        Path.of("docs", "alerting.md");
+
+    private static final Path POLICY_GUIDE =
+        Path.of("docs", "abuse-protection.md");
+
+    private static final Path RUNBOOK =
+        Path.of(
+            "docs",
+            "operations",
+            "abuse-protection-observability.md"
+        );
+
+    private static final Path ROADMAP =
+        Path.of("docs", "roadmap.md");
+
+    @Test
+    void shouldDescribeTheProvisionedMonitoringAndNotificationStack()
+        throws IOException {
+
+        String monitoring = Files.readString(MONITORING);
+        String alerting = Files.readString(ALERTING);
+
+        assertThat(monitoring)
+            .contains(
+                "Prometheus",
+                "Alertmanager",
+                "Grafana",
+                "Mailpit",
+                "abuse-protection.json",
+                "abuse-protection-alerts.yml"
+            )
+            .doesNotContain(
+                "Alertmanager is not currently part of the PayFlow stack"
+            );
+
+        assertThat(alerting)
+            .contains(
+                "alertmanager:9093",
+                "critical-email",
+                "warning-email",
+                "PayFlowAbuseProtectionRedisFailures",
+                "PayFlowAbuseProtectionBlockingPressure",
+                "PayFlowAbuseProtectionDependencyBypass"
+            );
+
+        int fenceCount =
+            alerting.split("```", -1).length - 1;
+
+        assertThat(fenceCount % 2).isZero();
+    }
+
+    @Test
+    void shouldDocumentActionableThresholdsAndSafeResponse()
+        throws IOException {
+
+        String runbook = Files.readString(RUNBOOK);
+
+        assertThat(runbook)
+            .contains(
+                "PayFlowAbuseProtectionRedisFailures",
+                "PayFlowAbuseProtectionBlockingPressure",
+                "PayFlowAbuseProtectionDependencyBypass",
+                "five-minute window",
+                "at least 25 blocked decisions",
+                "FAIL_CLOSED",
+                "FAIL_OPEN",
+                "ABUSE_PROTECTION_ENABLED",
+                "Do not switch the affected workflow to `FAIL_OPEN`",
+                "Do not silently disable generalized protection",
+                "Do not clear individual Redis quota keys"
+            );
+    }
+
+    @Test
+    void shouldKeepSensitiveMaterialOutOfTheOperationalWorkflow()
+        throws IOException {
+
+        String policyGuide = Files.readString(POLICY_GUIDE);
+        String runbook = Files.readString(RUNBOOK);
+
+        assertThat(policyGuide)
+            .contains(
+                "bounded `workflow`",
+                "`outcome`",
+                "`reason`",
+                "`failure_mode`",
+                "prohibited from metric labels"
+            );
+
+        assertThat(runbook)
+            .contains(
+                "Never copy the following into dashboards",
+                "email addresses",
+                "user UUIDs",
+                "raw client addresses",
+                "Redis keys, counters, or TTL values",
+                "request URIs",
+                "raw exception classes",
+                "Safe incident evidence includes alert name"
+            )
+            .doesNotContain(
+                "redis-cli DEL",
+                "KEYS abuse",
+                "FLUSHALL",
+                "disable generalized protection to recover"
+            );
+    }
+
+    @Test
+    void shouldMarkIncrementFiveDeliveredInTheRoadmap()
+        throws IOException {
+
+        String roadmap = Files.readString(ROADMAP);
+
+        assertThat(roadmap)
+            .contains(
+                "- [x] Expose bounded decision and Redis-failure metrics",
+                "- [x] Provision Grafana dashboards for quota outcomes",
+                "- [x] Provision actionable alert rules",
+                "- [x] Document investigation, safe mitigation, rollback",
+                "- [x] Verify logs, metrics, traces, dashboards, and alerts"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

Implements v0.15.0 Increment 5 from #162 by adding bounded operational observability for generalized abuse protection while preserving the existing enforcement, privacy, and login-limiter contracts.

Delivered checkpoints:

1. bounded adapter-side Micrometer metrics for generalized abuse-protection decisions and Redis dependency failures
2. dedicated PayFlow abuse-protection Grafana dashboard and Prometheus alert rules with executable provisioning/privacy contracts
3. completed monitoring/alerting documentation, abuse-protection operations runbook, documentation/privacy contracts, and Increment 5 roadmap alignment
4. corrective documentation-contract commit preserving the existing executable configuration wording without changing behavior

### Metrics

- records bounded `allowed`, `blocked`, `disabled`, and `dependency_bypass` outcomes
- records bounded Redis dependency failures by workflow and configured failure mode
- keeps workflow/outcome/reason/failure-mode tag vocabularies finite and application-owned
- records fail-open dependency bypass distinctly from an ordinary allowed Redis decision
- records fail-closed dependency failures before the existing unavailable exception escapes
- avoids request-level decision double counting on dependency failure
- keeps the existing login-rate-limit implementation and metrics unchanged

### Dashboard, alerts, and operations

- adds a dedicated `PayFlow Abuse Protection` Grafana dashboard
- visualizes decision rate by bounded workflow/outcome, blocked decisions by bounded workflow/reason, Redis failures, disabled enforcement, and dependency bypass
- adds Prometheus alerts for Redis dependency failures, sustained blocking pressure, and dependency bypass
- repairs and aligns local monitoring/Alertmanager/Mailpit guidance with the actual Compose stack
- adds an abuse-protection operations runbook covering investigation, safe mitigation, rollback, and false-positive handling
- keeps alert labels/annotations and operational guidance free of identity, credential, Redis-key, URI, or raw exception material
- adds executable contracts for provisioning, documentation structure, bounded dimensions, and privacy constraints

## Security and privacy invariants

- no email address, user UUID, JWT subject, MFA challenge, TOTP value, recovery code, step-up grant, raw client address, Redis key, counter value, TTL, URI, or raw exception class is emitted as an observability dimension
- metrics remain adapter-side; Micrometer concerns do not move into application policy ports
- disabled enforcement is observable without executing Redis
- existing trusted-client enforcement remains unchanged
- generalized Redis quota algorithms, expiration, public error contracts, endpoint limits, and login-limiter behavior remain unchanged
- incident guidance explicitly rejects weakening enforcement via unreviewed fail-open changes or targeted quota-key deletion

## Validation

### Checkpoint 1 — metrics

Commit `882d5670f683a0fa4b9b5dc4bd4e02a77f56a7b0`:

- focused metric/config/Redis adapter tests: passed
- real-Redis integration coverage: passed
- `mvnw.cmd -B -ntp clean verify`: passed
- tests: **1538 passed, 0 failures, 0 errors, 0 skipped**
- artifact: `target/payflow-0.15.0-SNAPSHOT.jar`
- JaCoCo analyzed: **518 classes**
- `git diff --check`: passed
- protected `CI` and `Docker Smoke`: passed

### Checkpoint 2 — dashboard and alerts

Commit `02f53e1454ca105f3c0bff87a84c69ed90275eea`:

- Grafana JSON validation: passed
- focused observability provisioning contract: passed
- Docker Compose monitoring configuration validation: passed
- Prometheus config/rule validation: passed
- `mvnw.cmd -B -ntp clean verify`: passed
- tests: **1541 passed, 0 failures, 0 errors, 0 skipped**
- artifact: `target/payflow-0.15.0-SNAPSHOT.jar`
- JaCoCo analyzed: **518 classes**
- `git diff --check`: passed
- exact committed scope: 3 expected files
- working tree after commit: clean
- protected `CI` run #229: passed
- protected `Docker Smoke` run #38: passed

### Checkpoint 3 — operations and documentation

Commit `66c00de1ae54fa3966dbf0e77d6b27b5d6fc9d73` delivered the operations/documentation scope. Its first local full verification exposed one executable documentation-contract failure caused solely by a Markdown line break splitting the pre-existing literal configuration wording.

Corrective commit `dea6c44c5ac28dceae37a6c1ca9074d77b715f50` restores that exact contract while keeping the new documentation content and behavior unchanged.

Final local verification on `dea6c44c5ac28dceae37a6c1ca9074d77b715f50`:

- focused regression/documentation/provisioning contracts: passed
- `mvnw.cmd -B -ntp clean verify`: passed
- tests: **1545 passed, 0 failures, 0 errors, 0 skipped**
- artifact: `target/payflow-0.15.0-SNAPSHOT.jar`
- JaCoCo analyzed: **518 classes**
- Surefire XML audit: **1545 / 0 / 0 / 0**
- `git diff --check`: passed
- corrective commit scope: exactly `docs/abuse-protection.md`
- working tree after commit: clean
- protected `CI` run #231: passed
- protected `Docker Smoke` run #40: passed

## Merge readiness

- latest PR HEAD: `dea6c44c5ac28dceae37a6c1ca9074d77b715f50`
- final protected CI and Docker Smoke are green
- PR is mergeable
- no review submissions or unresolved review threads are present
- Increment 5 implementation scope is complete

## Non-goals

- changing generalized Redis algorithms, limits, expiration, or public rejection behavior
- changing the existing login limiter or its metrics
- registration activation decision; remains part of Increment 6 evidence
- load/performance evidence; remains Increment 6
- OpenAPI/Postman release freeze or v0.15.0 publication; remains Increment 7
- introducing OpenTelemetry, Loki, Promtail, WAF, CAPTCHA, device fingerprinting, or adaptive risk scoring

Refs #162
Part of #149