### PR TITLE
ops(postgres): add backup restore rehearsal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added a repeatable PostgreSQL 17 backup and isolated-restore rehearsal through issue #173, including custom-format backup tooling, clean-target restore, Flyway/public-table integrity checks, restored-database application startup, sanitized local evidence, and a focused operations guide without changing runtime API, security, or Flyway schema behavior.
+
 ### Changed
 
 - Advanced the active development version to `0.16.0-SNAPSHOT`.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ The immutable v0.13.0 publication record remains anchored to annotated tag `v0.1
 
 See the [v0.15.0 release notes](docs/releases/v0.15.0.md), the [published GitHub Release](https://github.com/nursena-pc/payflow/releases/tag/v0.15.0), the [abuse-protection operations guide](docs/operations/abuse-protection-observability.md), [ADR 0015](docs/adr/0015-generalized-abuse-protection.md), the [v0.14.0 release notes](docs/releases/v0.14.0.md), and the [roadmap](docs/roadmap.md).
 
+## PostgreSQL backup/restore rehearsal
+
+v0.16.0 Increment 2 is tracked by [Issue #173](https://github.com/nursena-pc/payflow/issues/173). The committed local procedure creates a PostgreSQL 17 custom-format backup, restores only into a clean isolated target, verifies Flyway and persistence fingerprints, and starts PayFlow against the restored database without changing runtime API or security behavior.
+
+See the [PostgreSQL backup/restore operations guide](docs/operations/postgresql-backup-restore.md) for prerequisites, source-selection safeguards, evidence boundaries, exact commands, and recovery limitations.
+
 ## Structured logging
 
 PayFlow supports single-line JSON logs through the `structured-logging` and `production` Spring profiles. HTTP requests emit one bounded completion event containing the correlation ID, route template, method, status, duration, and outcome without logging bodies, query strings, authorization headers, cookies, raw URI paths, or financial/user data.

--- a/docs/operations/postgresql-backup-restore.md
+++ b/docs/operations/postgresql-backup-restore.md
@@ -1,0 +1,242 @@
+# PostgreSQL Backup and Restore Rehearsal
+
+Issue: [#173](https://github.com/nursena-pc/payflow/issues/173)
+
+PayFlow uses PostgreSQL as the system of record. This guide defines the local
+v0.16.0 backup-and-restore rehearsal that proves a PostgreSQL backup can be
+restored into a clean isolated target without changing the source database,
+Flyway schema, public `/api/v1` behavior, or security boundaries.
+
+This is a developer/stabilization rehearsal. It is **not** production
+disaster-recovery certification.
+
+## Tooling and prerequisites
+
+The committed rehearsal entry point is:
+
+```powershell
+.\scripts\operations\postgres-backup-restore-rehearsal.ps1
+```
+
+The current project database line is PostgreSQL 17 and `compose.yml` uses
+`postgres:17-alpine`.
+
+Before running the rehearsal:
+
+- Docker must be available.
+- Java 21 must be available for restored-database application startup.
+- the Maven wrapper must be present unless an already-built
+  `payflow-0.16.0-SNAPSHOT.jar` is intentionally reused with `-SkipPackage`.
+- the Git working tree must be clean and HEAD must be attached to a branch.
+- exactly one running Docker container must match the configured Compose project
+  and PostgreSQL service labels; defaults are project `payflow`, service
+  `postgres`.
+- the source database must already be at the latest versioned Flyway migration
+  present in the checked-out repository.
+- the source PayFlow `app` container must be stopped before the backup window.
+
+The rehearsal deliberately refuses a stale source schema. Migrating a previous
+release or older local database to the current schema belongs to the separate
+Flyway clean-install/upgrade rehearsal and is not hidden inside backup tooling.
+
+## Safe source selection
+
+The script resolves the source PostgreSQL container from Docker Compose labels
+instead of parsing the whole Compose model. This avoids unrelated Compose
+environment interpolation from changing source selection.
+
+The script then proves all of the following before creating a backup:
+
+- the selected source container is running PostgreSQL 17 tooling;
+- the resolved database is exactly the configured source database;
+- Flyway's latest successful version equals the latest checked-in migration;
+- the source application container is not running;
+- representative delivered persistence tables exist.
+
+The script never restores over the source database and contains no source
+database deletion or volume-removal operation.
+
+## Representative persistence boundary
+
+The complete public-table set is compared by table name and row count. The
+following delivered state is also required explicitly:
+
+- identity/account state: `users`
+- refresh-session state: `refresh_token_families`,
+  `refresh_token_records`
+- wallet state: `wallets`
+- transfer/payment state: `payment_transactions`
+- double-entry ledger state: `ledger_entries`
+- transactional outbox state: `outbox_events`
+- Kafka dead-letter state: `kafka_dead_letter_records`
+- operator command-audit state:
+  `kafka_dead_letter_command_audits`
+
+Flyway verification compares the successful history-row count, latest version,
+and a deterministic digest of non-sensitive Flyway metadata.
+
+No row values are written to committed documentation or sanitized evidence.
+
+## Backup procedure
+
+The script creates a PostgreSQL custom-format backup with PostgreSQL 17 tooling:
+
+```text
+pg_dump --format=custom --no-owner --no-privileges
+```
+
+The dump is copied only to:
+
+```text
+.runtime/postgres-rehearsal/<timestamp>/
+```
+
+`.runtime/` is ignored by Git. The dump is removed after a successful or failed
+rehearsal unless `-KeepDump` is supplied deliberately.
+
+A SHA-256 digest and byte size are recorded for the local runtime artifact, but
+the dump itself is never committed.
+
+The script captures a source fingerprint before and after backup. Any change in
+the public table set, row counts, or Flyway metadata aborts the rehearsal
+instead of treating a potentially moving backup window as valid evidence.
+
+## Clean isolated restore
+
+The restore target is a new ephemeral PostgreSQL 17 container with:
+
+- a separate container identity;
+- a separate database name;
+- a random process-local target password;
+- a loopback-only dynamically selected host port;
+- no persistent target volume;
+- automatic container removal after the rehearsal.
+
+The backup is restored with:
+
+```text
+pg_restore --exit-on-error --no-owner --no-privileges
+```
+
+Partial restore output is never accepted as success. The restored target must
+match the source fingerprint across the full public-table set and Flyway
+metadata.
+
+## Application startup verification
+
+After persistence comparison, the current PayFlow JAR is built by default and
+started against the isolated restored database.
+
+Background mail/outbox/Kafka consumers and generalized abuse protection are
+disabled for this isolated startup check. The source database is not used.
+
+Startup passes only when PayFlow reaches:
+
+```text
+GET /api/v1/system/health
+HTTP 200
+```
+
+The temporary PayFlow process and restore container are then terminated.
+
+## Generated evidence and privacy
+
+Runtime evidence is written below the ignored rehearsal directory. Sanitized
+evidence includes only bounded operational facts such as:
+
+- Git branch and HEAD;
+- PostgreSQL version;
+- backup byte size and SHA-256;
+- public-table count;
+- Flyway successful-row count/latest version/metadata digest;
+- representative table row counts;
+- PASS/FAIL state for restore, Flyway comparison, application startup, and
+  health.
+
+The evidence must not contain:
+
+- row values or unnecessary personal data;
+- passwords or password hashes;
+- refresh credentials or credential digests;
+- JWTs, MFA secrets, recovery codes, or step-up grants;
+- protected mail content;
+- random target-database passwords.
+
+## Failure behavior
+
+The rehearsal fails closed when:
+
+- the Git tree is dirty or HEAD is detached;
+- Docker is unavailable;
+- source selection is ambiguous;
+- PostgreSQL is not on the expected major line;
+- the source application is still running;
+- source Flyway is stale or ahead of the checked-out migration set;
+- representative persistence is missing;
+- source state changes across the backup window;
+- `pg_dump`, `docker cp`, or `pg_restore` fails;
+- restored table/Flyway fingerprints differ;
+- the application JAR cannot be built;
+- PayFlow exits during isolated startup;
+- restored-database health does not reach HTTP 200.
+
+The script does not compensate for these failures by deleting the source,
+resetting its schema, restoring over it, or removing its persistent volume.
+
+## Options
+
+`-KeepDump`
+: Keep the ignored custom-format dump after the rehearsal for explicit local
+inspection. The default removes it.
+
+`-SkipPackage`
+: Reuse an existing `target/payflow-0.16.0-SNAPSHOT.jar`. The script fails if
+that artifact is absent.
+
+`-ComposeProject`, `-PostgresService`, `-AppService`, `-SourceDatabase`,
+`-SourceUser`
+: Override the explicit local source selectors. These values never turn the
+isolated target into the source.
+
+## Recovery limitations
+
+This rehearsal proves a bounded local backup/restore path. It does **not**
+provide or claim:
+
+- point-in-time recovery or WAL archival;
+- down-migration support;
+- cloud-provider backup integration;
+- automated retention/rotation policy;
+- production RPO/RTO;
+- production disaster-recovery certification;
+- logical row-by-row content checksums.
+
+Row-count plus Flyway metadata verification is intended to detect an
+empty/partial restore while avoiding exposure of sensitive row contents.
+
+## Reviewed local rehearsal evidence
+
+On 2026-08-20, before committing this operational contract, the procedure was
+rehearsed from exact repository baseline
+`d5c888b41082af7e48d964b4f403719ce6e031a6`.
+
+The successful final rehearsal recorded:
+
+- PostgreSQL `17.11`;
+- Flyway latest `V24`;
+- `19` public tables, including `flyway_schema_history`;
+- custom-format backup: PASS;
+- clean isolated restore: PASS;
+- complete public-table row-count comparison: PASS;
+- Flyway metadata comparison: PASS;
+- PayFlow startup against the restored database: PASS;
+- `/api/v1/system/health`: HTTP `200`;
+- repository tree: CLEAN;
+- sanitized external evidence SHA-256:
+  `644a8d8573a7efe224d9e4e03396f1818ed0cf92d9d64a202fa46e34fa168b4f`.
+
+The developer's persistent local volume was initially at Flyway V6. A safety
+backup was taken and that local source was upgraded to V24 as environment
+preparation before the successful final backup/restore probe. That preparation
+is **not** the v0.16.0 Increment 3 clean-install/previous-release upgrade
+rehearsal and does not mark Increment 3 complete.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -850,12 +850,12 @@ Baseline: v0.15.0 publication-record merge
 
 ### Increment 2 — PostgreSQL backup and restore rehearsal
 
-- [ ] Define one repeatable local backup procedure for the PostgreSQL system of record
-- [ ] Restore into a clean isolated database/environment
-- [ ] Verify Flyway schema history and representative identity, session, wallet, transfer, ledger, outbox, DLQ, and audit data after restore
-- [ ] Verify application startup against the restored database
-- [ ] Document integrity checks, operator failure handling, and evidence-redaction boundaries
-- [ ] Keep secrets, credentials, and personal data out of committed rehearsal evidence
+- [x] Define one repeatable local backup procedure for the PostgreSQL system of record
+- [x] Restore into a clean isolated database/environment
+- [x] Verify Flyway schema history and representative identity, session, wallet, transfer, ledger, outbox, DLQ, and audit data after restore
+- [x] Verify application startup against the restored database
+- [x] Document integrity checks, operator failure handling, and evidence-redaction boundaries
+- [x] Keep secrets, credentials, and personal data out of committed rehearsal evidence
 
 ### Increment 3 — Flyway clean-install and upgrade rehearsal
 
@@ -926,7 +926,7 @@ Baseline: v0.15.0 publication-record merge
 
 - [x] `0.16.0-SNAPSHOT` development baseline is opened through a protected PR
 - [x] `/api/v1` compatibility boundary is documented and executable where practical
-- [ ] PostgreSQL backup and restore rehearsal is repeatable and passes integrity checks
+- [x] PostgreSQL backup and restore rehearsal is repeatable and passes integrity checks
 - [ ] clean-install and previous-release-to-current Flyway rehearsals pass
 - [ ] Redis and Kafka outage/recovery procedures are documented and verified against existing failure contracts
 - [ ] OpenAPI, Postman, README, architecture docs, ADRs, security/operations guidance, and implementation agree

--- a/scripts/operations/postgres-backup-restore-rehearsal.ps1
+++ b/scripts/operations/postgres-backup-restore-rehearsal.ps1
@@ -1,0 +1,991 @@
+# PayFlow local PostgreSQL backup/restore rehearsal.
+# Generates runtime artifacts only under ignored .runtime/.
+# Does not migrate the source database and never restores over the source.
+param(
+    [string] $ComposeProject = 'payflow',
+    [string] $PostgresService = 'postgres',
+    [string] $AppService = 'app',
+    [string] $SourceDatabase = 'payflow',
+    [string] $SourceUser = 'payflow',
+    [string] $TargetImage = 'postgres:17-alpine',
+    [switch] $KeepDump,
+    [switch] $SkipPackage
+)
+
+$ErrorActionPreference = 'Stop'
+
+$TargetDatabase = 'payflow_restore'
+$TargetUser = 'payflow_restore'
+
+if ($TargetImage -notmatch '^postgres:17(?:-|$)') {
+    throw "This v0.16 rehearsal requires PostgreSQL 17 target tooling; got: $TargetImage"
+}
+
+if ($SourceDatabase -eq $TargetDatabase) {
+    throw 'Source and isolated target database names must differ.'
+}
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory)][string] $FilePath,
+        [Parameter(Mandatory)][string[]] $Arguments,
+        [string] $FailureMessage = 'Command failed.'
+    )
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$FailureMessage Exit code: $LASTEXITCODE"
+    }
+}
+
+function Invoke-Captured {
+    param(
+        [Parameter(Mandatory)][string] $FilePath,
+        [Parameter(Mandatory)][string[]] $Arguments
+    )
+
+    $Output = @(& $FilePath @Arguments 2>&1)
+    $Exit = $LASTEXITCODE
+
+    return [pscustomobject]@{
+        ExitCode = $Exit
+        Text = (($Output | ForEach-Object { "$_" }) -join "`n").Trim()
+    }
+}
+
+function Get-FreeTcpPort {
+    $Listener = [System.Net.Sockets.TcpListener]::new(
+        [System.Net.IPAddress]::Loopback,
+        0
+    )
+
+    try {
+        $Listener.Start()
+        return ([System.Net.IPEndPoint] $Listener.LocalEndpoint).Port
+    }
+    finally {
+        $Listener.Stop()
+    }
+}
+
+function Wait-PostgresReady {
+    param(
+        [Parameter(Mandatory)][string] $ContainerId,
+        [Parameter(Mandatory)][string] $User,
+        [Parameter(Mandatory)][string] $Database,
+        [int] $TimeoutSeconds = 60
+    )
+
+    $Deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+
+    while ([DateTime]::UtcNow -lt $Deadline) {
+        $Ready = Invoke-Captured `
+            -FilePath 'docker' `
+            -Arguments @(
+                'exec',
+                $ContainerId,
+                'pg_isready',
+                '-U',
+                $User,
+                '-d',
+                $Database
+            )
+
+        if ($Ready.ExitCode -eq 0) {
+            return
+        }
+
+        Start-Sleep -Seconds 1
+    }
+
+    throw "PostgreSQL container did not become ready within $TimeoutSeconds seconds."
+}
+
+function Invoke-PsqlScalar {
+    param(
+        [Parameter(Mandatory)][string] $ContainerId,
+        [Parameter(Mandatory)][string] $User,
+        [Parameter(Mandatory)][string] $Database,
+        [Parameter(Mandatory)][string] $Sql
+    )
+
+    $Result = Invoke-Captured `
+        -FilePath 'docker' `
+        -Arguments @(
+            'exec',
+            $ContainerId,
+            'psql',
+            '-U',
+            $User,
+            '-d',
+            $Database,
+            '-X',
+            '-A',
+            '-t',
+            '-v',
+            'ON_ERROR_STOP=1',
+            '-c',
+            $Sql
+        )
+
+    if ($Result.ExitCode -ne 0) {
+        throw "psql query failed: $($Result.Text)"
+    }
+
+    return $Result.Text.Trim()
+}
+
+function Get-DatabaseFingerprint {
+    param(
+        [Parameter(Mandatory)][string] $ContainerId,
+        [Parameter(Mandatory)][string] $User,
+        [Parameter(Mandatory)][string] $Database
+    )
+
+    $TableText = Invoke-PsqlScalar `
+        -ContainerId $ContainerId `
+        -User $User `
+        -Database $Database `
+        -Sql @'
+select tablename
+from pg_tables
+where schemaname = 'public'
+order by tablename;
+'@
+
+    $Tables = @(
+        $TableText -split "`n" |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ }
+    )
+
+    $Counts = [ordered]@{}
+
+    foreach ($Table in $Tables) {
+        if ($Table -notmatch '^[a-z_][a-z0-9_]*$') {
+            throw "Unsafe table identifier encountered: $Table"
+        }
+
+        $Count = Invoke-PsqlScalar `
+            -ContainerId $ContainerId `
+            -User $User `
+            -Database $Database `
+            -Sql "select count(*) from `"$Table`";"
+
+        $Counts[$Table] = [long] $Count
+    }
+
+    $FlywaySuccessCount = Invoke-PsqlScalar `
+        -ContainerId $ContainerId `
+        -User $User `
+        -Database $Database `
+        -Sql @'
+select count(*)
+from flyway_schema_history
+where success = true;
+'@
+
+    $FlywayLatest = Invoke-PsqlScalar `
+        -ContainerId $ContainerId `
+        -User $User `
+        -Database $Database `
+        -Sql @'
+select coalesce(version, '')
+from flyway_schema_history
+where success = true
+  and version is not null
+order by installed_rank desc
+limit 1;
+'@
+
+    $FlywayDigest = Invoke-PsqlScalar `
+        -ContainerId $ContainerId `
+        -User $User `
+        -Database $Database `
+        -Sql @'
+select md5(
+    string_agg(
+        coalesce(installed_rank::text, '') || '|' ||
+        coalesce(version, '') || '|' ||
+        coalesce(description, '') || '|' ||
+        coalesce(type, '') || '|' ||
+        coalesce(script, '') || '|' ||
+        coalesce(checksum::text, '') || '|' ||
+        coalesce(success::text, ''),
+        E'\n'
+        order by installed_rank
+    )
+)
+from flyway_schema_history;
+'@
+
+    return [pscustomobject]@{
+        Tables = $Tables
+        Counts = $Counts
+        FlywaySuccessCount = [long] $FlywaySuccessCount
+        FlywayLatest = $FlywayLatest
+        FlywayDigest = $FlywayDigest
+    }
+}
+
+function Assert-FingerprintEqual {
+    param(
+        [Parameter(Mandatory)] $Expected,
+        [Parameter(Mandatory)] $Actual,
+        [Parameter(Mandatory)][string] $Label
+    )
+
+    $ExpectedTables = @($Expected.Tables | Sort-Object)
+    $ActualTables = @($Actual.Tables | Sort-Object)
+
+    $TableDiff = @(
+        Compare-Object `
+            -ReferenceObject $ExpectedTables `
+            -DifferenceObject $ActualTables
+    )
+
+    if ($TableDiff.Count -ne 0) {
+        $TableDiff | Format-Table | Out-Host
+        throw "$Label table set differs."
+    }
+
+    foreach ($Table in $ExpectedTables) {
+        $ExpectedCount = [long] $Expected.Counts[$Table]
+        $ActualCount = [long] $Actual.Counts[$Table]
+
+        if ($ExpectedCount -ne $ActualCount) {
+            throw "$Label row count mismatch for $Table`: expected $ExpectedCount, got $ActualCount."
+        }
+    }
+
+    if ($Expected.FlywaySuccessCount -ne $Actual.FlywaySuccessCount) {
+        throw "$Label Flyway successful-row count differs."
+    }
+
+    if ($Expected.FlywayLatest -ne $Actual.FlywayLatest) {
+        throw "$Label Flyway latest version differs."
+    }
+
+    if ($Expected.FlywayDigest -ne $Actual.FlywayDigest) {
+        throw "$Label Flyway metadata digest differs."
+    }
+}
+
+function Get-JarPath {
+    $Jar = @(
+        Get-ChildItem `
+            -LiteralPath 'target' `
+            -Filter 'payflow-0.16.0-SNAPSHOT.jar' `
+            -File `
+            -ErrorAction SilentlyContinue
+    )
+
+    if ($Jar.Count -ne 1) {
+        return $null
+    }
+
+    return $Jar[0].FullName
+}
+
+function Get-ExpectedFlywayVersion {
+    $MigrationFiles = @(
+        Get-ChildItem `
+            -LiteralPath 'src\main\resources\db\migration' `
+            -Filter 'V*__*.sql' `
+            -File `
+            -ErrorAction Stop
+    )
+
+    $Versions = @(
+        foreach ($File in $MigrationFiles) {
+            if ($File.Name -match '^V(\d+)__') {
+                [int] $Matches[1]
+            }
+        }
+    )
+
+    if ($Versions.Count -eq 0) {
+        throw 'No versioned Flyway migrations were found.'
+    }
+
+    $Latest = ($Versions | Measure-Object -Maximum).Maximum
+    $Expected = @(1..$Latest)
+    $Missing = @(
+        $Expected |
+            Where-Object { $Versions -notcontains $_ }
+    )
+
+    if ($Missing.Count -ne 0) {
+        throw "Flyway migration sequence contains gaps: $($Missing -join ', ')."
+    }
+
+    return [string] $Latest
+}
+
+function Set-TemporaryEnvironment {
+    param(
+        [Parameter(Mandatory)][hashtable] $Values
+    )
+
+    $Previous = @{}
+
+    foreach ($Key in $Values.Keys) {
+        $Item = Get-Item "Env:$Key" -ErrorAction SilentlyContinue
+
+        $Previous[$Key] = if ($null -eq $Item) {
+            $null
+        }
+        else {
+            $Item.Value
+        }
+
+        Set-Item "Env:$Key" -Value $Values[$Key]
+    }
+
+    return $Previous
+}
+
+function Restore-Environment {
+    param(
+        [Parameter(Mandatory)][hashtable] $Previous
+    )
+
+    foreach ($Key in $Previous.Keys) {
+        if ($null -eq $Previous[$Key]) {
+            Remove-Item "Env:$Key" -ErrorAction SilentlyContinue
+        }
+        else {
+            Set-Item "Env:$Key" -Value $Previous[$Key]
+        }
+    }
+}
+
+Write-Host '=== 1. VERIFY REPRODUCIBLE REHEARSAL BASELINE ===' -ForegroundColor Cyan
+
+$RepoRoot = (& git rev-parse --show-toplevel).Trim()
+if ($LASTEXITCODE -ne 0) {
+    throw 'Not inside a Git repository.'
+}
+
+Set-Location -LiteralPath $RepoRoot
+
+$Branch = (& git branch --show-current).Trim()
+$Head = (& git rev-parse HEAD).Trim()
+$ExpectedFlywayVersion = Get-ExpectedFlywayVersion
+
+Write-Host "Branch          : $Branch"
+Write-Host "HEAD            : $Head"
+Write-Host "Expected Flyway : V$ExpectedFlywayVersion"
+
+if ([string]::IsNullOrWhiteSpace($Branch)) {
+    throw 'Detached HEAD is not accepted for a reproducible rehearsal.'
+}
+
+if (@(& git status --porcelain=v1).Count -ne 0) {
+    & git status --short
+    throw 'Working tree must be clean.'
+}
+
+Write-Host 'Clean repository baseline PASS.' -ForegroundColor Green
+
+Write-Host ''
+Write-Host '=== 2. VERIFY DOCKER + SOURCE POSTGRES ===' -ForegroundColor Cyan
+
+$DockerVersion = Invoke-Captured `
+    -FilePath 'docker' `
+    -Arguments @('version', '--format', '{{.Server.Version}}')
+
+if ($DockerVersion.ExitCode -ne 0) {
+    throw "Docker daemon is unavailable: $($DockerVersion.Text)"
+}
+
+$SourceContainer = Invoke-Captured `
+    -FilePath 'docker' `
+    -Arguments @(
+        'ps',
+        '--filter',
+        "label=com.docker.compose.project=$ComposeProject",
+        '--filter',
+        "label=com.docker.compose.service=$PostgresService",
+        '--format',
+        '{{.ID}}'
+    )
+
+if ($SourceContainer.ExitCode -ne 0) {
+    throw "Could not resolve PayFlow PostgreSQL container: $($SourceContainer.Text)"
+}
+
+$SourceRows = @(
+    $SourceContainer.Text -split "`n" |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ }
+)
+
+if ($SourceRows.Count -ne 1) {
+    throw "Expected exactly one running source PostgreSQL container, found $($SourceRows.Count)."
+}
+
+$SourceContainerId = $SourceRows[0]
+
+$SourceRunning = Invoke-Captured `
+    -FilePath 'docker' `
+    -Arguments @(
+        'inspect',
+        '--format',
+        '{{.State.Running}}|{{.Config.Image}}|{{.Name}}',
+        $SourceContainerId
+    )
+
+if ($SourceRunning.ExitCode -ne 0) {
+    throw "Could not inspect source PostgreSQL container: $($SourceRunning.Text)"
+}
+
+$SourceParts = $SourceRunning.Text -split '\|'
+$SourceIsRunning = $SourceParts[0].Trim()
+$SourceImage = $SourceParts[1].Trim()
+$SourceName = $SourceParts[2].TrimStart('/').Trim()
+
+if ($SourceIsRunning -ne 'true') {
+    throw 'Source PostgreSQL container is not running.'
+}
+
+if ($SourceImage -notmatch '^postgres:17(?:-|$)') {
+    throw "Expected PostgreSQL 17 source tooling, got image: $SourceImage"
+}
+
+Wait-PostgresReady `
+    -ContainerId $SourceContainerId `
+    -User $SourceUser `
+    -Database $SourceDatabase
+
+$SourceServerVersion = Invoke-PsqlScalar `
+    -ContainerId $SourceContainerId `
+    -User $SourceUser `
+    -Database $SourceDatabase `
+    -Sql "select current_setting('server_version');"
+
+$SourceCurrentDatabase = Invoke-PsqlScalar `
+    -ContainerId $SourceContainerId `
+    -User $SourceUser `
+    -Database $SourceDatabase `
+    -Sql 'select current_database();'
+
+if ($SourceCurrentDatabase -ne $SourceDatabase) {
+    throw "Resolved source database is unexpected: $SourceCurrentDatabase"
+}
+
+Write-Host "Source container : $SourceName"
+Write-Host "Source image     : $SourceImage"
+Write-Host "PostgreSQL       : $SourceServerVersion"
+
+$SourceApp = Invoke-Captured `
+    -FilePath 'docker' `
+    -Arguments @(
+        'ps',
+        '--filter',
+        "label=com.docker.compose.project=$ComposeProject",
+        '--filter',
+        "label=com.docker.compose.service=$AppService",
+        '--format',
+        '{{.ID}}|{{.Names}}'
+    )
+
+if ($SourceApp.ExitCode -ne 0) {
+    throw "Could not inspect source app container: $($SourceApp.Text)"
+}
+
+$SourceAppRows = @(
+    $SourceApp.Text -split "`n" |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ }
+)
+
+if ($SourceAppRows.Count -gt 0) {
+    throw @"
+The source PayFlow app is running and may write to PostgreSQL:
+  $($SourceAppRows -join ', ')
+Stop the source app before starting the rehearsal. The script never stops
+or restarts source application containers implicitly.
+"@
+}
+
+Write-Host 'Source app is stopped; backup window is quiescent.' `
+    -ForegroundColor Green
+
+Write-Host ''
+Write-Host '=== 3. CAPTURE SOURCE FINGERPRINT ===' -ForegroundColor Cyan
+
+$SourceBefore = Get-DatabaseFingerprint `
+    -ContainerId $SourceContainerId `
+    -User $SourceUser `
+    -Database $SourceDatabase
+
+if ($SourceBefore.FlywayLatest -ne $ExpectedFlywayVersion) {
+    throw "Source database is not at current Flyway V$ExpectedFlywayVersion; got V$($SourceBefore.FlywayLatest). Upgrade rehearsal belongs to a separate checkpoint."
+}
+
+$RepresentativeTables = @(
+    'users',
+    'refresh_token_families',
+    'refresh_token_records',
+    'wallets',
+    'payment_transactions',
+    'ledger_entries',
+    'outbox_events',
+    'kafka_dead_letter_records',
+    'kafka_dead_letter_command_audits'
+)
+
+foreach ($Table in $RepresentativeTables) {
+    if ($SourceBefore.Tables -notcontains $Table) {
+        throw "Representative persistence table is missing from source: $Table"
+    }
+}
+
+Write-Host "Source public tables : $($SourceBefore.Tables.Count)"
+Write-Host "Flyway success rows  : $($SourceBefore.FlywaySuccessCount)"
+Write-Host "Flyway latest        : V$($SourceBefore.FlywayLatest)"
+
+Write-Host ''
+Write-Host '=== 4. CREATE CUSTOM-FORMAT BACKUP ===' -ForegroundColor Cyan
+
+$Timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$RuntimeRoot = Join-Path `
+    $RepoRoot `
+    ".runtime\postgres-rehearsal\$Timestamp"
+
+New-Item -ItemType Directory -Path $RuntimeRoot -Force | Out-Null
+
+$DumpName = "payflow-$Timestamp.dump"
+$HostDumpPath = Join-Path $RuntimeRoot $DumpName
+$ContainerDumpPath = "/tmp/$DumpName"
+
+$TargetContainerName = "payflow-pg-restore-$Timestamp"
+$TargetContainerId = $null
+$TargetPassword = [Guid]::NewGuid().ToString('N')
+$AppProcess = $null
+$AppStdout = Join-Path $RuntimeRoot 'app.stdout.log'
+$AppStderr = Join-Path $RuntimeRoot 'app.stderr.log'
+$ReportPath = Join-Path `
+    $RuntimeRoot `
+    'evidence.txt'
+
+try {
+    Invoke-Checked `
+        -FilePath 'docker' `
+        -Arguments @(
+            'exec',
+            $SourceContainerId,
+            'pg_dump',
+            '-U',
+            $SourceUser,
+            '-d',
+            $SourceDatabase,
+            '--format=custom',
+            '--no-owner',
+            '--no-privileges',
+            "--file=$ContainerDumpPath"
+        ) `
+        -FailureMessage 'pg_dump failed.'
+
+    Invoke-Checked `
+        -FilePath 'docker' `
+        -Arguments @(
+            'cp',
+            "$SourceContainerId`:$ContainerDumpPath",
+            $HostDumpPath
+        ) `
+        -FailureMessage 'docker cp of backup failed.'
+
+    Invoke-Checked `
+        -FilePath 'docker' `
+        -Arguments @(
+            'exec',
+            $SourceContainerId,
+            'rm',
+            '-f',
+            $ContainerDumpPath
+        ) `
+        -FailureMessage 'Could not remove temporary dump from source container.'
+
+    if (-not (Test-Path -LiteralPath $HostDumpPath -PathType Leaf)) {
+        throw 'Host backup file was not created.'
+    }
+
+    $DumpLength = (Get-Item -LiteralPath $HostDumpPath).Length
+
+    if ($DumpLength -le 0) {
+        throw 'Backup file is empty.'
+    }
+
+    $DumpHash = (
+        Get-FileHash `
+            -LiteralPath $HostDumpPath `
+            -Algorithm SHA256
+    ).Hash.ToLowerInvariant()
+
+    Write-Host "Backup bytes  : $DumpLength"
+    Write-Host "Backup SHA256 : $DumpHash"
+
+    Write-Host ''
+    Write-Host '=== 5. VERIFY SOURCE DID NOT DRIFT DURING BACKUP ===' -ForegroundColor Cyan
+
+    $SourceAfter = Get-DatabaseFingerprint `
+        -ContainerId $SourceContainerId `
+        -User $SourceUser `
+        -Database $SourceDatabase
+
+    Assert-FingerprintEqual `
+        -Expected $SourceBefore `
+        -Actual $SourceAfter `
+        -Label 'Source pre/post-backup'
+
+    Write-Host 'Source pre/post-backup fingerprint PASS.' -ForegroundColor Green
+
+    Write-Host ''
+    Write-Host '=== 6. START CLEAN ISOLATED POSTGRES 17 TARGET ===' -ForegroundColor Cyan
+
+    $TargetPort = Get-FreeTcpPort
+
+    $RunTarget = Invoke-Captured `
+        -FilePath 'docker' `
+        -Arguments @(
+            'run',
+            '--detach',
+            '--rm',
+            '--name',
+            $TargetContainerName,
+            '-e',
+            "POSTGRES_DB=$TargetDatabase",
+            '-e',
+            "POSTGRES_USER=$TargetUser",
+            '-e',
+            "POSTGRES_PASSWORD=$TargetPassword",
+            '-p',
+            "127.0.0.1:$TargetPort`:5432",
+            $TargetImage
+        )
+
+    if ($RunTarget.ExitCode -ne 0) {
+        throw "Could not start isolated restore target: $($RunTarget.Text)"
+    }
+
+    $TargetContainerId = $RunTarget.Text.Trim()
+
+    if ($TargetContainerId -eq $SourceContainerId) {
+        throw 'Safety violation: target container resolved to source container.'
+    }
+
+    Wait-PostgresReady `
+        -ContainerId $TargetContainerId `
+        -User $TargetUser `
+        -Database $TargetDatabase
+
+    Write-Host "Target container: $TargetContainerName"
+    Write-Host "Target image    : $TargetImage"
+    Write-Host "Target database : $TargetDatabase"
+    Write-Host "Target port     : $TargetPort"
+
+    Write-Host ''
+    Write-Host '=== 7. RESTORE BACKUP INTO CLEAN TARGET ===' -ForegroundColor Cyan
+
+    $TargetDumpPath = "/tmp/$DumpName"
+
+    Invoke-Checked `
+        -FilePath 'docker' `
+        -Arguments @(
+            'cp',
+            $HostDumpPath,
+            "$TargetContainerId`:$TargetDumpPath"
+        ) `
+        -FailureMessage 'Could not copy backup into target container.'
+
+    Invoke-Checked `
+        -FilePath 'docker' `
+        -Arguments @(
+            'exec',
+            $TargetContainerId,
+            'pg_restore',
+            '-U',
+            $TargetUser,
+            '-d',
+            $TargetDatabase,
+            '--exit-on-error',
+            '--no-owner',
+            '--no-privileges',
+            $TargetDumpPath
+        ) `
+        -FailureMessage 'pg_restore failed.'
+
+    Invoke-Checked `
+        -FilePath 'docker' `
+        -Arguments @(
+            'exec',
+            $TargetContainerId,
+            'rm',
+            '-f',
+            $TargetDumpPath
+        ) `
+        -FailureMessage 'Could not remove temporary dump from target container.'
+
+    Write-Host 'Restore completed without pg_restore errors.' -ForegroundColor Green
+
+    Write-Host ''
+    Write-Host '=== 8. COMPARE RESTORED PERSISTENCE ===' -ForegroundColor Cyan
+
+    $TargetFingerprint = Get-DatabaseFingerprint `
+        -ContainerId $TargetContainerId `
+        -User $TargetUser `
+        -Database $TargetDatabase
+
+    Assert-FingerprintEqual `
+        -Expected $SourceAfter `
+        -Actual $TargetFingerprint `
+        -Label 'Restored database'
+
+    foreach ($Table in $RepresentativeTables) {
+        Write-Host (
+            '{0,-40} source={1,-8} restored={2,-8}' -f
+                $Table,
+                $SourceAfter.Counts[$Table],
+                $TargetFingerprint.Counts[$Table]
+        )
+    }
+
+    Write-Host 'Full public-table row-count + Flyway comparison PASS.' `
+        -ForegroundColor Green
+
+    Write-Host ''
+    Write-Host '=== 9. BUILD CURRENT APPLICATION ARTIFACT ===' -ForegroundColor Cyan
+
+    if (-not $SkipPackage) {
+        $MavenWrapper = if (Test-Path -LiteralPath 'mvnw.cmd') {
+            '.\mvnw.cmd'
+        }
+        elseif (Test-Path -LiteralPath 'mvnw') {
+            '.\mvnw'
+        }
+        else {
+            throw 'Maven wrapper was not found.'
+        }
+
+        & $MavenWrapper -B -ntp -DskipTests package
+
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Maven package for restored-database startup verification failed.'
+        }
+    }
+
+    $JarPath = Get-JarPath
+
+    if ($null -eq $JarPath) {
+        throw 'Expected payflow-0.16.0-SNAPSHOT.jar was not found. Run without -SkipPackage first.'
+    }
+
+    Write-Host "Application JAR: $JarPath"
+
+    Write-Host ''
+    Write-Host '=== 10. START PAYFLOW AGAINST RESTORED DATABASE ===' -ForegroundColor Cyan
+
+    $AppPort = Get-FreeTcpPort
+
+    $EnvironmentValues = @{
+        DB_URL = "jdbc:postgresql://127.0.0.1:$TargetPort/$TargetDatabase"
+        DB_USERNAME = $TargetUser
+        DB_PASSWORD = $TargetPassword
+        SERVER_PORT = "$AppPort"
+        REDIS_HOST = '127.0.0.1'
+        REDIS_PORT = '6379'
+        KAFKA_BOOTSTRAP_SERVERS = '127.0.0.1:9092'
+        MAIL_OUTBOX_POLLING_ENABLED = 'false'
+        OUTBOX_POLLING_ENABLED = 'false'
+        TRANSFER_COMPLETED_CONSUMER_ENABLED = 'false'
+        TRANSFER_COMPLETED_DLT_INTAKE_ENABLED = 'false'
+        ABUSE_PROTECTION_ENABLED = 'false'
+        JWT_KEY_PROVIDER_MODE = 'ephemeral'
+        MAIL_CONTENT_PROTECTION_MODE = 'ephemeral'
+        MFA_SECRET_PROTECTION_MODE = 'ephemeral'
+    }
+
+    $PreviousEnvironment = Set-TemporaryEnvironment `
+        -Values $EnvironmentValues
+
+    try {
+        $AppProcess = Start-Process `
+            -FilePath 'java' `
+            -ArgumentList @('-jar', $JarPath) `
+            -PassThru `
+            -RedirectStandardOutput $AppStdout `
+            -RedirectStandardError $AppStderr
+
+        $Deadline = [DateTime]::UtcNow.AddSeconds(120)
+        $HealthUri = "http://127.0.0.1:$AppPort/api/v1/system/health"
+        $HealthStatus = $null
+
+        while ([DateTime]::UtcNow -lt $Deadline) {
+            $AppProcess.Refresh()
+
+            if ($AppProcess.HasExited) {
+                $StdoutTail = if (Test-Path $AppStdout) {
+                    (Get-Content $AppStdout -Tail 40) -join "`n"
+                }
+                else {
+                    ''
+                }
+
+                $StderrTail = if (Test-Path $AppStderr) {
+                    (Get-Content $AppStderr -Tail 40) -join "`n"
+                }
+                else {
+                    ''
+                }
+
+                throw @"
+PayFlow exited before restored-database startup verification completed.
+STDOUT tail:
+$StdoutTail
+
+STDERR tail:
+$StderrTail
+"@
+            }
+
+            try {
+                $Response = Invoke-WebRequest `
+                    -Uri $HealthUri `
+                    -Method Get `
+                    -UseBasicParsing `
+                    -TimeoutSec 2
+
+                $HealthStatus = [int] $Response.StatusCode
+
+                if ($HealthStatus -eq 200) {
+                    break
+                }
+            }
+            catch {
+                # Startup is still in progress.
+            }
+
+            Start-Sleep -Seconds 2
+        }
+
+        if ($HealthStatus -ne 200) {
+            throw 'PayFlow did not return HTTP 200 from /api/v1/system/health within 120 seconds.'
+        }
+
+        Write-Host "Restored DB startup health: HTTP $HealthStatus" `
+            -ForegroundColor Green
+    }
+    finally {
+        Restore-Environment -Previous $PreviousEnvironment
+    }
+
+    Write-Host ''
+    Write-Host '=== 11. WRITE SANITIZED REHEARSAL EVIDENCE ===' -ForegroundColor Cyan
+
+    $Evidence = New-Object System.Collections.Generic.List[string]
+
+    [void] $Evidence.Add('PayFlow PostgreSQL Backup/Restore Rehearsal Evidence')
+    [void] $Evidence.Add("Branch: $Branch")
+    [void] $Evidence.Add("Baseline HEAD: $Head")
+    [void] $Evidence.Add("Source image: $SourceImage")
+    [void] $Evidence.Add("Source PostgreSQL version: $SourceServerVersion")
+    [void] $Evidence.Add("Target image: $TargetImage")
+    [void] $Evidence.Add("Backup bytes: $DumpLength")
+    [void] $Evidence.Add("Backup SHA-256: $DumpHash")
+    [void] $Evidence.Add("Public table count: $($SourceAfter.Tables.Count)")
+    [void] $Evidence.Add("Flyway successful rows: $($SourceAfter.FlywaySuccessCount)")
+    [void] $Evidence.Add("Flyway latest: V$($SourceAfter.FlywayLatest)")
+    [void] $Evidence.Add("Flyway metadata digest: $($SourceAfter.FlywayDigest)")
+    [void] $Evidence.Add('Source stable across backup: PASS')
+    [void] $Evidence.Add('Clean isolated restore: PASS')
+    [void] $Evidence.Add('All public table row counts preserved: PASS')
+    [void] $Evidence.Add('Flyway metadata preserved: PASS')
+    [void] $Evidence.Add('PayFlow startup against restored database: PASS')
+    [void] $Evidence.Add('System health against restored database: HTTP 200')
+    [void] $Evidence.Add('')
+    [void] $Evidence.Add('Representative persistence row counts:')
+
+    foreach ($Table in $RepresentativeTables) {
+        [void] $Evidence.Add(
+            "  $Table=$($SourceAfter.Counts[$Table])"
+        )
+    }
+
+    [void] $Evidence.Add('')
+    [void] $Evidence.Add('No row values, credentials, tokens, MFA secrets, protected mail content, or passwords are included in this evidence.')
+
+    [System.IO.File]::WriteAllText(
+        $ReportPath,
+        (($Evidence -join "`r`n") + "`r`n"),
+        [System.Text.UTF8Encoding]::new($true)
+    )
+
+    $EvidenceHash = (
+        Get-FileHash `
+            -LiteralPath $ReportPath `
+            -Algorithm SHA256
+    ).Hash.ToLowerInvariant()
+
+    Write-Host "Evidence: $ReportPath"
+    Write-Host "SHA256 : $EvidenceHash"
+
+    if (@(& git status --porcelain=v1).Count -ne 0) {
+        & git status --short
+        throw 'Repository changed during rehearsal.'
+    }
+
+    Write-Host ''
+    Write-Host '=============================================' -ForegroundColor Green
+    Write-Host 'POSTGRES BACKUP/RESTORE REHEARSAL PASS' -ForegroundColor Green
+    Write-Host '=============================================' -ForegroundColor Green
+    Write-Host "Branch       : $Branch"
+    Write-Host "HEAD         : $Head"
+    Write-Host "PostgreSQL   : $SourceServerVersion"
+    Write-Host "Flyway latest: V$($SourceAfter.FlywayLatest)"
+    Write-Host "Public tables: $($SourceAfter.Tables.Count)"
+    Write-Host 'Backup       : PASS'
+    Write-Host 'Restore      : PASS'
+    Write-Host 'Row counts   : PASS'
+    Write-Host 'Flyway       : PASS'
+    Write-Host 'App startup  : PASS'
+    Write-Host 'Health       : HTTP 200'
+    Write-Host 'Repo tree    : CLEAN'
+    Write-Host "Evidence     : $ReportPath"
+    Write-Host "SHA256       : $EvidenceHash"
+}
+finally {
+    if ($null -ne $AppProcess) {
+        try {
+            $AppProcess.Refresh()
+
+            if (-not $AppProcess.HasExited) {
+                Stop-Process -Id $AppProcess.Id -Force
+                [void] $AppProcess.WaitForExit(10000)
+            }
+        }
+        catch {
+            Write-Warning "Could not stop temporary PayFlow process cleanly: $($_.Exception.Message)"
+        }
+    }
+
+    if ($null -ne $TargetContainerId) {
+        $CleanupTarget = Invoke-Captured `
+            -FilePath 'docker' `
+            -Arguments @('rm', '-f', $TargetContainerId)
+
+        if ($CleanupTarget.ExitCode -ne 0) {
+            Write-Warning "Could not remove isolated target container: $($CleanupTarget.Text)"
+        }
+    }
+
+    if (-not $KeepDump -and (Test-Path -LiteralPath $HostDumpPath)) {
+        Remove-Item -LiteralPath $HostDumpPath -Force
+    }
+
+    if (@(& git status --porcelain=v1).Count -ne 0) {
+        Write-Warning 'Repository became dirty during rehearsal; inspect git status.'
+        & git status --short
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/V016ApiCompatibilityBaselineContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V016ApiCompatibilityBaselineContractTest.java
@@ -216,7 +216,7 @@ class V016ApiCompatibilityBaselineContractTest {
     }
 
     @Test
-    void shouldMarkIncrementOneCompleteWithoutStartingLaterWork()
+    void shouldKeepCompatibilityCheckpointHistoricalDuringRecoveryWork()
         throws IOException {
 
         String roadmap = Files.readString(ROADMAP);
@@ -234,7 +234,7 @@ class V016ApiCompatibilityBaselineContractTest {
             )
             .contains(
                 "### Increment 2 — PostgreSQL backup and restore rehearsal",
-                "- [ ] Define one repeatable local backup procedure for the PostgreSQL system of record"
+                "- [x] Define one repeatable local backup procedure for the PostgreSQL system of record"
             );
 
         assertThat(Files.readString(CHANGELOG))

--- a/src/test/java/com/nursena/payflow/configuration/V016PostgresBackupRestoreContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V016PostgresBackupRestoreContractTest.java
@@ -1,0 +1,200 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class V016PostgresBackupRestoreContractTest {
+
+    private static final Path SCRIPT =
+        Path.of(
+            "scripts",
+            "operations",
+            "postgres-backup-restore-rehearsal.ps1"
+        );
+
+    private static final Path GUIDE =
+        Path.of(
+            "docs",
+            "operations",
+            "postgresql-backup-restore.md"
+        );
+
+    private static final Path ROADMAP =
+        Path.of("docs", "roadmap.md");
+
+    private static final Path README =
+        Path.of("README.md");
+
+    private static final Path CHANGELOG =
+        Path.of("CHANGELOG.md");
+
+    private static final Path GITIGNORE =
+        Path.of(".gitignore");
+
+    private static final Path COMPOSE =
+        Path.of("compose.yml");
+
+    private static final Path API_BASELINE =
+        Path.of("docs", "api-v1-compatibility.md");
+
+    @Test
+    void shouldCommitSafePostgres17BackupAndIsolatedRestoreProcedure()
+        throws IOException {
+
+        String script = Files.readString(SCRIPT);
+
+        assertThat(Files.readString(COMPOSE))
+            .contains("image: postgres:17-alpine");
+
+        assertThat(script)
+            .contains(
+                "postgres:17-alpine",
+                "Get-ExpectedFlywayVersion",
+                ".runtime\\postgres-rehearsal",
+                "pg_dump",
+                "--format=custom",
+                "--no-owner",
+                "--no-privileges",
+                "pg_restore",
+                "--exit-on-error",
+                "TargetContainerId -eq $SourceContainerId",
+                "The source PayFlow app is running and may write to PostgreSQL"
+            )
+            .doesNotContain(
+                "git reset --hard",
+                "docker compose down -v",
+                "docker volume rm",
+                "DROP DATABASE"
+            );
+    }
+
+    @Test
+    void shouldVerifyFlywayRepresentativePersistenceAndRestoredStartup()
+        throws IOException {
+
+        assertThat(Files.readString(SCRIPT))
+            .contains(
+                "flyway_schema_history",
+                "Assert-FingerprintEqual",
+                "users",
+                "refresh_token_families",
+                "refresh_token_records",
+                "wallets",
+                "payment_transactions",
+                "ledger_entries",
+                "outbox_events",
+                "kafka_dead_letter_records",
+                "kafka_dead_letter_command_audits",
+                "/api/v1/system/health",
+                "Restored DB startup health: HTTP"
+            )
+            .doesNotContain(
+                "refresh_token_sessions"
+            );
+    }
+
+    @Test
+    void shouldDocumentEvidencePrivacyAndRecoveryLimitations()
+        throws IOException {
+
+        String guide = Files.readString(GUIDE);
+
+        assertThat(guide)
+            .contains(
+                "Issue: [#173]",
+                "production disaster-recovery certification",
+                "point-in-time recovery or WAL archival",
+                "down-migration support",
+                "No row values are written",
+                "random target-database passwords",
+                "19` public tables",
+                "Flyway latest `V24`",
+                "HTTP `200`",
+                "644a8d8573a7efe224d9e4e03396f1818ed0cf92d9d64a202fa46e34fa168b4f",
+                "does not mark Increment 3 complete"
+            );
+
+        assertThat(Files.readString(GITIGNORE))
+            .contains(".runtime/");
+    }
+
+    @Test
+    void shouldMarkOnlyPostgresBackupRestoreIncrementComplete()
+        throws IOException {
+
+        String roadmap = Files.readString(ROADMAP);
+
+        String incrementTwo = sectionBetween(
+            roadmap,
+            "### Increment 2 — PostgreSQL backup and restore rehearsal",
+            "### Increment 3 — Flyway clean-install and upgrade rehearsal"
+        );
+
+        String incrementThree = sectionBetween(
+            roadmap,
+            "### Increment 3 — Flyway clean-install and upgrade rehearsal",
+            "### Increment 4 — Redis and Kafka outage/recovery operations"
+        );
+
+        assertThat(incrementTwo)
+            .contains("- [x]")
+            .doesNotContain("- [ ]");
+
+        assertThat(incrementThree)
+            .contains("- [ ]");
+
+        assertThat(roadmap)
+            .contains(
+                "- [x] PostgreSQL backup and restore rehearsal is repeatable and passes integrity checks"
+            );
+    }
+
+    @Test
+    void shouldPublishOperationalContractWithoutChangingApiOrSchema()
+        throws IOException {
+
+        assertThat(Files.readString(README))
+            .contains(
+                "[PostgreSQL backup/restore operations guide](docs/operations/postgresql-backup-restore.md)",
+                "Issue #173"
+            );
+
+        assertThat(Files.readString(CHANGELOG))
+            .contains(
+                "PostgreSQL 17 backup and isolated-restore rehearsal",
+                "issue #173",
+                "without changing runtime API, security, or Flyway schema behavior"
+            );
+
+        assertThat(Files.readString(API_BASELINE))
+            .contains(
+                "**30 canonical HTTP operations**",
+                "**28 unique route paths**"
+            );
+    }
+
+    private static String sectionBetween(
+        String source,
+        String startMarker,
+        String endMarker
+    ) {
+
+        int start = source.indexOf(startMarker);
+        int end = source.indexOf(endMarker, start + startMarker.length());
+
+        assertThat(start)
+            .as("start marker")
+            .isGreaterThanOrEqualTo(0);
+
+        assertThat(end)
+            .as("end marker")
+            .isGreaterThan(start);
+
+        return source.substring(start, end);
+    }
+}


