### PR TITLE
ops(recovery): add Redis Kafka outage rehearsal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Added a repeatable isolated Redis/Kafka outage-recovery rehearsal through issue #178, proving login fail-closed behavior, non-registration abuse side-effect suppression, automatic Redis recovery, PostgreSQL-backed outbox retry/recovery, durable DLT intake and replay recovery, acknowledgement ambiguity handling, and single-record idempotent processing without changing runtime API, security, retry, migration, or product semantics.
 - Added a repeatable PostgreSQL 17 Flyway clean-install and previous-release upgrade rehearsal through issue #175, proving empty-database V1 through V24 installation, immutable v0.13.0 / V17 to V24 upgrade, historical migration immutability, deterministic synthetic-data preservation, current constraint behavior, and application startup without changing runtime API, security, or migration schema content.
 - Added a repeatable PostgreSQL 17 backup and isolated-restore rehearsal through issue #173, including custom-format backup tooling, clean-target restore, Flyway/public-table integrity checks, restored-database application startup, sanitized local evidence, and a focused operations guide without changing runtime API, security, or Flyway schema behavior.
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ The rehearsal rejects historical V1 through V17 migration drift, verifies the co
 
 See the [Flyway clean-install / upgrade operations guide](docs/operations/flyway-clean-upgrade.md) for the approved previous-release baseline, synthetic-data fingerprint contract, exact command, failure behavior, and rollback limitations.
 
