### PR TITLE
docs(api): align v0.16 contracts and Postman coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and PayFlow uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Aligned v0.16.0 API/OpenAPI/Postman/architecture documentation through issue #180: OpenAPI metadata now follows `0.16.0-SNAPSHOT`, a manual compatibility collection closes the five previously recorded Postman operation gaps, and architecture guidance now describes delivered outbox/event-processing/mail/abuse/observability boundaries without changing runtime product or security semantics.
 - Advanced the active development version to `0.16.0-SNAPSHOT`.
 - Opened the v0.16.0 stabilization, recovery-rehearsal, API-freeze, and supply-chain hardening milestone through issue #169 without adding new product features.
 - Froze the source-backed `/api/v1` compatibility baseline through issue #171, including OpenAPI/Postman comparison, security and failure-contract boundaries, and concrete documentation-drift follow-ups without changing runtime behavior.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Completed capabilities include:
 - operator-only, paginated command-audit queries and chronological command timelines
 - Prometheus metrics, Grafana dashboards, and alert rules for Kafka consumer failures
 
-OpenAPI documentation covers the implemented API, while executable Postman workflows remain aligned with released end-to-end flows. PayFlow v0.15.0 is the latest published release, and the active development line uses `0.16.0-SNAPSHOT`. The v0.16.0 milestone focuses on stabilization, recovery rehearsals, API compatibility freeze, documentation consistency, dependency and supply-chain checks, and clean-environment verification without adding new product features.
+OpenAPI documentation covers the implemented API. Across the committed standard, MFA, login-rate-limit, and compatibility-coverage collections, Postman represents all 30 canonical `/api/v1` operations while keeping lifecycle-sensitive and privileged requests manually gated. PayFlow v0.15.0 is the latest published release, and the active development line uses `0.16.0-SNAPSHOT`. The v0.16.0 milestone focuses on stabilization, recovery rehearsals, API compatibility freeze, documentation consistency, dependency and supply-chain checks, and clean-environment verification without adding new product features.
 
 The immutable v0.15.0 publication record is anchored to annotated tag `v0.15.0`, merge commit `c29a067ca3a64514444e17db59a2b862d26f5950`, and successful release workflow run [32172653513](https://github.com/nursena-pc/payflow/actions/runs/32172653513). The published `payflow-0.15.0.jar` is 100236578 bytes and its independently verified SHA-256 is `7EDF5EAD1EB93966E750F917D9472B4383D2B3CDA7406A264AE78B106A779080`.
 
@@ -432,6 +432,7 @@ Import:
 
 - `postman/PayFlow.postman_collection.json`
 - `postman/PayFlow.mfa.postman_collection.json` for the MFA and step-up security workflow
+- `postman/PayFlow.api-compatibility.postman_collection.json` for the five manually gated compatibility-coverage operations
 - `postman/PayFlow.local.postman_environment.json`
 - `postman/PayFlow.login-rate-limit.postman_collection.json` for the separate, deliberately disruptive login-limiter workflow
 

--- a/docs/api-v1-compatibility.md
+++ b/docs/api-v1-compatibility.md
@@ -134,43 +134,15 @@ compatibility analysis, executable verification, and protected review.
 
 ## OpenAPI comparison
 
-The current generated OpenAPI contract is source-backed by
-`OpenApiJsonContractIntegrationTest` and exposes the same **28 unique
-`/api/v1` paths** as this baseline. Two of those paths support two methods,
-giving the **30 canonical operations** above.
+The generated OpenAPI contract continues to expose the same **28 unique `/api/v1` paths** and the same 30 method/path operations frozen by this baseline. Two paths intentionally support two methods.
 
-Current strengths:
+Increment 5 alignment changes documentation metadata only: `OpenApiConfiguration` now reports `info.version = 0.16.0-SNAPSHOT`, matching the active Maven development line. This value is build/development metadata; it does not rename `/api/v1`, introduce `/api/v2`, or authorize a compatibility break.
 
-- exact route-path presence is executable
-- registration, login, account-action, refresh, wallet, transfer, transaction,
-  dead-letter, and selected security/status contracts are explicitly tested
-- logout-all has a dedicated OpenAPI integration contract
-- Bearer JWT configuration is explicit
-
-Recorded OpenAPI follow-up items for the later documentation-drift alignment
-increment:
-
-1. `OpenApiConfiguration` still reports `info.version = 0.2.0`; this predates
-   the current v0.16.0 development line and must be reviewed rather than
-   silently interpreted as the application release version.
-2. MFA enrollment/status/cancel/disable/recovery-code controller operations
-   rely more heavily on generated/inferred OpenAPI metadata than the explicitly
-   annotated identity, wallet, transfer, and operator controllers. Their
-   response/security descriptions should be reviewed against the compatibility
-   table above.
-3. This checkpoint records those documentation gaps but does not add runtime
-   behavior or broadly rewrite controller documentation.
+`OpenApiJsonContractIntegrationTest` remains the executable authority for exact path presence, bearer/public security placement, and the material response-code contracts already covered by the stabilization baseline.
 
 ## Postman comparison
 
-The standard, MFA, and login-rate-limit collections together currently contain
-**25 unique canonical `/api/v1` operations** from this 30-operation baseline.
-
-There are no verified Postman-only API operations once the two concatenated
-operator audit routes are resolved correctly from source.
-
-The five implemented operations not currently represented as Postman requests
-are:
+At the #171 freeze checkpoint, the standard, MFA, and login-rate-limit collections together contained **25 unique canonical `/api/v1` operations** from this 30-operation baseline. The five implemented operations recorded then as **known executable-workflow coverage gaps** were:
 
 - `POST /api/v1/auth/email-verification/confirm`
 - `POST /api/v1/auth/refresh`
@@ -178,36 +150,22 @@ are:
 - `POST /api/v1/auth/logout-all`
 - `DELETE /api/v1/users/me/mfa/enrollment`
 
-These are recorded as **known executable-workflow coverage gaps**, not missing
-API endpoints. The existing collections are scenario-oriented rather than an
-exhaustive endpoint manifest. This inventory does not claim an omission is
-intentional unless existing workflow documentation supports that conclusion.
-Later Postman alignment may add coverage without changing the compatibility
-surface.
+Increment 5 alignment adds `postman/PayFlow.api-compatibility.postman_collection.json` as a deliberately manual collection for exactly those five lifecycle-sensitive operations. Across the four executable collections, the current committed Postman assets now cover **30 unique canonical `/api/v1` operations** with no Postman-only operation.
+
+The compatibility collection commits no credential value. Email-verification and refresh credentials remain empty secret environment values, while access and MFA tokens must be supplied or produced locally. The standard scenario workflow remains non-destructive; the compatibility collection makes refresh/logout and pending-MFA cancellation explicit manual branches rather than silently changing the normal run order.
+
+README contains 36 raw API table representations because the six Kafka operator operations are repeated in a later operations section; two of those repeated rows include query-string examples. Normalization still yields the same 30 canonical operations, so raw markdown row count is not treated as an API count.
 
 ## Documentation-drift inventory
 
-This checkpoint intentionally does not broadly rewrite architecture
-documentation. The following concrete follow-up items are frozen for the later
-v0.16 documentation-alignment increment:
+Increment 5 alignment resolves the concrete documentation drift recorded at the #171 checkpoint without changing product behavior:
 
-1. `docs/architecture.md` still says transactional outbox persistence is
-   "planned for a later milestone", while the delivered platform and README
-   describe transactional outbox persistence and Kafka publication as
-   implemented.
-2. The architecture package-convention example still lists `notification` and
-   `audit` as top-level capability packages even though the current source tree
-   uses delivered packages such as `outbox`, `eventprocessing`,
-   `maildelivery`, `abuseprotection`, and `observability`.
-3. The architecture document does not yet describe several delivered modules
-   and their current boundaries with the same completeness as older wallet,
-   transaction, ledger, and client-context sections.
-4. `OpenApiConfiguration` still contains the historical `0.2.0` metadata
-   version and requires an explicit documentation-version decision.
+1. `docs/architecture.md` now describes transactional outbox persistence, retryable Kafka publication, idempotent event processing, DLT/replay, mail delivery, abuse protection, and observability as delivered modular-monolith capabilities rather than future placeholders.
+2. The architecture package inventory now matches current top-level source packages such as `abuseprotection`, `eventprocessing`, `maildelivery`, `observability`, and `outbox`; obsolete `notification` and `audit` top-level examples are removed.
+3. OpenAPI metadata now uses the active `0.16.0-SNAPSHOT` development version instead of the historical `0.2.0` text while preserving the frozen `/api/v1` route contract.
+4. Postman coverage now maps all 30 canonical operations while keeping secret-bearing and destructive flows manually gated.
 
-These are documentation follow-ups. They are not authorization to redesign the
-modular monolith, extract microservices, change the database model, or change
-the public API.
+The alignment does not activate generalized registration abuse protection, change the separate login limiter, redesign DTOs, add product endpoints, alter retry policy, rewrite migrations, extract microservices, or make real-money/HA/production-certification claims.
 
 ## Stabilization decision
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,53 +12,29 @@ adapter -> application -> domain
 
 The domain model has no Spring, JPA, Kafka, Redis, or HTTP dependencies.
 
-Application services coordinate use cases and depend on input and output ports. Adapters translate between the application core and infrastructure concerns such as HTTP, PostgreSQL, security, and future messaging integrations.
+Application services coordinate use cases and depend on input and output ports. Adapters translate between the application core and delivered infrastructure concerns such as HTTP, PostgreSQL, Redis, Kafka, SMTP, security, and observability.
 
 ## Package convention
 
+The current top-level capability packages are source-backed:
+
 ```text
 com.nursena.payflow
-├── user
-│   ├── domain
-│   ├── application
-│   │   ├── port.in
-│   │   └── port.out
-│   └── adapter
-│       ├── in.web
-│       └── out
-├── wallet
-│   ├── domain
-│   ├── application
-│   │   ├── port.in
-│   │   └── port.out
-│   └── adapter
-│       ├── in.web
-│       └── out.persistence
-├── transaction
-│   ├── domain
-│   ├── application
-│   │   ├── port.in
-│   │   └── port.out
-│   └── adapter
-│       ├── in.web
-│       └── out.persistence
-├── ledger
-│   ├── domain
-│   ├── application
-│   │   └── port.out
-│   └── adapter
-│       └── out.persistence
-├── clientcontext
-│   ├── domain
-│   └── adapter
-│       └── in.web
-├── notification
-├── audit
-├── common
-└── configuration
+|-- abuseprotection
+|-- clientcontext
+|-- common
+|-- configuration
+|-- eventprocessing
+|-- ledger
+|-- maildelivery
+|-- observability
+|-- outbox
+|-- transaction
+|-- user
+`-- wallet
 ```
 
-Packages that represent future capabilities may remain empty until a concrete use case requires them. Infrastructure is not added only to demonstrate a technology.
+Business capabilities use domain, application/port, and adapter boundaries where the capability requires them; infrastructure-focused packages keep infrastructure concerns outside domain code. The package inventory describes delivered code rather than reserving empty top-level packages for speculative future capabilities.
 
 ## Module responsibilities
 
@@ -80,20 +56,34 @@ effective address through `ClientAddressResolver`.
 
 The user module owns:
 
-- registration
-- normalized email identity
-- password-hash persistence
-- authentication
-- RSA-signed JWT creation
-- adapter-local signing-key retrieval and startup validation
-- stable JWT key identifiers and active/previous verification overlap
+- registration and normalized email identity
+- password-hash persistence and authentication
+- email-verification and password-recovery credential lifecycles
+- opaque refresh-session rotation, reuse detection, and family revocation
+- RSA-signed JWT creation with active/previous signing-key overlap
 - authenticated current-user profile
+- TOTP enrollment, MFA login challenges, recovery codes, and step-up grants
+- the separate Redis-backed password-login limiter compatibility boundary
 
-JWT key resources, PEM parsing, Nimbus selection, and deployment rotation stay
-inside the outbound security adapter. Application and domain code depend only
-on the existing access-token generation port. Production key rings contain one
-active signer and at most one verification-only previous key; verification is
-pinned to RS256 and requires a configured `kid`.
+JWT key resources, PEM parsing, Nimbus selection, and deployment rotation stay inside the outbound security adapter. Application and domain code depend on application-facing token and persistence ports rather than key-file or servlet details.
+
+### Abuse-protection module
+
+The `abuseprotection` capability owns the generalized bounded policy and Redis enforcement used by the reviewed account-action, MFA-challenge, and step-up flows. Redis stores only expiring derived control state and low-cardinality decision data. Registration remains outside generalized abuse-protection wiring under the evidence-backed `DEFER` decision, and the password-login limiter remains a separate compatibility contract.
+
+### Mail-delivery module
+
+The `maildelivery` capability owns protected account-action mail persistence and SMTP dispatch. Provider-ready verification/recovery content is encrypted before PostgreSQL persistence, leased for delivery after commit, decrypted only in memory, and erased after terminal outcomes.
+
+### Outbox and event-processing modules
+
+The `outbox` capability persists transfer-completed publication intent in the same PostgreSQL unit of work as the completed transfer and publishes after commit through a leased retryable Kafka publisher. The `eventprocessing` capability owns idempotent event consumption, durable dead-letter intake, controlled replay/discard lifecycle handling, and append-only operator command audit evidence.
+
+Kafka delivery is intentionally treated as at-least-once. A producer acknowledgement timeout can leave publication outcome ambiguous, so downstream PostgreSQL idempotency is the durable duplicate-processing boundary rather than an exactly-once broker claim.
+
+### Observability module
+
+The `observability` capability owns trustworthy request correlation, bounded request-completion events, structured logging/redaction support, and adapter-side operational metrics. Credentials, raw client addresses, request bodies, financial values, and other sensitive high-cardinality values remain outside logs and metric labels.
 
 ### Wallet module
 
@@ -200,11 +190,13 @@ The rollback behavior is verified against PostgreSQL by forcing ledger persisten
 
 ## Transactional outbox strategy
 
-Transactional outbox persistence is planned for a later milestone and is not part of the current transfer transaction.
+Transactional outbox persistence is implemented as part of the current transfer transaction.
 
-When implemented, the outbox record will be written in the same PostgreSQL transaction as the completed transfer. Kafka publication will happen after commit through a separate publisher.
+A completed transfer and its publication intent are persisted in the same PostgreSQL unit of work. Kafka publication happens after commit through a separate leased, retryable publisher; the transfer use case does not publish directly to Kafka inside the database transaction.
 
-The transfer use case will not publish directly to Kafka inside the database transaction.
+PostgreSQL remains the system of record for transfer, ledger, outbox, dead-letter, replay, and processing evidence where designed. Kafka delivery has an at-least-once delivery boundary: an acknowledgement timeout can make a send outcome ambiguous and a later retry may produce duplicate broker delivery. Durable processed-event and audit/idempotency state prevents a second financial movement or a second effective processing result.
+
+Redis is not a system of record. It remains limited to bounded, explicitly expiring abuse-control state, including the separate password-login limiter and generalized abuse-protection decisions.
 
 ## Concurrency strategy
 
@@ -300,6 +292,8 @@ Clients cannot supply the source user or source wallet identifier for:
 This prevents a client from accessing or changing another user's data by supplying a different user or wallet identifier in request input.
 
 Spring Security uses a deny-by-default policy. New routes remain inaccessible until they are explicitly classified as public or authenticated.
+
+/api/v1/operations/** remains restricted to the application-owned PAYFLOW_OPERATIONS authority derived from the exact administrative JWT role contract. Registration remains outside generalized abuse-protection wiring under the reviewed DEFER decision; the password-login limiter remains a separate compatibility contract with unchanged fail-closed behavior.
 
 ### Trusted client-address boundary
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -876,11 +876,11 @@ Baseline: v0.15.0 publication-record merge
 
 ### Increment 5 — API, OpenAPI, Postman, and documentation drift review
 
-- [ ] Compare implemented `/api/v1` behavior with OpenAPI and Postman contracts
-- [ ] Align README, architecture documentation, ADR references, security guidance, operations guides, and roadmap with implementation
-- [ ] Resolve stale architecture documentation that still describes delivered capabilities as planned
-- [ ] Add executable documentation contracts only where they prevent meaningful compatibility or operations drift
-- [ ] Preserve the evidence-backed registration `DEFER` decision unless new evidence and a separately reviewed change justify activation
+- [x] Compare implemented `/api/v1` behavior with OpenAPI and Postman contracts
+- [x] Align README, architecture documentation, ADR references, security guidance, operations guides, and roadmap with implementation
+- [x] Resolve stale architecture documentation that still describes delivered capabilities as planned
+- [x] Add executable documentation contracts only where they prevent meaningful compatibility or operations drift
+- [x] Preserve the evidence-backed registration `DEFER` decision unless new evidence and a separately reviewed change justify activation
 
 ### Increment 6 — Dependency and supply-chain evidence
 

--- a/postman/PayFlow.api-compatibility.postman_collection.json
+++ b/postman/PayFlow.api-compatibility.postman_collection.json
@@ -1,0 +1,313 @@
+{
+  "info": {
+    "_postman_id": "5b8a0eb0-71c4-4c12-b95a-1ab45ea56202",
+    "name": "PayFlow API Compatibility Coverage",
+    "description": "Manual local coverage for five implemented /api/v1 operations that were absent from the earlier scenario-oriented collections. No credentials or environment-specific secrets are committed. Populate only the required local secret variables before sending a request.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Account Actions",
+      "item": [
+        {
+          "name": "Confirm Email Verification",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "noauth"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/email-verification/confirm",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "email-verification",
+                "confirm"
+              ]
+            },
+            "description": "Consumes one locally supplied opaque email-verification credential. Obtain the credential only through a trusted delivery or test channel and never commit or export it.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"credential\": \"{{emailVerificationCredential}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.environment.get('emailVerificationCredential')) { throw new Error('Set emailVerificationCredential locally before confirmation.'); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 204', function () { pm.response.to.have.status(204); });",
+                  "pm.test('Response body is empty', function () { pm.expect(pm.response.text()).to.eql(''); });"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Refresh Session Lifecycle",
+      "item": [
+        {
+          "name": "Rotate Refresh Credentials",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "noauth"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/refresh",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "refresh"
+              ]
+            },
+            "description": "Rotates one locally supplied active refresh credential. A successful response replaces the local accessToken and refreshToken values for subsequent manual compatibility requests.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"refreshToken\": \"{{refreshToken}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.environment.get('refreshToken')) { throw new Error('Set refreshToken locally before rotation.'); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Rotated credentials are returned', function () {",
+                  "    const response = pm.response.json();",
+                  "    pm.expect(response.accessToken).to.be.a('string').and.not.empty;",
+                  "    pm.expect(response.refreshToken).to.be.a('string').and.not.empty;",
+                  "    pm.environment.set('accessToken', response.accessToken);",
+                  "    pm.environment.set('refreshToken', response.refreshToken);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Revoke Current Refresh Session",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "noauth"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/logout",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "logout"
+              ]
+            },
+            "description": "Idempotently revokes the refresh-token family represented by the locally supplied refresh credential.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"refreshToken\": \"{{refreshToken}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.environment.get('refreshToken')) { throw new Error('Set refreshToken locally before logout.'); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 204', function () { pm.response.to.have.status(204); });",
+                  "pm.test('Response body is empty', function () { pm.expect(pm.response.text()).to.eql(''); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Logout All Refresh Sessions",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{accessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/logout-all",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "logout-all"
+              ]
+            },
+            "description": "Revokes every active refresh session owned by the authenticated JWT subject. Supply a local accessToken; the collection never commits one."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.environment.get('accessToken')) { throw new Error('Set accessToken locally before logout-all.'); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 204', function () { pm.response.to.have.status(204); });",
+                  "pm.test('Response body is empty', function () { pm.expect(pm.response.text()).to.eql(''); });"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MFA Pending Enrollment",
+      "item": [
+        {
+          "name": "Cancel Pending MFA Enrollment",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{mfaAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/users/me/mfa/enrollment",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "users",
+                "me",
+                "mfa",
+                "enrollment"
+              ]
+            },
+            "description": "Cancels only a pending MFA enrollment for the authenticated subject. This is a manual destructive branch from the MFA workflow: begin enrollment first, then cancel instead of confirming it."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.environment.get('mfaAccessToken')) { throw new Error('Set mfaAccessToken locally before pending-enrollment cancellation.'); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 204', function () { pm.response.to.have.status(204); });",
+                  "pm.test('Response body is empty', function () { pm.expect(pm.response.text()).to.eql(''); });"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/postman/PayFlow.local.postman_environment.json
+++ b/postman/PayFlow.local.postman_environment.json
@@ -171,6 +171,18 @@
       "enabled": true
     },
     {
+      "key": "emailVerificationCredential",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "refreshToken",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
       "key": "mfaEmail",
       "value": "",
       "type": "default",

--- a/postman/README.md
+++ b/postman/README.md
@@ -1,6 +1,6 @@
 # PayFlow Postman Collection
 
-The Postman assets provide an executable local workflow for the PayFlow simulated digital-wallet API, manually gated Kafka dead-letter operations, and a separate deliberately disruptive login rate-limit verification workflow.
+The Postman assets provide an executable local workflow for the PayFlow simulated digital-wallet API, manually gated Kafka dead-letter operations, a separate deliberately disruptive login rate-limit verification workflow, and a dedicated manual compatibility-coverage collection for lifecycle-sensitive operations.
 
 ## Import
 
@@ -20,6 +20,16 @@ security workflow. It uses the shared local environment but requires
 `mfaEmail`, `mfaPassword`, `mfaAccessToken`, and fresh `mfaCode` values to be
 supplied locally. Committed MFA credential variables are empty.
 
+Import `PayFlow.api-compatibility.postman_collection.json` separately for
+the five source-backed operations that were not represented in the earlier
+scenario collections: email-verification confirmation, refresh rotation,
+current-session logout, logout-all, and pending MFA-enrollment cancellation.
+The collection is intentionally manual. `emailVerificationCredential` and
+`refreshToken` are empty secret environment values; `accessToken` and
+`mfaAccessToken` must also be supplied or produced locally before the
+corresponding request is sent. Across the four executable collections, all
+30 canonical `/api/v1` operations are represented without introducing a
+Postman-only API operation.
 ## Prerequisites
 
 ```bash
@@ -133,7 +143,9 @@ Run `Create Transfer`, then run `Replay Last Transfer` without rerunning the fir
 
 ## Security
 
-The repository contains no real JWTs, password-recovery credentials, privileged operator credentials, personal credentials, or production secrets. `operatorAccessToken`, `deadLetterRecordId`, `auditCommandId`, and `auditOperatorId` are intentionally empty in the committed environment.
+The repository contains no real JWTs, password-recovery credentials, privileged operator credentials, personal credentials, or production secrets.
+
+`emailVerificationCredential` and `refreshToken` are committed only as empty secret environment values for the manual compatibility collection. Never export or commit the environment after populating them. `operatorAccessToken`, `deadLetterRecordId`, `auditCommandId`, and `auditOperatorId` are intentionally empty in the committed environment.
 
 Never commit a Postman environment exported after it contains a live user or admin token. Treat an admin JWT as a privileged credential and keep it in a local environment or another trusted secret store.
 

--- a/src/main/java/com/nursena/payflow/configuration/OpenApiConfiguration.java
+++ b/src/main/java/com/nursena/payflow/configuration/OpenApiConfiguration.java
@@ -17,7 +17,7 @@ public class OpenApiConfiguration {
         "PayFlow API";
 
     private static final String API_VERSION =
-        "0.2.0";
+        "0.16.0-SNAPSHOT";
 
     private static final String API_DESCRIPTION =
         """

--- a/src/test/java/com/nursena/payflow/configuration/OpenApiConfigurationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/OpenApiConfigurationTest.java
@@ -27,7 +27,7 @@ class OpenApiConfigurationTest {
             .isEqualTo("PayFlow API");
 
         assertThat(openApi.getInfo().getVersion())
-            .isEqualTo("0.2.0");
+            .isEqualTo("0.16.0-SNAPSHOT");
 
         assertThat(openApi.getInfo().getDescription())
             .contains(

--- a/src/test/java/com/nursena/payflow/configuration/V016ApiCompatibilityBaselineContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V016ApiCompatibilityBaselineContractTest.java
@@ -184,7 +184,7 @@ class V016ApiCompatibilityBaselineContractTest {
     }
 
     @Test
-    void shouldInventoryDocumentationDriftWithoutRewritingIt()
+    void shouldRecordResolvedDocumentationAlignment()
         throws IOException {
 
         String baseline = Files.readString(BASELINE);
@@ -194,27 +194,34 @@ class V016ApiCompatibilityBaselineContractTest {
 
         assertThat(architecture)
             .contains(
+                "Transactional outbox persistence is implemented",
+                "`abuseprotection`",
+                "`eventprocessing`",
+                "`maildelivery`",
+                "`observability`",
+                "`outbox`"
+            )
+            .doesNotContain(
                 "Transactional outbox persistence is planned for a later milestone",
-                "├── notification",
-                "├── audit"
+                "notification",
+                "future messaging integrations"
             );
 
         assertThat(openApiConfiguration)
             .contains(
                 "API_VERSION",
-                "\"0.2.0\""
-            );
+                "\"0.16.0-SNAPSHOT\""
+            )
+            .doesNotContain("\"0.2.0\"");
 
         assertThat(baseline)
             .contains(
-                "documentation-alignment increment",
-                "transactional outbox persistence is",
-                "`notification` and",
-                "`audit`",
-                "historical `0.2.0` metadata"
+                "Increment 5 alignment",
+                "**30 unique canonical `/api/v1` operations**",
+                "PayFlow.api-compatibility.postman_collection.json",
+                "`0.16.0-SNAPSHOT`"
             );
     }
-
     @Test
     void shouldKeepCompatibilityCheckpointHistoricalDuringRecoveryWork()
         throws IOException {

--- a/src/test/java/com/nursena/payflow/configuration/V016ApiDocumentationAlignmentContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V016ApiDocumentationAlignmentContractTest.java
@@ -1,0 +1,305 @@
+package com.nursena.payflow.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class V016ApiDocumentationAlignmentContractTest {
+
+    private static final Path BASELINE =
+        Path.of("docs", "api-v1-compatibility.md");
+
+    private static final Path ARCHITECTURE =
+        Path.of("docs", "architecture.md");
+
+    private static final Path README =
+        Path.of("README.md");
+
+    private static final Path POSTMAN_README =
+        Path.of("postman", "README.md");
+
+    private static final Path OPENAPI_CONFIGURATION =
+        Path.of(
+            "src",
+            "main",
+            "java",
+            "com",
+            "nursena",
+            "payflow",
+            "configuration",
+            "OpenApiConfiguration.java"
+        );
+
+    private static final List<Path> POSTMAN_COLLECTIONS =
+        List.of(
+            Path.of(
+                "postman",
+                "PayFlow.postman_collection.json"
+            ),
+            Path.of(
+                "postman",
+                "PayFlow.mfa.postman_collection.json"
+            ),
+            Path.of(
+                "postman",
+                "PayFlow.login-rate-limit.postman_collection.json"
+            ),
+            Path.of(
+                "postman",
+                "PayFlow.api-compatibility.postman_collection.json"
+            )
+        );
+
+    private static final Path COMPATIBILITY_COLLECTION =
+        Path.of(
+            "postman",
+            "PayFlow.api-compatibility.postman_collection.json"
+        );
+
+    private static final Pattern BASELINE_OPERATION =
+        Pattern.compile(
+            "^\\|\\s*`(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)`"
+                + "\\s*\\|\\s*`([^`]+)`\\s*\\|"
+        );
+
+    private static final ObjectMapper OBJECT_MAPPER =
+        new ObjectMapper();
+
+    @Test
+    void shouldCoverEveryCanonicalOperationAcrossPostmanAssets()
+        throws IOException {
+
+        Set<String> canonical = canonicalOperations();
+        Set<String> postman = postmanOperations(POSTMAN_COLLECTIONS);
+
+        assertThat(canonical).hasSize(30);
+        assertThat(postman)
+            .containsExactlyInAnyOrderElementsOf(canonical);
+
+        assertThat(postmanOperations(List.of(COMPATIBILITY_COLLECTION)))
+            .containsExactlyInAnyOrder(
+                "DELETE /api/v1/users/me/mfa/enrollment",
+                "POST /api/v1/auth/email-verification/confirm",
+                "POST /api/v1/auth/logout",
+                "POST /api/v1/auth/logout-all",
+                "POST /api/v1/auth/refresh"
+            );
+    }
+
+    @Test
+    void shouldKeepOpenApiAndDocumentationMetadataAligned()
+        throws IOException {
+
+        String openApi = Files.readString(OPENAPI_CONFIGURATION);
+        String architecture = Files.readString(ARCHITECTURE);
+        String baseline = Files.readString(BASELINE);
+        String readme = Files.readString(README);
+        String postmanReadme = Files.readString(POSTMAN_README);
+
+        assertThat(openApi)
+            .contains(
+                "API_VERSION",
+                "\"0.16.0-SNAPSHOT\""
+            )
+            .doesNotContain("\"0.2.0\"");
+
+        assertThat(architecture)
+            .contains(
+                "Transactional outbox persistence is implemented",
+                "`abuseprotection`",
+                "`eventprocessing`",
+                "`maildelivery`",
+                "`observability`",
+                "`outbox`",
+                "at-least-once delivery boundary"
+            )
+            .doesNotContain(
+                "Transactional outbox persistence is planned for a later milestone",
+                "notification",
+                "future messaging integrations"
+            );
+
+        assertThat(baseline)
+            .contains(
+                "Increment 5 alignment",
+                "**30 unique canonical `/api/v1` operations**",
+                "PayFlow.api-compatibility.postman_collection.json",
+                "`0.16.0-SNAPSHOT`"
+            );
+
+        assertThat(readme)
+            .contains(
+                "PayFlow.api-compatibility.postman_collection.json",
+                "30 canonical `/api/v1` operations"
+            );
+
+        assertThat(postmanReadme)
+            .contains(
+                "PayFlow.api-compatibility.postman_collection.json",
+                "emailVerificationCredential",
+                "refreshToken"
+            );
+    }
+
+    @Test
+    void shouldPreserveFrozenSecurityAndNonGoalBoundaries()
+        throws IOException {
+
+        String baseline = Files.readString(BASELINE);
+        String architecture = Files.readString(ARCHITECTURE);
+
+        assertThat(baseline)
+            .contains(
+                "Registration remains the reviewed `DEFER` case",
+                "simulated-money modular monolith",
+                "does not activate generalized registration abuse protection"
+            );
+
+        assertThat(architecture)
+            .contains(
+                "PostgreSQL remains the system of record",
+                "password-login limiter remains a separate compatibility contract",
+                "Registration remains outside generalized abuse-protection wiring"
+            );
+    }
+
+    private static Set<String> canonicalOperations()
+        throws IOException {
+
+        Set<String> operations = new TreeSet<>();
+
+        for (String line : Files.readAllLines(BASELINE)) {
+            Matcher matcher = BASELINE_OPERATION.matcher(line);
+
+            if (matcher.find()) {
+                operations.add(
+                    operationKey(
+                        matcher.group(1),
+                        matcher.group(2)
+                    )
+                );
+            }
+        }
+
+        return operations;
+    }
+
+    private static Set<String> postmanOperations(
+        List<Path> collections
+    ) throws IOException {
+
+        Set<String> operations = new TreeSet<>();
+
+        for (Path collection : collections) {
+            JsonNode root =
+                OBJECT_MAPPER.readTree(
+                    Files.readString(collection)
+                );
+
+            collectPostmanOperations(root, operations);
+        }
+
+        return operations;
+    }
+
+    private static void collectPostmanOperations(
+        JsonNode node,
+        Set<String> operations
+    ) {
+        if (node.isArray()) {
+            node.forEach(
+                child ->
+                    collectPostmanOperations(
+                        child,
+                        operations
+                    )
+            );
+            return;
+        }
+
+        if (!node.isObject()) {
+            return;
+        }
+
+        JsonNode request = node.path("request");
+
+        if (request.isObject()) {
+            String method =
+                request.path("method").asText();
+            String rawUrl =
+                request.path("url").path("raw").asText();
+            String path = normalizePath(rawUrl);
+
+            if (!method.isBlank()
+                && path.startsWith("/api/v1")) {
+
+                operations.add(
+                    method.toUpperCase()
+                        + " "
+                        + path
+                );
+            }
+        }
+
+        JsonNode items = node.path("item");
+        if (items.isArray()) {
+            collectPostmanOperations(items, operations);
+        }
+    }
+
+    private static String operationKey(
+        String method,
+        String route
+    ) {
+        return method.toUpperCase()
+            + " "
+            + normalizePath(route);
+    }
+
+    private static String normalizePath(String raw) {
+        String path = raw.trim();
+
+        if (path.startsWith("{{baseUrl}}")) {
+            path =
+                path.substring(
+                    "{{baseUrl}}".length()
+                );
+        }
+
+        int queryIndex = path.indexOf('?');
+        if (queryIndex >= 0) {
+            path = path.substring(0, queryIndex);
+        }
+
+        path = path.replaceAll(
+            "/\\{\\{[^/}]+}}",
+            "/{id}"
+        );
+        path = path.replaceAll(
+            "/\\{[^/{}]+}",
+            "/{id}"
+        );
+
+        if (path.length() > 1
+            && path.endsWith("/")) {
+            path =
+                path.substring(
+                    0,
+                    path.length() - 1
+                );
+        }
+
+        return path;
+    }
+}

--- a/src/test/java/com/nursena/payflow/configuration/V016RedisKafkaOutageRecoveryContractTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/V016RedisKafkaOutageRecoveryContractTest.java
@@ -196,7 +196,9 @@ class V016RedisKafkaOutageRecoveryContractTest {
             .contains(
                 "- [x] Redis and Kafka outage/recovery procedures are documented and verified against existing failure contracts",
                 "### Increment 5",
-                "- [ ] Compare implemented `/api/v1` behavior with OpenAPI and Postman contracts"
+                "- [x] Compare implemented `/api/v1` behavior with OpenAPI and Postman contracts",
+                "### Increment 6",
+                "- [ ] Run a repository-appropriate dependency vulnerability review"
             );
 
         assertThat(Files.readString(README))

--- a/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
+++ b/src/test/java/com/nursena/payflow/configuration/integration/OpenApiJsonContractIntegrationTest.java
@@ -175,7 +175,7 @@ class OpenApiJsonContractIntegrationTest {
             .isEqualTo("PayFlow API");
 
         assertThat(info.path("version").asText())
-            .isEqualTo("0.2.0");
+            .isEqualTo("0.16.0-SNAPSHOT");
 
         assertThat(info.path("description").asText())
             .contains(


### PR DESCRIPTION
## Summary

This pull request completes v0.16.0 Increment 5 by aligning the frozen `/api/v1` compatibility surface, OpenAPI metadata, Postman coverage, architecture/documentation state, and executable documentation contracts without changing runtime API behavior.

## Verified scope

- exact reviewed head: `bda88a041b127cc855d02cc1024426d67ab11180`
- exact base: `b4c4a1fa5e8146960b17fd6f1eb6030bae6230f4`
- 14 changed files
- candidate manifest SHA-256: `56219f63a47725c7ec7c8fdc37c0f50a6633135295b816a256055172b2c4cbd4`
- full Maven verification: `1617 / 0 / 0 / 0`
- Surefire XML reports: `369`
- canonical API remains `30 operations / 28 normalized paths`
- Postman candidate coverage is `30/30` canonical operations
- OpenAPI metadata is aligned to `0.16.0-SNAPSHOT`
- runtime API behavior is unchanged
- historical roadmap sections remain preserved; the stale Increment 4 checkpoint now records Increment 5 complete and Increment 6 open

## Boundaries preserved

- PostgreSQL remains the system of record
- Redis remains bounded/expiring abuse-control state, not a source of truth
- Kafka delivery remains at-least-once with PostgreSQL idempotency boundaries; no exactly-once broker claim is introduced
- registration abuse protection remains the evidence-backed `DEFER` decision
- existing login-limiter semantics are unchanged
- no controller mapping, DTO, migration, security-policy, Redis/Kafka runtime, package-boundary, microservice, or release/tag change is included

## Review gates

Please review the exact head above. Merge only after exact-head CI and Docker Smoke gates pass successfully.

Closes #180