### PR DESCRIPTION
## Summary

Completes v0.16.0 Increment 2 tracked by #173 with a repeatable PostgreSQL 17 backup/restore rehearsal and focused operational documentation/contracts.

## Scope

- add `scripts/operations/postgres-backup-restore-rehearsal.ps1`
- add `docs/operations/postgresql-backup-restore.md`
- verify source selection through Docker Compose labels and refuse a running source app
- require the source schema to already be at the latest checked-in Flyway version; migration remains Increment 3 work
- create a PostgreSQL 17 custom-format backup only under ignored `.runtime/`
- restore only into a fresh isolated PostgreSQL 17 container
- compare the complete public-table set, row counts, and bounded Flyway metadata
- verify representative identity/session/wallet/transfer/ledger/outbox/DLQ/audit persistence
- start the current PayFlow JAR against the restored database and require `GET /api/v1/system/health` = HTTP 200
- keep dumps, credentials, row values, plaintext security material, and personal-data evidence out of Git
- update README, changelog, roadmap, and focused executable contracts

No runtime API, security, DTO, Flyway migration, or schema behavior is changed.

## Verification

Exact reviewed head: `c9b8781678438f381d043ab006a4c7954729b42a`

Local verification on that branch:

- `git diff --check`: PASS
- focused backup/restore/documentation contracts: PASS
- complete Maven verification: **1600 tests, 0 failures, 0 errors, 0 skipped**
- committed rehearsal on exact head: PASS
- PostgreSQL source: **17.11**
- Flyway latest: **V24**
- public tables: **19**
- custom-format backup: PASS
- clean isolated restore: PASS
- full public-table row-count comparison: PASS
- Flyway metadata comparison: PASS
- PayFlow startup against restored database: PASS
- restored-database health: **HTTP 200**
- repository tree after rehearsal: CLEAN
- sanitized local post-commit evidence SHA-256: `2938f16e299e2a7047064e08505c9cda19b6e111104ad5469071fd9e284c8817`

## Safety boundary

The rehearsal never restores over or deletes the source database/volume, does not auto-migrate a stale source schema, and does not claim point-in-time recovery, down-migrations, RPO/RTO, or production disaster-recovery certification.

Closes #173 only after this exact head passes CI and Docker Smoke and the reviewed PR is merged.