+## Redis/Kafka outage-recovery rehearsal
+
+v0.16.0 Increment 4 is tracked by [Issue #178](https://github.com/nursena-pc/payflow/issues/178). The committed rehearsal uses isolated Testcontainers targets to verify Redis fail-closed behavior and recovery, PostgreSQL-backed Kafka outbox durability, consumer/DLT persistence, replay recovery, and the documented at-least-once acknowledgement-ambiguity boundary without retuning runtime semantics.
+
+Registration abuse protection remains deferred, the separate login limiter keeps its existing contract, and PostgreSQL remains the durable system of record. The rehearsal does not claim Redis/Kafka high availability, exactly-once end-to-end delivery, zero data loss, production RPO/RTO, or real-money operation.
+
+See the [Redis/Kafka outage-recovery operations guide](docs/operations/redis-kafka-outage-recovery.md) for the exact command, observable symptoms, safe operator actions, recovery checks, idempotency boundary, privacy requirements, and limitations.
+
 ## Structured logging
 
 PayFlow supports single-line JSON logs through the `structured-logging` and `production` Spring profiles. HTTP requests emit one bounded completion event containing the correlation ID, route template, method, status, duration, and outcome without logging bodies, query strings, authorization headers, cookies, raw URI paths, or financial/user data.

--- a/docs/operations/redis-kafka-outage-recovery.md
+++ b/docs/operations/redis-kafka-outage-recovery.md
@@ -1,0 +1,248 @@
+# Redis and Kafka Outage/Recovery Rehearsal
+
+Issue: [#178](https://github.com/nursena-pc/payflow/issues/178)
+
+PayFlow v0.16.0 uses this stabilization rehearsal to verify the already-reviewed
+Redis and Kafka dependency-failure contracts without changing runtime API,
+security, retry, or persistence semantics.
+
+The committed entry point is:
+
+```powershell
+.\scripts\operations\redis-kafka-outage-recovery-rehearsal.ps1
+```
+
+The procedure is local Testcontainers evidence. It is not production
+high-availability, disaster-recovery, RPO/RTO, or zero-data-loss
+certification.
+
+## Boundaries under test
+
+PostgreSQL remains the durable system of record. Redis contains only bounded,
+expiring abuse-control state. Kafka is asynchronous delivery and
+event-processing infrastructure.
+
+The rehearsal does not activate generalized registration abuse protection.
+Registration remains the reviewed `DEFER` case. Login-limiter thresholds,
+generalized abuse limits, Kafka producer/consumer retries, DLT behavior, and
+replay semantics are not retuned to make the rehearsal pass.
+
+Two focused executable contracts own the runtime proof:
+
+- `V016RedisOutageRecoveryRehearsalTest`
+- `V016KafkaOutageRecoveryRehearsalTest`
+
+Both use isolated PostgreSQL and dependency containers created by Testcontainers.
+Dependency isolation targets the exact container ID created by the test through
+Docker pause/unpause. It never selects or stops a developer service by a generic
+container name.
+
+## Prerequisites
+
+Before running:
+
+- Docker must be available.
+- `JAVA_HOME` must point to Java 21.
+- the Maven wrapper must be present.
+- HEAD must be attached to a branch.
+- the Git working tree must be clean.
+- `.runtime/` must remain ignored by Git.
+
+The script refuses a dirty tree and never falls back to an unrelated bare Java
+runtime. It does not run `git reset --hard`, `git clean`, `docker compose down`,
+or volume deletion.
+
+## Redis healthy, outage, and recovery proof
+
+The Redis contract starts PostgreSQL 17 and Redis 8 in isolated Testcontainers
+targets. The existing login limiter remains enabled. Generalized abuse
+protection is enabled only for the already-implemented password-recovery
+request workflow, while registration protection is explicitly disabled.
+
+Healthy-state proof requires:
+
+- the mapped Redis endpoint answers a raw Redis `PING`;
+- an invalid login reaches the normal coarse `401` path;
+- an eligible synthetic password-recovery request returns the existing generic
+  `202 Accepted`;
+- exactly one password-recovery credential and one mail-outbox row are created
+  for that eligible healthy request.
+
+The rehearsal then pauses only the exact Redis test container.
+
+While Redis is unavailable:
+
+- login must fail closed with HTTP `503`;
+- the public code remains `LOGIN_RATE_LIMIT_UNAVAILABLE`;
+- the response must not expose Redis host, mapped port, connection class, or
+  connection-refused details;
+- password recovery must preserve the anti-enumeration `202 Accepted` response;
+- the fail-closed password-recovery path must create no credential and no mail
+  side effect;
+- the reviewed login-limiter and generalized abuse Redis-failure counters must
+  increase; and
+- the synthetic PostgreSQL user fingerprint must remain unchanged.
+
+After the same container is unpaused, the same mapped Redis endpoint must
+recover and the running application client must resume the normal protected
+request path without key surgery, PostgreSQL repair, application restart, or
+semantic retuning.
+
+Redis state is intentionally ephemeral. Recovery of Redis availability is not
+a claim that previously held quota counters survive a real process replacement
+or data-loss event. PostgreSQL business/session state is a separate durable
+boundary.
+
+## Kafka healthy outbox proof
+
+The Kafka contract starts isolated PostgreSQL 17 and Kafka infrastructure with
+the existing transfer-completed consumer and DLT intake enabled only for the
+test.
+
+A deterministic synthetic outbox event is inserted using the current schema.
+Healthy publication must:
+
+- claim exactly one available event;
+- mark that outbox event `PUBLISHED`;
+- publish the semantic JSON payload to Kafka;
+- reach exactly one processed-event idempotency row; and
+- reach exactly one transfer-completed audit row.
+
+JSON payloads are compared semantically rather than as raw strings because the
+PostgreSQL `jsonb` representation may normalize whitespace and object-key order.
+
+## Kafka broker outage and durable outbox recovery
+
+A second synthetic outbox event is stored in PostgreSQL before the exact Kafka
+test container is paused.
+
+While Kafka is unavailable, the existing publisher must not fabricate success.
+The event remains durably represented through the existing retry lifecycle:
+`PENDING`, incremented attempt count, future `available_at`, and bounded
+`last_error` state with no lingering lease.
+
+After Kafka is unpaused and the existing retry delay becomes eligible, the same
+durable event must publish successfully and transition to `PUBLISHED`.
+
+The rehearsal does not manually update outbox status to force recovery.
+
+## DLT intake and replay recovery
+
+The test sends one deterministic invalid transfer-completed record through the
+existing consumer failure path. Bounded retries and the configured DLT must
+lead to a durable PostgreSQL `kafka_dead_letter_records` row.
+
+A separate deterministic replayable dead-letter row then exercises replay while
+Kafka is unavailable. The existing replay service must persist
+`REPLAY_FAILED`, clear the lease, increment replay accounting, and retain a
+bounded error rather than claiming replay success.
+
+After Kafka recovery, a second replay claim must complete as `REPLAYED` and
+preserve the replay-origin and replay-attempt headers.
+
+## Kafka acknowledgement ambiguity
+
+A producer send that times out at the application acknowledgement boundary is
+not proof that the broker did not eventually accept that send.
+
+The pre-commit runtime probe for #178 demonstrated this boundary directly: a
+timed-out replay attempt could become visible after the broker recovered even
+though the durable replay record had already moved to `REPLAY_FAILED`.
+
+Therefore the committed rehearsal deliberately tolerates a delayed earlier
+replay attempt while requiring the later successful attempt to appear with the
+correct attempt header.
+
+This is an at-least-once delivery boundary, not a zero-duplicate delivery
+claim. Safety is established at the durable PostgreSQL processing boundary:
+even if both replay deliveries become visible, `processed_kafka_events` and the
+transfer-completed audit remain single-record for the event. The rehearsal also
+proves that no `payment_transactions` or `ledger_entries` rows are added by
+these synthetic delivery/replay checks.
+
+Operators must not manually mark an outbox or dead-letter record successful
+solely because a client-side Kafka timeout occurred.
+
+## Observable symptoms and safe operator actions
+
+For a Redis incident, expected signals include coarse login `503` responses and
+the existing bounded Redis-failure metrics. Account-action workflows with the
+reviewed fail-closed anti-enumeration contract may continue returning generic
+accepted responses while suppressing protected side effects.
+
+Safe recovery is to restore the configured Redis dependency, verify the
+dependency endpoint is reachable, and verify protected application requests
+resume. Do not disable the login limiter, change dependency failure mode, or
+activate registration protection as an incident shortcut.
+
+For a Kafka incident, expected signals include outbox retry/error state, Kafka
+producer errors, consumer retry/DLT activity, and durable replay status. Safe
+recovery is to restore broker availability, verify pending outbox work becomes
+eligible and publishes through the existing lifecycle, inspect durable DLT
+records, and use the existing authorized replay path where appropriate.
+
+Do not edit PostgreSQL outbox/DLT rows manually to manufacture success. Do not
+assume a timed-out send was definitely lost. Escalate when the dependency is
+healthy but the application does not recover, durable state no longer advances
+according to the documented lifecycle, replay remains unresolved, or invariant
+counts diverge.
+
+## Evidence and privacy
+
+The committed script writes only sanitized bounded evidence below:
+
+```text
+.runtime/dependency-outage-recovery/<timestamp>/evidence.txt
+```
+
+`.runtime/` is ignored by Git.
+
+Evidence contains branch/HEAD, toolchain version, PASS/FAIL counts, named
+bounded invariants, and limitations. It must not contain real email addresses,
+user identifiers, raw client addresses, passwords, JWTs, refresh credentials,
+MFA material, Redis keys, real mail content, real financial payloads, or
+production data.
+
+All test identities use fixed documentation-only `example.invalid` values and
+synthetic UUIDs.
+
+## Reviewed pre-commit proof
+
+Before committing the permanent rehearsal contract, issue #178 was exercised on
+exact baseline:
+
+```text
+ed9cf4259bf6dd24185fa4bf258bec8593d6f1b8
+```
+
+The Redis reversible-isolation probe passed one test with zero failures, errors,
+or skips and proved same-endpoint recovery plus automatic application-client
+recovery.
+
+The Kafka reversible-isolation probe passed one test with zero failures, errors,
+or skips and proved semantic JSON publication, durable outbox retry/recovery,
+durable DLT intake, replay failure/recovery, replay header accounting,
+acknowledgement ambiguity handling, and a single durable idempotency/audit
+boundary with unchanged payment and ledger row counts.
+
+Earlier exploratory failures were retained as issue evidence and classified
+before source changes: raw JSON string equality was a probe defect; Redis
+stop/start failed below the application at the mapped-host-port layer; and the
+first replay header assertion exposed acknowledgement ambiguity rather than a
+PayFlow lifecycle defect.
+
+## Limitations
+
+This rehearsal does not certify:
+
+- Redis persistence, replication, Sentinel, or cluster failover;
+- Kafka multi-broker failover, partition reassignment, or capacity;
+- exactly-once end-to-end delivery;
+- zero data loss;
+- production retention or recovery objectives;
+- production RPO/RTO;
+- point-in-time recovery;
+- production disaster recovery; or
+- real-money processing.
+
+Those claims require separate infrastructure, evidence, and review.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -867,12 +867,12 @@ Baseline: v0.15.0 publication-record merge
 
 ### Increment 4 — Redis and Kafka outage/recovery operations
 
-- [ ] Rehearse Redis outage and recovery for generalized abuse controls and the separate login limiter
-- [ ] Preserve existing fail-closed security behavior during dependency failure
-- [ ] Rehearse Kafka outage and recovery for transactional-outbox publication and consumer/DLQ paths
-- [ ] Verify PostgreSQL remains the durable source of truth where designed
-- [ ] Document observable symptoms, safe operator actions, recovery checks, and escalation conditions
-- [ ] Verify recovery procedures do not expose credentials, identities, raw client addresses, or payload content
+- [x] Rehearse Redis outage and recovery for generalized abuse controls and the separate login limiter
+- [x] Preserve existing fail-closed security behavior during dependency failure
+- [x] Rehearse Kafka outage and recovery for transactional-outbox publication and consumer/DLQ paths
+- [x] Verify PostgreSQL remains the durable source of truth where designed
+- [x] Document observable symptoms, safe operator actions, recovery checks, and escalation conditions
+- [x] Verify recovery procedures do not expose credentials, identities, raw client addresses, or payload content
 
 ### Increment 5 — API, OpenAPI, Postman, and documentation drift review
 
@@ -928,7 +928,7 @@ Baseline: v0.15.0 publication-record merge
 - [x] `/api/v1` compatibility boundary is documented and executable where practical
 - [x] PostgreSQL backup and restore rehearsal is repeatable and passes integrity checks
 - [x] clean-install and previous-release-to-current Flyway rehearsals pass
-- [ ] Redis and Kafka outage/recovery procedures are documented and verified against existing failure contracts
+- [x] Redis and Kafka outage/recovery procedures are documented and verified against existing failure contracts
 - [ ] OpenAPI, Postman, README, architecture docs, ADRs, security/operations guidance, and implementation agree
 - [ ] dependency vulnerability and secret scans have no unresolved critical/high release blockers
 - [ ] an SBOM and build/provenance evidence are produced for the stabilization candidate

--- a/scripts/operations/redis-kafka-outage-recovery-rehearsal.ps1
+++ b/scripts/operations/redis-kafka-outage-recovery-rehearsal.ps1
@@ -1,0 +1,405 @@
+$ErrorActionPreference = 'Stop'
+
+$RedisTest = 'V016RedisOutageRecoveryRehearsalTest'
+$KafkaTest = 'V016KafkaOutageRecoveryRehearsalTest'
+$FocusedTests = "$RedisTest,$KafkaTest"
+
+function Git-Scalar {
+    param(
+        [Parameter(Mandatory)][string[]] $Arguments
+    )
+
+    $Output = @(& git @Arguments 2>&1)
+    $ExitCode = $LASTEXITCODE
+
+    if ($ExitCode -ne 0) {
+        throw "git $($Arguments -join ' ') failed:`n$($Output -join "`n")"
+    }
+
+    return (($Output | ForEach-Object { "$_" }) -join "`n").Trim()
+}
+
+function Resolve-Java21 {
+    if ([string]::IsNullOrWhiteSpace($env:JAVA_HOME)) {
+        throw 'JAVA_HOME must point to the PayFlow Java 21 JDK.'
+    }
+
+    $Java = Join-Path $env:JAVA_HOME 'bin\java.exe'
+
+    if (-not (Test-Path -LiteralPath $Java -PathType Leaf)) {
+        throw "JAVA_HOME does not contain bin\java.exe: $env:JAVA_HOME"
+    }
+
+    $QuotedJava = '"' + $Java + '"'
+
+    $VersionOutput = @(
+        & cmd.exe /d /s /c "$QuotedJava -version 2>&1"
+    )
+
+    $ExitCode = $LASTEXITCODE
+
+    if ($ExitCode -ne 0) {
+        throw "JAVA_HOME java -version failed with exit code $ExitCode."
+    }
+
+    $VersionText = ($VersionOutput -join "`n")
+
+    $MajorMatch = [regex]::Match(
+        $VersionText,
+        '(?im)^(?:openjdk|java) version "([0-9]+)(?:\.|")'
+    )
+
+    if (
+        -not $MajorMatch.Success -or
+        [int] $MajorMatch.Groups[1].Value -ne 21
+    ) {
+        throw 'The outage/recovery rehearsal requires JAVA_HOME Java 21.'
+    }
+
+    return [pscustomobject]@{
+        Executable = $Java
+        VersionText = $VersionText
+    }
+}
+
+function Assert-FileContains {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string[]] $Needles
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Required rehearsal file is missing: $Path"
+    }
+
+    $Content = [System.IO.File]::ReadAllText(
+        (Resolve-Path -LiteralPath $Path)
+    )
+
+    foreach ($Needle in $Needles) {
+        if (-not $Content.Contains($Needle)) {
+            throw "Required rehearsal marker missing from ${Path}: $Needle"
+        }
+    }
+}
+
+Write-Host '=== 1. VERIFY CLEAN REPOSITORY CHECKPOINT ===' `
+    -ForegroundColor Cyan
+
+$RepoRoot = Git-Scalar -Arguments @(
+    'rev-parse',
+    '--show-toplevel'
+)
+
+Set-Location -LiteralPath $RepoRoot
+
+$Branch = Git-Scalar -Arguments @(
+    'branch',
+    '--show-current'
+)
+
+if ([string]::IsNullOrWhiteSpace($Branch)) {
+    throw 'The outage/recovery rehearsal requires an attached Git branch.'
+}
+
+$Head = Git-Scalar -Arguments @(
+    'rev-parse',
+    'HEAD'
+)
+
+$Status = @(
+    git status --porcelain=v1 --untracked-files=all
+)
+
+if ($LASTEXITCODE -ne 0) {
+    throw 'Could not inspect the Git working tree.'
+}
+
+if ($Status.Count -ne 0) {
+    $Status | Out-Host
+    throw 'The outage/recovery rehearsal requires a clean working tree.'
+}
+
+$IgnoredRuntime = @(
+    git check-ignore .runtime 2>$null
+)
+
+if (
+    $LASTEXITCODE -ne 0 -or
+    $IgnoredRuntime.Count -eq 0
+) {
+    throw '.runtime/ must remain ignored before rehearsal evidence is written.'
+}
+
+Write-Host "Branch: $Branch"
+Write-Host "HEAD  : $Head"
+Write-Host 'Repository checkpoint PASS.' `
+    -ForegroundColor Green
+
+Write-Host ''
+Write-Host '=== 2. VERIFY REHEARSAL CONTRACT FILES ===' `
+    -ForegroundColor Cyan
+
+Assert-FileContains `
+    -Path 'src\test\java\com\nursena\payflow\configuration\V016RedisOutageRecoveryRehearsalTest.java' `
+    -Needles @(
+        'pauseContainerCmd',
+        'unpauseContainerCmd',
+        'LOGIN_RATE_LIMIT_UNAVAILABLE',
+        'password-recovery-request.dependency-failure-mode=FAIL_CLOSED',
+        'registration.enabled=false'
+    )
+
+Assert-FileContains `
+    -Path 'src\test\java\com\nursena\payflow\configuration\V016KafkaOutageRecoveryRehearsalTest.java' `
+    -Needles @(
+        'pauseContainerCmd',
+        'unpauseContainerCmd',
+        'REPLAY_FAILED',
+        'REPLAYED',
+        'awaitReplayAttempt',
+        'processedCount'
+    )
+
+Write-Host 'Committed focused rehearsal contracts PASS.' `
+    -ForegroundColor Green
+
+Write-Host ''
+Write-Host '=== 3. VERIFY JAVA 21 + DOCKER ===' `
+    -ForegroundColor Cyan
+
+$Java = Resolve-Java21
+
+Write-Host (
+    ($Java.VersionText -split "`r?`n")[0]
+)
+
+$DockerVersion = @(
+    docker version --format '{{.Server.Version}}' 2>&1
+)
+
+if ($LASTEXITCODE -ne 0) {
+    throw 'Docker daemon is unavailable.'
+}
+
+$DockerServer = (
+    ($DockerVersion | ForEach-Object { "$_" }) -join ''
+).Trim()
+
+Write-Host "Docker server: $DockerServer"
+Write-Host 'Toolchain PASS.' `
+    -ForegroundColor Green
+
+Write-Host ''
+Write-Host '=== 4. PREPARE IGNORED SANITIZED EVIDENCE DIRECTORY ===' `
+    -ForegroundColor Cyan
+
+$Stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$RuntimeRoot = Join-Path `
+    $RepoRoot `
+    ".runtime\dependency-outage-recovery\$Stamp"
+
+New-Item `
+    -ItemType Directory `
+    -Path $RuntimeRoot `
+    -Force |
+    Out-Null
+
+$EvidencePath = Join-Path `
+    $RuntimeRoot `
+    'evidence.txt'
+
+Write-Host "Evidence root: $RuntimeRoot"
+
+Write-Host ''
+Write-Host '=== 5. RUN FOCUSED REDIS + KAFKA OUTAGE/RECOVERY CONTRACTS ===' `
+    -ForegroundColor Cyan
+
+& .\mvnw.cmd `
+    -B `
+    -ntp `
+    "-Dtest=$FocusedTests" `
+    test
+
+if ($LASTEXITCODE -ne 0) {
+    throw 'Focused Redis/Kafka outage-recovery rehearsal failed.'
+}
+
+$SurefireRoot = Join-Path `
+    $RepoRoot `
+    'target\surefire-reports'
+
+$ExpectedReports = @(
+    "TEST-com.nursena.payflow.configuration.$RedisTest.xml",
+    "TEST-com.nursena.payflow.configuration.$KafkaTest.xml"
+)
+
+[long] $Tests = 0
+[long] $Failures = 0
+[long] $Errors = 0
+[long] $Skipped = 0
+
+foreach ($ReportName in $ExpectedReports) {
+    $ReportPath = Join-Path `
+        $SurefireRoot `
+        $ReportName
+
+    if (-not (Test-Path -LiteralPath $ReportPath -PathType Leaf)) {
+        throw "Focused Surefire report is missing: $ReportPath"
+    }
+
+    [xml] $Xml = Get-Content `
+        -LiteralPath $ReportPath `
+        -Raw
+
+    $Tests += [long] $Xml.testsuite.tests
+    $Failures += [long] $Xml.testsuite.failures
+    $Errors += [long] $Xml.testsuite.errors
+    $Skipped += [long] $Xml.testsuite.skipped
+}
+
+Write-Host (
+    "Focused tests: {0}, failures: {1}, errors: {2}, skipped: {3}" -f
+        $Tests,
+        $Failures,
+        $Errors,
+        $Skipped
+)
+
+if (
+    $Tests -ne 2 -or
+    $Failures -ne 0 -or
+    $Errors -ne 0 -or
+    $Skipped -ne 0
+) {
+    throw 'Focused rehearsal result must be exactly 2 / 0 / 0 / 0.'
+}
+
+Write-Host 'Focused runtime rehearsal PASS.' `
+    -ForegroundColor Green
+
+Write-Host ''
+Write-Host '=== 6. VERIFY REPOSITORY HYGIENE ===' `
+    -ForegroundColor Cyan
+
+& git diff --check
+
+if ($LASTEXITCODE -ne 0) {
+    throw 'git diff --check failed.'
+}
+
+$FinalHead = Git-Scalar -Arguments @(
+    'rev-parse',
+    'HEAD'
+)
+
+if ($FinalHead -ne $Head) {
+    throw 'HEAD changed while the rehearsal was running.'
+}
+
+$FinalStatus = @(
+    git status --porcelain=v1 --untracked-files=all
+)
+
+if ($LASTEXITCODE -ne 0) {
+    throw 'Could not inspect final Git working tree.'
+}
+
+if ($FinalStatus.Count -ne 0) {
+    $FinalStatus | Out-Host
+    throw 'Tracked repository content changed during the rehearsal.'
+}
+
+Write-Host 'Repository hygiene PASS.' `
+    -ForegroundColor Green
+
+Write-Host ''
+Write-Host '=== 7. WRITE SANITIZED EVIDENCE ===' `
+    -ForegroundColor Cyan
+
+$Evidence = @"
+PayFlow v0.16.0 Redis/Kafka Outage-Recovery Rehearsal
+Issue: #178
+Branch: $Branch
+HEAD: $Head
+Java major: 21
+Docker server: $DockerServer
+
+Focused tests: 2
+Failures: 0
+Errors: 0
+Skipped: 0
+
+Redis:
+  isolated dependency outage: PASS
+  login limiter fail-closed HTTP 503: PASS
+  dependency-detail leakage check: PASS
+  non-registration password-recovery FAIL_CLOSED side-effect suppression: PASS
+  registration abuse protection activation: NONE
+  PostgreSQL durable user fingerprint preserved: PASS
+  host endpoint recovery: PASS
+  running client automatic recovery: PASS
+  bounded Redis-failure metrics: PASS
+
+Kafka:
+  healthy PostgreSQL-backed outbox publication: PASS
+  semantic JSON delivery comparison: PASS
+  broker isolation: PASS
+  durable outbox retry lifecycle: PASS
+  broker recovery publication: PASS
+  transfer-completed audit/idempotency boundary: PASS
+  durable DLT intake: PASS
+  replay outage -> REPLAY_FAILED: PASS
+  replay recovery -> REPLAYED: PASS
+  acknowledgement ambiguity: delayed earlier attempt tolerated
+  replay origin and attempt accounting: PASS
+  processed/audit boundary after possible duplicate delivery: single-record PASS
+  payment transaction count: unchanged
+  ledger entry count: unchanged
+
+Repository tree: CLEAN
+Repository mutation during rehearsal: NONE
+Release/tag mutation: NONE
+
+Limitations:
+  local isolated Testcontainers rehearsal only
+  no Redis HA/persistence certification
+  no Kafka multi-broker/partition failover certification
+  no zero-data-loss claim
+  no production RPO/RTO or disaster-recovery certification
+"@
+
+$EvidenceCrlf = (
+    $Evidence.Replace("`r`n", "`n")
+).Replace("`r", "`n").Replace("`n", "`r`n")
+
+[System.IO.File]::WriteAllText(
+    $EvidencePath,
+    $EvidenceCrlf,
+    [System.Text.UTF8Encoding]::new($true)
+)
+
+$EvidenceHash = (
+    Get-FileHash `
+        -LiteralPath $EvidencePath `
+        -Algorithm SHA256
+).Hash.ToLowerInvariant()
+
+Write-Host ''
+Write-Host '=============================================' `
+    -ForegroundColor Green
+Write-Host 'v0.16 REDIS/KAFKA OUTAGE REHEARSAL PASS' `
+    -ForegroundColor Green
+Write-Host '=============================================' `
+    -ForegroundColor Green
+Write-Host "Branch       : $Branch"
+Write-Host "HEAD         : $Head"
+Write-Host 'Focused tests: 2 / 0 / 0 / 0'
+Write-Host 'Redis        : outage + fail-closed + recovery PASS'
+Write-Host 'Abuse flow   : password recovery fail-closed PASS'
+Write-Host 'Kafka outbox : outage + retry + recovery PASS'
+Write-Host 'Kafka DLT    : intake + replay recovery PASS'
+Write-Host 'Idempotency  : single durable processing boundary PASS'
+Write-Host 'Tree         : CLEAN'
+Write-Host "Evidence     : $EvidencePath"
+Write-Host "SHA256       : $EvidenceHash"

--- a/src/test/java/com/nursena/payflow/configuration/V016KafkaOutageRecoveryRehearsalTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V016KafkaOutageRecoveryRehearsalTest.java
@@ -1,0 +1,1260 @@
+package com.nursena.payflow.configuration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import com.github.dockerjava.api.DockerClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nursena.payflow.eventprocessing.adapter.kafka
+    .KafkaDeadLetterReplayHeaders;
+import com.nursena.payflow.eventprocessing.application.model
+    .ReplayKafkaDeadLetterRecordCommand;
+import com.nursena.payflow.eventprocessing.application.model
+    .ReplayKafkaDeadLetterRecordResult;
+import com.nursena.payflow.eventprocessing.application.port.in
+    .ReplayKafkaDeadLetterRecordUseCase;
+import com.nursena.payflow.outbox.application.port.in
+    .PublishOutboxEventsCommand;
+import com.nursena.payflow.outbox.application.port.in
+    .PublishOutboxEventsResult;
+import com.nursena.payflow.outbox.application.port.in
+    .PublishOutboxEventsUseCase;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+
+@SpringBootTest(properties = {
+    "payflow.security.login-rate-limit.enabled=false",
+    "payflow.outbox.polling.enabled=false",
+    "payflow.mail.outbox.polling.enabled=false",
+    "payflow.outbox.kafka.send-timeout=10s",
+    "payflow.outbox.retry.max-attempts=5",
+    "payflow.outbox.retry.initial-delay=10s",
+    "payflow.outbox.retry.maximum-delay=1m",
+    "payflow.event-processing.transfer-completed.enabled=true",
+    "payflow.event-processing.transfer-completed.topic=wallet.transfer.completed.v016-outage",
+    "payflow.event-processing.transfer-completed.group-id=v016-outage-consumer",
+    "payflow.event-processing.transfer-completed.consumer-name=v016-outage-consumer",
+    "payflow.event-processing.transfer-completed.failure.dead-letter-topic=wallet.transfer.completed.v016-outage.dlt",
+    "payflow.event-processing.transfer-completed.failure.max-retries=3",
+    "payflow.event-processing.transfer-completed.failure.initial-delay=500ms",
+    "payflow.event-processing.transfer-completed.failure.multiplier=2.0",
+    "payflow.event-processing.transfer-completed.failure.maximum-delay=5s",
+    "payflow.event-processing.transfer-completed.failure.send-timeout=10s",
+    "payflow.event-processing.transfer-completed.dead-letter-intake.enabled=true",
+    "payflow.event-processing.transfer-completed.dead-letter-intake.group-id=v016-outage-dlt-intake",
+    "payflow.event-processing.transfer-completed.dead-letter-replay.worker-id=v016-outage-replay",
+    "payflow.event-processing.transfer-completed.dead-letter-replay.lease-duration=30s",
+    "payflow.event-processing.transfer-completed.dead-letter-replay.max-attempts=3",
+    "payflow.event-processing.transfer-completed.dead-letter-replay.send-timeout=10s",
+    "spring.kafka.consumer.enable-auto-commit=false",
+    "spring.kafka.consumer.auto-offset-reset=earliest",
+    "spring.kafka.listener.ack-mode=record"
+})
+@Testcontainers
+@Import(
+    V016KafkaOutageRecoveryRehearsalTest
+        .KafkaTopicConfiguration.class
+)
+class V016KafkaOutageRecoveryRehearsalTest {
+
+    private static final String SOURCE_TOPIC =
+        "wallet.transfer.completed.v016-outage";
+
+    private static final String DLT_TOPIC =
+        SOURCE_TOPIC + ".dlt";
+
+    private static final String CONSUMER_NAME =
+        "v016-outage-consumer";
+
+    private static final UUID HEALTHY_EVENT_ID =
+        UUID.fromString(
+            "92000000-0000-0000-0000-000000000101"
+        );
+
+    private static final UUID HEALTHY_TX_ID =
+        UUID.fromString(
+            "93000000-0000-0000-0000-000000000101"
+        );
+
+    private static final UUID RECOVERY_EVENT_ID =
+        UUID.fromString(
+            "92000000-0000-0000-0000-000000000102"
+        );
+
+    private static final UUID RECOVERY_TX_ID =
+        UUID.fromString(
+            "93000000-0000-0000-0000-000000000102"
+        );
+
+    private static final UUID REPLAY_RECORD_ID =
+        UUID.fromString(
+            "94000000-0000-0000-0000-000000000101"
+        );
+
+    private static final UUID REPLAY_EVENT_ID =
+        UUID.fromString(
+            "92000000-0000-0000-0000-000000000103"
+        );
+
+    private static final UUID REPLAY_TX_ID =
+        UUID.fromString(
+            "93000000-0000-0000-0000-000000000103"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Container
+    @ServiceConnection
+    private static final KafkaContainer KAFKA =
+        new KafkaContainer(
+            "apache/kafka:4.1.2"
+        );
+
+    @Autowired
+    private PublishOutboxEventsUseCase
+        publishOutboxEvents;
+
+    @Autowired
+    private ReplayKafkaDeadLetterRecordUseCase
+        replayDeadLetterRecord;
+
+    @Autowired
+    private KafkaTemplate<String, String>
+        kafkaTemplate;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void shouldKeepDurableOutboxAndReplayStateAcrossBrokerOutage()
+        throws Exception {
+
+        cleanDatabase();
+
+        int paymentTransactionsBefore =
+            count("payment_transactions");
+        int ledgerEntriesBefore =
+            count("ledger_entries");
+
+        try (
+            KafkaConsumer<String, String> observer =
+                observerConsumer()
+        ) {
+            observer.subscribe(
+                List.of(SOURCE_TOPIC)
+            );
+
+            String healthyPayload =
+                payload(
+                    HEALTHY_EVENT_ID,
+                    HEALTHY_TX_ID,
+                    "2026-08-21T12:00:00Z"
+                );
+
+            insertOutboxEvent(
+                HEALTHY_EVENT_ID,
+                HEALTHY_TX_ID,
+                healthyPayload
+            );
+
+            PublishOutboxEventsResult healthy =
+                publishOne();
+
+            assertThat(healthy.claimedCount())
+                .isEqualTo(1);
+            assertThat(healthy.publishedCount())
+                .isEqualTo(1);
+            assertThat(healthy.retriedCount())
+                .isZero();
+
+            assertOutboxState(
+                HEALTHY_EVENT_ID,
+                "PUBLISHED",
+                1,
+                true,
+                false
+            );
+
+            ConsumerRecord<String, String>
+                healthyRecord =
+                awaitRecord(
+                    observer,
+                    HEALTHY_EVENT_ID
+                );
+
+            assertThat(healthyRecord.key())
+                .isEqualTo(
+                    HEALTHY_TX_ID.toString()
+                );
+            assertJsonEquivalent(
+                healthyRecord.value(),
+                healthyPayload
+            );
+
+            await(
+                () ->
+                    processedCount(
+                        HEALTHY_EVENT_ID
+                    ) == 1
+                        && auditCount(
+                            HEALTHY_EVENT_ID
+                        ) == 1,
+                "healthy transfer-completed persistence"
+            );
+
+            String recoveryPayload =
+                payload(
+                    RECOVERY_EVENT_ID,
+                    RECOVERY_TX_ID,
+                    "2026-08-21T12:01:00Z"
+                );
+
+            insertOutboxEvent(
+                RECOVERY_EVENT_ID,
+                RECOVERY_TX_ID,
+                recoveryPayload
+            );
+
+            pauseKafka();
+
+            try {
+                PublishOutboxEventsResult outage =
+                    publishOne();
+
+                assertThat(outage.claimedCount())
+                    .isEqualTo(1);
+                assertThat(outage.publishedCount())
+                    .isZero();
+                assertThat(outage.retriedCount())
+                    .isEqualTo(1);
+
+                assertOutboxState(
+                    RECOVERY_EVENT_ID,
+                    "PENDING",
+                    1,
+                    false,
+                    true
+                );
+
+                assertThat(
+                    count("payment_transactions")
+                )
+                    .isEqualTo(
+                        paymentTransactionsBefore
+                    );
+
+                assertThat(
+                    count("ledger_entries")
+                )
+                    .isEqualTo(
+                        ledgerEntriesBefore
+                    );
+            } finally {
+                unpauseKafka();
+                awaitKafka();
+            }
+
+            waitUntilOutboxAvailable(
+                RECOVERY_EVENT_ID
+            );
+
+            PublishOutboxEventsResult recovered =
+                publishOne();
+
+            assertThat(recovered.claimedCount())
+                .isEqualTo(1);
+            assertThat(recovered.publishedCount())
+                .isEqualTo(1);
+            assertThat(recovered.retriedCount())
+                .isZero();
+
+            assertOutboxState(
+                RECOVERY_EVENT_ID,
+                "PUBLISHED",
+                2,
+                true,
+                false
+            );
+
+            ConsumerRecord<String, String>
+                recoveryRecord =
+                awaitRecord(
+                    observer,
+                    RECOVERY_EVENT_ID
+                );
+
+            assertThat(recoveryRecord.key())
+                .isEqualTo(
+                    RECOVERY_TX_ID.toString()
+                );
+            assertJsonEquivalent(
+                recoveryRecord.value(),
+                recoveryPayload
+            );
+
+            await(
+                () ->
+                    processedCount(
+                        RECOVERY_EVENT_ID
+                    ) == 1
+                        && auditCount(
+                            RECOVERY_EVENT_ID
+                        ) == 1,
+                "recovered outbox event persistence"
+            );
+
+            kafkaTemplate
+                .send(
+                    SOURCE_TOPIC,
+                    "invalid-dlt-key",
+                    "{invalid-json"
+                )
+                .get(
+                    20,
+                    TimeUnit.SECONDS
+                );
+
+            await(
+                () ->
+                    dltRecordCountByKey(
+                        "invalid-dlt-key"
+                    ) == 1,
+                "durable DLT intake"
+            );
+
+            Map<String, Object> receivedDlt =
+                jdbcTemplate.queryForMap(
+                    """
+                    SELECT
+                        id,
+                        status,
+                        replay_count,
+                        replay_origin_id,
+                        replay_attempt_base
+                    FROM kafka_dead_letter_records
+                    WHERE record_key = ?
+                    """,
+                    "invalid-dlt-key"
+                );
+
+            assertThat(receivedDlt.get("status"))
+                .isEqualTo("RECEIVED");
+            assertThat(
+                ((Number) receivedDlt.get(
+                    "replay_count"
+                )).intValue()
+            )
+                .isZero();
+
+            insertReplayableDeadLetterRecord();
+
+            pauseKafka();
+
+            try {
+                ReplayKafkaDeadLetterRecordResult
+                    failedReplay =
+                    replayDeadLetterRecord.replay(
+                        new ReplayKafkaDeadLetterRecordCommand(
+                            REPLAY_RECORD_ID
+                        )
+                    );
+
+                assertThat(
+                    failedReplay.isReplayFailed()
+                )
+                    .isTrue();
+
+                ReplayState failedState =
+                    replayState();
+
+                assertThat(failedState.status())
+                    .isEqualTo("REPLAY_FAILED");
+                assertThat(failedState.replayCount())
+                    .isEqualTo(1);
+                assertThat(failedState.leaseOwner())
+                    .isNull();
+                assertThat(failedState.leaseUntil())
+                    .isNull();
+                assertThat(failedState.lastError())
+                    .isNotBlank();
+                assertThat(failedState.originId())
+                    .isEqualTo(REPLAY_RECORD_ID);
+                assertThat(failedState.attemptBase())
+                    .isZero();
+            } finally {
+                unpauseKafka();
+                awaitKafka();
+            }
+
+            ReplayKafkaDeadLetterRecordResult
+                successfulReplay =
+                replayDeadLetterRecord.replay(
+                    new ReplayKafkaDeadLetterRecordCommand(
+                        REPLAY_RECORD_ID
+                    )
+                );
+
+            assertThat(
+                successfulReplay.isReplayed()
+            )
+                .isTrue();
+
+            ReplayState replayedState =
+                replayState();
+
+            assertThat(replayedState.status())
+                .isEqualTo("REPLAYED");
+            assertThat(replayedState.replayCount())
+                .isEqualTo(2);
+            assertThat(replayedState.leaseOwner())
+                .isNull();
+            assertThat(replayedState.leaseUntil())
+                .isNull();
+            assertThat(replayedState.lastError())
+                .isNull();
+            assertThat(replayedState.originId())
+                .isEqualTo(REPLAY_RECORD_ID);
+            assertThat(replayedState.attemptBase())
+                .isZero();
+
+            ConsumerRecord<String, String>
+                replayedRecord =
+                awaitReplayAttempt(
+                    observer,
+                    REPLAY_EVENT_ID,
+                    REPLAY_RECORD_ID,
+                    2
+                );
+
+            assertThat(
+                headerValue(
+                    replayedRecord,
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ORIGIN_ID
+                )
+            )
+                .isEqualTo(
+                    REPLAY_RECORD_ID.toString()
+                );
+
+            assertThat(
+                headerValue(
+                    replayedRecord,
+                    KafkaDeadLetterReplayHeaders
+                        .REPLAY_ATTEMPT
+                )
+            )
+                .isEqualTo("2");
+
+            await(
+                () ->
+                    processedCount(
+                        REPLAY_EVENT_ID
+                    ) == 1
+                        && auditCount(
+                            REPLAY_EVENT_ID
+                        ) == 1,
+                "replayed transfer-completed persistence"
+            );
+
+            /*
+             * The first replay send may time out at the
+             * application acknowledgement boundary and
+             * still complete later after broker recovery.
+             * Once attempt 2 is observed, give the
+             * consumer a short grace interval and prove
+             * that the PostgreSQL idempotency/audit
+             * boundary remains single-record.
+             */
+            TimeUnit.SECONDS.sleep(2);
+
+            assertThat(
+                processedCount(
+                    REPLAY_EVENT_ID
+                )
+            )
+                .isEqualTo(1);
+
+            assertThat(
+                auditCount(
+                    REPLAY_EVENT_ID
+                )
+            )
+                .isEqualTo(1);
+
+            assertThat(
+                count("payment_transactions")
+            )
+                .isEqualTo(
+                    paymentTransactionsBefore
+                );
+
+            assertThat(
+                count("ledger_entries")
+            )
+                .isEqualTo(
+                    ledgerEntriesBefore
+                );
+
+            assertThat(
+                dltRecordCountByKey(
+                    "invalid-dlt-key"
+                )
+            )
+                .isEqualTo(1);
+        }
+    }
+
+    private PublishOutboxEventsResult
+    publishOne() {
+        return publishOutboxEvents
+            .publishAvailable(
+                new PublishOutboxEventsCommand(
+                    "v016-outage-probe",
+                    1,
+                    Duration.ofSeconds(30)
+                )
+            );
+    }
+
+    private void insertOutboxEvent(
+        UUID eventId,
+        UUID transactionId,
+        String payload
+    ) {
+        Instant now =
+            Instant.now().minusSeconds(1);
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO outbox_events (
+                id,
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                event_version,
+                topic,
+                partition_key,
+                deduplication_key,
+                payload,
+                status,
+                attempt_count,
+                available_at,
+                created_at
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?,
+                CAST(? AS jsonb),
+                'PENDING',
+                0,
+                ?,
+                ?
+            )
+            """,
+            eventId,
+            "PAYMENT_TRANSACTION",
+            transactionId,
+            "wallet.transfer.completed",
+            1,
+            SOURCE_TOPIC,
+            transactionId.toString(),
+            SOURCE_TOPIC
+                + ":1:"
+                + eventId,
+            payload,
+            Timestamp.from(now),
+            Timestamp.from(now)
+        );
+    }
+
+    private void insertReplayableDeadLetterRecord() {
+        String replayPayload =
+            payload(
+                REPLAY_EVENT_ID,
+                REPLAY_TX_ID,
+                "2026-08-21T12:02:00Z"
+            );
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO kafka_dead_letter_records (
+                id,
+                dlt_topic,
+                dlt_partition,
+                dlt_offset,
+                original_topic,
+                original_partition,
+                original_offset,
+                original_consumer_group,
+                record_key,
+                payload,
+                exception_type,
+                exception_message,
+                status,
+                replay_count,
+                received_at,
+                last_replayed_at,
+                replay_lease_owner,
+                replay_lease_until,
+                last_replay_error,
+                replay_origin_id,
+                replay_attempt_base
+            )
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            REPLAY_RECORD_ID,
+            DLT_TOPIC,
+            0,
+            9000000L,
+            SOURCE_TOPIC,
+            0,
+            8000000L,
+            CONSUMER_NAME,
+            REPLAY_TX_ID.toString(),
+            replayPayload,
+            "java.lang.IllegalStateException",
+            "Synthetic transient processing failure.",
+            "RECEIVED",
+            0,
+            Timestamp.from(
+                Instant.now()
+                    .minusSeconds(60)
+            ),
+            null,
+            null,
+            null,
+            null,
+            REPLAY_RECORD_ID,
+            0
+        );
+    }
+
+    private void assertOutboxState(
+        UUID eventId,
+        String expectedStatus,
+        int expectedAttempts,
+        boolean expectPublishedAt,
+        boolean expectError
+    ) {
+        Map<String, Object> state =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT
+                    status,
+                    attempt_count,
+                    published_at,
+                    last_error,
+                    locked_at,
+                    locked_until,
+                    locked_by
+                FROM outbox_events
+                WHERE id = ?
+                """,
+                eventId
+            );
+
+        assertThat(state.get("status"))
+            .isEqualTo(expectedStatus);
+
+        assertThat(
+            ((Number) state.get(
+                "attempt_count"
+            )).intValue()
+        )
+            .isEqualTo(expectedAttempts);
+
+        if (expectPublishedAt) {
+            assertThat(
+                state.get("published_at")
+            )
+                .isNotNull();
+        } else {
+            assertThat(
+                state.get("published_at")
+            )
+                .isNull();
+        }
+
+        if (expectError) {
+            assertThat(
+                state.get("last_error")
+            )
+                .asString()
+                .isNotBlank();
+        } else {
+            assertThat(
+                state.get("last_error")
+            )
+                .isNull();
+        }
+
+        assertThat(state.get("locked_at"))
+            .isNull();
+        assertThat(state.get("locked_until"))
+            .isNull();
+        assertThat(state.get("locked_by"))
+            .isNull();
+    }
+
+    private void waitUntilOutboxAvailable(
+        UUID eventId
+    ) throws Exception {
+        Timestamp availableAt =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT available_at
+                FROM outbox_events
+                WHERE id = ?
+                """,
+                Timestamp.class,
+                eventId
+            );
+
+        assertThat(availableAt)
+            .isNotNull();
+
+        while (
+            Instant.now().isBefore(
+                availableAt.toInstant()
+            )
+        ) {
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+
+        TimeUnit.MILLISECONDS.sleep(250);
+    }
+
+    private int processedCount(
+        UUID eventId
+    ) {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM processed_kafka_events
+                WHERE consumer_name = ?
+                  AND event_id = ?
+                """,
+                Integer.class,
+                CONSUMER_NAME,
+                eventId
+            );
+
+        return count == null ? 0 : count;
+    }
+
+    private int auditCount(
+        UUID eventId
+    ) {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM transfer_completed_event_audits
+                WHERE event_id = ?
+                """,
+                Integer.class,
+                eventId
+            );
+
+        return count == null ? 0 : count;
+    }
+
+    private int dltRecordCountByKey(
+        String recordKey
+    ) {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM kafka_dead_letter_records
+                WHERE record_key = ?
+                """,
+                Integer.class,
+                recordKey
+            );
+
+        return count == null ? 0 : count;
+    }
+
+    private ReplayState replayState() {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT
+                status,
+                replay_count,
+                replay_lease_owner,
+                replay_lease_until,
+                last_replay_error,
+                replay_origin_id,
+                replay_attempt_base
+            FROM kafka_dead_letter_records
+            WHERE id = ?
+            """,
+            (resultSet, rowNumber) ->
+                new ReplayState(
+                    resultSet.getString(
+                        "status"
+                    ),
+                    resultSet.getInt(
+                        "replay_count"
+                    ),
+                    resultSet.getString(
+                        "replay_lease_owner"
+                    ),
+                    instant(
+                        resultSet.getTimestamp(
+                            "replay_lease_until"
+                        )
+                    ),
+                    resultSet.getString(
+                        "last_replay_error"
+                    ),
+                    resultSet.getObject(
+                        "replay_origin_id",
+                        UUID.class
+                    ),
+                    resultSet.getInt(
+                        "replay_attempt_base"
+                    )
+                ),
+            REPLAY_RECORD_ID
+        );
+    }
+
+    private static Instant instant(
+        Timestamp value
+    ) {
+        return value == null
+            ? null
+            : value.toInstant();
+    }
+
+    private static String payload(
+        UUID eventId,
+        UUID transactionId,
+        String occurredAt
+    ) {
+        return """
+            {
+              "eventId": "%s",
+              "eventType": "wallet.transfer.completed",
+              "eventVersion": 1,
+              "occurredAt": "%s",
+              "transactionId": "%s",
+              "sourceWalletId": "95000000-0000-0000-0000-000000000101",
+              "targetWalletId": "95000000-0000-0000-0000-000000000102",
+              "amount": "125.50",
+              "currency": "TRY"
+            }
+            """.formatted(
+                eventId,
+                occurredAt,
+                transactionId
+            );
+    }
+
+    private static KafkaConsumer<String, String>
+    observerConsumer() {
+        Map<String, Object> properties =
+            new HashMap<>();
+
+        properties.put(
+            ConsumerConfig
+                .BOOTSTRAP_SERVERS_CONFIG,
+            KAFKA.getBootstrapServers()
+        );
+
+        properties.put(
+            ConsumerConfig.GROUP_ID_CONFIG,
+            "v016-outage-observer-"
+                + UUID.randomUUID()
+        );
+
+        properties.put(
+            ConsumerConfig
+                .AUTO_OFFSET_RESET_CONFIG,
+            "earliest"
+        );
+
+        properties.put(
+            ConsumerConfig
+                .ENABLE_AUTO_COMMIT_CONFIG,
+            false
+        );
+
+        return new KafkaConsumer<>(
+            properties,
+            new StringDeserializer(),
+            new StringDeserializer()
+        );
+    }
+
+    private static ConsumerRecord<String, String>
+    awaitReplayAttempt(
+        KafkaConsumer<String, String> consumer,
+        UUID eventId,
+        UUID replayOriginId,
+        int expectedAttempt
+    ) {
+        String expectedEventId =
+            eventId.toString();
+
+        String expectedOriginId =
+            replayOriginId.toString();
+
+        long deadline =
+            System.nanoTime()
+                + Duration.ofSeconds(30)
+                    .toNanos();
+
+        boolean observedEarlierAttempt = false;
+
+        while (
+            System.nanoTime() < deadline
+        ) {
+            ConsumerRecords<String, String> records =
+                consumer.poll(
+                    Duration.ofMillis(250)
+                );
+
+            for (
+                ConsumerRecord<String, String>
+                    record : records
+            ) {
+                if (
+                    record.value() == null
+                        || !record.value()
+                            .contains(
+                                expectedEventId
+                            )
+                ) {
+                    continue;
+                }
+
+                assertThat(
+                    headerValue(
+                        record,
+                        KafkaDeadLetterReplayHeaders
+                            .REPLAY_ORIGIN_ID
+                    )
+                )
+                    .isEqualTo(
+                        expectedOriginId
+                    );
+
+                int attempt =
+                    Integer.parseInt(
+                        headerValue(
+                            record,
+                            KafkaDeadLetterReplayHeaders
+                                .REPLAY_ATTEMPT
+                        )
+                    );
+
+                assertThat(attempt)
+                    .isBetween(
+                        1,
+                        expectedAttempt
+                    );
+
+                if (attempt < expectedAttempt) {
+                    observedEarlierAttempt = true;
+                    continue;
+                }
+
+                return record;
+            }
+        }
+
+        throw new AssertionError(
+            "Timed out waiting for replay attempt "
+                + expectedAttempt
+                + " for Kafka event "
+                + eventId
+                + ". Earlier timed-out attempt "
+                + "observed="
+                + observedEarlierAttempt
+        );
+    }
+
+    private static ConsumerRecord<String, String>
+    awaitRecord(
+        KafkaConsumer<String, String> consumer,
+        UUID eventId
+    ) {
+        String expected =
+            eventId.toString();
+
+        long deadline =
+            System.nanoTime()
+                + Duration.ofSeconds(30)
+                    .toNanos();
+
+        while (
+            System.nanoTime() < deadline
+        ) {
+            ConsumerRecords<String, String> records =
+                consumer.poll(
+                    Duration.ofMillis(250)
+                );
+
+            for (
+                ConsumerRecord<String, String>
+                    record : records
+            ) {
+                if (
+                    record.value() != null
+                        && record.value()
+                            .contains(expected)
+                ) {
+                    return record;
+                }
+            }
+        }
+
+        throw new AssertionError(
+            "Timed out waiting for Kafka event "
+                + eventId
+        );
+    }
+
+    private static String headerValue(
+        ConsumerRecord<String, String> record,
+        String headerName
+    ) {
+        Header header =
+            record.headers()
+                .lastHeader(headerName);
+
+        assertThat(header)
+            .isNotNull();
+
+        return new String(
+            header.value(),
+            UTF_8
+        );
+    }
+
+    private void assertJsonEquivalent(
+        String actual,
+        String expected
+    ) throws Exception {
+
+        JsonNode actualJson =
+            objectMapper.readTree(actual);
+
+        JsonNode expectedJson =
+            objectMapper.readTree(expected);
+
+        assertThat(actualJson)
+            .isEqualTo(expectedJson);
+    }
+
+    private void cleanDatabase() {
+        jdbcTemplate.update(
+            "DELETE FROM kafka_dead_letter_command_audits"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM kafka_dead_letter_records"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM transfer_completed_event_audits"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM processed_kafka_events"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM outbox_events"
+        );
+    }
+
+    private int count(String table) {
+        Integer value =
+            jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM " + table,
+                Integer.class
+            );
+
+        return value == null ? 0 : value;
+    }
+
+    private static void pauseKafka() {
+        dockerClient()
+            .pauseContainerCmd(
+                KAFKA.getContainerId()
+            )
+            .exec();
+    }
+
+    private static void unpauseKafka() {
+        dockerClient()
+            .unpauseContainerCmd(
+                KAFKA.getContainerId()
+            )
+            .exec();
+    }
+
+    private static void awaitKafka()
+        throws Exception {
+
+        long deadline =
+            System.nanoTime()
+                + Duration.ofSeconds(60)
+                    .toNanos();
+
+        Exception lastFailure = null;
+
+        while (
+            System.nanoTime() < deadline
+        ) {
+            try (
+                Admin admin = Admin.create(
+                    Map.of(
+                        AdminClientConfig
+                            .BOOTSTRAP_SERVERS_CONFIG,
+                        KAFKA.getBootstrapServers()
+                    )
+                )
+            ) {
+                if (
+                    admin.listTopics()
+                        .names()
+                        .get(
+                            5,
+                            TimeUnit.SECONDS
+                        )
+                        .contains(SOURCE_TOPIC)
+                ) {
+                    return;
+                }
+            } catch (Exception exception) {
+                lastFailure = exception;
+            }
+
+            TimeUnit.MILLISECONDS.sleep(500);
+        }
+
+        throw new AssertionError(
+            "Kafka did not recover in time.",
+            lastFailure
+        );
+    }
+
+    private static void await(
+        BooleanSupplier condition,
+        String description
+    ) throws Exception {
+
+        long deadline =
+            System.nanoTime()
+                + Duration.ofSeconds(30)
+                    .toNanos();
+
+        Throwable lastFailure = null;
+
+        while (
+            System.nanoTime() < deadline
+        ) {
+            try {
+                if (condition.getAsBoolean()) {
+                    return;
+                }
+            } catch (Throwable failure) {
+                lastFailure = failure;
+            }
+
+            TimeUnit.MILLISECONDS.sleep(200);
+        }
+
+        throw new AssertionError(
+            "Timed out waiting for "
+                + description,
+            lastFailure
+        );
+    }
+
+    private static DockerClient dockerClient() {
+        return DockerClientFactory
+            .instance()
+            .client();
+    }
+
+    private record ReplayState(
+        String status,
+        int replayCount,
+        String leaseOwner,
+        Instant leaseUntil,
+        String lastError,
+        UUID originId,
+        int attemptBase
+    ) {
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class KafkaTopicConfiguration {
+
+        @Bean
+        NewTopic sourceTopic() {
+            return TopicBuilder
+                .name(SOURCE_TOPIC)
+                .partitions(1)
+                .replicas(1)
+                .build();
+        }
+
+        @Bean
+        NewTopic deadLetterTopic() {
+            return TopicBuilder
+                .name(DLT_TOPIC)
+                .partitions(1)
+                .replicas(1)
+                .build();
+        }
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/V016RedisKafkaOutageRecoveryContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V016RedisKafkaOutageRecoveryContractTest.java
@@ -1,0 +1,272 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+class V016RedisKafkaOutageRecoveryContractTest {
+
+    private static final Path SCRIPT =
+        Path.of(
+            "scripts",
+            "operations",
+            "redis-kafka-outage-recovery-rehearsal.ps1"
+        );
+
+    private static final Path GUIDE =
+        Path.of(
+            "docs",
+            "operations",
+            "redis-kafka-outage-recovery.md"
+        );
+
+    private static final Path REDIS_TEST =
+        Path.of(
+            "src",
+            "test",
+            "java",
+            "com",
+            "nursena",
+            "payflow",
+            "configuration",
+            "V016RedisOutageRecoveryRehearsalTest.java"
+        );
+
+    private static final Path KAFKA_TEST =
+        Path.of(
+            "src",
+            "test",
+            "java",
+            "com",
+            "nursena",
+            "payflow",
+            "configuration",
+            "V016KafkaOutageRecoveryRehearsalTest.java"
+        );
+
+    private static final Path ROADMAP =
+        Path.of("docs", "roadmap.md");
+
+    private static final Path README =
+        Path.of("README.md");
+
+    private static final Path CHANGELOG =
+        Path.of("CHANGELOG.md");
+
+    private static final Path API_BASELINE =
+        Path.of("docs", "api-v1-compatibility.md");
+
+    private static final Path MIGRATIONS =
+        Path.of(
+            "src",
+            "main",
+            "resources",
+            "db",
+            "migration"
+        );
+
+    @Test
+    void shouldCommitRepeatableIsolatedFocusedRehearsal()
+        throws IOException {
+
+        String script = Files.readString(SCRIPT);
+
+        assertThat(script)
+            .contains(
+                "V016RedisOutageRecoveryRehearsalTest",
+                "V016KafkaOutageRecoveryRehearsalTest",
+                "Resolve-Java21",
+                "JAVA_HOME",
+                "Docker server",
+                ".runtime\\dependency-outage-recovery",
+                "git diff --check",
+                "Focused rehearsal result must be exactly 2 / 0 / 0 / 0"
+            )
+            .doesNotContain(
+                "git reset --hard",
+                "git clean",
+                "docker compose down",
+                "docker volume rm",
+                "DROP DATABASE",
+                "flyway repair",
+                "-FilePath 'java'"
+            );
+    }
+
+    @Test
+    void shouldVerifyRedisFailClosedAbuseAndAutomaticRecovery()
+        throws IOException {
+
+        String source = Files.readString(REDIS_TEST);
+
+        assertThat(source)
+            .contains(
+                "postgres:17-alpine",
+                "redis:8-alpine",
+                "registration.enabled=false",
+                "password-recovery-request.enabled=true",
+                "password-recovery-request.dependency-failure-mode=FAIL_CLOSED",
+                "pauseContainerCmd",
+                "unpauseContainerCmd",
+                "LOGIN_RATE_LIMIT_UNAVAILABLE",
+                "/api/v1/auth/password-recovery/requests",
+                "payflow.auth.login.rate_limit.redis.failures",
+                "payflow.security.abuse_protection.redis.failures",
+                "passwordRecoveryCredentialCount",
+                "mailOutboxCount",
+                "durableUserFingerprint",
+                "awaitApplicationLoginRecovery",
+                "example.invalid"
+            );
+    }
+
+    @Test
+    void shouldVerifyKafkaDurabilityDltReplayAndAmbiguousAcknowledgement()
+        throws IOException {
+
+        String source = Files.readString(KAFKA_TEST);
+
+        assertThat(source)
+            .contains(
+                "postgres:17-alpine",
+                "apache/kafka:4.1.2",
+                "pauseContainerCmd",
+                "unpauseContainerCmd",
+                "ObjectMapper",
+                "assertJsonEquivalent",
+                "PENDING",
+                "PUBLISHED",
+                "kafka_dead_letter_records",
+                "REPLAY_FAILED",
+                "REPLAYED",
+                "awaitReplayAttempt",
+                "REPLAY_ORIGIN_ID",
+                "REPLAY_ATTEMPT",
+                "processedCount",
+                "auditCount",
+                "payment_transactions",
+                "ledger_entries"
+            );
+    }
+
+    @Test
+    void shouldDocumentSafeOperationsPrivacyAndDeliveryLimitations()
+        throws IOException {
+
+        String guide = Files.readString(GUIDE);
+
+        assertThat(guide.replaceAll("\\s+", " "))
+            .contains(
+                "PostgreSQL remains the durable system of record",
+                "Registration remains the reviewed `DEFER` case",
+                "acknowledgement ambiguity",
+                "at-least-once delivery boundary",
+                "must not manually mark",
+                "Do not disable the login limiter",
+                "single durable idempotency/audit boundary",
+                "must not contain real email addresses",
+                "zero-data-loss",
+                "does not certify"
+            );
+    }
+
+    @Test
+    void shouldMarkIncrementFourCompleteAndKeepLaterWorkOpen()
+        throws IOException {
+
+        String roadmap = Files.readString(ROADMAP);
+
+        String incrementFour = sectionBetween(
+            roadmap,
+            "### Increment 4",
+            "### Increment 5"
+        );
+
+        assertThat(incrementFour)
+            .contains("- [x]")
+            .doesNotContain("- [ ]");
+
+        assertThat(roadmap)
+            .contains(
+                "- [x] Redis and Kafka outage/recovery procedures are documented and verified against existing failure contracts",
+                "### Increment 5",
+                "- [ ] Compare implemented `/api/v1` behavior with OpenAPI and Postman contracts"
+            );
+
+        assertThat(Files.readString(README))
+            .contains(
+                "[Issue #178]",
+                "[Redis/Kafka outage-recovery operations guide](docs/operations/redis-kafka-outage-recovery.md)"
+            );
+
+        assertThat(Files.readString(CHANGELOG))
+            .contains(
+                "issue #178",
+                "acknowledgement ambiguity"
+            );
+    }
+
+    @Test
+    void shouldPreserveFrozenApiAndMigrationBaseline()
+        throws IOException {
+
+        assertThat(Files.readString(API_BASELINE))
+            .contains(
+                "**30 canonical HTTP operations**",
+                "**28 unique route paths**",
+                "Registration remains the reviewed `DEFER` case"
+            );
+
+        List<String> migrationNames;
+        try (var paths = Files.list(MIGRATIONS)) {
+            migrationNames = paths
+                .filter(Files::isRegularFile)
+                .map(path -> path.getFileName().toString())
+                .filter(name -> name.matches("V\\d+__.+\\.sql"))
+                .sorted()
+                .toList();
+        }
+
+        assertThat(migrationNames)
+            .hasSize(24);
+
+        IntStream.rangeClosed(1, 24)
+            .forEach(version ->
+                assertThat(migrationNames)
+                    .anyMatch(name ->
+                        name.startsWith(
+                            "V" + version + "__"
+                        )
+                    )
+            );
+    }
+
+    private static String sectionBetween(
+        String source,
+        String startMarker,
+        String endMarker
+    ) {
+
+        int start = source.indexOf(startMarker);
+        int end = source.indexOf(
+            endMarker,
+            start + startMarker.length()
+        );
+
+        assertThat(start)
+            .as("start marker")
+            .isGreaterThanOrEqualTo(0);
+
+        assertThat(end)
+            .as("end marker")
+            .isGreaterThan(start);
+
+        return source.substring(start, end);
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/V016RedisOutageRecoveryRehearsalTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V016RedisOutageRecoveryRehearsalTest.java
@@ -1,0 +1,662 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request
+    .MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result
+    .MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import com.github.dockerjava.api.DockerClient;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet
+    .AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection
+    .ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(properties = {
+    "payflow.security.login-rate-limit.enabled=true",
+    "payflow.security.login-rate-limit.window=30s",
+    "payflow.security.login-rate-limit.identity-limit=5",
+    "payflow.security.login-rate-limit.client-limit=20",
+    "payflow.security.abuse-protection.enabled=true",
+    "payflow.security.abuse-protection.registration.enabled=false",
+    "payflow.security.abuse-protection.password-recovery-request.enabled=true",
+    "payflow.security.abuse-protection.password-recovery-request.dependency-failure-mode=FAIL_CLOSED",
+    "spring.data.redis.connect-timeout=500ms",
+    "spring.data.redis.timeout=500ms",
+    "payflow.mail.outbox.polling.enabled=false",
+    "payflow.outbox.polling.enabled=false",
+    "payflow.event-processing.transfer-completed.enabled=false",
+    "payflow.event-processing.transfer-completed.dead-letter-intake.enabled=false"
+})
+@AutoConfigureMockMvc
+@Testcontainers
+class V016RedisOutageRecoveryRehearsalTest {
+
+    private static final int REDIS_PORT = 6379;
+
+    private static final UUID USER_ID =
+        UUID.fromString(
+            "91000000-0000-0000-0000-000000000101"
+        );
+
+    private static final String USER_EMAIL =
+        "v016.redis.recovery@example.invalid";
+
+    @Container
+    @ServiceConnection
+    private static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>(
+            "postgres:17-alpine"
+        );
+
+    @Container
+    private static final GenericContainer<?> REDIS =
+        new GenericContainer<>(
+            DockerImageName.parse(
+                "redis:8-alpine"
+            )
+        )
+            .withExposedPorts(REDIS_PORT);
+
+    @DynamicPropertySource
+    static void redisProperties(
+        DynamicPropertyRegistry registry
+    ) {
+        registry.add(
+            "spring.data.redis.host",
+            REDIS::getHost
+        );
+
+        registry.add(
+            "spring.data.redis.port",
+            () ->
+                REDIS.getMappedPort(
+                    REDIS_PORT
+                )
+        );
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    @Test
+    void shouldFailClosedAndRecoverWithoutDurableStateRepair()
+        throws Exception {
+
+        cleanDurableState();
+        insertVerifiedSyntheticUser();
+
+        String durableFingerprint =
+            durableUserFingerprint();
+
+        int mappedRedisPort =
+            REDIS.getMappedPort(
+                REDIS_PORT
+            );
+
+        assertHostPortPong(
+            mappedRedisPort,
+            "healthy baseline"
+        );
+
+        login(
+            "healthy.login@example.invalid"
+        )
+            .andExpect(status().isUnauthorized());
+
+        passwordRecovery(USER_EMAIL)
+            .andExpect(status().isAccepted());
+
+        assertThat(passwordRecoveryCredentialCount())
+            .isEqualTo(1);
+        assertThat(mailOutboxCount())
+            .isEqualTo(1);
+
+        clearRecoverySideEffects();
+
+        double loginFailuresBefore =
+            counter(
+                "payflow.auth.login.rate_limit.redis.failures",
+                "operation",
+                "evaluate"
+            );
+
+        double abuseFailuresBefore =
+            counter(
+                "payflow.security.abuse_protection.redis.failures",
+                "workflow",
+                "password-recovery-request",
+                "failure_mode",
+                "fail_closed"
+            );
+
+        pauseRedis();
+
+        try {
+            awaitHostPortUnavailable(
+                mappedRedisPort
+            );
+            MvcResult failedLogin =
+                login(
+                    "redis.down@example.invalid"
+                )
+                    .andExpect(
+                        status()
+                            .isServiceUnavailable()
+                    )
+                    .andExpect(
+                        jsonPath("$.status")
+                            .value(503)
+                    )
+                    .andExpect(
+                        jsonPath("$.code")
+                            .value(
+                                "LOGIN_RATE_LIMIT_UNAVAILABLE"
+                            )
+                    )
+                    .andExpect(
+                        jsonPath("$.message")
+                            .value(
+                                "Login protection is "
+                                    + "temporarily unavailable."
+                            )
+                    )
+                    .andReturn();
+
+            String responseBody =
+                failedLogin
+                    .getResponse()
+                    .getContentAsString();
+
+            assertThat(responseBody)
+                .doesNotContain(
+                    "127.0.0.1",
+                    Integer.toString(
+                        REDIS.getMappedPort(
+                            REDIS_PORT
+                        )
+                    ),
+                    "redis://",
+                    "RedisConnection",
+                    "Connection refused"
+                );
+
+            /*
+             * Password recovery intentionally keeps its
+             * public anti-enumeration response generic.
+             * FAIL_CLOSED means no lookup/credential/mail
+             * side effect occurs when Redis is unavailable.
+             */
+            passwordRecovery(USER_EMAIL)
+                .andExpect(status().isAccepted());
+
+            assertThat(passwordRecoveryCredentialCount())
+                .isZero();
+            assertThat(mailOutboxCount())
+                .isZero();
+            assertThat(durableUserFingerprint())
+                .isEqualTo(durableFingerprint);
+
+            assertThat(
+                counter(
+                    "payflow.auth.login.rate_limit.redis.failures",
+                    "operation",
+                    "evaluate"
+                )
+            )
+                .isGreaterThan(loginFailuresBefore);
+
+            assertThat(
+                counter(
+                    "payflow.security.abuse_protection.redis.failures",
+                    "workflow",
+                    "password-recovery-request",
+                    "failure_mode",
+                    "fail_closed"
+                )
+            )
+                .isGreaterThan(abuseFailuresBefore);
+        } finally {
+            unpauseRedis();
+        }
+
+        awaitHostPortPong(
+            mappedRedisPort
+        );
+
+        awaitApplicationLoginRecovery();
+
+        login(
+            "redis.recovered@example.invalid"
+        )
+            .andExpect(status().isUnauthorized());
+
+        passwordRecovery(USER_EMAIL)
+            .andExpect(status().isAccepted());
+
+        assertThat(passwordRecoveryCredentialCount())
+            .isEqualTo(1);
+        assertThat(mailOutboxCount())
+            .isEqualTo(1);
+        assertThat(durableUserFingerprint())
+            .isEqualTo(durableFingerprint);
+
+        assertThat(userCount())
+            .isEqualTo(1);
+        assertThat(paymentTransactionCount())
+            .isZero();
+        assertThat(ledgerEntryCount())
+            .isZero();
+    }
+
+    private org.springframework.test.web.servlet.ResultActions
+    login(
+        String email
+    ) throws Exception {
+
+        return mockMvc.perform(
+            post("/api/v1/auth/login")
+                .with(request -> {
+                    request.setRemoteAddr(
+                        "203.0.113.101"
+                    );
+                    return request;
+                })
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    """
+                    {
+                      "email": "%s",
+                      "password": "WrongPassword123!"
+                    }
+                    """.formatted(email)
+                )
+        );
+    }
+
+    private org.springframework.test.web.servlet.ResultActions
+    passwordRecovery(
+        String email
+    ) throws Exception {
+
+        return mockMvc.perform(
+            post(
+                "/api/v1/auth/password-recovery/requests"
+            )
+                .with(request -> {
+                    request.setRemoteAddr(
+                        "203.0.113.102"
+                    );
+                    return request;
+                })
+                .contentType(
+                    MediaType.APPLICATION_JSON
+                )
+                .content(
+                    """
+                    {
+                      "email": "%s"
+                    }
+                    """.formatted(email)
+                )
+        );
+    }
+
+    private void cleanDurableState() {
+        jdbcTemplate.update(
+            "DELETE FROM mail_outbox_messages"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM account_action_credentials"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM users"
+        );
+    }
+
+    private void clearRecoverySideEffects() {
+        jdbcTemplate.update(
+            "DELETE FROM mail_outbox_messages"
+        );
+        jdbcTemplate.update(
+            "DELETE FROM account_action_credentials"
+        );
+    }
+
+    private void insertVerifiedSyntheticUser() {
+        jdbcTemplate.update(
+            """
+            INSERT INTO users (
+                id,
+                email,
+                password_hash,
+                role,
+                status,
+                created_at,
+                updated_at,
+                email_verified_at
+            )
+            VALUES (
+                ?, ?, ?,
+                'USER',
+                'ACTIVE',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            """,
+            USER_ID,
+            USER_EMAIL,
+            "synthetic-unused-password-hash"
+        );
+    }
+
+    private String durableUserFingerprint() {
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT md5(
+                id::text
+                || '|'
+                || email
+                || '|'
+                || password_hash
+                || '|'
+                || role
+                || '|'
+                || status
+                || '|'
+                || (email_verified_at IS NOT NULL)::text
+            )
+            FROM users
+            WHERE id = ?
+            """,
+            String.class,
+            USER_ID
+        );
+    }
+
+    private int passwordRecoveryCredentialCount() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM account_action_credentials
+                WHERE user_id = ?
+                  AND purpose = 'PASSWORD_RECOVERY'
+                """,
+                Integer.class,
+                USER_ID
+            );
+
+        return count == null ? 0 : count;
+    }
+
+    private int mailOutboxCount() {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM mail_outbox_messages",
+                Integer.class
+            );
+
+        return count == null ? 0 : count;
+    }
+
+    private int userCount() {
+        return count("users");
+    }
+
+    private int paymentTransactionCount() {
+        return count("payment_transactions");
+    }
+
+    private int ledgerEntryCount() {
+        return count("ledger_entries");
+    }
+
+    private int count(String table) {
+        Integer count =
+            jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM " + table,
+                Integer.class
+            );
+
+        return count == null ? 0 : count;
+    }
+
+    private double counter(
+        String name,
+        String... tags
+    ) {
+        Counter counter =
+            meterRegistry
+                .find(name)
+                .tags(tags)
+                .counter();
+
+        return counter == null
+            ? 0.0
+            : counter.count();
+    }
+
+    private static void pauseRedis() {
+        dockerClient()
+            .pauseContainerCmd(
+                REDIS.getContainerId()
+            )
+            .exec();
+    }
+
+    private static void unpauseRedis() {
+        dockerClient()
+            .unpauseContainerCmd(
+                REDIS.getContainerId()
+            )
+            .exec();
+    }
+
+    private void awaitApplicationLoginRecovery()
+        throws Exception {
+
+        long deadline =
+            System.nanoTime()
+                + Duration.ofSeconds(60)
+                    .toNanos();
+
+        int attempt = 0;
+        int lastStatus = -1;
+
+        while (
+            System.nanoTime() < deadline
+        ) {
+            attempt++;
+
+            lastStatus =
+                login(
+                    "redis.recovery."
+                        + attempt
+                        + "@example.invalid"
+                )
+                    .andReturn()
+                    .getResponse()
+                    .getStatus();
+
+            if (lastStatus == 401) {
+                return;
+            }
+
+            assertThat(lastStatus)
+                .as(
+                    "Recovery polling must remain "
+                        + "fail-closed until Redis "
+                        + "becomes usable again"
+                )
+                .isEqualTo(503);
+
+            TimeUnit.MILLISECONDS.sleep(500);
+        }
+
+        throw new AssertionError(
+            "Redis host endpoint recovered but "
+                + "the running PayFlow login limiter "
+                + "did not recover within 60 seconds. "
+                + "Last HTTP status="
+                + lastStatus
+        );
+    }
+
+    private static void awaitHostPortUnavailable(
+        int port
+    ) throws Exception {
+
+        long deadline =
+            System.nanoTime()
+                + Duration.ofSeconds(10)
+                    .toNanos();
+
+        while (
+            System.nanoTime() < deadline
+        ) {
+            try {
+                assertHostPortPong(
+                    port,
+                    "paused"
+                );
+            } catch (Exception | AssertionError expected) {
+                return;
+            }
+
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+
+        throw new AssertionError(
+            "Mapped Redis endpoint continued answering "
+                + "PING while the isolated rehearsal "
+                + "container was paused."
+        );
+    }
+
+    private static void awaitHostPortPong(
+        int port
+    ) throws Exception {
+
+        long deadline =
+            System.nanoTime()
+                + Duration.ofSeconds(30)
+                    .toNanos();
+
+        Throwable lastFailure = null;
+
+        while (
+            System.nanoTime() < deadline
+        ) {
+            try {
+                assertHostPortPong(
+                    port,
+                    "post-unpause"
+                );
+                return;
+            } catch (Throwable failure) {
+                lastFailure = failure;
+            }
+
+            TimeUnit.MILLISECONDS.sleep(250);
+        }
+
+        throw new AssertionError(
+            "Mapped Redis endpoint did not recover "
+                + "after the isolated container "
+                + "was unpaused.",
+            lastFailure
+        );
+    }
+
+    private static void assertHostPortPong(
+        int port,
+        String phase
+    ) throws Exception {
+
+        try (Socket socket = new Socket()) {
+            socket.connect(
+                new InetSocketAddress(
+                    REDIS.getHost(),
+                    port
+                ),
+                750
+            );
+
+            socket.setSoTimeout(750);
+
+            OutputStream output =
+                socket.getOutputStream();
+
+            output.write(
+                "*1\r\n$4\r\nPING\r\n"
+                    .getBytes(
+                        StandardCharsets.US_ASCII
+                    )
+            );
+
+            output.flush();
+
+            InputStream input =
+                socket.getInputStream();
+
+            byte[] response =
+                input.readNBytes(7);
+
+            assertThat(
+                new String(
+                    response,
+                    StandardCharsets.US_ASCII
+                )
+            )
+                .as(
+                    "host-port Redis PING during "
+                        + phase
+                )
+                .isEqualTo("+PONG\r\n");
+        }
+    }
+
+    private static DockerClient dockerClient() {
+        return DockerClientFactory
+            .instance()
+            .client();
+    }
+}


### PR DESCRIPTION
## Summary

Completes v0.16.0 Increment 4 for issue #178 by adding a repeatable isolated Redis/Kafka outage-recovery rehearsal around the already-reviewed runtime semantics.

This PR adds:
- an operations runbook for Redis/Kafka outage and recovery;
- a guarded PowerShell rehearsal entry point using Java 21 and isolated Testcontainers infrastructure;
- focused Redis outage/recovery coverage for the login limiter plus the selected non-registration password-recovery abuse workflow;
- focused Kafka outbox, consumer/DLT, replay, acknowledgement-ambiguity, and durable idempotency coverage;
- executable documentation/scope contracts;
- README, CHANGELOG, and roadmap alignment for Increment 4 completion.

## Runtime boundaries preserved

- PostgreSQL remains the durable system of record.
- Redis remains bounded/expiring abuse-control state only.
- Login-limiter fail-closed semantics are unchanged.
- Password-recovery preserves its existing anti-enumeration response while suppressing protected side effects when Redis is unavailable.
- Registration abuse protection remains `DEFER` and is not activated or retuned.
- Kafka producer/consumer retry counts, outbox lifecycle, DLT/replay semantics, API contracts, migrations, and product behavior are unchanged.
- No `src/main`, Flyway migration, `pom.xml`, compose, workflow, or application-config changes are included.

## Exact reviewed scope

Base: `ed9cf4259bf6dd24185fa4bf258bec8593d6f1b8`
Head: `4356e153fe322a29b03c916c3cbadb7eb38398ee`

Exactly 8 files changed:
1. `CHANGELOG.md`
2. `README.md`
3. `docs/operations/redis-kafka-outage-recovery.md`
4. `docs/roadmap.md`
5. `scripts/operations/redis-kafka-outage-recovery-rehearsal.ps1`
6. `src/test/java/com/nursena/payflow/configuration/V016KafkaOutageRecoveryRehearsalTest.java`
7. `src/test/java/com/nursena/payflow/configuration/V016RedisKafkaOutageRecoveryContractTest.java`
8. `src/test/java/com/nursena/payflow/configuration/V016RedisOutageRecoveryRehearsalTest.java`

## Evidence

Pre-commit focused Increment 4 suite:
- `8` tests
- `0` failures
- `0` errors
- `0` skipped

Complete Maven verification at the exact candidate content:
- `1614` tests
- `0` failures
- `0` errors
- `0` skipped
- `368` Surefire XML reports
- `git diff --check`: PASS
- candidate manifest SHA-256: `dd2cdbad74da1a1ac4b0b455303427d6a856314c7c7858557b6225aa90dab891`
- full-verification evidence SHA-256: `b3f991734dafe6f88553b9b518356520e72e0a72d75ff070ad64f97b73a155f3`

Committed-head rehearsal at exact head `4356e153fe322a29b03c916c3cbadb7eb38398ee`:
- `2` runtime tests
- `0` failures
- `0` errors
- `0` skipped
- Redis outage + fail-closed + automatic recovery: PASS
- selected password-recovery fail-closed/no-side-effect path: PASS
- Kafka outbox outage + retry + recovery: PASS
- Kafka DLT intake + replay recovery: PASS
- acknowledgement ambiguity handled as an at-least-once boundary: PASS
- durable PostgreSQL processing/idempotency remains single-record: PASS
- payment/ledger row counts unchanged by the synthetic rehearsal
- committed rehearsal evidence SHA-256: `03e8864aa2a0daab6cd8038b8b8e780dd88e15687847b46b893224e4517463f7`
- repository tree clean after rehearsal

## Review notes

The outage mechanism intentionally uses exact Testcontainers container pause/unpause rather than stop/start. Earlier runtime classification proved that Docker Desktop/Testcontainers mapped-host-port reconstruction can fail below the application layer on restart, while reversible isolation preserves the same endpoint and proves actual application-client recovery without manual connection repair.

Kafka replay verification deliberately tolerates a delayed earlier timed-out replay delivery and requires the later successful replay attempt plus durable single-record processing. A client-side timeout is not treated as proof that the broker definitely lost the send.

Closes #178 after this PR is merged and the exact-head CI and Docker Smoke checks are green.