### PR TITLE
ops(flyway): add clean install and upgrade rehearsal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Added a repeatable PostgreSQL 17 Flyway clean-install and previous-release upgrade rehearsal through issue #175, proving empty-database V1 through V24 installation, immutable v0.13.0 / V17 to V24 upgrade, historical migration immutability, deterministic synthetic-data preservation, current constraint behavior, and application startup without changing runtime API, security, or migration schema content.
 - Added a repeatable PostgreSQL 17 backup and isolated-restore rehearsal through issue #173, including custom-format backup tooling, clean-target restore, Flyway/public-table integrity checks, restored-database application startup, sanitized local evidence, and a focused operations guide without changing runtime API, security, or Flyway schema behavior.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ v0.16.0 Increment 2 is tracked by [Issue #173](https://github.com/nursena-pc/pay
 
 See the [PostgreSQL backup/restore operations guide](docs/operations/postgresql-backup-restore.md) for prerequisites, source-selection safeguards, evidence boundaries, exact commands, and recovery limitations.
 
+## Flyway clean-install / upgrade rehearsal
+
+v0.16.0 Increment 3 is tracked by [Issue #175](https://github.com/nursena-pc/payflow/issues/175). The committed rehearsal proves a fresh PostgreSQL 17 database reaches the complete V1 through V24 schema and separately proves the immutable v0.13.0 / V17 release baseline upgrades through V18 through V24 while preserving deterministic synthetic representative data.
+
+The rehearsal rejects historical V1 through V17 migration drift, verifies the complete current Flyway history and database invariants, starts PayFlow against both resulting databases, and keeps recovery responsibility in the separate backup/restore boundary.
+
+See the [Flyway clean-install / upgrade operations guide](docs/operations/flyway-clean-upgrade.md) for the approved previous-release baseline, synthetic-data fingerprint contract, exact command, failure behavior, and rollback limitations.
+
 ## Structured logging
 
 PayFlow supports single-line JSON logs through the `structured-logging` and `production` Spring profiles. HTTP requests emit one bounded completion event containing the correlation ID, route template, method, status, duration, and outcome without logging bodies, query strings, authorization headers, cookies, raw URI paths, or financial/user data.

--- a/docs/operations/flyway-clean-upgrade.md
+++ b/docs/operations/flyway-clean-upgrade.md
@@ -1,0 +1,234 @@
+# Flyway Clean-Install and Upgrade Rehearsal
+
+Issue: [#175](https://github.com/nursena-pc/payflow/issues/175)
+
+PayFlow v0.16.0 uses this local stabilization rehearsal to prove two separate
+forward-migration paths on PostgreSQL 17:
+
+1. an empty database reaches the complete current V1 through V24 schema; and
+2. the approved immutable `v0.13.0` / V17 release schema and representative
+   synthetic data upgrade through V18 through V24 without hidden historical
+   drift.
+
+The committed entry point is:
+
+```powershell
+.\scripts\operations\flyway-clean-upgrade-rehearsal.ps1
+```
+
+This is developer/stabilization evidence. It is not production migration,
+rollback, disaster-recovery, RPO, or RTO certification.
+
+## Approved previous-release baseline
+
+The reviewed previous-release source is immutable tag `v0.13.0`, whose release
+commit is:
+
+```text
+726f631a0de800870813ccb0c00b2676eb5d172b
+```
+
+That release carries Flyway V1 through V17. The current v0.16.0 line carries V1
+through V24. Inventory performed for issue #175 proved that the current V1
+through V17 migration blobs are identical to the immutable v0.13.0 blobs, so
+the upgrade delta is exactly V18 through V24.
+
+`v0.14.0` and `v0.15.0` are deliberately not used as schema-upgrade sources:
+both already carry the same V24 migration tree as the current line and
+therefore would not exercise a real schema upgrade.
+
+The rehearsal refuses an unexpected `v0.13.0` tag target or historical V1
+through V17 blob drift.
+
+## Prerequisites and isolation
+
+Before running:
+
+- Docker must be available.
+- Java 21 and the Maven wrapper must be available.
+- immutable tag `v0.13.0` must exist locally at the reviewed commit.
+- HEAD must be attached to a branch and the Git working tree must be clean.
+- PostgreSQL 17 container images must be available.
+
+The procedure never uses the developer's persistent PayFlow database. It starts
+two separate loopback-only, ephemeral `postgres:17-alpine` containers with
+random process-local passwords:
+
+- one clean-install target;
+- one previous-release upgrade target.
+
+The temporary v0.13.0 source checkout is a detached Git worktree outside the
+main working tree and is removed after the rehearsal. Runtime logs, synthetic
+SQL, and sanitized evidence live below:
+
+```text
+.runtime/flyway-rehearsal/<timestamp>/
+```
+
+`.runtime/` is ignored by Git.
+
+## Clean-install proof
+
+The current `0.16.0-SNAPSHOT` application is built and started against an empty
+PostgreSQL 17 database. Application startup owns normal Flyway execution;
+Hibernate remains `ddl-auto: validate`.
+
+Success requires:
+
+- exactly 24 successful versioned Flyway rows;
+- ordered V1 through V24 versions;
+- script names matching the checked-in migration files;
+- the complete current 19-table public schema, including
+  `flyway_schema_history`;
+- the current refresh-family and account-security check constraints;
+- successful PayFlow startup; and
+- `GET /api/v1/system/health` returning HTTP 200.
+
+No `flyway repair`, baseline shortcut, schema import, dump restore, or manual DDL
+is used to make the clean installation pass.
+
+## Previous-release V17 baseline
+
+The rehearsal creates the upgrade source by building the immutable v0.13.0
+source in its detached worktree and starting that JAR against a second empty
+PostgreSQL 17 database.
+
+That startup must produce exactly V1 through V17 and the expected V17 public
+table set.
+
+Only after the immutable release baseline is proven does the script insert
+deterministic synthetic rehearsal state.
+
+## Representative synthetic data boundary
+
+All 13 non-Flyway V17 data tables are deliberately non-empty before upgrade:
+
+- `users`
+- `wallets`
+- `payment_transactions`
+- `ledger_entries`
+- `outbox_events`
+- `processed_kafka_events`
+- `transfer_completed_event_audits`
+- `kafka_dead_letter_records`
+- `kafka_dead_letter_command_audits`
+- `refresh_token_families`
+- `refresh_token_records`
+- `account_action_credentials`
+- `mail_outbox_messages`
+
+The seed contains only fixed synthetic identifiers and `example.invalid` /
+`payflow.invalid` values. It is not copied from a developer or production
+database.
+
+Before the current application is allowed to run V18 through V24, each table
+receives a deterministic fingerprint consisting of row count plus an MD5 digest
+of sorted PostgreSQL `to_jsonb(row)::text` values.
+
+After the upgrade, every one of those 13 table fingerprints must match exactly.
+This is stronger than a count-only check and is appropriate here because the
+input is deliberately synthetic and contains no real credentials or personal
+data.
+
+Fingerprint digests, not row values, are written to sanitized evidence.
+
+## Upgrade and current-schema proof
+
+The current v0.16.0 application then starts against the V17 database and applies
+only V18 through V24.
+
+Success requires:
+
+- the final Flyway sequence to match checked-in V1 through V24;
+- the deterministic V1 through V17 Flyway metadata digest to remain unchanged;
+- all 13 V17 table content fingerprints to remain unchanged;
+- V18 through V22 current MFA/account-security tables to exist;
+- the V23 refresh-family constraint to accept `MFA_DISABLED`;
+- the V24 account-security audit constraint to accept
+  `RECOVERY_CODES_ROTATED`;
+- the V23/V24 behavior probe to roll back without persisting rehearsal rows;
+- successful current PayFlow startup; and
+- `/api/v1/system/health` to return HTTP 200.
+
+## Failure and drift handling
+
+The rehearsal fails rather than repairing history when it sees:
+
+- a dirty or detached Git state;
+- an unexpected immutable v0.13.0 tag target;
+- missing, extra, duplicated, renamed, or failed Flyway history;
+- historical V1 through V17 blob drift;
+- a migration sequence other than current V1 through V24;
+- a v0.13.0 baseline other than V1 through V17;
+- a missing current table or required constraint value;
+- an empty representative V17 data table;
+- a changed V17 row count or row-content fingerprint after upgrade;
+- failed PostgreSQL startup;
+- failed current or previous-release application startup; or
+- health that does not reach HTTP 200.
+
+The script does not contain `flyway repair`, `git reset --hard`, database-volume
+deletion, source-database overwrite, or an automated down-migration.
+
+## Recovery and rollback boundary
+
+Flyway versioned migrations are treated as forward migrations. PayFlow does not
+claim automated down-migration support.
+
+If an operational upgrade must be abandoned and returning to a pre-upgrade
+database state is required, use the separately reviewed
+[PostgreSQL backup/restore procedure](postgresql-backup-restore.md) with an
+appropriate pre-upgrade backup. Increment 3 does not silently couple database
+backup creation to migration execution.
+
+This local rehearsal does not establish point-in-time recovery, WAL archival,
+production rollback automation, production RPO/RTO, or disaster-recovery
+certification.
+
+## Evidence and privacy
+
+Generated evidence contains bounded operational facts only:
+
+- branch and exact HEAD;
+- immutable previous-release tag/commit;
+- PostgreSQL image line;
+- clean-install and upgrade PASS state;
+- migration ranges;
+- historical-drift result;
+- table counts and content digests for synthetic V17 state;
+- constraint checks; and
+- application health results.
+
+It must not contain real email addresses, passwords, password hashes from real
+users, refresh credentials, JWTs, MFA secrets, recovery codes, step-up grants,
+protected mail content, production payloads, random target-database passwords,
+or database dumps.
+
+## Reviewed local proof
+
+Before this contract was committed, the exact issue #175 branch baseline
+`08670c89a5a673cecaa87dcc6f48871cbcc504d8` was rehearsed successfully on
+2026-08-20.
+
+The successful probe proved:
+
+- clean PostgreSQL 17 install V1 through V24: PASS;
+- clean-installed application health: HTTP 200;
+- approved upgrade source: immutable v0.13.0 / V17;
+- exact upgrade delta V18 through V24: PASS;
+- historical migration drift: zero;
+- all 13 V17 data tables seeded with synthetic state;
+- all 13 V17 row-content fingerprints preserved;
+- upgraded application health: HTTP 200;
+- V23 `MFA_DISABLED` constraint behavior: PASS;
+- V24 `RECOVERY_CODES_ROTATED` constraint behavior: PASS; and
+- repository tree remained clean.
+
+Sanitized external probe evidence SHA-256:
+
+```text
+7709c3e1f56d8d5128cbcd98318b5a1d0b8aaab05d1ce41196646dd2ce7d585e
+```
+
+The committed script is rerun from its own reviewed commit before the branch is
+pushed for PR review.

--- a/docs/operations/flyway-clean-upgrade.md
+++ b/docs/operations/flyway-clean-upgrade.md
@@ -45,14 +45,18 @@ through V17 blob drift.
 Before running:
 
 - Docker must be available.
-- Java 21 and the Maven wrapper must be available.
+- `JAVA_HOME` must point to the Java 21 JDK used by PayFlow, and the Maven
+  wrapper must be available.
 - immutable tag `v0.13.0` must exist locally at the reviewed commit.
 - HEAD must be attached to a branch and the Git working tree must be clean.
 - PostgreSQL 17 container images must be available.
 
-The procedure never uses the developer's persistent PayFlow database. It starts
-two separate loopback-only, ephemeral `postgres:17-alpine` containers with
-random process-local passwords:
+The procedure never uses the developer's persistent PayFlow database. Application
+startup resolves `JAVA_HOME/bin/java.exe`, verifies that it is Java 21, and
+never falls back to an unrelated bare `java` earlier on `PATH`.
+
+The procedure starts two separate loopback-only, ephemeral
+`postgres:17-alpine` containers with random process-local passwords:
 
 - one clean-install target;
 - one previous-release upgrade target.
@@ -155,6 +159,8 @@ Success requires:
 The rehearsal fails rather than repairing history when it sees:
 
 - a dirty or detached Git state;
+- missing `JAVA_HOME`, a missing `JAVA_HOME/bin/java.exe`, or a `JAVA_HOME`
+  runtime whose major version is not Java 21;
 - an unexpected immutable v0.13.0 tag target;
 - missing, extra, duplicated, renamed, or failed Flyway history;
 - historical V1 through V17 blob drift;

--- a/docs/operations/postgresql-backup-restore.md
+++ b/docs/operations/postgresql-backup-restore.md
@@ -238,5 +238,6 @@ The successful final rehearsal recorded:
 The developer's persistent local volume was initially at Flyway V6. A safety
 backup was taken and that local source was upgraded to V24 as environment
 preparation before the successful final backup/restore probe. That preparation
-is **not** the v0.16.0 Increment 3 clean-install/previous-release upgrade
-rehearsal and does not mark Increment 3 complete.
+was **not** the v0.16.0 Increment 3 clean-install/previous-release upgrade
+rehearsal and did not by itself mark Increment 3 complete. Increment 3 is
+verified separately by the Flyway clean-install / upgrade rehearsal.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -859,11 +859,11 @@ Baseline: v0.15.0 publication-record merge
 
 ### Increment 3 — Flyway clean-install and upgrade rehearsal
 
-- [ ] Prove a clean database reaches the current schema through the complete migration chain
-- [ ] Prove an approved previous-release schema/data set upgrades to the current schema without drift
-- [ ] Verify Flyway history and required database invariants after migration
-- [ ] Document recovery and rollback boundaries without claiming unsupported down-migrations
-- [ ] Keep migration rehearsal commands reproducible and isolated from developer data
+- [x] Prove a clean database reaches the current schema through the complete migration chain
+- [x] Prove an approved previous-release schema/data set upgrades to the current schema without drift
+- [x] Verify Flyway history and required database invariants after migration
+- [x] Document recovery and rollback boundaries without claiming unsupported down-migrations
+- [x] Keep migration rehearsal commands reproducible and isolated from developer data
 
 ### Increment 4 — Redis and Kafka outage/recovery operations
 
@@ -927,7 +927,7 @@ Baseline: v0.15.0 publication-record merge
 - [x] `0.16.0-SNAPSHOT` development baseline is opened through a protected PR
 - [x] `/api/v1` compatibility boundary is documented and executable where practical
 - [x] PostgreSQL backup and restore rehearsal is repeatable and passes integrity checks
-- [ ] clean-install and previous-release-to-current Flyway rehearsals pass
+- [x] clean-install and previous-release-to-current Flyway rehearsals pass
 - [ ] Redis and Kafka outage/recovery procedures are documented and verified against existing failure contracts
 - [ ] OpenAPI, Postman, README, architecture docs, ADRs, security/operations guidance, and implementation agree
 - [ ] dependency vulnerability and secret scans have no unresolved critical/high release blockers

--- a/scripts/operations/flyway-clean-upgrade-rehearsal.ps1
+++ b/scripts/operations/flyway-clean-upgrade-rehearsal.ps1
@@ -294,6 +294,49 @@ function Restore-Env([hashtable]$Old) {
     }
 }
 
+function Resolve-Java21 {
+    if ([string]::IsNullOrWhiteSpace($env:JAVA_HOME)) {
+        throw 'JAVA_HOME must point to the Java 21 JDK used by PayFlow.'
+    }
+
+    $javaExecutable = Join-Path `
+        $env:JAVA_HOME `
+        'bin\java.exe'
+
+    if (-not (
+        Test-Path `
+            -LiteralPath $javaExecutable `
+            -PathType Leaf
+    )) {
+        throw "JAVA_HOME does not contain bin\java.exe: $env:JAVA_HOME"
+    }
+
+    $version = Run-Captured `
+        $javaExecutable `
+        @('-version')
+
+    if ($version.Code -ne 0) {
+        throw "JAVA_HOME Java version check failed: $($version.Text)"
+    }
+
+    $match = [regex]::Match(
+        $version.Text,
+        '(?im)^(?:openjdk|java) version "([0-9]+)(?:\.|")'
+    )
+
+    if (-not $match.Success) {
+        throw "Could not parse JAVA_HOME Java version: $($version.Text)"
+    }
+
+    $major = [int] $match.Groups[1].Value
+
+    if ($major -ne 21) {
+        throw "Flyway rehearsal requires JAVA_HOME Java 21; got Java $major."
+    }
+
+    return $javaExecutable
+}
+
 function Run-App(
     [string]$Jar,[string]$Url,[string]$User,[string]$Password,
     [string]$LogPrefix,[string]$Label
@@ -316,10 +359,13 @@ function Run-App(
         MANAGEMENT_HEALTH_REDIS_ENABLED = 'false'
     }
 
+    $javaExecutable = Resolve-Java21
+    Write-Host "$Label runtime: JAVA_HOME Java 21"
+
     $proc = $null
     try {
         $proc = Start-Process `
-            -FilePath 'java' `
+            -FilePath $javaExecutable `
             -ArgumentList @('-jar',$Jar) `
             -PassThru `
             -RedirectStandardOutput "$LogPrefix.stdout.log" `

--- a/scripts/operations/flyway-clean-upgrade-rehearsal.ps1
+++ b/scripts/operations/flyway-clean-upgrade-rehearsal.ps1
@@ -1,0 +1,828 @@
+# PayFlow v0.16 local Flyway clean-install / previous-release upgrade rehearsal.
+# Uses fresh PostgreSQL 17 targets, immutable v0.13.0/V17 as the approved
+# upgrade source, synthetic data only, never repairs Flyway history, and
+# does not implement a down-migration.
+$ErrorActionPreference = 'Stop'
+
+$ExpectedV013Commit = '726f631a0de800870813ccb0c00b2676eb5d172b'
+$PostgresImage = 'postgres:17-alpine'
+
+$V17Tables = @(
+    'users','wallets','payment_transactions','ledger_entries',
+    'outbox_events','processed_kafka_events',
+    'transfer_completed_event_audits','kafka_dead_letter_records',
+    'kafka_dead_letter_command_audits','refresh_token_families',
+    'refresh_token_records','account_action_credentials',
+    'mail_outbox_messages'
+)
+
+$CurrentTables = @(
+    $V17Tables +
+    @(
+        'mfa_authenticators','mfa_login_challenges','mfa_recovery_codes',
+        'step_up_grants','account_security_audits','flyway_schema_history'
+    )
+)
+
+function Run-Captured([string]$Exe,[string[]]$CommandArgs) {
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $out = @(& $Exe @CommandArgs 2>&1)
+        $code = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $old
+    }
+    [pscustomobject]@{
+        Code = $code
+        Text = (($out | ForEach-Object { "$_" }) -join "`n").Trim()
+    }
+}
+
+function Run-Checked([string]$Exe,[string[]]$CommandArgs,[string]$Message) {
+    & $Exe @CommandArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Message Exit code: $LASTEXITCODE"
+    }
+}
+
+function Git-Scalar([string[]]$CommandArgs) {
+    $r = Run-Captured 'git' $CommandArgs
+    if ($r.Code -ne 0) {
+        throw "git $($CommandArgs -join ' ') failed: $($r.Text)"
+    }
+    $r.Text.Trim()
+}
+
+function Free-Port {
+    $l = [System.Net.Sockets.TcpListener]::new(
+        [System.Net.IPAddress]::Loopback, 0
+    )
+    try {
+        $l.Start()
+        ([System.Net.IPEndPoint]$l.LocalEndpoint).Port
+    }
+    finally {
+        $l.Stop()
+    }
+}
+
+function Wait-Pg([string]$Id,[string]$User,[string]$Db) {
+    $deadline = [DateTime]::UtcNow.AddSeconds(60)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $r = Run-Captured 'docker' @(
+            'exec',$Id,'pg_isready','-U',$User,'-d',$Db
+        )
+        if ($r.Code -eq 0) { return }
+        Start-Sleep -Seconds 1
+    }
+    throw 'PostgreSQL readiness timeout.'
+}
+
+function Start-Pg(
+    [string]$Name,[string]$Db,[string]$User,[string]$Password,[int]$Port
+) {
+    $r = Run-Captured 'docker' @(
+        'run','--detach','--rm','--name',$Name,
+        '-e',"POSTGRES_DB=$Db",
+        '-e',"POSTGRES_USER=$User",
+        '-e',"POSTGRES_PASSWORD=$Password",
+        '-p',"127.0.0.1:$Port`:5432",
+        $PostgresImage
+    )
+    if ($r.Code -ne 0) {
+        throw "PostgreSQL container start failed: $($r.Text)"
+    }
+    $id = $r.Text.Trim()
+    Wait-Pg $id $User $Db
+    $id
+}
+
+function Psql(
+    [string]$Id,[string]$User,[string]$Db,[string]$Sql
+) {
+    $r = Run-Captured 'docker' @(
+        'exec',$Id,'psql','-U',$User,'-d',$Db,
+        '-X','-A','-t','-v','ON_ERROR_STOP=1','-c',$Sql
+    )
+    if ($r.Code -ne 0) {
+        throw "psql failed: $($r.Text)"
+    }
+    $r.Text.Trim()
+}
+
+function Psql-File(
+    [string]$Id,[string]$User,[string]$Db,
+    [string]$HostPath,[string]$ContainerPath
+) {
+    Run-Checked 'docker' @(
+        'cp',$HostPath,"$Id`:$ContainerPath"
+    ) 'docker cp failed.'
+    try {
+        Run-Checked 'docker' @(
+            'exec',$Id,'psql','-U',$User,'-d',$Db,
+            '-X','-v','ON_ERROR_STOP=1','-f',$ContainerPath
+        ) 'psql file execution failed.'
+    }
+    finally {
+        $null = Run-Captured 'docker' @(
+            'exec',$Id,'rm','-f',$ContainerPath
+        )
+    }
+}
+
+function Expected-Migrations([string]$Ref) {
+    $paths = @(
+        git ls-tree -r --name-only $Ref -- 'src/main/resources/db/migration'
+    )
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not list migrations at $Ref."
+    }
+
+    @(
+        $paths |
+        Where-Object { $_ -match '/V(\d+)__.+\.sql$' } |
+        ForEach-Object {
+            $_ -match '/V(\d+)__(.+)\.sql$' | Out-Null
+            [pscustomobject]@{
+                Version = [int]$Matches[1]
+                Script = [IO.Path]::GetFileName($_)
+            }
+        } |
+        Sort-Object Version
+    )
+}
+
+function Flyway-Rows([string]$Id,[string]$User,[string]$Db) {
+    $text = Psql $Id $User $Db @'
+select installed_rank::text || '|' ||
+       version || '|' ||
+       script || '|' ||
+       coalesce(checksum::text,'') || '|' ||
+       success::text
+from flyway_schema_history
+where version is not null
+order by installed_rank;
+'@
+    $rows = @()
+    foreach ($line in ($text -split "`n")) {
+        if (-not $line.Trim()) { continue }
+        $p = $line.Split('|')
+        if ($p.Count -ne 5) { throw "Bad Flyway row: $line" }
+        $rows += [pscustomobject]@{
+            Rank = [int]$p[0]
+            Version = [int]$p[1]
+            Script = $p[2]
+            Checksum = $p[3]
+            Success = $p[4]
+        }
+    }
+    $rows
+}
+
+function Assert-Flyway(
+    [string]$Id,[string]$User,[string]$Db,$Expected,[string]$Label
+) {
+    $actual = @(Flyway-Rows $Id $User $Db)
+    if ($actual.Count -ne $Expected.Count) {
+        throw "$Label Flyway count mismatch: expected $($Expected.Count), got $($actual.Count)."
+    }
+    for ($i = 0; $i -lt $Expected.Count; $i++) {
+        if ($actual[$i].Version -ne $Expected[$i].Version) {
+            throw "$Label Flyway version mismatch at index $i."
+        }
+        if ($actual[$i].Script -ne $Expected[$i].Script) {
+            throw "$Label Flyway script mismatch at V$($Expected[$i].Version)."
+        }
+        if ($actual[$i].Success -ne 'true') {
+            throw "$Label Flyway V$($actual[$i].Version) was not successful."
+        }
+    }
+    $actual
+}
+
+function History-Prefix-Digest(
+    [string]$Id,[string]$User,[string]$Db,[int]$Max
+) {
+    Psql $Id $User $Db @"
+select md5(string_agg(
+    installed_rank::text || '|' || version || '|' ||
+    description || '|' || type || '|' || script || '|' ||
+    coalesce(checksum::text,'') || '|' || success::text,
+    E'\n' order by installed_rank))
+from flyway_schema_history
+where version is not null and version::integer <= $Max;
+"@
+}
+
+function Table-Set([string]$Id,[string]$User,[string]$Db) {
+    $t = Psql $Id $User $Db @'
+select tablename
+from pg_tables
+where schemaname='public'
+order by tablename;
+'@
+    @($t -split "`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+}
+
+function Assert-Set([string[]]$Actual,[string[]]$Expected,[string]$Label) {
+    $d = @(
+        Compare-Object `
+            -ReferenceObject @($Expected | Sort-Object -Unique) `
+            -DifferenceObject @($Actual | Sort-Object -Unique)
+    )
+    if ($d.Count -ne 0) {
+        $d | Format-Table | Out-Host
+        throw "$Label mismatch."
+    }
+}
+
+function Fingerprints(
+    [string]$Id,[string]$User,[string]$Db,[string[]]$Tables
+) {
+    $map = @{}
+    foreach ($table in $Tables) {
+        if ($table -notmatch '^[a-z_][a-z0-9_]*$') {
+            throw "Unsafe table: $table"
+        }
+        $v = Psql $Id $User $Db @"
+select count(*)::text || '|' ||
+       coalesce(md5(string_agg(to_jsonb(t)::text, E'\n'
+           order by to_jsonb(t)::text)), md5(''))
+from "$table" t;
+"@
+        $p = $v.Split('|')
+        if ($p.Count -ne 2) { throw "Bad fingerprint for $table`: $v" }
+        $map[$table] = [pscustomobject]@{
+            Count = [long]$p[0]
+            Digest = $p[1]
+        }
+    }
+    $map
+}
+
+function Assert-Fingerprints($Before,$After,[string[]]$Tables) {
+    foreach ($table in $Tables) {
+        if ($Before[$table].Count -ne $After[$table].Count) {
+            throw "Count changed for $table."
+        }
+        if ($Before[$table].Digest -ne $After[$table].Digest) {
+            throw "Content fingerprint changed for $table."
+        }
+    }
+}
+
+function Set-Env([hashtable]$Values) {
+    $old = @{}
+    foreach ($k in $Values.Keys) {
+        $item = Get-Item "Env:$k" -ErrorAction SilentlyContinue
+        $old[$k] = if ($null -eq $item) { $null } else { $item.Value }
+        Set-Item "Env:$k" -Value $Values[$k]
+    }
+    $old
+}
+
+function Restore-Env([hashtable]$Old) {
+    foreach ($k in $Old.Keys) {
+        if ($null -eq $Old[$k]) {
+            Remove-Item "Env:$k" -ErrorAction SilentlyContinue
+        }
+        else {
+            Set-Item "Env:$k" -Value $Old[$k]
+        }
+    }
+}
+
+function Run-App(
+    [string]$Jar,[string]$Url,[string]$User,[string]$Password,
+    [string]$LogPrefix,[string]$Label
+) {
+    $port = Free-Port
+    $old = Set-Env @{
+        DB_URL = $Url
+        DB_USERNAME = $User
+        DB_PASSWORD = $Password
+        SERVER_PORT = "$port"
+        LOGIN_RATE_LIMIT_ENABLED = 'false'
+        ABUSE_PROTECTION_ENABLED = 'false'
+        MAIL_OUTBOX_POLLING_ENABLED = 'false'
+        OUTBOX_POLLING_ENABLED = 'false'
+        TRANSFER_COMPLETED_CONSUMER_ENABLED = 'false'
+        TRANSFER_COMPLETED_DLT_INTAKE_ENABLED = 'false'
+        JWT_KEY_PROVIDER_MODE = 'ephemeral'
+        MAIL_CONTENT_PROTECTION_MODE = 'ephemeral'
+        MFA_SECRET_PROTECTION_MODE = 'ephemeral'
+        MANAGEMENT_HEALTH_REDIS_ENABLED = 'false'
+    }
+
+    $proc = $null
+    try {
+        $proc = Start-Process `
+            -FilePath 'java' `
+            -ArgumentList @('-jar',$Jar) `
+            -PassThru `
+            -RedirectStandardOutput "$LogPrefix.stdout.log" `
+            -RedirectStandardError "$LogPrefix.stderr.log"
+
+        $deadline = [DateTime]::UtcNow.AddSeconds(150)
+        $status = $null
+        while ([DateTime]::UtcNow -lt $deadline) {
+            $proc.Refresh()
+            if ($proc.HasExited) {
+                $out = if (Test-Path "$LogPrefix.stdout.log") {
+                    (Get-Content "$LogPrefix.stdout.log" -Tail 60) -join "`n"
+                } else { '' }
+                $err = if (Test-Path "$LogPrefix.stderr.log") {
+                    (Get-Content "$LogPrefix.stderr.log" -Tail 60) -join "`n"
+                } else { '' }
+                throw "$Label exited early.`nSTDOUT:`n$out`nSTDERR:`n$err"
+            }
+            try {
+                $r = Invoke-WebRequest `
+                    -Uri "http://127.0.0.1:$port/api/v1/system/health" `
+                    -UseBasicParsing -TimeoutSec 2
+                $status = [int]$r.StatusCode
+                if ($status -eq 200) { break }
+            }
+            catch {}
+            Start-Sleep -Seconds 2
+        }
+        if ($status -ne 200) {
+            throw "$Label health did not reach HTTP 200."
+        }
+        Write-Host "$Label health: HTTP 200" -ForegroundColor Green
+    }
+    finally {
+        if ($null -ne $proc) {
+            try {
+                $proc.Refresh()
+                if (-not $proc.HasExited) {
+                    Stop-Process -Id $proc.Id -Force
+                    [void]$proc.WaitForExit(10000)
+                }
+            }
+            catch {}
+        }
+        Restore-Env $old
+    }
+}
+
+function Assert-Current-Schema(
+    [string]$Id,[string]$User,[string]$Db,[string]$Label
+) {
+    Assert-Set (Table-Set $Id $User $Db) $CurrentTables "$Label table set"
+
+    $refresh = Psql $Id $User $Db @'
+select pg_get_constraintdef(oid)
+from pg_constraint
+where conname='chk_refresh_token_families_revocation_reason';
+'@
+    if (-not $refresh.Contains('PASSWORD_RECOVERY') -or
+        -not $refresh.Contains('MFA_DISABLED')) {
+        throw "$Label refresh-family constraint mismatch."
+    }
+
+    $audit = Psql $Id $User $Db @'
+select pg_get_constraintdef(oid)
+from pg_constraint
+where conname='chk_account_security_audits_action';
+'@
+    if (-not $audit.Contains('MFA_DISABLED') -or
+        -not $audit.Contains('RECOVERY_CODES_ROTATED')) {
+        throw "$Label account-security constraint mismatch."
+    }
+}
+
+Write-Host '=== 1. VERIFY CLEAN REHEARSAL BASELINE ===' -ForegroundColor Cyan
+
+$RepoRoot = Git-Scalar @('rev-parse','--show-toplevel')
+Set-Location $RepoRoot
+
+$Branch = Git-Scalar @('branch','--show-current')
+$Head = Git-Scalar @('rev-parse','HEAD')
+
+Write-Host "Branch: $Branch"
+Write-Host "HEAD  : $Head"
+
+if ([string]::IsNullOrWhiteSpace($Branch)) {
+    throw 'Detached HEAD is not accepted for a reproducible Flyway rehearsal.'
+}
+
+if (@(git status --porcelain=v1).Count -ne 0) {
+    git status --short
+    throw 'Working tree must be clean.'
+}
+
+$V013Commit = Git-Scalar @('rev-list','-n','1','v0.13.0')
+if ($V013Commit -ne $ExpectedV013Commit) {
+    throw "Unexpected immutable v0.13.0 commit: $V013Commit"
+}
+
+$docker = Run-Captured 'docker' @('version','--format','{{.Server.Version}}')
+if ($docker.Code -ne 0) {
+    throw "Docker unavailable: $($docker.Text)"
+}
+
+Write-Host 'Clean branch/tag baseline PASS.' -ForegroundColor Green
+
+Write-Host ''
+Write-Host '=== 2. VERIFY MIGRATION HISTORY BASELINES ===' -ForegroundColor Cyan
+
+$CurrentExpected = @(Expected-Migrations 'HEAD')
+$V013Expected = @(Expected-Migrations 'v0.13.0')
+
+if ($CurrentExpected.Count -ne 24) { throw 'Current migration count is not 24.' }
+if ($V013Expected.Count -ne 17) { throw 'v0.13.0 migration count is not 17.' }
+
+for ($i=0; $i -lt 17; $i++) {
+    if ($CurrentExpected[$i].Version -ne $V013Expected[$i].Version -or
+        $CurrentExpected[$i].Script -ne $V013Expected[$i].Script) {
+        throw "Historical migration name/version drift at index $i."
+    }
+
+    $a = Git-Scalar @(
+        'rev-parse',
+        "HEAD:src/main/resources/db/migration/$($CurrentExpected[$i].Script)"
+    )
+    $b = Git-Scalar @(
+        'rev-parse',
+        "v0.13.0:src/main/resources/db/migration/$($V013Expected[$i].Script)"
+    )
+    if ($a -ne $b) {
+        throw "Historical blob drift: $($CurrentExpected[$i].Script)"
+    }
+}
+
+$delta = @(
+    $CurrentExpected |
+        Where-Object { $_.Version -gt 17 } |
+        ForEach-Object { "$($_.Version)" }
+)
+Assert-Set $delta @('18','19','20','21','22','23','24') 'V18..V24 delta'
+Write-Host 'V1..V17 immutable; V18..V24 exact delta PASS.' -ForegroundColor Green
+
+$Stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$RuntimeRoot = Join-Path `
+    $RepoRoot `
+    ".runtime\flyway-rehearsal\$Stamp"
+$ExternalWorktreeRoot = Join-Path `
+    (Split-Path -Parent $RepoRoot) `
+    "payflow.runtime\flyway-worktree\$Stamp"
+$Worktree = Join-Path $ExternalWorktreeRoot 'v0.13.0-source'
+$SeedFile = Join-Path $RuntimeRoot 'v0.13.0-upgrade-seed.sql'
+$ConstraintFile = Join-Path $RuntimeRoot 'current-constraint-probe.sql'
+$Evidence = Join-Path $RuntimeRoot 'evidence.txt'
+
+New-Item -ItemType Directory -Path $RuntimeRoot -Force | Out-Null
+New-Item -ItemType Directory -Path $ExternalWorktreeRoot -Force | Out-Null
+
+$CleanId = $null
+$UpgradeId = $null
+$WorktreeAdded = $false
+
+try {
+    Write-Host ''
+    Write-Host '=== 3. BUILD CURRENT V0.16 JAR ===' -ForegroundColor Cyan
+
+    & .\mvnw.cmd -B -ntp -DskipTests package
+    if ($LASTEXITCODE -ne 0) { throw 'Current package build failed.' }
+
+    $CurrentJar = Join-Path `
+        $RepoRoot `
+        'target\payflow-0.16.0-SNAPSHOT.jar'
+    if (-not (Test-Path $CurrentJar)) { throw 'Current JAR missing.' }
+
+    Write-Host ''
+    Write-Host '=== 4. CLEAN INSTALL: EMPTY POSTGRESQL 17 -> V24 ===' -ForegroundColor Cyan
+
+    $CleanPort = Free-Port
+    $CleanDb = 'payflow_clean'
+    $CleanUser = 'payflow_clean'
+    $CleanPass = [Guid]::NewGuid().ToString('N')
+    $CleanId = Start-Pg `
+        "payflow-flyway-clean-$Stamp" `
+        $CleanDb $CleanUser $CleanPass $CleanPort
+
+    Run-App `
+        $CurrentJar `
+        "jdbc:postgresql://127.0.0.1:$CleanPort/$CleanDb" `
+        $CleanUser $CleanPass `
+        (Join-Path $RuntimeRoot 'clean-current') `
+        'Current clean-install app'
+
+    $cleanHistory = @(
+        Assert-Flyway $CleanId $CleanUser $CleanDb $CurrentExpected 'Clean install'
+    )
+    Assert-Current-Schema $CleanId $CleanUser $CleanDb 'Clean install'
+    Write-Host "Clean install history: $($cleanHistory.Count) successful rows." `
+        -ForegroundColor Green
+
+    Write-Host ''
+    Write-Host '=== 5. BUILD IMMUTABLE V0.13.0 JAR ===' -ForegroundColor Cyan
+
+    Run-Checked 'git' @(
+        'worktree','add','--detach',$Worktree,'v0.13.0'
+    ) 'Temporary v0.13.0 worktree creation failed.'
+    $WorktreeAdded = $true
+
+    $wtHead = (Run-Captured 'git' @('-C',$Worktree,'rev-parse','HEAD'))
+    if ($wtHead.Code -ne 0 -or $wtHead.Text.Trim() -ne $ExpectedV013Commit) {
+        throw 'Temporary v0.13.0 worktree has unexpected HEAD.'
+    }
+
+    Push-Location $Worktree
+    try {
+        & .\mvnw.cmd -B -ntp -DskipTests package
+        if ($LASTEXITCODE -ne 0) { throw 'v0.13.0 package build failed.' }
+    }
+    finally {
+        Pop-Location
+    }
+
+    $V013Jar = Join-Path $Worktree 'target\payflow-0.13.0.jar'
+    if (-not (Test-Path $V013Jar)) { throw 'v0.13.0 JAR missing.' }
+
+    Write-Host ''
+    Write-Host '=== 6. IMMUTABLE PREVIOUS-RELEASE BASELINE -> V17 ===' `
+        -ForegroundColor Cyan
+
+    $UpgradePort = Free-Port
+    $UpgradeDb = 'payflow_upgrade'
+    $UpgradeUser = 'payflow_upgrade'
+    $UpgradePass = [Guid]::NewGuid().ToString('N')
+    $UpgradeId = Start-Pg `
+        "payflow-flyway-upgrade-$Stamp" `
+        $UpgradeDb $UpgradeUser $UpgradePass $UpgradePort
+
+    Run-App `
+        $V013Jar `
+        "jdbc:postgresql://127.0.0.1:$UpgradePort/$UpgradeDb" `
+        $UpgradeUser $UpgradePass `
+        (Join-Path $RuntimeRoot 'upgrade-v013') `
+        'Immutable v0.13.0 baseline app'
+
+    $null = Assert-Flyway `
+        $UpgradeId $UpgradeUser $UpgradeDb $V013Expected 'v0.13.0 baseline'
+
+    Assert-Set `
+        (Table-Set $UpgradeId $UpgradeUser $UpgradeDb) `
+        @($V17Tables + 'flyway_schema_history') `
+        'v0.13.0 table set'
+
+    $HistoryBefore = History-Prefix-Digest `
+        $UpgradeId $UpgradeUser $UpgradeDb 17
+
+    Write-Host 'Immutable v0.13.0 V17 baseline PASS.' -ForegroundColor Green
+
+    Write-Host ''
+    Write-Host '=== 7. SEED ALL 13 V17 DATA TABLES ===' -ForegroundColor Cyan
+
+    $seed = @'
+BEGIN;
+
+INSERT INTO users
+(id,email,password_hash,role,status,created_at,updated_at,email_verified_at)
+VALUES
+('00000000-0000-0000-0000-000000000101','upgrade-user-1@example.invalid','synthetic-hash-not-a-credential','USER','ACTIVE','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z'),
+('00000000-0000-0000-0000-000000000102','upgrade-user-2@example.invalid','synthetic-hash-not-a-credential','USER','ACTIVE','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z');
+
+INSERT INTO wallets
+(id,owner_id,balance,currency,status,version,created_at,updated_at)
+VALUES
+('00000000-0000-0000-0000-000000000201','00000000-0000-0000-0000-000000000101',900.00,'USD','ACTIVE',1,'2026-01-01T00:00:00Z','2026-01-01T00:10:00Z'),
+('00000000-0000-0000-0000-000000000202','00000000-0000-0000-0000-000000000102',1100.00,'USD','ACTIVE',1,'2026-01-01T00:00:00Z','2026-01-01T00:10:00Z');
+
+INSERT INTO payment_transactions
+(id,source_wallet_id,target_wallet_id,transaction_type,status,amount,currency,idempotency_key,failure_reason,created_at,completed_at)
+VALUES
+('00000000-0000-0000-0000-000000000301','00000000-0000-0000-0000-000000000201','00000000-0000-0000-0000-000000000202','TRANSFER','COMPLETED',100.00,'USD','v013-upgrade-rehearsal',NULL,'2026-01-01T00:05:00Z','2026-01-01T00:05:01Z');
+
+INSERT INTO ledger_entries
+(id,transaction_id,wallet_id,entry_type,amount,currency,created_at)
+VALUES
+('00000000-0000-0000-0000-000000000401','00000000-0000-0000-0000-000000000301','00000000-0000-0000-0000-000000000201','DEBIT',100.00,'USD','2026-01-01T00:05:01Z'),
+('00000000-0000-0000-0000-000000000402','00000000-0000-0000-0000-000000000301','00000000-0000-0000-0000-000000000202','CREDIT',100.00,'USD','2026-01-01T00:05:01Z');
+
+INSERT INTO outbox_events
+(id,aggregate_type,aggregate_id,event_type,event_version,topic,partition_key,deduplication_key,payload,status,attempt_count,available_at,locked_at,locked_until,locked_by,created_at,published_at,last_error)
+VALUES
+('00000000-0000-0000-0000-000000000501','PAYMENT_TRANSACTION','00000000-0000-0000-0000-000000000301','wallet.transfer.completed',1,'wallet.transfer.completed','00000000-0000-0000-0000-000000000301','v013-upgrade-rehearsal-outbox','{"synthetic":true,"source":"v0.13.0"}'::jsonb,'PENDING',0,'2026-01-01T00:05:01Z',NULL,NULL,NULL,'2026-01-01T00:05:01Z',NULL,NULL);
+
+INSERT INTO processed_kafka_events
+(consumer_name,event_id,event_type,event_version,topic,partition_number,record_offset,processed_at)
+VALUES
+('v013-upgrade-rehearsal-consumer','00000000-0000-0000-0000-000000000601','wallet.transfer.completed',1,'wallet.transfer.completed',0,42,'2026-01-01T00:06:00Z');
+
+INSERT INTO transfer_completed_event_audits
+(event_id,event_type,event_version,occurred_at,transaction_id,source_wallet_id,target_wallet_id,amount,currency,recorded_at)
+VALUES
+('00000000-0000-0000-0000-000000000601','wallet.transfer.completed',1,'2026-01-01T00:05:01Z','00000000-0000-0000-0000-000000000301','00000000-0000-0000-0000-000000000201','00000000-0000-0000-0000-000000000202',100.00,'USD','2026-01-01T00:06:00Z');
+
+INSERT INTO kafka_dead_letter_records
+(id,dlt_topic,dlt_partition,dlt_offset,original_topic,original_partition,original_offset,original_consumer_group,record_key,payload,exception_type,exception_message,status,replay_count,received_at,last_replayed_at,replay_lease_owner,replay_lease_until,last_replay_error,replay_origin_id,replay_attempt_base)
+VALUES
+('00000000-0000-0000-0000-000000000701','wallet.transfer.completed.dlt',0,7,'wallet.transfer.completed',0,6,'v013-upgrade-rehearsal-group',NULL,NULL,'SyntheticRehearsalException',NULL,'RECEIVED',0,'2026-01-01T00:07:00Z',NULL,NULL,NULL,NULL,'00000000-0000-0000-0000-000000000701',0);
+
+INSERT INTO kafka_dead_letter_command_audits
+(id,command_id,stage,operator_id,dead_letter_record_id,command_type,outcome,error_code,occurred_at)
+VALUES
+('00000000-0000-0000-0000-000000000801','00000000-0000-0000-0000-000000000802','ATTEMPTED','00000000-0000-0000-0000-000000000101','00000000-0000-0000-0000-000000000701','REPLAY',NULL,NULL,'2026-01-01T00:08:00Z');
+
+INSERT INTO refresh_token_families
+(id,user_id,created_at,expires_at,revoked_at,revocation_reason)
+VALUES
+('00000000-0000-0000-0000-000000000901','00000000-0000-0000-0000-000000000101','2026-01-01T00:00:00Z','2026-01-31T00:00:00Z','2026-01-02T00:00:00Z','PASSWORD_RECOVERY');
+
+INSERT INTO refresh_token_records
+(id,family_id,token_digest,issued_at,expires_at,consumed_at,successor_id)
+VALUES
+('00000000-0000-0000-0000-000000000902','00000000-0000-0000-0000-000000000901',decode(repeat('11',32),'hex'),'2026-01-01T00:00:00Z','2026-01-07T00:00:00Z',NULL,NULL);
+
+INSERT INTO account_action_credentials
+(id,user_id,purpose,credential_digest,issued_at,expires_at,consumed_at,superseded_at)
+VALUES
+('00000000-0000-0000-0000-000000001001','00000000-0000-0000-0000-000000000101','PASSWORD_RECOVERY',decode(repeat('22',32),'hex'),'2026-01-01T01:00:00Z','2026-01-01T02:00:00Z','2026-01-01T01:30:00Z',NULL);
+
+INSERT INTO mail_outbox_messages
+(id,user_id,purpose,recipient,subject,protected_body,message_id,status,attempt_count,available_at,expires_at,locked_at,locked_until,locked_by,created_at,sent_at,last_error)
+VALUES
+('00000000-0000-0000-0000-000000001101','00000000-0000-0000-0000-000000000101','PASSWORD_RECOVERY','upgrade-mail@example.invalid','Synthetic Flyway upgrade rehearsal',NULL,'<v013-upgrade-rehearsal@payflow.invalid>','SENT',1,'2026-01-01T01:00:00Z','2026-01-01T02:00:00Z',NULL,NULL,NULL,'2026-01-01T01:00:00Z','2026-01-01T01:05:00Z',NULL);
+
+COMMIT;
+'@
+
+    [IO.File]::WriteAllText(
+        $SeedFile,$seed + "`r`n",[Text.UTF8Encoding]::new($true)
+    )
+    Psql-File `
+        $UpgradeId $UpgradeUser $UpgradeDb `
+        $SeedFile '/tmp/v013-seed.sql'
+
+    $Before = Fingerprints `
+        $UpgradeId $UpgradeUser $UpgradeDb $V17Tables
+
+    foreach ($table in $V17Tables) {
+        if ($Before[$table].Count -le 0) {
+            throw "Seed left $table empty."
+        }
+    }
+
+    Write-Host '13 / 13 V17 data tables seeded.' -ForegroundColor Green
+
+    Write-Host ''
+    Write-Host '=== 8. UPGRADE V17 -> V24 WITH CURRENT APP ===' -ForegroundColor Cyan
+
+    Run-App `
+        $CurrentJar `
+        "jdbc:postgresql://127.0.0.1:$UpgradePort/$UpgradeDb" `
+        $UpgradeUser $UpgradePass `
+        (Join-Path $RuntimeRoot 'upgrade-current') `
+        'Current upgrade app'
+
+    $null = Assert-Flyway `
+        $UpgradeId $UpgradeUser $UpgradeDb $CurrentExpected `
+        'v0.13.0 -> current upgrade'
+
+    $HistoryAfter = History-Prefix-Digest `
+        $UpgradeId $UpgradeUser $UpgradeDb 17
+    if ($HistoryBefore -ne $HistoryAfter) {
+        throw 'Historical V1..V17 Flyway metadata changed.'
+    }
+
+    $After = Fingerprints `
+        $UpgradeId $UpgradeUser $UpgradeDb $V17Tables
+    Assert-Fingerprints $Before $After $V17Tables
+    Assert-Current-Schema `
+        $UpgradeId $UpgradeUser $UpgradeDb 'Upgrade'
+
+    Write-Host 'All 13 V17 row-content fingerprints preserved.' `
+        -ForegroundColor Green
+
+    Write-Host ''
+    Write-Host '=== 9. VERIFY V23/V24 NEW CONSTRAINT VALUES WITH ROLLBACK ===' `
+        -ForegroundColor Cyan
+
+    $constraintSql = @'
+BEGIN;
+UPDATE refresh_token_families
+SET revocation_reason='MFA_DISABLED'
+WHERE id='00000000-0000-0000-0000-000000000901';
+
+INSERT INTO account_security_audits
+(id,subject_user_id,action,occurred_at)
+VALUES
+('00000000-0000-0000-0000-000000001201',
+ '00000000-0000-0000-0000-000000000101',
+ 'RECOVERY_CODES_ROTATED',
+ '2026-01-03T00:00:00Z');
+ROLLBACK;
+'@
+
+    [IO.File]::WriteAllText(
+        $ConstraintFile,
+        $constraintSql + "`r`n",
+        [Text.UTF8Encoding]::new($true)
+    )
+    Psql-File `
+        $UpgradeId $UpgradeUser $UpgradeDb `
+        $ConstraintFile '/tmp/constraint-probe.sql'
+
+    $AfterProbe = Fingerprints `
+        $UpgradeId $UpgradeUser $UpgradeDb $V17Tables
+    Assert-Fingerprints $After $AfterProbe $V17Tables
+
+    if ([long](Psql $UpgradeId $UpgradeUser $UpgradeDb `
+        'select count(*) from account_security_audits;') -ne 0) {
+        throw 'Constraint probe persisted data unexpectedly.'
+    }
+
+    Write-Host 'V23/V24 constraint expansion PASS; transaction rolled back.' `
+        -ForegroundColor Green
+
+    Write-Host ''
+    Write-Host '=== 10. WRITE SANITIZED EVIDENCE ===' -ForegroundColor Cyan
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    [void]$lines.Add('PayFlow v0.16.0 Flyway Clean-Install / Upgrade Rehearsal Evidence')
+    [void]$lines.Add("Branch: $Branch")
+    [void]$lines.Add("HEAD: $Head")
+    [void]$lines.Add("Previous release: v0.13.0 @ $ExpectedV013Commit")
+    [void]$lines.Add("PostgreSQL image: $PostgresImage")
+    [void]$lines.Add('Historical V1..V17 blob drift: 0')
+    [void]$lines.Add('Clean install V1..V24: PASS')
+    [void]$lines.Add('Clean-install health HTTP 200: PASS')
+    [void]$lines.Add('Immutable v0.13.0 V1..V17 baseline: PASS')
+    [void]$lines.Add('Synthetic V17 seed: all 13 data tables non-empty')
+    [void]$lines.Add('Upgrade V18..V24: PASS')
+    [void]$lines.Add('Historical V1..V17 Flyway metadata preserved: PASS')
+    [void]$lines.Add('All 13 V17 row-content fingerprints preserved: PASS')
+    [void]$lines.Add('Upgrade health HTTP 200: PASS')
+    [void]$lines.Add('V23 MFA_DISABLED constraint expansion: PASS')
+    [void]$lines.Add('V24 RECOVERY_CODES_ROTATED constraint expansion: PASS')
+    [void]$lines.Add('')
+    [void]$lines.Add('V17 table evidence (count + digest only):')
+    foreach ($table in $V17Tables) {
+        [void]$lines.Add(
+            "  $table count=$($After[$table].Count) digest=$($After[$table].Digest)"
+        )
+    }
+    [void]$lines.Add('')
+    [void]$lines.Add(
+        'No real credentials, customer data, plaintext security material, row values, dumps, or production data are included.'
+    )
+
+    [IO.File]::WriteAllText(
+        $Evidence,
+        ($lines -join "`r`n") + "`r`n",
+        [Text.UTF8Encoding]::new($true)
+    )
+
+    $EvidenceHash = (
+        Get-FileHash $Evidence -Algorithm SHA256
+    ).Hash.ToLowerInvariant()
+
+    if (@(git status --porcelain=v1).Count -ne 0) {
+        git status --short
+        throw 'Repository changed during probe.'
+    }
+
+    Write-Host ''
+    Write-Host '=============================================' -ForegroundColor Green
+    Write-Host 'v0.16 FLYWAY CLEAN/UPGRADE REHEARSAL PASS' -ForegroundColor Green
+    Write-Host '=============================================' -ForegroundColor Green
+    Write-Host "Branch           : $Branch"
+    Write-Host "HEAD             : $Head"
+    Write-Host 'Clean install    : V1 -> V24 PASS'
+    Write-Host 'Clean health     : HTTP 200'
+    Write-Host 'Upgrade source   : immutable v0.13.0 / V17'
+    Write-Host 'Upgrade delta    : V18 -> V24 PASS'
+    Write-Host 'Historical drift : 0'
+    Write-Host 'Seeded V17 tables: 13 / 13'
+    Write-Host 'Data fingerprints: PRESERVED'
+    Write-Host 'Upgrade health   : HTTP 200'
+    Write-Host 'V23 constraint   : PASS'
+    Write-Host 'V24 constraint   : PASS'
+    Write-Host 'Repo tree        : CLEAN'
+    Write-Host "Evidence         : $Evidence"
+    Write-Host "SHA256           : $EvidenceHash"
+}
+finally {
+    if ($null -ne $CleanId) {
+        $null = Run-Captured 'docker' @('rm','-f',$CleanId)
+    }
+    if ($null -ne $UpgradeId) {
+        $null = Run-Captured 'docker' @('rm','-f',$UpgradeId)
+    }
+    if ($WorktreeAdded) {
+        $null = Run-Captured 'git' @(
+            'worktree','remove','--force',$Worktree
+        )
+        $null = Run-Captured 'git' @('worktree','prune')
+    }
+
+    if (@(git status --porcelain=v1).Count -ne 0) {
+        Write-Warning 'Repository is not clean after probe.'
+        git status --short
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/V016FlywayCleanUpgradeContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V016FlywayCleanUpgradeContractTest.java
@@ -1,0 +1,280 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+class V016FlywayCleanUpgradeContractTest {
+
+    private static final Path SCRIPT =
+        Path.of(
+            "scripts",
+            "operations",
+            "flyway-clean-upgrade-rehearsal.ps1"
+        );
+
+    private static final Path GUIDE =
+        Path.of(
+            "docs",
+            "operations",
+            "flyway-clean-upgrade.md"
+        );
+
+    private static final Path ROADMAP =
+        Path.of("docs", "roadmap.md");
+
+    private static final Path README =
+        Path.of("README.md");
+
+    private static final Path CHANGELOG =
+        Path.of("CHANGELOG.md");
+
+    private static final Path API_BASELINE =
+        Path.of("docs", "api-v1-compatibility.md");
+
+    private static final Path MIGRATIONS =
+        Path.of(
+            "src",
+            "main",
+            "resources",
+            "db",
+            "migration"
+        );
+
+    private static final List<String> V17_TABLES = List.of(
+        "users",
+        "wallets",
+        "payment_transactions",
+        "ledger_entries",
+        "outbox_events",
+        "processed_kafka_events",
+        "transfer_completed_event_audits",
+        "kafka_dead_letter_records",
+        "kafka_dead_letter_command_audits",
+        "refresh_token_families",
+        "refresh_token_records",
+        "account_action_credentials",
+        "mail_outbox_messages"
+    );
+
+    @Test
+    void shouldCommitIsolatedPostgres17CleanInstallAndUpgradeProcedure()
+        throws IOException {
+
+        String script = Files.readString(SCRIPT);
+
+        assertThat(script)
+            .contains(
+                "postgres:17-alpine",
+                "=== 4. CLEAN INSTALL: EMPTY POSTGRESQL 17 -> V24 ===",
+                "=== 6. IMMUTABLE PREVIOUS-RELEASE BASELINE -> V17 ===",
+                "=== 8. UPGRADE V17 -> V24 WITH CURRENT APP ===",
+                "payflow_clean",
+                "payflow_upgrade",
+                ".runtime\\flyway-rehearsal",
+                "ExternalWorktreeRoot",
+                "worktree','add','--detach"
+            )
+            .doesNotContain(
+                "docker compose down -v",
+                "docker volume rm",
+                "DROP DATABASE",
+                "git reset --hard"
+            );
+    }
+
+    @Test
+    void shouldPinApprovedImmutableV013BaselineAndRejectHistoricalDrift()
+        throws IOException {
+
+        String script = Files.readString(SCRIPT);
+        String guide = Files.readString(GUIDE);
+
+        assertThat(script)
+            .contains(
+                "v0.13.0",
+                "726f631a0de800870813ccb0c00b2676eb5d172b",
+                "Current migration count is not 24",
+                "v0.13.0 migration count is not 17",
+                "Historical blob drift",
+                "V18..V24 delta"
+            );
+
+        assertThat(guide)
+            .contains(
+                "immutable `v0.13.0` / V17",
+                "V18 through V24",
+                "`v0.14.0` and `v0.15.0`",
+                "would not exercise a real schema upgrade"
+            );
+    }
+
+    @Test
+    void shouldSeedAndPreserveEveryV17PersistenceTable()
+        throws IOException {
+
+        String script = Files.readString(SCRIPT);
+
+        assertThat(V17_TABLES)
+            .hasSize(13);
+
+        assertThat(script)
+            .contains(
+                V17_TABLES.toArray(String[]::new)
+            )
+            .contains(
+                "13 / 13 V17 data tables seeded.",
+                "Fingerprints",
+                "Assert-Fingerprints",
+                "to_jsonb(t)::text",
+                "Content fingerprint changed"
+            );
+
+        assertThat(Files.readString(GUIDE))
+            .contains(
+                "All 13 non-Flyway V17 data tables",
+                "row count plus an MD5 digest",
+                "synthetic"
+            );
+    }
+
+    @Test
+    void shouldVerifyExactCurrentHistoryConstraintsAndApplicationHealth()
+        throws IOException {
+
+        String script = Files.readString(SCRIPT);
+
+        assertThat(script)
+            .contains(
+                "flyway_schema_history",
+                "Assert-Flyway",
+                "History-Prefix-Digest",
+                "mfa_authenticators",
+                "mfa_login_challenges",
+                "mfa_recovery_codes",
+                "step_up_grants",
+                "account_security_audits",
+                "MFA_DISABLED",
+                "RECOVERY_CODES_ROTATED",
+                "/api/v1/system/health",
+                "Current clean-install app",
+                "Current upgrade app"
+            );
+    }
+
+    @Test
+    void shouldDocumentForwardOnlyRecoveryPrivacyAndNoRepairBoundary()
+        throws IOException {
+
+        String script = Files.readString(SCRIPT);
+        String guide = Files.readString(GUIDE);
+
+        assertThat(script.toLowerCase())
+            .doesNotContain(
+                "flyway repair",
+                "flyway:repair",
+                "flyway undo"
+            );
+
+        assertThat(guide)
+            .contains(
+                "forward migrations",
+                "PayFlow does not",
+                "claim automated down-migration support",
+                "PostgreSQL backup/restore procedure",
+                "production RPO/RTO",
+                "7709c3e1f56d8d5128cbcd98318b5a1d0b8aaab05d1ce41196646dd2ce7d585e",
+                "must not contain real email addresses"
+            );
+    }
+
+    @Test
+    void shouldMarkIncrementCompleteWithoutChangingApiOrMigrationSet()
+        throws IOException {
+
+        String roadmap = Files.readString(ROADMAP);
+
+        String incrementThree = sectionBetween(
+            roadmap,
+            "### Increment 3 — Flyway clean-install and upgrade rehearsal",
+            "### Increment 4 — Redis and Kafka outage/recovery operations"
+        );
+
+        assertThat(incrementThree)
+            .contains("- [x]")
+            .doesNotContain("- [ ]");
+
+        assertThat(roadmap)
+            .contains(
+                "- [x] clean-install and previous-release-to-current Flyway rehearsals pass"
+            );
+
+        assertThat(Files.readString(README))
+            .contains(
+                "[Issue #175]",
+                "[Flyway clean-install / upgrade operations guide](docs/operations/flyway-clean-upgrade.md)"
+            );
+
+        assertThat(Files.readString(CHANGELOG))
+            .contains(
+                "issue #175",
+                "without changing runtime API, security, or migration schema content"
+            );
+
+        assertThat(Files.readString(API_BASELINE))
+            .contains(
+                "**30 canonical HTTP operations**",
+                "**28 unique route paths**"
+            );
+
+        List<String> migrationNames;
+        try (var paths = Files.list(MIGRATIONS)) {
+            migrationNames = paths
+                .filter(Files::isRegularFile)
+                .map(path -> path.getFileName().toString())
+                .filter(name -> name.matches("V\\d+__.+\\.sql"))
+                .sorted()
+                .toList();
+        }
+
+        assertThat(migrationNames)
+            .hasSize(24);
+
+        IntStream.rangeClosed(1, 24)
+            .forEach(version ->
+                assertThat(migrationNames)
+                    .anyMatch(name ->
+                        name.startsWith("V" + version + "__")
+                    )
+            );
+    }
+
+    private static String sectionBetween(
+        String source,
+        String startMarker,
+        String endMarker
+    ) {
+
+        int start = source.indexOf(startMarker);
+        int end = source.indexOf(
+            endMarker,
+            start + startMarker.length()
+        );
+
+        assertThat(start)
+            .as("start marker")
+            .isGreaterThanOrEqualTo(0);
+
+        assertThat(end)
+            .as("end marker")
+            .isGreaterThan(start);
+
+        return source.substring(start, end);
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/V016FlywayCleanUpgradeContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V016FlywayCleanUpgradeContractTest.java
@@ -79,13 +79,17 @@ class V016FlywayCleanUpgradeContractTest {
                 "payflow_upgrade",
                 ".runtime\\flyway-rehearsal",
                 "ExternalWorktreeRoot",
-                "worktree','add','--detach"
+                "worktree','add','--detach",
+                "Resolve-Java21",
+                "JAVA_HOME",
+                "-FilePath $javaExecutable"
             )
             .doesNotContain(
                 "docker compose down -v",
                 "docker volume rm",
                 "DROP DATABASE",
-                "git reset --hard"
+                "git reset --hard",
+                "-FilePath 'java'"
             );
     }
 
@@ -190,7 +194,9 @@ class V016FlywayCleanUpgradeContractTest {
                 "PostgreSQL backup/restore procedure",
                 "production RPO/RTO",
                 "7709c3e1f56d8d5128cbcd98318b5a1d0b8aaab05d1ce41196646dd2ce7d585e",
-                "must not contain real email addresses"
+                "must not contain real email addresses",
+                "`JAVA_HOME` must point to the Java 21 JDK",
+                "never falls back to an unrelated bare `java`"
             );
     }
 

--- a/src/test/java/com/nursena/payflow/configuration/V016PostgresBackupRestoreContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V016PostgresBackupRestoreContractTest.java
@@ -116,7 +116,7 @@ class V016PostgresBackupRestoreContractTest {
                 "Flyway latest `V24`",
                 "HTTP `200`",
                 "644a8d8573a7efe224d9e4e03396f1818ed0cf92d9d64a202fa46e34fa168b4f",
-                "does not mark Increment 3 complete"
+                "did not by itself mark Increment 3 complete"
             );
 
         assertThat(Files.readString(GITIGNORE))
@@ -124,7 +124,7 @@ class V016PostgresBackupRestoreContractTest {
     }
 
     @Test
-    void shouldMarkOnlyPostgresBackupRestoreIncrementComplete()
+    void shouldKeepPostgresBackupRestoreIncrementHistorical()
         throws IOException {
 
         String roadmap = Files.readString(ROADMAP);
@@ -146,7 +146,8 @@ class V016PostgresBackupRestoreContractTest {
             .doesNotContain("- [ ]");
 
         assertThat(incrementThree)
-            .contains("- [ ]");
+            .contains("- [x]")
+            .doesNotContain("- [ ]");
 
         assertThat(roadmap)
             .contains(


### PR DESCRIPTION
## Summary

Completes v0.16.0 Increment 3 by adding a repeatable PostgreSQL 17 Flyway clean-install and approved previous-release upgrade rehearsal.

The reviewed upgrade source is immutable `v0.13.0` / V17 because `v0.14.0` and `v0.15.0` already carry the current V24 migration tree and would not exercise a real schema upgrade.

## Scope

- prove empty PostgreSQL 17 reaches the complete checked-in V1..V24 schema
- verify exact ordered/successful Flyway history and current schema invariants
- start PayFlow against the clean-installed database and require HTTP 200 health
- materialize immutable `v0.13.0` / V17 in an isolated detached worktree
- seed deterministic synthetic representative state across all 13 V17 data tables
- upgrade that baseline through V18..V24
- require V1..V17 historical migration immutability and Flyway-history preservation
- require all 13 V17 row-content fingerprints to remain unchanged
- verify V23/V24 expanded constraint behavior and current application startup
- document forward-only recovery boundaries and reference the separate reviewed PostgreSQL backup/restore procedure
- pin rehearsal application startup to validated `JAVA_HOME` Java 21 instead of ambient PATH `java`

No API, runtime product behavior, security semantics, historical migration SQL, registration-abuse decision, login-limiter semantics, or release/tag state is changed.

## Exact reviewed head

`3ff3189519ca2215f53bb0397bed14a27f35bfdc`

Two commits are intentionally retained:

1. `24c4a404e2ab6f4670b0cfc692715b9b55bd5ee2` — add the rehearsal, guide, roadmap/changelog/README alignment, and executable contracts
2. `3ff3189519ca2215f53bb0397bed14a27f35bfdc` — pin the rehearsal runtime to validated Java 21 after local diagnostics proved PATH `java` resolved to Java 25 while Maven/JAVA_HOME used Java 21

## Local verification

- focused v0.16 Flyway/PostgreSQL/API contracts: PASS
- complete Maven verification: `1606` tests, `0` failures, `0` errors, `0` skipped
- `git diff --check`: PASS
- committed clean install rehearsal: PostgreSQL 17 V1..V24 PASS
- committed previous-release upgrade rehearsal: immutable v0.13.0 / V17 -> V24 PASS
- all 13 V17 representative data fingerprints preserved
- clean-installed and upgraded application health: HTTP 200
- V23 `MFA_DISABLED` constraint behavior: PASS
- V24 `RECOVERY_CODES_ROTATED` constraint behavior: PASS
- working tree clean after rehearsal and push

Sanitized pre-commit probe evidence SHA-256: `7709c3e1f56d8d5128cbcd98318b5a1d0b8aaab05d1ce41196646dd2ce7d585e`.

## Recovery boundary

No `flyway repair`, historical migration rewrite, automated down-migration, source-database overwrite, PITR/WAL, production RPO/RTO, or disaster-recovery certification is introduced or claimed.

Closes #175
Part of #169